### PR TITLE
Make MetricFlow Unit Tests run on every PR

### DIFF
--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -6,11 +6,8 @@ on:
     # synchronize = commit(s) pushed to the pull request
     types:
       - opened
-      - edited
       - reopened
       - synchronize
-    paths:
-      - "metricflow/**"
 jobs:
   metricflow-unit-tests:
     name: MetricFlow Unit Tests


### PR DESCRIPTION
For this action to be required for merge it must execute on every
PR, so we remove restrictions on execution. To cut down on pointless
retries we no longer trigger on PR edit, as that includes all manner
of metadata updates like PR descriptions.
