### PR TITLE
Sync package version handling

### DIFF
--- a/metricflow/cli/__init__.py
+++ b/metricflow/cli/__init__.py
@@ -1,2 +1,1 @@
-__version__ = "0.91.9"
 PACKAGE_NAME = "metricflow"

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -8,11 +8,12 @@ import textwrap
 import time
 
 from halo import Halo
+from importlib.metadata import version as pkg_version
 from packaging.version import parse
 from typing import List, Optional
 from update_checker import UpdateChecker
 
-from metricflow.cli import PACKAGE_NAME, __version__
+from metricflow.cli import PACKAGE_NAME
 from metricflow.cli.config_builder import YamlTemplateBuilder
 from metricflow.cli.constants import DEFAULT_RESULT_DECIMAL_PLACES, MAX_LIST_OBJECT_ELEMENTS
 from metricflow.cli.cli_context import CLIContext
@@ -48,7 +49,7 @@ def cli(cfg: CLIContext, verbose: bool) -> None:  # noqa: D
     cfg.verbose = verbose
 
     checker = UpdateChecker()
-    result = checker.check(PACKAGE_NAME, __version__)
+    result = checker.check(PACKAGE_NAME, pkg_version(PACKAGE_NAME))
     # result is None when an update was not found or a failure occurred
     if result:
         click.secho(
@@ -65,7 +66,7 @@ def cli(cfg: CLIContext, verbose: bool) -> None:  # noqa: D
 @cli.command()
 def version() -> None:
     """Print the current version of the MetricFlow CLI."""
-    click.echo(__version__)
+    click.echo(pkg_version(PACKAGE_NAME))
 
 
 @cli.command()

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -10,6 +10,7 @@ from metricflow.cli.main import (
     materialize,
     query,
     validate_configs,
+    version,
 )
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.validations.validator_helpers import (
@@ -83,4 +84,11 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
         resp = cli_runner.run(validate_configs)
 
     assert "future_error" in resp.output
+    assert resp.exit_code == 0
+
+
+def test_version(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+    resp = cli_runner.run(version)
+
+    assert resp.output
     assert resp.exit_code == 0


### PR DESCRIPTION
## Context
We are using `pyproject.toml` to package the library to publish to pypi. Since the `.toml` wasn't able to read from another file and the cli code couldn't reach outside the top-level directory, we needed a way to sync the current version of the library without having to hardcode the version on both `pyproject.toml` and `metricflow/cli/__init__.py`. Instead, we can aggregate the current package version using `importlib.metadata.version` in the CLI. This allows us to keep the hardcoded version in 1 file which is inside `pyproject.toml`

## Changes
- Removed version in `metricflow/cli/__init__.py`
- Use `importlib.metadata` to get current package version in CLI
- Added test for version CLI command