### PR TITLE
Composite identifiers validation

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -10,7 +10,11 @@ from metricflow.model.validations.data_sources import (
 )
 from metricflow.model.validations.dimension_const import DimensionConsistencyRule
 from metricflow.model.validations.element_const import ElementConsistencyRule
-from metricflow.model.validations.identifiers import IdentifierConfigRule, OnePrimaryIdentifierPerDataSourceRule
+from metricflow.model.validations.identifiers import (
+    IdentifierConfigRule,
+    OnePrimaryIdentifierPerDataSourceRule,
+    IdentifierConsistencyRule,
+)
 from metricflow.model.validations.materializations import ValidMaterializationRule
 from metricflow.model.validations.metrics import MetricMeasuresRule, CumulativeMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
@@ -34,6 +38,7 @@ class ModelValidator:
         DimensionConsistencyRule(),
         ElementConsistencyRule(),
         IdentifierConfigRule(),
+        IdentifierConsistencyRule(),
         OnePrimaryIdentifierPerDataSourceRule(),
         MetricMeasuresRule(),
         CumulativeMetricRule(),

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 class ModelBuildResult:  # noqa: D
     model: Optional[UserConfiguredModel] = None
     # Issues found in the model.
-    issues: Optional[Tuple[ValidationIssueType, ...]] = None
+    issues: Tuple[ValidationIssueType, ...] = tuple()
 
 
 def parse_directory_of_yaml_files_to_model(

--- a/metricflow/model/validations/identifiers.py
+++ b/metricflow/model/validations/identifiers.py
@@ -1,9 +1,11 @@
 import logging
+from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import date
-from typing import List, MutableSet
+from typing import List, MutableSet, Tuple, Sequence
 
 from metricflow.model.objects.data_source import DataSource
-from metricflow.model.objects.elements.identifier import IdentifierType
+from metricflow.model.objects.elements.identifier import Identifier, IdentifierType, CompositeSubIdentifier
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
@@ -11,8 +13,10 @@ from metricflow.model.validations.validator_helpers import (
     ValidationError,
     ValidationIssueType,
     validate_safely,
+    ValidationWarning,
 )
 from metricflow.model.validations.validator_helpers import ValidationFutureError
+from metricflow.specs import IdentifierReference
 
 logger = logging.getLogger(__name__)
 
@@ -118,4 +122,87 @@ class OnePrimaryIdentifierPerDataSourceRule(ModelValidationRule):
         for data_source in model.data_sources:
             issues += OnePrimaryIdentifierPerDataSourceRule._only_one_primary_identifier(data_source=data_source)
 
+        return issues
+
+
+@dataclass(frozen=True)
+class SubIdentifierContext:
+    """Organizes the context behind identifiers and their sub-identifiers."""
+
+    data_source_name: str
+    identifier_reference: IdentifierReference
+    sub_identifier_names: Tuple[str, ...]
+
+
+class IdentifierConsistencyRule(ModelValidationRule):
+    """Checks identifiers with the same name are defined with the same set of sub-identifiers in all data sources"""
+
+    @staticmethod
+    def _get_sub_identifier_names(identifier: Identifier) -> Sequence[str]:
+        sub_identifier_names = []
+        sub_identifier: CompositeSubIdentifier
+        for sub_identifier in identifier.identifiers or []:
+            if sub_identifier.name:
+                sub_identifier_names.append(sub_identifier.name.element_name)
+            elif sub_identifier.ref:
+                sub_identifier_names.append(sub_identifier.ref)
+        return sub_identifier_names
+
+    @staticmethod
+    def _get_sub_identifier_context(data_source: DataSource) -> Sequence[SubIdentifierContext]:
+        contexts = []
+        for identifier in data_source.identifiers or []:
+            contexts.append(
+                SubIdentifierContext(
+                    data_source_name=data_source.name,
+                    identifier_reference=identifier.name,
+                    sub_identifier_names=tuple(IdentifierConsistencyRule._get_sub_identifier_names(identifier)),
+                )
+            )
+        return contexts
+
+    @staticmethod
+    @validate_safely(whats_being_done="running model validation to ensure identifiers have consistent sub-identifiers")
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+        issues: List[ValidationIssueType] = []
+        # The expected sub identifiers that an identifier has.
+        identifier_to_sub_identifiers: OrderedDict[str, Tuple[str, ...]] = OrderedDict()
+        # The identifiers that have different sub-identifiers in different data sources.
+        identifiers_with_inconsistent_sub_identifiers = []
+
+        identifier_contexts = []
+        issues = []
+        for data_source in model.data_sources or []:
+            sub_identifier_contexts = IdentifierConsistencyRule._get_sub_identifier_context(data_source)
+            for sub_identifier_context in sub_identifier_contexts:
+                identifier_contexts.append(sub_identifier_context)
+
+                identifier_reference = sub_identifier_context.identifier_reference
+                if identifier_reference.element_name not in identifier_to_sub_identifiers:
+                    identifier_to_sub_identifiers[
+                        identifier_reference.element_name
+                    ] = sub_identifier_context.sub_identifier_names
+
+                elif (
+                    identifier_to_sub_identifiers[identifier_reference.element_name]
+                    != sub_identifier_context.sub_identifier_names
+                ):
+                    identifiers_with_inconsistent_sub_identifiers.append(identifier_reference)
+
+        for identifier_reference in identifiers_with_inconsistent_sub_identifiers:
+            for identifier_context in identifier_contexts:
+                if identifier_context.identifier_reference.element_name == identifier_reference.element_name:
+                    issues.append(
+                        ValidationWarning(
+                            model_object_reference=ValidationIssue.make_object_reference(
+                                data_source_name=identifier_context.data_source_name,
+                                identifier_name=identifier_context.identifier_reference.element_name,
+                            ),
+                            message=(
+                                f"Identifier '{identifier_reference.element_name}' does not have consistent sub-identifiers "
+                                f"throughout the model. In data source '{identifier_context.data_source_name}', "
+                                f"it has sub-identifiers {list(identifier_context.sub_identifier_names)}."
+                            ),
+                        )
+                    )
         return issues

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -69,7 +69,6 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -119,7 +118,6 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -170,7 +168,6 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
-                                    time_format="YYYY-MM-DD",
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -235,4 +235,4 @@ def test_mismatched_identifier(simple_model__pre_transforms: UserConfiguredModel
     expected_error_message_fragment = "does not have consistent sub-identifiers"
     error_count = len([issue for issue in build.issues if re.search(expected_error_message_fragment, issue.message)])
 
-    assert error_count == 2
+    assert error_count == 1


### PR DESCRIPTION
Adding Validation and Test for Composite Identifiers

MetricFlow enforces that each identifier is defined uniquely, one aspect of this is that the sub identifiers are the same.
This is not a problem when an identifier is only requested once in a model. But this can become a problem when a model requests the same identifier across multiple data sources of a model. Each time that identifier is requested, it must share the same sub-identifier structure.

Defaulting the issues attribute of ModelBuildResult to an empty tuple for more intuitive handling.