### PR TITLE
References names types

### DIFF
--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -330,9 +330,9 @@ class DataSourceToDataSetConverter:
 
                     expr = sub_id.expr
                     if expr is None:
-                        assert sub_id.name is not None
-                        expr = sub_id.name.element_name
-                    sub_id_name = sub_id.ref or sub_id.name
+                        assert sub_id.ref is not None
+                        expr = sub_id.ref.element_name
+                    sub_id_name = sub_id.name or sub_id.ref
                     assert sub_id_name, f"Sub-identifier {sub_id} must have 'name' or 'ref' defined"
 
                     select_columns.append(

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -130,7 +130,7 @@ class DataSourceToDataSetConverter:
     ) -> IdentifierInstance:
         """Create an identifier instance from the identifier object from a data sourcein the model."""
         identifier_spec = IdentifierSpec(
-            element_name=identifier.name.element_name,
+            element_name=identifier.ref.element_name,
             identifier_links=identifier_links,
         )
         column_associations = identifier_spec.column_associations(self._column_association_resolver)
@@ -141,7 +141,7 @@ class DataSourceToDataSetConverter:
             defined_from=(
                 DataSourceElementReference(
                     data_source_name=data_source_name,
-                    element_name=identifier.name.element_name,
+                    element_name=identifier.ref.element_name,
                 ),
             ),
         )
@@ -312,7 +312,7 @@ class DataSourceToDataSetConverter:
             # identifier.
             if (
                 len(identifier_links) == 1
-                and LinklessIdentifierSpec.from_element_name(identifier.name.element_name) == identifier_links[0]
+                and LinklessIdentifierSpec.from_element_name(identifier.ref.element_name) == identifier_links[0]
             ):
                 continue
 
@@ -350,7 +350,7 @@ class DataSourceToDataSetConverter:
                     SqlSelectColumn(
                         expr=DataSourceToDataSetConverter._make_element_sql_expr(
                             table_alias=table_alias,
-                            element_name=identifier.name.element_name,
+                            element_name=identifier.ref.element_name,
                             element_expr=identifier.expr,
                         ),
                         column_alias=identifier_instance.associated_column.column_name,
@@ -410,7 +410,7 @@ class DataSourceToDataSetConverter:
         for identifier in data_source.identifiers:
             if identifier.type in (IdentifierType.PRIMARY, IdentifierType.UNIQUE):
                 possible_identifier_links.append(
-                    (LinklessIdentifierSpec.from_element_name(element_name=identifier.name.element_name),)
+                    (LinklessIdentifierSpec.from_element_name(element_name=identifier.ref.element_name),)
                 )
 
         # Handle dimensions

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -79,7 +79,7 @@ class DataSourceToDataSetConverter:
     ) -> DimensionInstance:
         """Create a dimension instance from the dimension object in the model."""
         dimension_spec = DimensionSpec(
-            element_name=dimension.name.element_name,
+            element_name=dimension.ref.element_name,
             identifier_links=identifier_links,
         )
         column_associations = dimension_spec.column_associations(self._column_association_resolver)
@@ -90,7 +90,7 @@ class DataSourceToDataSetConverter:
             defined_from=(
                 DataSourceElementReference(
                     data_source_name=data_source_name,
-                    element_name=dimension.name.element_name,
+                    element_name=dimension.ref.element_name,
                 ),
             ),
         )
@@ -104,7 +104,7 @@ class DataSourceToDataSetConverter:
     ) -> TimeDimensionInstance:
         """Create a time dimension instance from the dimension object from a data source in the model."""
         time_dimension_spec = TimeDimensionSpec(
-            element_name=time_dimension.name.element_name,
+            element_name=time_dimension.ref.element_name,
             identifier_links=identifier_links,
             time_granularity=time_granularity,
         )
@@ -117,7 +117,7 @@ class DataSourceToDataSetConverter:
             defined_from=(
                 DataSourceElementReference(
                     data_source_name=data_source_name,
-                    element_name=time_dimension.name.element_name,
+                    element_name=time_dimension.ref.element_name,
                 ),
             ),
         )
