### PR TITLE
Removing Unnecessary Lone Identifiers Validation

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -4,7 +4,6 @@ from typing import List
 
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
-from metricflow.model.validations.common_identifiers import CommonIdentifiersRule
 from metricflow.model.validations.data_sources import (
     DataSourceMeasuresUniqueRule,
     DataSourceTimeDimensionWarningsRule,
@@ -30,7 +29,6 @@ class ModelValidator:
     """A Validator that acts on UserConfiguredModel"""
 
     VALIDATION_RULES: List[ModelValidationRule] = [
-        CommonIdentifiersRule(),
         DataSourceMeasuresUniqueRule(),
         DataSourceTimeDimensionWarningsRule(),
         DimensionConsistencyRule(),

--- a/metricflow/test/model/validations/test_common_identifiers.py
+++ b/metricflow/test/model/validations/test_common_identifiers.py
@@ -1,4 +1,5 @@
 import copy
+import pytest
 import re
 from typing import Callable
 
@@ -9,6 +10,7 @@ from metricflow.specs import IdentifierSpec
 from metricflow.test.test_utils import find_data_source_with
 
 
+@pytest.mark.skip("TODO: re-enforce after validations improvements")
 def test_lonely_identifier_raises_issue(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
     model = copy.deepcopy(simple_model__pre_transforms)
     lonely_identifier_name = "hi_im_lonely"


### PR DESCRIPTION
This validation added a nonblocking warning to the resulting validation issues.
Removing this warning is generally what customers want as the lone identifier doesn't cause any problems.