### PR TITLE
Move DAG Visualization Methods out of test/

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -34,7 +34,7 @@ from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFl
 from metricflow.model.model_validator import ModelValidator
 from metricflow.telemetry.models import TelemetryLevel
 from metricflow.telemetry.reporter import TelemetryReporter, log_call
-from metricflow.test.dataflow_plan_to_svg import display_dag_as_svg
+from metricflow.dag.dag_visualization import display_dag_as_svg
 
 pass_config = click.make_pass_decorator(CLIContext, ensure=True)
 _telemetry_reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)

--- a/metricflow/dag/dag_visualization.py
+++ b/metricflow/dag/dag_visualization.py
@@ -1,0 +1,44 @@
+import logging
+import os
+from typing import TypeVar
+
+import graphviz
+
+from metricflow.dag.mf_dag import DagNode, MetricFlowDag
+from metricflow.object_utils import random_id
+
+logger = logging.getLogger(__name__)
+DagNodeT = TypeVar("DagNodeT", bound=DagNode)
+
+
+def add_nodes_to_digraph(node: DagNodeT, dot: graphviz.Digraph) -> None:
+    """Adds the node (and parent nodes) to the dot for visualization."""
+    for parent_node in node.parent_nodes:
+        add_nodes_to_digraph(parent_node, dot)
+
+    dot.node(name=node.node_id.id_str, label=node.graphviz_label)
+    for parent_node in node.parent_nodes:
+        dot.edge(tail_name=parent_node.node_id.id_str, head_name=node.node_id.id_str)
+
+
+DagGraphT = TypeVar("DagGraphT", bound=MetricFlowDag)
+
+
+def display_dag_as_svg(dag_graph: DagGraphT, mf_config_dir: str) -> str:
+    """Create and display the plan as an SVG in the browser.
+
+    Returns the path where the SVG file was created within "mf_config_dir".
+    """
+    svg_dir = os.path.join(mf_config_dir, "generated_svg")
+    random_file_path = os.path.join(svg_dir, f"dag_{random_id()}")
+    _render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=random_file_path)
+    return random_file_path + ".svg"
+
+
+def _render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str) -> None:
+    dot = graphviz.Digraph(comment=dag_graph.dag_id, node_attr={"shape": "box", "fontname": "Courier"})
+    # Not quite correct if there are shared nodes.
+    for sink_node in dag_graph.sink_nodes:
+        add_nodes_to_digraph(sink_node, dot)
+    dot.format = "svg"
+    dot.render(file_path_without_svg_suffix, view=True, format="svg", cleanup=True)

--- a/metricflow/dag/dag_visualization.py
+++ b/metricflow/dag/dag_visualization.py
@@ -31,11 +31,17 @@ def display_dag_as_svg(dag_graph: DagGraphT, mf_config_dir: str) -> str:
     """
     svg_dir = os.path.join(mf_config_dir, "generated_svg")
     random_file_path = os.path.join(svg_dir, f"dag_{random_id()}")
-    _render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=random_file_path)
+    render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=random_file_path)
     return random_file_path + ".svg"
 
 
-def _render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str) -> None:
+def render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str) -> None:
+    """Render the DAG using graphviz.
+
+    Args:
+        dag_graph: The DAG to render.
+        file_path_without_svg_suffix: Path to the SVG file that should be created, without ".svg" suffix.
+    """
     dot = graphviz.Digraph(comment=dag_graph.dag_id, node_attr={"shape": "box", "fontname": "Courier"})
     # Not quite correct if there are shared nodes.
     for sink_node in dag_graph.sink_nodes:

--- a/metricflow/test/dataflow_plan_to_svg.py
+++ b/metricflow/test/dataflow_plan_to_svg.py
@@ -2,7 +2,7 @@ import os
 
 from _pytest.fixtures import FixtureRequest
 
-from metricflow.dag.dag_visualization import DagGraphT, _render_via_graphviz
+from metricflow.dag.dag_visualization import DagGraphT, render_via_graphviz
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.plan_utils import snapshot_path_prefix
 
@@ -28,5 +28,5 @@ def display_graph_if_requested(
         raise RuntimeError(
             f"Can't display plan - hit limit of {mf_test_session_state.max_plans_displayed} plans displayed."
         )
-    _render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=plan_svg_output_path_prefix)
+    render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=plan_svg_output_path_prefix)
     mf_test_session_state.plans_displayed += 1

--- a/metricflow/test/dataflow_plan_to_svg.py
+++ b/metricflow/test/dataflow_plan_to_svg.py
@@ -1,32 +1,10 @@
-import logging
 import os
-from typing import TypeVar
 
-import graphviz
 from _pytest.fixtures import FixtureRequest
 
-from metricflow.dag.mf_dag import DagNode, MetricFlowDag
-from metricflow.object_utils import random_id
+from metricflow.dag.dag_visualization import DagGraphT, _render_via_graphviz
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.plan_utils import snapshot_path_prefix
-
-logger = logging.getLogger(__name__)
-
-
-DagNodeT = TypeVar("DagNodeT", bound=DagNode)
-
-
-def add_nodes_to_digraph(node: DagNodeT, dot: graphviz.Digraph) -> None:
-    """Adds the node (and parent nodes) to the dot for visualization."""
-    for parent_node in node.parent_nodes:
-        add_nodes_to_digraph(parent_node, dot)
-
-    dot.node(name=node.node_id.id_str, label=node.graphviz_label)
-    for parent_node in node.parent_nodes:
-        dot.edge(tail_name=parent_node.node_id.id_str, head_name=node.node_id.id_str)
-
-
-DagGraphT = TypeVar("DagGraphT", bound=MetricFlowDag)
 
 
 def display_graph_if_requested(
@@ -52,23 +30,3 @@ def display_graph_if_requested(
         )
     _render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=plan_svg_output_path_prefix)
     mf_test_session_state.plans_displayed += 1
-
-
-def display_dag_as_svg(dag_graph: DagGraphT, mf_config_dir: str) -> str:
-    """Create and display the plan as an SVG in the browser.
-
-    Returns the path where the SVG file was created within "mf_config_dir".
-    """
-    svg_dir = os.path.join(mf_config_dir, "generated_svg")
-    random_file_path = os.path.join(svg_dir, f"dag_{random_id()}")
-    _render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=random_file_path)
-    return random_file_path + ".svg"
-
-
-def _render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str) -> None:
-    dot = graphviz.Digraph(comment=dag_graph.dag_id, node_attr={"shape": "box", "fontname": "Courier"})
-    # Not quite correct if there are shared nodes.
-    for sink_node in dag_graph.sink_nodes:
-        add_nodes_to_digraph(sink_node, dot)
-    dot.format = "svg"
-    dot.render(file_path_without_svg_suffix, view=True, format="svg", cleanup=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metricflow"
-version = "0.92"
+version = "0.92.1"
 description = ""
 authors = ["Transform <hello@transformdata.io>"]
 


### PR DESCRIPTION
Moving these methods out will fix dependencies on the test environment.