### PR TITLE
Use Warnings for Materialization Validations

### DIFF
--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -1,21 +1,21 @@
 import logging
 from typing import List
 
-from metricflow.errors.errors import UnableToSatisfyQueryError
 from metricflow.model.objects.materialization import Materialization
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.semantic_containers import DataSourceSemantics
-from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
-from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationIssue,
     ValidationError,
     ValidationIssueType,
     validate_safely,
+    ValidationIssueLevel,
 )
+from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
+from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs import TimeDimensionReference
 
 logger = logging.getLogger(__name__)
@@ -53,9 +53,11 @@ class ValidMaterializationRule(ModelValidationRule):
                 metric_names=materialization.metrics,
                 group_by_names=materialization.dimensions,
             )
-        except UnableToSatisfyQueryError as err:
+        # TODO: Using broad exception clause until the query validation returns a list of errors.
+        except Exception as err:
             issues.append(
-                ValidationError(
+                ValidationIssue(
+                    level=ValidationIssueLevel.WARNING,
                     model_object_reference=ValidationIssue.make_object_reference(
                         materialization_name=materialization.name
                     ),

--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from typing import List
 
@@ -12,7 +13,7 @@ from metricflow.model.validations.validator_helpers import (
     ValidationError,
     ValidationIssueType,
     validate_safely,
-    ValidationIssueLevel,
+    ValidationFutureError,
 )
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.query.query_parser import MetricFlowQueryParser
@@ -56,12 +57,12 @@ class ValidMaterializationRule(ModelValidationRule):
         # TODO: Using broad exception clause until the query validation returns a list of errors.
         except Exception as err:
             issues.append(
-                ValidationIssue(
-                    level=ValidationIssueLevel.WARNING,
+                ValidationFutureError(
                     model_object_reference=ValidationIssue.make_object_reference(
                         materialization_name=materialization.name
                     ),
                     message=str(err),
+                    error_date=datetime.date(2022, 5, 23),
                 )
             )
 


### PR DESCRIPTION
Since the materialization validation was recently introduced, this changes the issue type to warning to that migrations are easier.