@@ -235,7 +235,7 @@ class DataSourceToDataSetConverter:
                     SqlSelectColumn(
                         expr=DataSourceToDataSetConverter._make_element_sql_expr(
                             table_alias=table_alias,
-                            element_name=dimension.name.element_name,
+                            element_name=dimension.ref.element_name,
                             element_expr=dimension.expr,
                         ),
                         column_alias=dimension_instance.associated_column.column_name,
@@ -258,7 +258,7 @@ class DataSourceToDataSetConverter:
                     SqlSelectColumn(
                         expr=DataSourceToDataSetConverter._make_element_sql_expr(
                             table_alias=table_alias,
-                            element_name=dimension.name.element_name,
+                            element_name=dimension.ref.element_name,
                             element_expr=dimension.expr,
                         ),
                         column_alias=time_dimension_instance.associated_column.column_name,
@@ -282,7 +282,7 @@ class DataSourceToDataSetConverter:
                                     time_granularity=time_granularity,
                                     arg=DataSourceToDataSetConverter._make_element_sql_expr(
                                         table_alias=table_alias,
-                                        element_name=dimension.name.element_name,
+                                        element_name=dimension.ref.element_name,
                                         element_expr=dimension.expr,
                                     ),
                                 ),
@@ -373,7 +373,7 @@ class DataSourceToDataSetConverter:
         ), f"Primary time dimension missing time granularity: {primary_time_dimension}"
 
         return TimeDimensionSpec(
-            element_name=primary_time_dimension.name.element_name,
+            element_name=primary_time_dimension.ref.element_name,
             identifier_links=(),
             time_granularity=primary_time_dimension.type_params.time_granularity,
         )

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -184,7 +184,7 @@ class DataSourceToDataSetConverter:
         select_columns = []
         for measure in measures or []:
             measure_spec = MeasureSpec(
-                element_name=measure.name.element_name,
+                element_name=measure.ref.element_name,
             )
             measure_instance = MeasureInstance(
                 associated_columns=measure_spec.column_associations(self._column_association_resolver),
@@ -193,7 +193,7 @@ class DataSourceToDataSetConverter:
                 defined_from=(
                     DataSourceElementReference(
                         data_source_name=data_source_name,
-                        element_name=measure.name.element_name,
+                        element_name=measure.ref.element_name,
                     ),
                 ),
                 aggregation_state=AggregationState.NON_AGGREGATED,
@@ -203,7 +203,7 @@ class DataSourceToDataSetConverter:
                 SqlSelectColumn(
                     expr=DataSourceToDataSetConverter._make_element_sql_expr(
                         table_alias=table_alias,
-                        element_name=measure.name.element_name,
+                        element_name=measure.ref.element_name,
                         element_expr=measure.expr,
                     ),
                     column_alias=measure_instance.associated_column.column_name,

--- a/metricflow/model/objects/common.py
+++ b/metricflow/model/objects/common.py
@@ -35,7 +35,7 @@ class Version(HashableBaseModel):  # noqa: D
 
 
 class Element:  # noqa: D
-    name: LinkableElementReference
+    ref: LinkableElementReference
     expr: Optional[str]
     type: ExtendedEnum
 

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -85,11 +85,11 @@ class DataSource(HashableBaseModel, ParseableObject):
 
     @property
     def measure_names(self) -> List[MeasureReference]:  # noqa: D
-        return [i.name for i in self.measures]
+        return [i.ref for i in self.measures]
 
     def get_measure(self, measure_name: MeasureReference) -> Measure:  # noqa: D
         for measure in self.measures:
-            if measure.name == measure_name:
+            if measure.ref == measure_name:
                 return measure
 
         raise ValueError(f"No dimension with name ({measure_name}) in data source with name ({self.name})")

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -72,16 +72,16 @@ class DataSource(HashableBaseModel, ParseableObject):
         return res
 
     @property
-    def element_names(self) -> List[LinkableElementReference]:  # noqa: D
-        return [n.name for n in self.elements]
+    def element_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
+        return [n.ref for n in self.elements]
 
     @property
     def identifier_names(self) -> List[LinkableElementReference]:  # noqa: D
         return [i.name for i in self.identifiers]
 
     @property
-    def dimension_names(self) -> List[LinkableElementReference]:  # noqa: D
-        return [i.name for i in self.dimensions]
+    def dimension_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
+        return [i.ref for i in self.dimensions]
 
     @property
     def measure_names(self) -> List[MeasureReference]:  # noqa: D
@@ -94,9 +94,9 @@ class DataSource(HashableBaseModel, ParseableObject):
 
         raise ValueError(f"No dimension with name ({measure_name}) in data source with name ({self.name})")
 
-    def get_element(self, name: LinkableElementReference) -> Element:  # noqa: D
+    def get_element(self, name: LinkableElementReference) -> Element:  # noqa: D chtodo: ref
         for dim in self.dimensions:
-            if dim.name == name:
+            if dim.ref == name:
                 return dim
         for ident in self.identifiers:
             if ident.name == name:
@@ -104,9 +104,9 @@ class DataSource(HashableBaseModel, ParseableObject):
 
         raise ValueError(f"No dimension with name ({name}) in data source with name ({self.name})")
 
-    def get_dimension(self, dimension_name: LinkableElementReference) -> Dimension:  # noqa: D
+    def get_dimension(self, dimension_name: LinkableElementReference) -> Dimension:  # noqa: D chtodo: ref
         for dim in self.dimensions:
-            if dim.name == dimension_name:
+            if dim.ref == dimension_name:
                 return dim
 
         raise ValueError(f"No dimension with name ({dimension_name}) in data source with name ({self.name})")

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -76,8 +76,8 @@ class DataSource(HashableBaseModel, ParseableObject):
         return [n.ref for n in self.elements]
 
     @property
-    def identifier_names(self) -> List[LinkableElementReference]:  # noqa: D
-        return [i.name for i in self.identifiers]
+    def identifier_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
+        return [i.ref for i in self.identifiers]
 
     @property
     def dimension_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
@@ -99,7 +99,7 @@ class DataSource(HashableBaseModel, ParseableObject):
             if dim.ref == name:
                 return dim
         for ident in self.identifiers:
-            if ident.name == name:
+            if ident.ref == name:
                 return ident
 
         raise ValueError(f"No dimension with name ({name}) in data source with name ({self.name})")
@@ -111,9 +111,9 @@ class DataSource(HashableBaseModel, ParseableObject):
 
         raise ValueError(f"No dimension with name ({dimension_name}) in data source with name ({self.name})")
 
-    def get_identifier(self, identifier_name: LinkableElementReference) -> Identifier:  # noqa: D
+    def get_identifier(self, identifier_name: LinkableElementReference) -> Identifier:  # noqa: D chtodo: ref
         for ident in self.identifiers:
-            if ident.name == identifier_name:
+            if ident.ref == identifier_name:
                 return ident
 
         raise ValueError(f"No identifier with name ({identifier_name}) in data source with name ({self.name})")

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -109,14 +109,18 @@ class DataSource(HashableBaseModel, ParseableObject):
             if dim.ref == dimension_ref:
                 return dim
 
-        raise ValueError(f"No dimension with name ({dimension_ref.element_name}) in data source with name ({self.name})")
+        raise ValueError(
+            f"No dimension with name ({dimension_ref.element_name}) in data source with name ({self.name})"
+        )
 
     def get_identifier(self, identifier_ref: LinkableElementReference) -> Identifier:  # noqa: D chtodo: ref
         for ident in self.identifiers:
             if ident.ref == identifier_ref:
                 return ident
 
-        raise ValueError(f"No identifier with name ({identifier_ref.element_name}) in data source with name ({self.name})")
+        raise ValueError(
+            f"No identifier with name ({identifier_ref.element_name}) in data source with name ({self.name})"
+        )
 
     @property
     def partitions(self) -> List[Dimension]:  # noqa: D

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -72,51 +72,51 @@ class DataSource(HashableBaseModel, ParseableObject):
         return res
 
     @property
-    def element_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
+    def element_refs(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
         return [n.ref for n in self.elements]
 
     @property
-    def identifier_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
+    def identifier_refs(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
         return [i.ref for i in self.identifiers]
 
     @property
-    def dimension_names(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
+    def dimension_refs(self) -> List[LinkableElementReference]:  # noqa: D chtodo: ref
         return [i.ref for i in self.dimensions]
 
     @property
-    def measure_names(self) -> List[MeasureReference]:  # noqa: D
+    def measure_refs(self) -> List[MeasureReference]:  # noqa: D
         return [i.ref for i in self.measures]
 
-    def get_measure(self, measure_name: MeasureReference) -> Measure:  # noqa: D
+    def get_measure(self, measure_ref: MeasureReference) -> Measure:  # noqa: D
         for measure in self.measures:
-            if measure.ref == measure_name:
+            if measure.ref == measure_ref:
                 return measure
 
-        raise ValueError(f"No dimension with name ({measure_name}) in data source with name ({self.name})")
+        raise ValueError(f"No dimension with name ({measure_ref.element_name}) in data source with name ({self.name})")
 
-    def get_element(self, name: LinkableElementReference) -> Element:  # noqa: D chtodo: ref
+    def get_element(self, ref: LinkableElementReference) -> Element:  # noqa: D chtodo: ref
         for dim in self.dimensions:
-            if dim.ref == name:
+            if dim.ref == ref:
                 return dim
         for ident in self.identifiers:
-            if ident.ref == name:
+            if ident.ref == ref:
                 return ident
 
-        raise ValueError(f"No dimension with name ({name}) in data source with name ({self.name})")
+        raise ValueError(f"No dimension with name ({ref.element_name}) in data source with name ({self.name})")
 
-    def get_dimension(self, dimension_name: LinkableElementReference) -> Dimension:  # noqa: D chtodo: ref
+    def get_dimension(self, dimension_ref: LinkableElementReference) -> Dimension:  # noqa: D chtodo: ref
         for dim in self.dimensions:
-            if dim.ref == dimension_name:
+            if dim.ref == dimension_ref:
                 return dim
 
-        raise ValueError(f"No dimension with name ({dimension_name}) in data source with name ({self.name})")
+        raise ValueError(f"No dimension with name ({dimension_ref.element_name}) in data source with name ({self.name})")
 
-    def get_identifier(self, identifier_name: LinkableElementReference) -> Identifier:  # noqa: D chtodo: ref
+    def get_identifier(self, identifier_ref: LinkableElementReference) -> Identifier:  # noqa: D chtodo: ref
         for ident in self.identifiers:
-            if ident.ref == identifier_name:
+            if ident.ref == identifier_ref:
                 return ident
 
-        raise ValueError(f"No identifier with name ({identifier_name}) in data source with name ({self.name})")
+        raise ValueError(f"No identifier with name ({identifier_ref.element_name}) in data source with name ({self.name})")
 
     @property
     def partitions(self) -> List[Dimension]:  # noqa: D

--- a/metricflow/model/objects/elements/dimension.py
+++ b/metricflow/model/objects/elements/dimension.py
@@ -34,7 +34,7 @@ class DimensionTypeParams(HashableBaseModel, ParseableObject):
 class Dimension(HashableBaseModel, Element, ParseableObject):
     """Describes a dimension"""
 
-    name: DimensionReference
+    ref: DimensionReference
     type: DimensionType
     is_partition: bool = False
     type_params: Optional[DimensionTypeParams]

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -22,9 +22,9 @@ class IdentifierType(ExtendedEnum):
 class CompositeSubIdentifier(HashableBaseModel, ParseableObject):
     """CompositeSubIdentifiers either describe or reference the identifiers that comprise a composite identifier"""
 
-    name: Optional[IdentifierReference]
+    ref: Optional[IdentifierReference]
     expr: Optional[str]
-    ref: Optional[str]
+    name: Optional[str]
 
 
 class Identifier(HashableBaseModel, Element, ParseableObject):
@@ -39,7 +39,7 @@ class Identifier(HashableBaseModel, Element, ParseableObject):
 
     def __init__(  # type: ignore
         self,
-        name: IdentifierReference,
+        ref: IdentifierReference,
         type: IdentifierType,
         role: Optional[str] = None,
         entity: Optional[str] = None,
@@ -49,7 +49,7 @@ class Identifier(HashableBaseModel, Element, ParseableObject):
     ) -> None:
         """Normal pydantic initializer except we set entity to name"""
         super().__init__(
-            name=name,
+            ref=ref,
             type=type,
             role=role,
             entity=entity,

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -30,7 +30,7 @@ class CompositeSubIdentifier(HashableBaseModel, ParseableObject):
 class Identifier(HashableBaseModel, Element, ParseableObject):
     """Describes a identifier"""
 
-    name: IdentifierReference
+    ref: IdentifierReference
     type: IdentifierType
     role: Optional[str]
     entity: Optional[str]
@@ -57,7 +57,7 @@ class Identifier(HashableBaseModel, Element, ParseableObject):
             expr=expr,
         )
         if self.entity is None:
-            self.entity = self.name.element_name
+            self.entity = self.ref.element_name
 
     @property
     def is_primary_time(self) -> bool:  # noqa: D

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -48,5 +48,5 @@ class Measure(HashableBaseModel, ParseableObject):
 
     agg: AggregationType
     create_metric: Optional[bool]
-    name: MeasureReference
+    ref: MeasureReference
     expr: Optional[str] = None

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -330,7 +330,7 @@ def _generate_linkable_time_dimensions(
 
         linkable_dimensions.append(
             LinkableDimension(
-                element_name=dimension.name.element_name,
+                element_name=dimension.ref.element_name,
                 identifier_links=identifier_links,
                 time_granularity=time_granularity,
                 properties=frozenset(properties),
@@ -368,7 +368,7 @@ class DataSourceJoinPath:
             if dimension_type == DimensionType.CATEGORICAL:
                 linkable_dimensions.append(
                     LinkableDimension(
-                        element_name=dimension.name.element_name,
+                        element_name=dimension.ref.element_name,
                         identifier_links=identifier_links,
                         properties=with_properties,
                     )
@@ -480,7 +480,7 @@ class ValidLinkableSpecResolver:
             if dimension_type == DimensionType.CATEGORICAL:
                 linkable_dimensions.append(
                     LinkableDimension(
-                        element_name=dimension.name.element_name,
+                        element_name=dimension.ref.element_name,
                         identifier_links=(),
                         properties=frozenset({LinkableElementProperties.LOCAL}),
                     )

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -386,10 +386,10 @@ class DataSourceJoinPath:
 
         for identifier in data_source.identifiers:
             # Avoid creating "booking_id__booking_id"
-            if identifier.name.element_name != identifier_links[-1]:
+            if identifier.ref.element_name != identifier_links[-1]:
                 linkable_identifiers.append(
                     LinkableIdentifier(
-                        element_name=identifier.name.element_name,
+                        element_name=identifier.ref.element_name,
                         identifier_links=identifier_links,
                         properties=with_properties.union({LinkableElementProperties.IDENTIFIER}),
                     )
@@ -442,7 +442,7 @@ class ValidLinkableSpecResolver:
         for data_source in self._data_sources:
             for identifier in data_source.identifiers:
                 if identifier.type in (IdentifierType.PRIMARY, IdentifierType.UNIQUE):
-                    self._identifier_to_data_source[identifier.name.element_name].append(data_source)
+                    self._identifier_to_data_source[identifier.ref.element_name].append(data_source)
 
         self._metric_to_linkable_element_sets: Dict[str, List[LinkableElementSet]] = {}
 
@@ -500,7 +500,7 @@ class ValidLinkableSpecResolver:
         for identifier in data_source.identifiers:
             linkable_identifiers.append(
                 LinkableIdentifier(
-                    element_name=identifier.name.element_name,
+                    element_name=identifier.ref.element_name,
                     identifier_links=(),
                     properties=frozenset({LinkableElementProperties.LOCAL, LinkableElementProperties.IDENTIFIER}),
                 )
@@ -518,7 +518,7 @@ class ValidLinkableSpecResolver:
                     additional_linkable_dimensions.append(
                         LinkableDimension(
                             element_name=linkable_dimension.element_name,
-                            identifier_links=(identifier.name.element_name,),
+                            identifier_links=(identifier.ref.element_name,),
                             time_granularity=linkable_dimension.time_granularity,
                             properties=frozenset(linkable_dimension.properties.union(properties)),
                         )
@@ -546,7 +546,7 @@ class ValidLinkableSpecResolver:
 
         # Create 1-hop elements
         for identifier in measure_data_source.identifiers:
-            data_sources = self._get_data_sources_with_joinable_identifier(identifier.name.element_name)
+            data_sources = self._get_data_sources_with_joinable_identifier(identifier.ref.element_name)
             for data_source in data_sources:
                 if data_source.name == measure_data_source.name:
                     continue
@@ -554,7 +554,7 @@ class ValidLinkableSpecResolver:
                     DataSourceJoinPath(
                         path_elements=(
                             DataSourceJoinPathElement(
-                                data_source=data_source, join_on_identifier=identifier.name.element_name
+                                data_source=data_source, join_on_identifier=identifier.ref.element_name
                             ),
                         )
                     )
@@ -620,7 +620,7 @@ class ValidLinkableSpecResolver:
         new_join_paths = []
 
         for identifier in data_source.identifiers:
-            identifier_name = identifier.name.element_name
+            identifier_name = identifier.ref.element_name
 
             if identifier_name in set(x.join_on_identifier for x in current_join_path.path_elements):
                 continue

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -458,7 +458,7 @@ class ValidLinkableSpecResolver:
     def _get_data_source_for_measure(self, measure_reference: MeasureReference) -> DataSource:  # noqa: D
         data_sources_where_measure_was_found = []
         for data_source in self._data_sources:
-            if any([x.name.element_name == measure_reference.element_name for x in data_source.measures]):
+            if any([x.ref.element_name == measure_reference.element_name for x in data_source.measures]):
                 data_sources_where_measure_was_found.append(data_source)
 
         if len(data_sources_where_measure_was_found) == 0:

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -334,9 +334,9 @@ class DataSourceSemantics:
             self._linkable_reference_index[dim.ref].append(data_source)
             self._dimension_index[dim.ref].append(data_source)
         for ident in data_source.identifiers:
-            self._identifier_ref_to_entity[ident.name] = ident.entity
+            self._identifier_ref_to_entity[ident.ref] = ident.entity
             self._entity_index[ident.entity].append(data_source)
-            self._linkable_reference_index[ident.name].append(data_source)
+            self._linkable_reference_index[ident.ref].append(data_source)
 
         dsource_partition = data_source.partition
         # Add links to other data sources based on the names and types of identifiers available.
@@ -356,7 +356,7 @@ class DataSourceSemantics:
 
                 for other_ident in other.identifiers:
                     # TODO: Replace with entity check when entities are supported.
-                    if other_ident.name != ident.name:
+                    if other_ident.ref != ident.ref:
                         continue
 
                     # add edge data_source -> other "other is joinable to data_source"

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -302,9 +302,9 @@ class DataSourceSemantics:
             )
 
         for measure in data_source.measures:
-            if measure.name in self._measure_aggs and self._measure_aggs[measure.name] != measure.agg:
+            if measure.ref in self._measure_aggs and self._measure_aggs[measure.ref] != measure.agg:
                 errors.append(
-                    f"conflicting aggregation (agg) for measure `{measure.name}` registered as `{self._measure_aggs[measure.name]}`; "
+                    f"conflicting aggregation (agg) for measure `{measure.ref}` registered as `{self._measure_aggs[measure.ref]}`; "
                     f"Got `{measure.agg}"
                 )
 
@@ -328,8 +328,8 @@ class DataSourceSemantics:
                 self._element_types[elem.ref] = type(elem)
 
         for meas in data_source.measures:
-            self._measure_aggs[meas.name] = meas.agg
-            self._measure_index[meas.name].append(data_source)
+            self._measure_aggs[meas.ref] = meas.agg
+            self._measure_index[meas.ref].append(data_source)
         for dim in data_source.dimensions:
             self._linkable_reference_index[dim.ref].append(data_source)
             self._dimension_index[dim.ref].append(data_source)

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -239,7 +239,7 @@ class DataSourceSemantics:
         res = []
         for name, links in self._data_source_links.adj(data_source_name).items():
             for link in links:
-                if link.via_from.name.element_name == identifier_spec.element_name:
+                if link.via_from.ref.element_name == identifier_spec.element_name:
                     res.append(name)
                     break
 
@@ -261,7 +261,7 @@ class DataSourceSemantics:
     def get_data_source_element(self, ref: DataSourceElementReference) -> Optional[Element]:  # Noqa: d
         data_source = self[ref.data_source_name]
         for elem in data_source.elements:
-            if elem.name.element_name == ref.element_name:
+            if elem.ref.element_name == ref.element_name:
                 return elem
 
         return None
@@ -324,15 +324,15 @@ class DataSourceSemantics:
         self._data_source_names.add(data_source.name)
 
         for elem in data_source.elements:
-            if elem.name not in self._element_types:
-                self._element_types[elem.name] = type(elem)
+            if elem.ref not in self._element_types:
+                self._element_types[elem.ref] = type(elem)
 
         for meas in data_source.measures:
             self._measure_aggs[meas.name] = meas.agg
             self._measure_index[meas.name].append(data_source)
         for dim in data_source.dimensions:
-            self._linkable_reference_index[dim.name].append(data_source)
-            self._dimension_index[dim.name].append(data_source)
+            self._linkable_reference_index[dim.ref].append(data_source)
+            self._dimension_index[dim.ref].append(data_source)
         for ident in data_source.identifiers:
             self._identifier_ref_to_entity[ident.name] = ident.entity
             self._entity_index[ident.entity].append(data_source)
@@ -349,10 +349,10 @@ class DataSourceSemantics:
                 # handle whether or not this join is partitioned
                 partitions: List[DimensionReference] = list()
                 other_partition = other.partition
-                if dsource_partition and other_partition and dsource_partition.name != other_partition.name:
+                if dsource_partition and other_partition and dsource_partition.ref != other_partition.ref:
                     continue
                 if dsource_partition and other_partition:
-                    partitions.append(dsource_partition.name)
+                    partitions.append(dsource_partition.ref)
 
                 for other_ident in other.identifiers:
                     # TODO: Replace with entity check when entities are supported.
@@ -393,7 +393,7 @@ class DataSourceSemantics:
         for data_source in self._configured_data_source_container.values():
             for dimension in data_source.dimensions:
                 if dimension.type == DimensionType.TIME and dimension.type_params and dimension.type_params.is_primary:
-                    return TimeDimensionReference(element_name=dimension.name.element_name)
+                    return TimeDimensionReference(element_name=dimension.ref.element_name)
         raise RuntimeError("No primary time dimension found in the model")
 
     @property

--- a/metricflow/model/transformations/boolean_measure.py
+++ b/metricflow/model/transformations/boolean_measure.py
@@ -16,7 +16,7 @@ class BooleanMeasureAggregationRule(ModelTransformRule):
             for measure in data_source.measures:
                 if measure.agg == AggregationType.BOOLEAN:
                     logger.warning(
-                        f"In data source {data_source.name}, measure `{measure.name}` is configured as "
+                        f"In data source {data_source.name}, measure `{measure.ref}` is configured as "
                         f"aggregation type `boolean`, which has been deprecated. Please use `sum_boolean` "
                         f"instead."
                     )
@@ -24,7 +24,7 @@ class BooleanMeasureAggregationRule(ModelTransformRule):
                     if measure.expr:
                         measure.expr = f"CASE WHEN {measure.expr} THEN 1 ELSE 0 END"
                     else:
-                        measure.expr = f"CASE WHEN {measure.name} THEN 1 ELSE 0 END"
+                        measure.expr = f"CASE WHEN {measure.ref} THEN 1 ELSE 0 END"
 
                     measure.agg = AggregationType.SUM
 

--- a/metricflow/model/transformations/identifiers.py
+++ b/metricflow/model/transformations/identifiers.py
@@ -25,9 +25,9 @@ class CompositeIdentifierExpressionRule(ModelTransformRule):
                         continue
 
                     for identifier in data_source.identifiers:
-                        if sub_identifier.ref == identifier.name.element_name:
+                        if sub_identifier.ref == identifier.ref.element_name:
                             sub_identifier.ref = None
-                            sub_identifier.name = identifier.name
+                            sub_identifier.name = identifier.ref
                             sub_identifier.expr = identifier.expr
                             break
 

--- a/metricflow/model/transformations/identifiers.py
+++ b/metricflow/model/transformations/identifiers.py
@@ -21,13 +21,13 @@ class CompositeIdentifierExpressionRule(ModelTransformRule):
                     continue
 
                 for sub_identifier in identifier.identifiers:
-                    if sub_identifier.name or sub_identifier.expr:
+                    if sub_identifier.ref or sub_identifier.expr:
                         continue
 
                     for identifier in data_source.identifiers:
-                        if sub_identifier.ref == identifier.ref.element_name:
-                            sub_identifier.ref = None
-                            sub_identifier.name = identifier.ref
+                        if sub_identifier.name == identifier.ref.element_name:
+                            sub_identifier.name = None
+                            sub_identifier.ref = identifier.ref
                             sub_identifier.expr = identifier.expr
                             break
 

--- a/metricflow/model/transformations/names.py
+++ b/metricflow/model/transformations/names.py
@@ -30,7 +30,7 @@ class LowerCaseNamesRule(ModelTransformRule):
                 identifier.name = IdentifierReference(element_name=identifier.name.element_name.lower())
         if data_source.dimensions:
             for dimension in data_source.dimensions:
-                dimension.name = DimensionReference(element_name=dimension.name.element_name.lower())
+                dimension.ref = DimensionReference(element_name=dimension.ref.element_name.lower())
 
     @staticmethod
     def _lowercase_top_level_objects(model: UserConfiguredModel) -> None:

--- a/metricflow/model/transformations/names.py
+++ b/metricflow/model/transformations/names.py
@@ -24,7 +24,7 @@ class LowerCaseNamesRule(ModelTransformRule):
         """Lowercases the names of data source elements."""
         if data_source.measures:
             for measure in data_source.measures:
-                measure.name = MeasureReference(element_name=measure.name.element_name.lower())
+                measure.ref = MeasureReference(element_name=measure.ref.element_name.lower())
         if data_source.identifiers:
             for identifier in data_source.identifiers:
                 identifier.ref = IdentifierReference(element_name=identifier.ref.element_name.lower())

--- a/metricflow/model/transformations/names.py
+++ b/metricflow/model/transformations/names.py
@@ -27,7 +27,7 @@ class LowerCaseNamesRule(ModelTransformRule):
                 measure.name = MeasureReference(element_name=measure.name.element_name.lower())
         if data_source.identifiers:
             for identifier in data_source.identifiers:
-                identifier.name = IdentifierReference(element_name=identifier.name.element_name.lower())
+                identifier.ref = IdentifierReference(element_name=identifier.ref.element_name.lower())
         if data_source.dimensions:
             for dimension in data_source.dimensions:
                 dimension.ref = DimensionReference(element_name=dimension.ref.element_name.lower())

--- a/metricflow/model/transformations/proxy_measure.py
+++ b/metricflow/model/transformations/proxy_measure.py
@@ -27,14 +27,14 @@ class CreateProxyMeasureRule(ModelTransformRule):
 
                 add_metric = True
                 for metric in model.metrics:
-                    if metric.name == measure.name:
+                    if metric.name == measure.ref:
                         if metric.type != MetricType.MEASURE_PROXY:
                             raise ModelTransformError(
-                                f"Cannot have metric with the same name as a measure ({measure.name}) that is not a "
+                                f"Cannot have metric with the same name as a measure ({measure.ref}) that is not a "
                                 f"proxy for that measure"
                             )
                         logger.warning(
-                            f"Metric already exists with name ({measure.name}). *Not* adding measure proxy metric for "
+                            f"Metric already exists with name ({measure.ref}). *Not* adding measure proxy metric for "
                             f"that measure"
                         )
                         add_metric = False
@@ -42,9 +42,9 @@ class CreateProxyMeasureRule(ModelTransformRule):
                 if add_metric is True:
                     model.metrics.append(
                         Metric(
-                            name=measure.name.element_name,
+                            name=measure.ref.element_name,
                             type=MetricType.MEASURE_PROXY,
-                            type_params=MetricTypeParams(measures=[measure.name], expr=measure.name.element_name),
+                            type_params=MetricTypeParams(measures=[measure.ref], expr=measure.ref.element_name),
                         )
                     )
 

--- a/metricflow/model/validations/common_identifiers.py
+++ b/metricflow/model/validations/common_identifiers.py
@@ -22,10 +22,10 @@ class CommonIdentifiersRule(ModelValidationRule):
         identifiers_to_data_sources: Dict[IdentifierReference, Set[str]] = {}
         for data_source in data_sources or []:
             for identifier in data_source.identifiers or []:
-                if identifier.name in identifiers_to_data_sources:
-                    identifiers_to_data_sources[identifier.name].add(data_source.name)
+                if identifier.ref in identifiers_to_data_sources:
+                    identifiers_to_data_sources[identifier.ref].add(data_source.name)
                 else:
-                    identifiers_to_data_sources[identifier.name] = {data_source.name}
+                    identifiers_to_data_sources[identifier.ref] = {data_source.name}
         return identifiers_to_data_sources
 
     @staticmethod
@@ -39,15 +39,15 @@ class CommonIdentifiersRule(ModelValidationRule):
         # If the identifier is the dict and if the set of data sources minus this data source is empty,
         # then we warn the user that their identifier will be unused in joins
         if (
-            identifier.name in identifiers_to_data_sources
-            and len(identifiers_to_data_sources[identifier.name].difference({data_source.name})) == 0
+            identifier.ref in identifiers_to_data_sources
+            and len(identifiers_to_data_sources[identifier.ref].difference({data_source.name})) == 0
         ):
             issues.append(
                 ValidationWarning(
                     model_object_reference=ValidationIssue.make_object_reference(
-                        data_source_name=data_source.name, identifier_name=identifier.name.element_name
+                        data_source_name=data_source.name, identifier_name=identifier.ref.element_name
                     ),
-                    message=f"Identifier `{identifier.name.element_name}` "
+                    message=f"Identifier `{identifier.ref.element_name}` "
                     f"only found in one data source `{data_source.name}` "
                     f"which means it will be unused in joins.",
                 )

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -65,7 +65,7 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
                     and dimension.type_params is not None
                     and dimension.type_params.is_primary is True
                 ):
-                    primary_time_dimension_name = dimension.name
+                    primary_time_dimension_name = dimension.ref
 
         for data_source in model.data_sources:
             issues.extend(
@@ -85,7 +85,7 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
 
         for dim in data_source.dimensions:
             model_object_reference = ValidationIssue.make_object_reference(
-                data_source_name=data_source.name, dimension_name=dim.name.element_name
+                data_source_name=data_source.name, dimension_name=dim.ref.element_name
             )
 
             if dim.type == DimensionType.TIME:
@@ -93,12 +93,12 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
                     continue
                 elif dim.type_params.is_primary:
                     primary_time_present = True
-                    if primary_time_dimension_name and dim.name != primary_time_dimension_name:
+                    if primary_time_dimension_name and dim.ref != primary_time_dimension_name:
                         issues.append(
                             ValidationFatal(
                                 model_object_reference=model_object_reference,
                                 message=f"In data source {data_source.name}, "
-                                f"found primary time dimension with name: {dim.name}, "
+                                f"found primary time dimension with name: {dim.ref}, "
                                 f"another primary time dimension with name: {primary_time_dimension_name} "
                                 f"was already found in model.",
                             )
@@ -108,7 +108,7 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
                         issues.append(
                             ValidationError(
                                 model_object_reference=model_object_reference,
-                                message=f"Unsupported time granularity in time dimension with name: {dim.name}, "
+                                message=f"Unsupported time granularity in time dimension with name: {dim.ref}, "
                                 f"Please use {[s.value for s in SUPPORTED_GRANULARITIES]}",
                             )
                         )

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -32,18 +32,18 @@ class DataSourceMeasuresUniqueRule(ModelValidationRule):
         measure_names_to_data_sources: Dict[MeasureReference, List] = defaultdict(list)
         for data_source in model.data_sources:
             for measure in data_source.measures:
-                if measure.name in measure_names_to_data_sources:
+                if measure.ref in measure_names_to_data_sources:
                     model_object_reference = ValidationIssue.make_object_reference(
-                        data_source_name=data_source.name, measure_name=measure.name.element_name
+                        data_source_name=data_source.name, measure_name=measure.ref.element_name
                     )
                     issues.append(
                         ValidationError(
                             model_object_reference=model_object_reference,
-                            message=f"Found measure with name {measure.name} in multiple data sources with names "
-                            f"({measure_names_to_data_sources[measure.name]})",
+                            message=f"Found measure with name {measure.ref} in multiple data sources with names "
+                            f"({measure_names_to_data_sources[measure.ref]})",
                         )
                     )
-                measure_names_to_data_sources[measure.name].append(data_source.name)
+                measure_names_to_data_sources[measure.ref].append(data_source.name)
 
         return issues
 

--- a/metricflow/model/validations/dim_names.py
+++ b/metricflow/model/validations/dim_names.py
@@ -55,7 +55,7 @@ class DimensionAndIdentifierNameValidator:
         self._identifier_key_to_dimension_names: Dict[IdentifierKey, List[str]] = defaultdict(list)
         data_source: DataSource
         for data_source in model.data_sources:
-            dimension_names = [x.name.element_name for x in data_source.dimensions]
+            dimension_names = [x.ref.element_name for x in data_source.dimensions]
             identifier: Identifier
             for identifier in data_source.identifiers:
                 identifier_key = IdentifierKey(identifier.name.element_name, identifier.type)
@@ -88,7 +88,7 @@ class DimensionAndIdentifierNameValidator:
         # Populate the list of local dimension for each measure
         self._measure_to_local_dimension: Dict[MeasureReference, List[DimensionReference]] = defaultdict(list)
         for data_source in model.data_sources:
-            local_dimension_references = [dimension.name for dimension in data_source.dimensions]
+            local_dimension_references = [dimension.ref for dimension in data_source.dimensions]
             for measure in data_source.measures:
                 self._measure_to_local_dimension[measure.name].extend(local_dimension_references)
 
@@ -105,7 +105,7 @@ class DimensionAndIdentifierNameValidator:
             for measure in data_source.measures:
                 self._element_name_to_type[measure.name.element_name] = ModelObjectType.MEASURE
             for dimension in data_source.dimensions:
-                self._element_name_to_type[dimension.name.element_name] = ModelObjectType.DIMENSION
+                self._element_name_to_type[dimension.ref.element_name] = ModelObjectType.DIMENSION
             for identifier in data_source.identifiers:
                 self._element_name_to_type[identifier.name.element_name] = ModelObjectType.IDENTIFIER
 

--- a/metricflow/model/validations/dim_names.py
+++ b/metricflow/model/validations/dim_names.py
@@ -66,7 +66,7 @@ class DimensionAndIdentifierNameValidator:
         # Values are (name of identifier, IdentifierType value)
         self._measure_to_associated_identifier_keys: Dict[MeasureReference, List[IdentifierKey]] = defaultdict(list)
         for data_source in model.data_sources:
-            measure_references = [x.name for x in data_source.measures]
+            measure_references = [x.ref for x in data_source.measures]
             # List of identifiers and their types in the data source
             identifier_keys: List[IdentifierKey] = []
             for identifier in data_source.identifiers:
@@ -90,20 +90,20 @@ class DimensionAndIdentifierNameValidator:
         for data_source in model.data_sources:
             local_dimension_references = [dimension.ref for dimension in data_source.dimensions]
             for measure in data_source.measures:
-                self._measure_to_local_dimension[measure.name].extend(local_dimension_references)
+                self._measure_to_local_dimension[measure.ref].extend(local_dimension_references)
 
         # Populate the list of identifiers for each measure
         self._measures_to_identifiers: Dict[MeasureReference, List[IdentifierReference]] = defaultdict(list)
         for data_source in model.data_sources:
             identifier_references = [identifier.ref for identifier in data_source.identifiers]
             for measure in data_source.measures:
-                self._measures_to_identifiers[measure.name].extend(identifier_references)
+                self._measures_to_identifiers[measure.ref].extend(identifier_references)
 
         # Populate the name of the element to the type
         self._element_name_to_type: Dict[str, ModelObjectType] = {}
         for data_source in model.data_sources:
             for measure in data_source.measures:
-                self._element_name_to_type[measure.name.element_name] = ModelObjectType.MEASURE
+                self._element_name_to_type[measure.ref.element_name] = ModelObjectType.MEASURE
             for dimension in data_source.dimensions:
                 self._element_name_to_type[dimension.ref.element_name] = ModelObjectType.DIMENSION
             for identifier in data_source.identifiers:

--- a/metricflow/model/validations/dim_names.py
+++ b/metricflow/model/validations/dim_names.py
@@ -58,7 +58,7 @@ class DimensionAndIdentifierNameValidator:
             dimension_names = [x.ref.element_name for x in data_source.dimensions]
             identifier: Identifier
             for identifier in data_source.identifiers:
-                identifier_key = IdentifierKey(identifier.name.element_name, identifier.type)
+                identifier_key = IdentifierKey(identifier.ref.element_name, identifier.type)
                 self._identifier_key_to_dimension_names[identifier_key].extend(dimension_names)
 
         # Map the measure to the identifier name / type present in the data source where the measure is defined.
@@ -70,7 +70,7 @@ class DimensionAndIdentifierNameValidator:
             # List of identifiers and their types in the data source
             identifier_keys: List[IdentifierKey] = []
             for identifier in data_source.identifiers:
-                identifier_keys.append(IdentifierKey(identifier.name.element_name, identifier.type))
+                identifier_keys.append(IdentifierKey(identifier.ref.element_name, identifier.type))
             for measure_reference in measure_references:
                 self._measure_to_associated_identifier_keys[measure_reference].extend(identifier_keys)
 
@@ -95,7 +95,7 @@ class DimensionAndIdentifierNameValidator:
         # Populate the list of identifiers for each measure
         self._measures_to_identifiers: Dict[MeasureReference, List[IdentifierReference]] = defaultdict(list)
         for data_source in model.data_sources:
-            identifier_references = [identifier.name for identifier in data_source.identifiers]
+            identifier_references = [identifier.ref for identifier in data_source.identifiers]
             for measure in data_source.measures:
                 self._measures_to_identifiers[measure.name].extend(identifier_references)
 
@@ -107,7 +107,7 @@ class DimensionAndIdentifierNameValidator:
             for dimension in data_source.dimensions:
                 self._element_name_to_type[dimension.ref.element_name] = ModelObjectType.DIMENSION
             for identifier in data_source.identifiers:
-                self._element_name_to_type[identifier.name.element_name] = ModelObjectType.IDENTIFIER
+                self._element_name_to_type[identifier.ref.element_name] = ModelObjectType.IDENTIFIER
 
     def _is_identifier_valid_for_measure(self, measure_reference: MeasureReference, identifier_name: str) -> bool:
         assert measure_reference in self._measures_to_identifiers

--- a/metricflow/model/validations/dimension_const.py
+++ b/metricflow/model/validations/dimension_const.py
@@ -60,25 +60,25 @@ class DimensionConsistencyRule(ModelValidationRule):
         """
         issues: List[ValidationIssueType] = []
         obj_ref = ValidationIssue.make_object_reference(
-            data_source_name=data_source_name, dimension_name=dimension.name.element_name
+            data_source_name=data_source_name, dimension_name=dimension.ref.element_name
         )
 
         if dimension.type == DimensionType.TIME:
-            if dimension.name not in time_dims_to_granularity and dimension.type_params:
-                time_dims_to_granularity[dimension.name] = dimension.type_params.time_granularity
+            if dimension.ref not in time_dims_to_granularity and dimension.type_params:
+                time_dims_to_granularity[dimension.ref] = dimension.type_params.time_granularity
 
                 # The primary time dimension can be of different time granularities, so don't check for it.
                 if (
                     dimension.type_params is not None
                     and not dimension.type_params.is_primary
-                    and dimension.type_params.time_granularity != time_dims_to_granularity[dimension.name]
+                    and dimension.type_params.time_granularity != time_dims_to_granularity[dimension.ref]
                 ):
-                    expected_granularity = time_dims_to_granularity[dimension.name]
+                    expected_granularity = time_dims_to_granularity[dimension.ref]
                     issues.append(
                         ValidationError(
                             model_object_reference=obj_ref,
                             message=f"Time granularity must be the same for time dimensions with the same name. "
-                            f"Problematic dimension: {dimension.name.element_name} in data source with name: "
+                            f"Problematic dimension: {dimension.ref.element_name} in data source with name: "
                             f"`{data_source_name}`. Expected granularity is {expected_granularity.name}.",
                         )
                     )
@@ -105,12 +105,12 @@ class DimensionConsistencyRule(ModelValidationRule):
         issues: List[ValidationIssueType] = []
 
         for dimension in data_source.dimensions:
-            dimension_invariant = dimension_to_invariant.get(dimension.name)
+            dimension_invariant = dimension_to_invariant.get(dimension.ref)
 
             if dimension_invariant is None:
                 if update_invariant_dict:
                     dimension_invariant = DimensionInvariants(dimension.type, dimension.is_partition or False)
-                    dimension_to_invariant[dimension.name] = dimension_invariant
+                    dimension_to_invariant[dimension.ref] = dimension_invariant
                     continue
                 # TODO: Can't check for unknown dimensions easily as the name follows <id>__<name> format.
                 # e.g. user__created_at
@@ -120,13 +120,13 @@ class DimensionConsistencyRule(ModelValidationRule):
             is_partition = dimension.is_partition or False
 
             model_object_reference = ValidationIssue.make_object_reference(
-                data_source_name=data_source.name, dimension_name=dimension.name.element_name
+                data_source_name=data_source.name, dimension_name=dimension.ref.element_name
             )
             if dimension_invariant.type != dimension.type:
                 issues.append(
                     ValidationError(
                         model_object_reference=model_object_reference,
-                        message=f"In data source `{data_source.name}`, type conflict for dimension `{dimension.name}` "
+                        message=f"In data source `{data_source.name}`, type conflict for dimension `{dimension.ref}` "
                         f"- already in model as type `{dimension_invariant.type}` but got `{dimension.type}`",
                     )
                 )
@@ -135,7 +135,7 @@ class DimensionConsistencyRule(ModelValidationRule):
                     ValidationError(
                         model_object_reference=model_object_reference,
                         message=f"In data source `{data_source.name}, conflicting is_partition attribute for dimension "
-                        f"`{dimension.name}` - already in model"
+                        f"`{dimension.ref}` - already in model"
                         f" with is_partition as `{dimension_invariant.is_partition}` but got "
                         f"`{is_partition}``",
                     )

--- a/metricflow/model/validations/element_const.py
+++ b/metricflow/model/validations/element_const.py
@@ -87,7 +87,7 @@ class ElementConsistencyRule(ModelValidationRule):
                     element_types[dimension.ref.element_name] = ModelObjectType.DIMENSION
             if data_source.identifiers:
                 for identifier in data_source.identifiers:
-                    element_types[identifier.name.element_name] = ModelObjectType.IDENTIFIER
+                    element_types[identifier.ref.element_name] = ModelObjectType.IDENTIFIER
         return element_types
 
     @staticmethod
@@ -105,7 +105,7 @@ class ElementConsistencyRule(ModelValidationRule):
         """
         measure_name_tuples = [(x.name, ModelObjectType.MEASURE) for x in data_source.measures or []]
         dimension_name_tuples = [(x.ref, ModelObjectType.DIMENSION) for x in data_source.dimensions or []]
-        identifier_name_tuples = [(x.name, ModelObjectType.IDENTIFIER) for x in data_source.identifiers or []]
+        identifier_name_tuples = [(x.ref, ModelObjectType.IDENTIFIER) for x in data_source.identifiers or []]
         issues = []
         for element_name, element_type in measure_name_tuples + dimension_name_tuples + identifier_name_tuples:
             issues += ElementConsistencyRule._check_element_type(

--- a/metricflow/model/validations/element_const.py
+++ b/metricflow/model/validations/element_const.py
@@ -81,7 +81,7 @@ class ElementConsistencyRule(ModelValidationRule):
         for data_source in model.data_sources:
             if data_source.measures:
                 for measure in data_source.measures:
-                    element_types[measure.name.element_name] = ModelObjectType.MEASURE
+                    element_types[measure.ref.element_name] = ModelObjectType.MEASURE
             if data_source.dimensions:
                 for dimension in data_source.dimensions:
                     element_types[dimension.ref.element_name] = ModelObjectType.DIMENSION
@@ -103,7 +103,7 @@ class ElementConsistencyRule(ModelValidationRule):
         :param data_source: the data source to check
         :param add_to_dict: if the given element does not exist in the dictionary, whether to add it.
         """
-        measure_name_tuples = [(x.name, ModelObjectType.MEASURE) for x in data_source.measures or []]
+        measure_name_tuples = [(x.ref, ModelObjectType.MEASURE) for x in data_source.measures or []]
         dimension_name_tuples = [(x.ref, ModelObjectType.DIMENSION) for x in data_source.dimensions or []]
         identifier_name_tuples = [(x.ref, ModelObjectType.IDENTIFIER) for x in data_source.identifiers or []]
         issues = []

--- a/metricflow/model/validations/element_const.py
+++ b/metricflow/model/validations/element_const.py
@@ -84,7 +84,7 @@ class ElementConsistencyRule(ModelValidationRule):
                     element_types[measure.name.element_name] = ModelObjectType.MEASURE
             if data_source.dimensions:
                 for dimension in data_source.dimensions:
-                    element_types[dimension.name.element_name] = ModelObjectType.DIMENSION
+                    element_types[dimension.ref.element_name] = ModelObjectType.DIMENSION
             if data_source.identifiers:
                 for identifier in data_source.identifiers:
                     element_types[identifier.name.element_name] = ModelObjectType.IDENTIFIER
@@ -104,7 +104,7 @@ class ElementConsistencyRule(ModelValidationRule):
         :param add_to_dict: if the given element does not exist in the dictionary, whether to add it.
         """
         measure_name_tuples = [(x.name, ModelObjectType.MEASURE) for x in data_source.measures or []]
-        dimension_name_tuples = [(x.name, ModelObjectType.DIMENSION) for x in data_source.dimensions or []]
+        dimension_name_tuples = [(x.ref, ModelObjectType.DIMENSION) for x in data_source.dimensions or []]
         identifier_name_tuples = [(x.name, ModelObjectType.IDENTIFIER) for x in data_source.identifiers or []]
         issues = []
         for element_name, element_type in measure_name_tuples + dimension_name_tuples + identifier_name_tuples:

--- a/metricflow/model/validations/identifiers.py
+++ b/metricflow/model/validations/identifiers.py
@@ -42,7 +42,7 @@ class IdentifierConfigRule(ModelValidationRule):
         for ident in data_source.identifiers:
             if ident.identifiers:
                 for sub_id in ident.identifiers:
-                    if sub_id.ref and (sub_id.name or sub_id.expr):
+                    if sub_id.name and (sub_id.ref or sub_id.expr):
                         logger.warning(f"Identifier with error is: {ident}")
                         issues.append(
                             ValidationError(
@@ -54,17 +54,17 @@ class IdentifierConfigRule(ModelValidationRule):
                                 f"({ident.ref.element_name}), please set one",
                             )
                         )
-                    elif sub_id.ref is not None and sub_id.ref not in [i.ref for i in data_source.identifiers]:
+                    elif sub_id.name is not None and sub_id.name not in [i.ref for i in data_source.identifiers]:
                         issues.append(
                             ValidationError(
                                 model_object_reference=ValidationIssue.make_object_reference(
                                     data_source_name=data_source.name, identifier_name=ident.ref.element_name
                                 ),
                                 message=f"Identifier ref must reference an existing identifier by name. "
-                                f"No identifier in this data source has name: {sub_id.ref}",
+                                f"No identifier in this data source has name: {sub_id.name}",
                             )
                         )
-                    elif not sub_id.ref and not sub_id.name:
+                    elif not sub_id.name and not sub_id.ref:
                         issues.append(
                             ValidationError(
                                 model_object_reference=ValidationIssue.make_object_reference(
@@ -75,15 +75,15 @@ class IdentifierConfigRule(ModelValidationRule):
                             )
                         )
 
-                    if sub_id.name:
+                    if sub_id.ref:
                         for i in data_source.identifiers:
-                            if i.ref == sub_id.name and i.expr != sub_id.expr:
+                            if i.ref == sub_id.ref and i.expr != sub_id.expr:
                                 issues.append(
                                     ValidationError(
                                         model_object_reference=ValidationIssue.make_object_reference(
                                             data_source_name=data_source.name, identifier_name=ident.ref.element_name
                                         ),
-                                        message=f"If sub identifier has same name ({sub_id.name.element_name}) "
+                                        message=f"If sub identifier has same name ({sub_id.ref.element_name}) "
                                         f"as an existing Identifier they must have the same expr",
                                     )
                                 )
@@ -144,10 +144,10 @@ class IdentifierConsistencyRule(ModelValidationRule):
         sub_identifier_names = []
         sub_identifier: CompositeSubIdentifier
         for sub_identifier in identifier.identifiers or []:
-            if sub_identifier.name:
-                sub_identifier_names.append(sub_identifier.name.element_name)
-            elif sub_identifier.ref:
-                sub_identifier_names.append(sub_identifier.ref)
+            if sub_identifier.ref:
+                sub_identifier_names.append(sub_identifier.ref.element_name)
+            elif sub_identifier.name:
+                sub_identifier_names.append(sub_identifier.name)
         return sub_identifier_names
 
     @staticmethod

--- a/metricflow/model/validations/identifiers.py
+++ b/metricflow/model/validations/identifiers.py
@@ -48,17 +48,17 @@ class IdentifierConfigRule(ModelValidationRule):
                             ValidationError(
                                 model_object_reference=ValidationIssue.make_object_reference(
                                     data_source_name=data_source.name,
-                                    identifier_name=ident.name.element_name,
+                                    identifier_name=ident.ref.element_name,
                                 ),
                                 message=f"Both ref and name/expr set in sub identifier of identifier "
-                                f"({ident.name.element_name}), please set one",
+                                f"({ident.ref.element_name}), please set one",
                             )
                         )
-                    elif sub_id.ref is not None and sub_id.ref not in [i.name for i in data_source.identifiers]:
+                    elif sub_id.ref is not None and sub_id.ref not in [i.ref for i in data_source.identifiers]:
                         issues.append(
                             ValidationError(
                                 model_object_reference=ValidationIssue.make_object_reference(
-                                    data_source_name=data_source.name, identifier_name=ident.name.element_name
+                                    data_source_name=data_source.name, identifier_name=ident.ref.element_name
                                 ),
                                 message=f"Identifier ref must reference an existing identifier by name. "
                                 f"No identifier in this data source has name: {sub_id.ref}",
@@ -68,20 +68,20 @@ class IdentifierConfigRule(ModelValidationRule):
                         issues.append(
                             ValidationError(
                                 model_object_reference=ValidationIssue.make_object_reference(
-                                    data_source_name=data_source.name, identifier_name=ident.name.element_name
+                                    data_source_name=data_source.name, identifier_name=ident.ref.element_name
                                 ),
                                 message=f"Must provide either name or ref for sub identifier of identifier "
-                                f"with name: {ident.name.element_name}",
+                                f"with name: {ident.ref.element_name}",
                             )
                         )
 
                     if sub_id.name:
                         for i in data_source.identifiers:
-                            if i.name == sub_id.name and i.expr != sub_id.expr:
+                            if i.ref == sub_id.name and i.expr != sub_id.expr:
                                 issues.append(
                                     ValidationError(
                                         model_object_reference=ValidationIssue.make_object_reference(
-                                            data_source_name=data_source.name, identifier_name=ident.name.element_name
+                                            data_source_name=data_source.name, identifier_name=ident.ref.element_name
                                         ),
                                         message=f"If sub identifier has same name ({sub_id.name.element_name}) "
                                         f"as an existing Identifier they must have the same expr",
@@ -101,7 +101,7 @@ class OnePrimaryIdentifierPerDataSourceRule(ModelValidationRule):
         primary_identifier_names: MutableSet[str] = set()
         for identifier in data_source.identifiers or []:
             if identifier.type == IdentifierType.PRIMARY:
-                primary_identifier_names.add(identifier.name.element_name)
+                primary_identifier_names.add(identifier.ref.element_name)
 
         if len(primary_identifier_names) > 1:
             return [
@@ -157,7 +157,7 @@ class IdentifierConsistencyRule(ModelValidationRule):
             contexts.append(
                 SubIdentifierContext(
                     data_source_name=data_source.name,
-                    identifier_reference=identifier.name,
+                    identifier_reference=identifier.ref,
                     sub_identifier_names=tuple(IdentifierConsistencyRule._get_sub_identifier_names(identifier)),
                 )
             )

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -53,7 +53,7 @@ class MetricMeasuresRule(ModelValidationRule):
         valid_measure_names = []
         for data_source in model.data_sources:
             for measure in data_source.measures:
-                valid_measure_names.append(measure.name.element_name)
+                valid_measure_names.append(measure.ref.element_name)
 
         for metric in model.metrics or []:
             issues += MetricMeasuresRule._validate_metric_measure_references(

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -63,7 +63,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
         if data_source.measures:
             for measure in data_source.measures:
-                name_and_type_tuples.append((measure.name, "measure"))
+                name_and_type_tuples.append((measure.ref, "measure"))
         if data_source.identifiers:
             for identifier in data_source.identifiers:
                 name_and_type_tuples.append((identifier.ref, "identifier"))

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -69,7 +69,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                 name_and_type_tuples.append((identifier.name, "identifier"))
         if data_source.dimensions:
             for dimension in data_source.dimensions:
-                name_and_type_tuples.append((dimension.name, "dimension"))
+                name_and_type_tuples.append((dimension.ref, "dimension"))
 
         name_to_type: Dict[ElementReference, str] = {}
 

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -66,7 +66,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                 name_and_type_tuples.append((measure.name, "measure"))
         if data_source.identifiers:
             for identifier in data_source.identifiers:
-                name_and_type_tuples.append((identifier.name, "identifier"))
+                name_and_type_tuples.append((identifier.ref, "identifier"))
         if data_source.dimensions:
             for dimension in data_source.dimensions:
                 name_and_type_tuples.append((dimension.ref, "dimension"))

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -70,7 +70,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
         sub_id_specs = []
         for data_source in self._semantic_model.user_configured_model.data_sources:
             for identifier in data_source.identifiers:
-                if identifier.name.element_name == identifier_spec.element_name:
+                if identifier.ref.element_name == identifier_spec.element_name:
                     sub_id_specs = [sub_id.name for sub_id in identifier.identifiers]
                     break
 

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -71,7 +71,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
         for data_source in self._semantic_model.user_configured_model.data_sources:
             for identifier in data_source.identifiers:
                 if identifier.ref.element_name == identifier_spec.element_name:
-                    sub_id_specs = [sub_id.name for sub_id in identifier.identifiers]
+                    sub_id_specs = [sub_id.ref for sub_id in identifier.identifiers]
                     break
 
         # composite identifier case

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -483,7 +483,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         for dimension_reference in self._data_source_semantics.get_dimension_references():
             dimension = self._data_source_semantics.get_linkable(dimension_reference)
             if dimension.is_primary_time:
-                primary_time_dimension_name = dimension.name.element_name
+                primary_time_dimension_name = dimension.ref.element_name
 
         if not primary_time_dimension_name:
             raise RuntimeError("No primary time dimension found in data sources.")

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -88,9 +88,9 @@ class MetricFlowQueryParser:
         for linkable_name in self._data_source_semantics.get_linkable_element_references():
             linkable = self._data_source_semantics.get_linkable(linkable_name)
             if linkable.type == DimensionType.CATEGORICAL:
-                self._known_dimension_element_references.append(linkable.name)
+                self._known_dimension_element_references.append(linkable.ref)
             elif linkable.type == DimensionType.TIME:
-                self._known_time_dimension_element_references.append(linkable.name)
+                self._known_time_dimension_element_references.append(linkable.ref)
             elif (
                 linkable.type == IdentifierType.FOREIGN
                 or linkable.type == IdentifierType.PRIMARY

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -78,7 +78,7 @@ def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # n
 def test_get_elements(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
     for dimension_reference in new_data_source_semantics.get_dimension_references():
         assert (
-            new_data_source_semantics.get_dimension(dimension_reference=dimension_reference).name == dimension_reference
+                new_data_source_semantics.get_dimension(dimension_reference=dimension_reference).ref == dimension_reference
         )
     for measure_reference in new_data_source_semantics.measure_references:
         measure_reference = MeasureReference(element_name=measure_reference.element_name)

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -82,7 +82,7 @@ def test_get_elements(new_data_source_semantics: DataSourceSemantics) -> None:  
         )
     for measure_reference in new_data_source_semantics.measure_references:
         measure_reference = MeasureReference(element_name=measure_reference.element_name)
-        assert new_data_source_semantics.get_measure(measure_reference=measure_reference).name == measure_reference
+        assert new_data_source_semantics.get_measure(measure_reference=measure_reference).ref == measure_reference
 
 
 def test_get_data_sources_for_measure(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -78,7 +78,7 @@ def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # n
 def test_get_elements(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
     for dimension_reference in new_data_source_semantics.get_dimension_references():
         assert (
-                new_data_source_semantics.get_dimension(dimension_reference=dimension_reference).ref == dimension_reference
+            new_data_source_semantics.get_dimension(dimension_reference=dimension_reference).ref == dimension_reference
         )
     for measure_reference in new_data_source_semantics.measure_references:
         measure_reference = MeasureReference(element_name=measure_reference.element_name)

--- a/metricflow/test/model/validations/test_common_identifiers.py
+++ b/metricflow/test/model/validations/test_common_identifiers.py
@@ -17,7 +17,7 @@ def test_lonely_identifier_raises_issue(simple_model__pre_transforms: UserConfig
 
     func: Callable[[DataSource], bool] = lambda data_source: len(data_source.identifiers) > 0
     data_source_with_identifiers, _ = find_data_source_with(model, func)
-    data_source_with_identifiers.identifiers[0].name = IdentifierSpec.parse(lonely_identifier_name)
+    data_source_with_identifiers.identifiers[0].ref = IdentifierSpec.parse(lonely_identifier_name)
     build = ModelValidator.validate_model(model)
 
     found_warning = False

--- a/metricflow/test/model/validations/test_data_sources.py
+++ b/metricflow/test/model/validations/test_data_sources.py
@@ -16,7 +16,7 @@ def test_data_source_invalid_sql() -> None:  # noqa:D
             sql_query="SELECT foo FROM bar;",
             dimensions=[
                 Dimension(
-                    name=dimension_reference,
+                    ref=dimension_reference,
                     type=DimensionType.TIME,
                     type_params=DimensionTypeParams(
                         time_granularity=TimeGranularity.DAY,

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -22,10 +22,10 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     DataSource(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name} FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
@@ -38,7 +38,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     DataSource(
                         name="categoricaldim",
                         sql_query="SELECT foo FROM bar",
-                        dimensions=[Dimension(name=dim_reference, type=DimensionType.CATEGORICAL)],
+                        dimensions=[Dimension(ref=dim_reference, type=DimensionType.CATEGORICAL)],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     ),
                 ],
@@ -65,10 +65,10 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                     DataSource(
                         name="dim1",
                         sql_query=f"SELECT ds, {measure_reference.element_name} FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dimension_reference,
+                                ref=dimension_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
@@ -83,7 +83,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                         sql_query="SELECT foo1 FROM bar",
                         dimensions=[
                             Dimension(
-                                name=dimension_reference2,
+                                ref=dimension_reference2,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
@@ -116,10 +116,10 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                     DataSource(
                         name="dim1",
                         sql_query=f"SELECT {dim_ref1.element_name}, {measure_reference.element_name} FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_ref1,
+                                ref=dim_ref1,
                                 type=DimensionType.TIME,
                                 is_partition=True,
                                 type_params=DimensionTypeParams(
@@ -135,7 +135,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                         sql_query="SELECT foo1 FROM bar",
                         dimensions=[
                             Dimension(
-                                name=dim_ref1,
+                                ref=dim_ref1,
                                 type=DimensionType.TIME,
                                 is_partition=False,
                                 type_params=DimensionTypeParams(

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -24,7 +24,7 @@ def test_inconsistent_elements() -> None:  # noqa:D
                         sql_query="SELECT foo FROM bar",
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type_=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     time_granularity=TimeGranularity.DAY,
@@ -36,7 +36,7 @@ def test_inconsistent_elements() -> None:  # noqa:D
                     DataSource(
                         name="s2",
                         sql_query="SELECT foo FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     ),
                 ],

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -62,10 +62,10 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
                     DataSource(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name}, thorium_id FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
@@ -74,12 +74,12 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
                             )
                         ],
                         identifiers=[
-                            Identifier(name=identifier_reference, type=IdentifierType.PRIMARY, expr="thorium_id"),
+                            Identifier(ref=identifier_reference, type=IdentifierType.PRIMARY, expr="thorium_id"),
                             Identifier(
-                                name=foreign_identifier_reference,
+                                ref=foreign_identifier_reference,
                                 type=IdentifierType.FOREIGN,
                                 identifiers=[
-                                    CompositeSubIdentifier(name=identifier_reference, expr="not_thorium_id"),
+                                    CompositeSubIdentifier(ref=identifier_reference, expr="not_thorium_id"),
                                 ],
                             ),
                         ],
@@ -111,10 +111,10 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
                     DataSource(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name}, thorium_id FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
@@ -123,12 +123,12 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
                             )
                         ],
                         identifiers=[
-                            Identifier(name=identifier_reference, type=IdentifierType.PRIMARY, expr="thorium_id"),
+                            Identifier(ref=identifier_reference, type=IdentifierType.PRIMARY, expr="thorium_id"),
                             Identifier(
-                                name=foreign_identifier_reference,
+                                ref=foreign_identifier_reference,
                                 type=IdentifierType.FOREIGN,
                                 identifiers=[
-                                    CompositeSubIdentifier(ref="ident_that_doesnt_exist"),
+                                    CompositeSubIdentifier(name="ident_that_doesnt_exist"),
                                 ],
                             ),
                         ],
@@ -161,10 +161,10 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
                     DataSource(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name}, thorium_id FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     is_primary=True,
@@ -173,13 +173,13 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
                             )
                         ],
                         identifiers=[
-                            Identifier(name=identifier_reference, type=IdentifierType.PRIMARY, expr="thorium_id"),
+                            Identifier(ref=identifier_reference, type=IdentifierType.PRIMARY, expr="thorium_id"),
                             Identifier(
-                                name=foreign_identifier_reference,
+                                ref=foreign_identifier_reference,
                                 type=IdentifierType.FOREIGN,
                                 identifiers=[
                                     CompositeSubIdentifier(
-                                        ref="ident_that_doesnt_exist", name=foreign_identifier2_reference
+                                        name="ident_that_doesnt_exist", ref=foreign_identifier2_reference
                                     ),
                                 ],
                             ),
@@ -217,16 +217,16 @@ def test_mismatched_identifier(simple_model__pre_transforms: UserConfiguredModel
     )
 
     identifier_bookings = Identifier(
-        name=IdentifierReference(element_name="composite_identifier"),
+        ref=IdentifierReference(element_name="composite_identifier"),
         type=IdentifierType.FOREIGN,
-        identifiers=[CompositeSubIdentifier(ref="sub_identifier1")],
+        identifiers=[CompositeSubIdentifier(name="sub_identifier1")],
     )
     bookings_source.identifiers = flatten_nested_sequence([bookings_source.identifiers, [identifier_bookings]])
 
     identifier_listings = Identifier(
-        name=IdentifierReference(element_name="composite_identifier"),
+        ref=IdentifierReference(element_name="composite_identifier"),
         type=IdentifierType.FOREIGN,
-        identifiers=[CompositeSubIdentifier(ref="sub_identifier2")],
+        identifiers=[CompositeSubIdentifier(name="sub_identifier2")],
     )
     listings_latest.identifiers = flatten_nested_sequence([listings_latest.identifiers, [identifier_listings]])
 

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -30,7 +30,7 @@ def test_data_source_cant_have_more_than_one_primary_identifier(
     identifier_names = set()
     for identifier in multiple_identifier_data_source.identifiers:
         identifier.type = IdentifierType.PRIMARY
-        identifier_names.add(identifier.name)
+        identifier_names.add(identifier.ref)
 
     build = ModelValidator.validate_model(model)
 

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -24,7 +24,7 @@ def test_metric_missing_measure() -> None:  # noqa:D
                     DataSource(
                         name="sum_measure",
                         sql_query="SELECT foo FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     )
                 ],
@@ -50,17 +50,17 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                     name="sum_measure",
                     sql_query="SELECT foo, country FROM bar",
                     measures=[],
-                    dimensions=[Dimension(name=dim_reference, type=DimensionType.CATEGORICAL)],
+                    dimensions=[Dimension(ref=dim_reference, type=DimensionType.CATEGORICAL)],
                     mutability=Mutability(type=MutabilityType.IMMUTABLE),
                 ),
                 DataSource(
                     name="sum_measure2",
                     sql_query="SELECT foo, country FROM bar",
-                    measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                    measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                     dimensions=[
-                        Dimension(name=dim_reference, type=DimensionType.CATEGORICAL),
+                        Dimension(ref=dim_reference, type=DimensionType.CATEGORICAL),
                         Dimension(
-                            name=dim2_reference,
+                            ref=dim2_reference,
                             type=DimensionType.TIME,
                             type_params=DimensionTypeParams(
                                 is_primary=True,
@@ -93,10 +93,10 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                     DataSource(
                         name="sum_measure",
                         sql_query="SELECT foo, country FROM bar",
-                        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+                        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type=DimensionType.CATEGORICAL,
                             )
                         ],
@@ -129,14 +129,14 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
                         dimensions=[
                             Dimension(
-                                name=dim_reference,
+                                ref=dim_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             ),
                             Dimension(
-                                name=dim2_reference,
+                                ref=dim2_reference,
                                 type=DimensionType.TIME,
                                 type_params=DimensionTypeParams(
                                     time_granularity=TimeGranularity.DAY,
@@ -166,11 +166,11 @@ def test_generated_metrics_only() -> None:  # noqa:D
     data_source = DataSource(
         name="dim1",
         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name} FROM bar",
-        measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
+        measures=[Measure(ref=measure_reference, agg=AggregationType.SUM)],
         dimensions=[
-            Dimension(name=dim_reference, type=DimensionType.CATEGORICAL),
+            Dimension(ref=dim_reference, type=DimensionType.CATEGORICAL),
             Dimension(
-                name=dim2_reference,
+                ref=dim2_reference,
                 type=DimensionType.TIME,
                 type_params=DimensionTypeParams(
                     is_primary=True,
@@ -180,7 +180,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
         ],
         mutability=Mutability(type=MutabilityType.IMMUTABLE),
         identifiers=[
-            Identifier(name=identifier_reference, type=IdentifierType.PRIMARY),
+            Identifier(ref=identifier_reference, type=IdentifierType.PRIMARY),
         ],
     )
     data_source.measures[0].create_metric = True

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -119,7 +119,7 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
         and len(_categorical_dimensions(data_source=data_source)) > 0,
     )
 
-    measure_reference = usable_ds.measures[0].name
+    measure_reference = usable_ds.measures[0].ref
     # If the matching dimension is a time dimension we can accidentally create two primary time dimensions, and then
     # the validation will throw a different error and fail the test
     dimension_reference = _categorical_dimensions(data_source=usable_ds)[0].ref
@@ -167,7 +167,7 @@ def test_duplicate_measure_name(simple_model__pre_transforms: UserConfiguredMode
 
     with pytest.raises(
         ModelValidationException,
-        match=rf"can't use name `{duplicated_measure.name.element_name}` for a measure when it was already used for a measure",
+        match=rf"can't use name `{duplicated_measure.ref.element_name}` for a measure when it was already used for a measure",
     ):
         ModelValidator.checked_validations(model)
 

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -130,8 +130,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
 
     # We update the matching categorical dimension by reference for convenience
     ds_measure_x_dimension.get_dimension(dimension_reference).ref = measure_reference
-    ds_measure_x_identifier.identifiers[1].name = measure_reference
-    ds_dimension_x_identifier.identifiers[1].name = dimension_reference
+    ds_measure_x_identifier.identifiers[1].ref = measure_reference
+    ds_dimension_x_identifier.identifiers[1].ref = dimension_reference
 
     model.data_sources[usable_ds_index] = ds_measure_x_dimension
     with pytest.raises(
@@ -202,7 +202,7 @@ def test_duplicate_identifier_name(simple_model__pre_transforms: UserConfiguredM
 
     with pytest.raises(
         ModelValidationException,
-        match=rf"can't use name `{duplicated_identifier.name.element_name}` for a identifier when it was already used for a identifier",
+        match=rf"can't use name `{duplicated_identifier.ref.element_name}` for a identifier when it was already used for a identifier",
     ):
         ModelValidator.checked_validations(model)
 

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -122,14 +122,14 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     measure_reference = usable_ds.measures[0].name
     # If the matching dimension is a time dimension we can accidentally create two primary time dimensions, and then
     # the validation will throw a different error and fail the test
-    dimension_reference = _categorical_dimensions(data_source=usable_ds)[0].name
+    dimension_reference = _categorical_dimensions(data_source=usable_ds)[0].ref
 
     ds_measure_x_dimension = copy.deepcopy(usable_ds)
     ds_measure_x_identifier = copy.deepcopy(usable_ds)
     ds_dimension_x_identifier = copy.deepcopy(usable_ds)
 
     # We update the matching categorical dimension by reference for convenience
-    ds_measure_x_dimension.get_dimension(dimension_reference).name = measure_reference
+    ds_measure_x_dimension.get_dimension(dimension_reference).ref = measure_reference
     ds_measure_x_identifier.identifiers[1].name = measure_reference
     ds_dimension_x_identifier.identifiers[1].name = dimension_reference
 
@@ -184,7 +184,7 @@ def test_duplicate_dimension_name(simple_model__pre_transforms: UserConfiguredMo
 
     with pytest.raises(
         ModelValidationException,
-        match=rf"can't use name `{duplicated_dimension.name.element_name}` for a "
+        match=rf"can't use name `{duplicated_dimension.ref.element_name}` for a "
         rf"dimension when it was already used for a dimension",
     ):
         ModelValidator.checked_validations(model)

--- a/metricflow/test/plan_utils.py
+++ b/metricflow/test/plan_utils.py
@@ -72,7 +72,7 @@ def snapshot_path_prefix(
     .../snapshots/test_file.py/DataflowPlan/test_name__plan1.xml
     .../snapshots/test_file.py/DataflowPlan/test_name__plan1.svg
     """
-    test_name = request.node.name
+    test_name = request.node.name  # chtodo: maybe ref
     snapshot_file_name = test_name + "__" + snapshot_id
     path_items: List[str] = []
 

--- a/metricflow/test/test_utils.py
+++ b/metricflow/test/test_utils.py
@@ -28,7 +28,7 @@ def should_skip_multi_threaded(
     if not sql_client.sql_engine_attributes.multi_threading_supported:
         logger.warning(
             f"Multi-threading is not supported with {sql_client.__class__.__name__}, so should skip "
-            f"{request.node.fspath}::{request.node.name}`"
+            f"{request.node.fspath}::{request.node.name}`"  # chtodo: maybe ref
         )
         return True
 

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -75,7 +75,7 @@ class TimeGranularitySolver:
                     for measure in data_source.measures:
                         self._local_time_dimension_granularities[
                             LocalTimeDimensionGranularityKey(
-                                measure_reference=MeasureReference(element_name=measure.name.element_name),
+                                measure_reference=MeasureReference(element_name=measure.ref.element_name),
                                 local_time_dimension_reference=TimeDimensionReference(
                                     element_name=dimension.ref.element_name
                                 ),

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -77,7 +77,7 @@ class TimeGranularitySolver:
                             LocalTimeDimensionGranularityKey(
                                 measure_reference=MeasureReference(element_name=measure.name.element_name),
                                 local_time_dimension_reference=TimeDimensionReference(
-                                    element_name=dimension.name.element_name
+                                    element_name=dimension.ref.element_name
                                 ),
                             )
                         ].add(time_granularity)


### PR DESCRIPTION
Currently the `name` attribute of `Dimension`, `Measure`, `Identifier`, `SubIdentifier` objects points to a reference object. While inside `DataSource`, `Metric` this attribute points to a string. This PR renames `name` to `ref` where it points to a reference object so that instances of `name` only point to strings.

Intent is to make development easier by being more consistent and clear throughout MetricFlow.