### PR TITLE
Fix snowflake hanging issue on CLI

### DIFF
--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -102,6 +102,7 @@ class CLIContext:
                     password=password,
                     database=database,
                     url_query_params={"warehouse": warehouse},
+                    client_session_keep_alive=False,
                 )
             elif dialect == SupportedSqlEngine.REDSHIFT.name:
                 host = not_empty(self.config.get_config_value(CONFIG_DWH_HOST), CONFIG_DWH_HOST, url)


### PR DESCRIPTION
### Context:
Having `client_session_keep_alive=True` the connection thread for the snowflake client was kept alive even after the program was running which caused the CLI to hang during any queries.

### Changes:
- removed the previous solution of using `__del__` destructor to close the connection as the issue still lingered with it
- made `client_session_keep_alive` an arg to pass to instantiate the snowflake client so that the CLI can pass `False` to it.

Similar issue: https://github.com/snowflakedb/snowflake-connector-python/issues/836