### PR TITLE
Adding Materialization checks to Validations

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -12,6 +12,7 @@ from metricflow.model.validations.data_sources import (
 from metricflow.model.validations.dimension_const import DimensionConsistencyRule
 from metricflow.model.validations.element_const import ElementConsistencyRule
 from metricflow.model.validations.identifiers import IdentifierConfigRule, OnePrimaryIdentifierPerDataSourceRule
+from metricflow.model.validations.materializations import ValidMaterializationRule
 from metricflow.model.validations.metrics import MetricMeasuresRule, CumulativeMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
@@ -40,6 +41,7 @@ class ModelValidator:
         CumulativeMetricRule(),
         NonEmptyRule(),
         UniqueAndValidNameRule(),
+        ValidMaterializationRule(),
     ]
 
     @staticmethod
@@ -61,7 +63,7 @@ class ModelValidator:
         return ModelBuildResult(model=model_copy, issues=tuple(issues))
 
     @staticmethod
-    def checked_validations(model: UserConfiguredModel) -> UserConfiguredModel:
+    def checked_validations(model: UserConfiguredModel) -> UserConfiguredModel:  # chTODO: remember checked_build
         """Similar to validate(), but throws an exception if validation fails."""
         model_copy = copy.deepcopy(model)
         build_result = ModelValidator.validate_model(model_copy)

--- a/metricflow/model/validations/dim_names.py
+++ b/metricflow/model/validations/dim_names.py
@@ -13,7 +13,6 @@ from metricflow.specs import (
     MeasureReference,
     DimensionReference,
     IdentifierReference,
-    IdentifierSpec,
     DimensionSpec,
     LinklessIdentifierSpec,
 )
@@ -112,8 +111,8 @@ class DimensionAndIdentifierNameValidator:
 
     def _is_identifier_valid_for_measure(self, measure_reference: MeasureReference, identifier_name: str) -> bool:
         assert measure_reference in self._measures_to_identifiers
-        identifier_spec = IdentifierSpec.parse(identifier_name)
-        return identifier_spec in self._measures_to_identifiers[measure_reference]
+        identifier_ref = IdentifierReference.parse(identifier_name)
+        return identifier_ref in self._measures_to_identifiers[measure_reference]
 
     def is_dimension_valid_for_measure(self, measure_reference: MeasureReference, dimension_name: str) -> bool:
         """Return true iff the given measure and dimension could be queried together."""

--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -1,0 +1,116 @@
+import logging
+from typing import List
+
+from metricflow.errors.errors import UnableToSatisfyQueryError
+from metricflow.model.objects.materialization import Materialization
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantic_model import SemanticModel
+from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
+from metricflow.model.semantics.semantic_containers import DataSourceSemantics
+from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
+from metricflow.query.query_parser import MetricFlowQueryParser
+from metricflow.model.validations.validator_helpers import (
+    ModelValidationRule,
+    ValidationIssue,
+    ValidationError,
+    ValidationIssueType,
+    validate_safely,
+)
+from metricflow.specs import TimeDimensionReference
+
+logger = logging.getLogger(__name__)
+
+
+class ValidMaterializationRule(ModelValidationRule):
+    """Check that a materialization config is valid.
+
+    * Metrics listed are valid.
+    * Dimensions or identifiers are valid for the listed metrics.
+    * Primary time dimension is listed in the dimensions section.
+    """
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking materialization is defined correctly")
+    def _validate_materialization(
+        materialization: Materialization,
+        primary_time_dimensions_reference: TimeDimensionReference,
+        mf_query_parser: MetricFlowQueryParser,
+    ) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+
+        if not materialization.dimensions:
+            return [
+                ValidationError(
+                    model_object_reference=ValidationIssue.make_object_reference(
+                        materialization_name=materialization.name
+                    ),
+                    message=f"Materialization '{materialization.name}' does not have dimensions listed",
+                )
+            ]
+
+        try:
+            mf_query_parser.parse_and_validate_query(
+                metric_names=materialization.metrics,
+                group_by_names=materialization.dimensions,
+            )
+        except UnableToSatisfyQueryError as err:
+            issues.append(
+                ValidationError(
+                    model_object_reference=ValidationIssue.make_object_reference(
+                        materialization_name=materialization.name
+                    ),
+                    message=str(err),
+                )
+            )
+
+        # Primary dimension checks
+        mat_primary_time_dimension_names: List[str] = []
+        for mat_dimension_or_identifier_name in materialization.dimensions:
+            structured_spec = StructuredLinkableSpecName.from_name(mat_dimension_or_identifier_name)
+            if structured_spec.element_name == primary_time_dimensions_reference.element_name:
+                mat_primary_time_dimension_names.append(mat_dimension_or_identifier_name)
+
+        if len(mat_primary_time_dimension_names) == 0:
+            issues.append(
+                ValidationError(
+                    model_object_reference=ValidationIssue.make_object_reference(
+                        materialization_name=materialization.name
+                    ),
+                    message=f"Primary time dimension {primary_time_dimensions_reference.element_name} not listed"
+                    f" as a dimension in materialization {materialization.name}",
+                )
+            )
+
+        if len(mat_primary_time_dimension_names) > 1:
+            issues.append(
+                ValidationError(
+                    model_object_reference=ValidationIssue.make_object_reference(
+                        materialization_name=materialization.name
+                    ),
+                    message=f"Multiple primary time dimensions {mat_primary_time_dimension_names} listed in "
+                    f"materialization {materialization.name}",
+                )
+            )
+
+        return issues
+
+    @staticmethod
+    @validate_safely(whats_being_done="running model validation ensuring materializations are valid")
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+        """Check that all of the metrics and dimensions listed in a materialization are valid."""
+        issues: List[ValidationIssueType] = []
+        ds_semantics = DataSourceSemantics(
+            model=model, configured_data_source_container=PydanticDataSourceContainer(model.data_sources)
+        )
+        primary_time_dimensions_reference = ds_semantics.primary_time_dimension_reference
+        mf_query_parser = MetricFlowQueryParser(
+            model=SemanticModel(user_configured_model=model),
+            primary_time_dimension_reference=primary_time_dimensions_reference,
+        )
+        for materialization in model.materializations:
+            issues += ValidMaterializationRule._validate_materialization(
+                materialization=materialization,
+                primary_time_dimensions_reference=primary_time_dimensions_reference,
+                mf_query_parser=mf_query_parser,
+            )
+        return issues

