### PR TITLE
Removing time_format (legacy)

### DIFF
--- a/metricflow/test/fixtures/model_yamls/composite_identifier_model/messages_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/composite_identifier_model/messages_source.yaml
@@ -18,7 +18,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: team_id
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/composite_identifier_model/users_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/composite_identifier_model/users_source.yaml
@@ -14,7 +14,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: team_id
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/bookings_from_sql_query_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/bookings_from_sql_query_source.yaml
@@ -18,7 +18,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
 
   identifiers:

--- a/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/bookings_monthly_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/bookings_monthly_source.yaml
@@ -17,7 +17,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: month
     - name: is_instant
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/extended_bookings_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/extended_bookings_source.yaml
@@ -22,7 +22,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: is_instant
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/listings_extended_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/extended_date_model/data_sources/listings_extended_source.yaml
@@ -11,7 +11,6 @@ data_source:
     - name: listing_creation_ds
       type: time
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
 
   identifiers:

--- a/metricflow/test/fixtures/model_yamls/join_types_model/bookings_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/join_types_model/bookings_source.yaml
@@ -18,7 +18,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
 
   identifiers:

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/account_month_txns.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/account_month_txns.yaml
@@ -17,14 +17,12 @@ data_source:
       type: time
       type_params:
         is_primary: false
-        time_format: YYYY-MM-DD
         time_granularity: day
       is_partition: true
     - name: ds
       type: time
       type_params:
         is_primary: true
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: account_month
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/bridge_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/bridge_table.yaml
@@ -14,7 +14,6 @@ data_source:
       type: time
       type_params:
         is_primary: false
-        time_format: YYYY-MM-DD
         time_granularity: day
       is_partition: true
 

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/customer_other_data.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/customer_other_data.yaml
@@ -12,7 +12,6 @@ data_source:
       type: time
       type_params:
         is_primary: false
-        time_format: YYYY-MM-DD
         time_granularity: day
       is_partition: true
     - name: country

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/customer_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/customer_table.yaml
@@ -16,7 +16,6 @@ data_source:
       type: time
       type_params:
         is_primary: false
-        time_format: YYYY-MM-DD
         time_granularity: day
       is_partition: true
 

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/third_hop_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/third_hop_table.yaml
@@ -12,7 +12,6 @@ data_source:
       type: time
       type_params:
         is_primary: false
-        time_format: YYYY-MM-DD
         time_granularity: day
       is_partition: true
     - name: value

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/account_month_txns.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/account_month_txns.yaml
@@ -17,7 +17,6 @@ data_source:
       type: time
       type_params:
         is_primary: true
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: account_month
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/non_ds_model/bookings_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/non_ds_model/bookings_source.yaml
@@ -21,7 +21,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
 
   identifiers:

--- a/metricflow/test/fixtures/model_yamls/non_ds_model/listings_latest.yaml
+++ b/metricflow/test/fixtures/model_yamls/non_ds_model/listings_latest.yaml
@@ -18,12 +18,10 @@ data_source:
       expr: created_at
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: created_at
       type: time
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: country_latest
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/id_verifications.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/id_verifications.yaml
@@ -17,13 +17,11 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: ds_partitioned
       type: time
       is_partition: true
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: verification_type
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/listings_latest.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/listings_latest.yaml
@@ -24,12 +24,10 @@ data_source:
       expr: created_at
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: created_at
       type: time
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: country_latest
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/revenue.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/revenue.yaml
@@ -20,7 +20,6 @@ data_source:
       expr: created_at
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
 
   identifiers:

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/user_ds_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/user_ds_source.yaml
@@ -12,18 +12,15 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: created_at
       type: time
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: ds_partitioned
       type: time
       is_partition: true
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: home_state
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/users_latest.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/users_latest.yaml
@@ -12,7 +12,6 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: home_state_latest
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/views_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/views_source.yaml
@@ -19,13 +19,11 @@ data_source:
       type: time
       type_params:
         is_primary: True
-        time_format: YYYY-MM-DD
         time_granularity: day
     - name: ds_partitioned
       type: time
       is_partition: true
       type_params:
-        time_format: YYYY-MM-DD
         time_granularity: day
 
   identifiers:

--- a/metricflow/test/model/validations/test_data_sources.py
+++ b/metricflow/test/model/validations/test_data_sources.py
@@ -19,7 +19,6 @@ def test_data_source_invalid_sql() -> None:  # noqa:D
                     name=dimension_reference,
                     type=DimensionType.TIME,
                     type_params=DimensionTypeParams(
-                        time_format="YYYY-MM-DD",
                         time_granularity=TimeGranularity.DAY,
                     ),
                 )

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -29,7 +29,6 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -73,7 +72,6 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -89,7 +87,6 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -127,7 +124,6 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                                 is_partition=True,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -143,7 +139,6 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 is_partition=False,
                                 type_params=DimensionTypeParams(
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -27,7 +27,6 @@ def test_inconsistent_elements() -> None:  # noqa:D
                                 name=dim_reference,
                                 type_=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -68,7 +68,6 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -118,7 +117,6 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -169,7 +167,6 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -64,7 +64,6 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                             type=DimensionType.TIME,
                             type_params=DimensionTypeParams(
                                 is_primary=True,
-                                time_format="YYYY-MM-DD",
                                 time_granularity=TimeGranularity.DAY,
                             ),
                         ),
@@ -133,7 +132,6 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                                 name=dim_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             ),
@@ -141,7 +139,6 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                                 name=dim2_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             ),
@@ -177,7 +174,6 @@ def test_generated_metrics_only() -> None:  # noqa:D
                 type=DimensionType.TIME,
                 type_params=DimensionTypeParams(
                     is_primary=True,
-                    time_format="YYYY-MM-DD",
                     time_granularity=TimeGranularity.DAY,
                 ),
             ),


### PR DESCRIPTION
## Context
MetricFlow no longer requires `time_format` for time dimensions. 

## Changes
This PR removes `time_format` from all sample models and tests. 