### PR TITLE
Add LOCAL_LINKED Property for Available Dimensions

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -22,6 +22,7 @@ from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
 from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.execution.executor import SequentialPlanExecutor
 from metricflow.model.semantic_model import SemanticModel
+from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
 from metricflow.object_utils import pformat_big_objects, random_id
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_execution import DataflowToExecutionPlanConverter
@@ -443,9 +444,13 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             Dimension(name=dim.qualified_name)
             for dim in self._semantic_model.metric_semantics.element_specs_for_metrics(
                 metric_specs=[MetricSpec(element_name=mname) for mname in metric_names],
-                dimensions_only=True,
-                exclude_derived_time_granularities=True,
-                exclude_local_linked_primary_time=True,
+                without_any_property=frozenset(
+                    {
+                        LinkableElementProperties.IDENTIFIER,
+                        LinkableElementProperties.DERIVED_TIME_GRANULARITY,
+                        LinkableElementProperties.LOCAL_LINKED,
+                    }
+                ),
             )
         ]
 

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -237,13 +237,7 @@ class MetricFlowQueryParser:
         if len(invalid_group_bys) > 0:
             valid_group_by_names_for_metrics = sorted(
                 x.qualified_name
-                for x in self._metric_semantics.element_specs_for_metrics(
-                    metric_specs=list(metric_specs),
-                    local_only=False,
-                    dimensions_only=False,
-                    exclude_multi_hop=False,
-                    exclude_derived_time_granularities=False,
-                )
+                for x in self._metric_semantics.element_specs_for_metrics(metric_specs=list(metric_specs))
             )
             # Create suggestions for invalid dimensions in case the user made a typo.
             suggestion_sections = {}
@@ -631,13 +625,7 @@ class MetricFlowQueryParser:
         """Checks that each requested linkable instance can be retrieved for the given metric"""
         invalid_linkable_specs: List[LinkableInstanceSpec] = []
         # TODO: distinguish between dimensions that invalid via typo vs ambiguous join path
-        valid_linkable_specs = self._metric_semantics.element_specs_for_metrics(
-            metric_specs=list(metric_specs),
-            local_only=False,
-            dimensions_only=False,
-            exclude_multi_hop=False,
-            exclude_derived_time_granularities=False,
-        )
+        valid_linkable_specs = self._metric_semantics.element_specs_for_metrics(metric_specs=list(metric_specs))
 
         for dimension_spec in dimension_specs:
             if dimension_spec not in valid_linkable_specs:


### PR DESCRIPTION
This PR adds the `LOCAL_LINKED` property to indicate if an available dimension for a metric is the same as a local one, but linked with a local primary identifier. For example, if a data source has the primary identifier `listing` and dimension `capacity_latest`, then the dimension `listing__capacity_latest` for a measure in that data source would have the property `LOCAL_LINKED`.

This also updates the function for getting available dimensions for a metric to use properties, instead of a set of flags.