--- a/metricflow/test/model/validations/test_materializations.py
+++ b/metricflow/test/model/validations/test_materializations.py
@@ -1,0 +1,135 @@
+import logging
+
+from metricflow.model.objects.materialization import Materialization
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.materializations import ValidMaterializationRule
+from metricflow.test.test_utils import (
+    model_with_materialization,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_materialization_validation(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    ValidMaterializationRule.validate_model(simple_model__pre_transforms)
+
+
+def test_identifier(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    assert (
+        len(
+            ValidMaterializationRule.validate_model(
+                model_with_materialization(
+                    simple_model__pre_transforms,
+                    [
+                        Materialization(
+                            name="foobar",
+                            metrics=["bookings"],
+                            dimensions=["ds", "listing"],
+                        )
+                    ],
+                )
+            )
+        )
+        == 0
+    )
+
+
+def test_invalid_metric_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    assert (
+        len(
+            ValidMaterializationRule.validate_model(
+                model_with_materialization(
+                    simple_model__pre_transforms,
+                    [
+                        Materialization(
+                            name="foobar",
+                            metrics=["invalid_bookings"],
+                            dimensions=["ds"],
+                        )
+                    ],
+                )
+            )
+        )
+        == 1
+    )
+
+
+def test_invalid_dimension_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    assert (
+        len(
+            ValidMaterializationRule.validate_model(
+                model_with_materialization(
+                    simple_model__pre_transforms,
+                    [
+                        Materialization(
+                            name="foobar",
+                            metrics=["bookings"],
+                            dimensions=["ds", "invalid_dimension_name"],
+                        )
+                    ],
+                )
+            )
+        )
+        == 1
+    )
+
+
+def test_missing_primary_time_dimension(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    """Materializations should have the primary time dimension listed as a dimension"""
+    assert (
+        len(
+            ValidMaterializationRule.validate_model(
+                model_with_materialization(
+                    simple_model__pre_transforms,
+                    [
+                        Materialization(
+                            name="foobar",
+                            metrics=["bookings"],
+                            dimensions=["is_instant"],
+                        )
+                    ],
+                )
+            )
+        )
+        == 1
+    )
+
+
+def test_valid_time_granularity(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    assert (
+        len(
+            ValidMaterializationRule.validate_model(
+                model_with_materialization(
+                    simple_model__pre_transforms,
+                    [
+                        Materialization(
+                            name="materialization_test_case",
+                            metrics=["bookings"],
+                            dimensions=["ds__day"],
+                        )
+                    ],
+                )
+            )
+        )
+        == 0
+    )
+
+
+def test_invalid_time_granularity(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    assert (
+        len(
+            ValidMaterializationRule.validate_model(
+                model_with_materialization(
+                    simple_model__pre_transforms,
+                    [
+                        Materialization(
+                            name="materialization_test_case",
+                            metrics=["revenue"],
+                            dimensions=["ds__hour"],
+                        )
+                    ],
+                )
+            )
+        )
+        == 2
+    )

--- a/metricflow/test/test_utils.py
+++ b/metricflow/test/test_utils.py
@@ -1,11 +1,13 @@
+import copy
 import datetime
 import logging
 
 import dateutil.parser
 from _pytest.fixtures import FixtureRequest
-from typing import Callable, Tuple
+from typing import Callable, Tuple, List
 
 from metricflow.model.objects.data_source import DataSource
+from metricflow.model.objects.materialization import Materialization
 from metricflow.model.objects.metric import Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.protocols.sql_client import SqlClient
@@ -63,3 +65,12 @@ def find_metric_with(model: UserConfiguredModel, function: Callable[[Metric], bo
             return metric, index
 
     raise Exception("Unable to find a metric matching function criteria")
+
+
+def model_with_materialization(
+    initial_model: UserConfiguredModel, materializations: List[Materialization]
+) -> UserConfiguredModel:
+    """Returns a copy of the model but with the materialization added"""
+    model_copy = copy.deepcopy(initial_model)
+    model_copy.materializations.extend(materializations)
+    return model_copy


### PR DESCRIPTION
Problem: Materializations did not have validation coverage

Solution: Added coverage within the `ModelValidator` for Materializations. In addition, we altered some of the attributes of Materialization to default to empty list instead of None to avoid returning null when returning a collection. In addition, some supplemental methods were added to other objects for easier usage of them.