### PR TITLE
Removing duplicate MeasureReference definition

### DIFF
--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -16,6 +16,7 @@ from metricflow.specs import (
     LinklessIdentifierSpec,
     DEFAULT_TIME_GRANULARITY,
     TimeDimensionReference,
+    MeasureReference,
 )
 from metricflow.model.objects.metric import MetricType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -34,13 +35,6 @@ class PartialTimeDimensionSpec:
 
     element_name: str
     identifier_links: Tuple[LinklessIdentifierSpec, ...]
-
-
-@dataclass(frozen=True)
-class MeasureReference:
-    """Refers to a measure where we don't know other attributes."""
-
-    element_name: str
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
There was a duplicate `MeasureReference` definition hiding in time granularity solver. It is deleted in this PR, and the usages of `MeasureReference` now point to our singular definition of `MeasureReference`.