### PR TITLE
[README] Removing > from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,21 @@ Then, proceed with the regular installation as follows:
 
 MetricFlow can be installed from PyPi for use as a Python library with the following command:
 
-`pip install metricflow`
+```
+pip install metricflow
+```
 
 Once installed, MetricFlow can be setup and connected to a data warehouse by following the instructions after issuing the command:
 
-`mf setup`
+```
+mf setup
+```
 
 To see what MetricFlow can do without custom configurations, start the tutorial by running:
 
-`mf tutorial`
+```
+mf tutorial
+```
 
 To get up and running with your own metrics, you should rely on MetricFlow’s documentation available at [MetricFlow docs](https://docs.transform.co/docs/metricflow/guides/introduction).
 

--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@ Then, proceed with the regular installation as follows:
 
 MetricFlow can be installed from PyPi for use as a Python library with the following command:
 
-`> pip install metricflow`
+`pip install metricflow`
 
 Once installed, MetricFlow can be setup and connected to a data warehouse by following the instructions after issuing the command:
 
-`> mf setup`
+`mf setup`
 
 To see what MetricFlow can do without custom configurations, start the tutorial by running:
 
-`> mf tutorial`
+`mf tutorial`
 
 To get up and running with your own metrics, you should rely on MetricFlow’s documentation available at [MetricFlow docs](https://docs.transform.co/docs/metricflow/guides/introduction).
 
 ### Tutorial
 
 ```
-> mf tutorial # optionally add `--skip-dw` if you have already confirmed your datawarehouse connection works
+mf tutorial # optionally add `--skip-dw` if you have already confirmed your datawarehouse connection works
 ```
 
 For reference, the tutorial steps are below:


### PR DESCRIPTION
### Context
Some users accidentally include the `>` when copy/paste-ing from the README. The `>` is used to indicate the terminal commands in the README. I removed the `>` and rendered the code as code blocks to clearly indicate the code.

### Screenshots:
**BEFORE** with the `>`
<kbd>
<img width="686" alt="Screen Shot 2022-04-11 at 9 25 50 PM" src="https://user-images.githubusercontent.com/4993704/162866824-f40ec754-7dde-4a4f-9609-87ec7e93c97a.png">
</kbd>

**AFTER** without the `>`
<kbd>
<img width="890" alt="Screen Shot 2022-04-11 at 9 24 58 PM" src="https://user-images.githubusercontent.com/4993704/162866754-cd7ef5bd-da7b-4a90-beaa-6ed14a948a2f.png">
</kbd>


## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)

