### PR TITLE
Add Metadata to Model objects

### DIFF
--- a/metricflow/model/objects/common.py
+++ b/metricflow/model/objects/common.py
@@ -71,3 +71,8 @@ class YamlConfigFile(HashableBaseModel):  # noqa: D
 
 class SourceContext(HashableBaseModel):  # noqa: D
     definition_hash: str
+
+
+class Metadata(HashableBaseModel):  # noqa: D
+    repo_file_path: str
+    file_slice: FileSlice

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -62,7 +62,7 @@ class DataSource(HashableBaseModel, ParseableObject):
     mutability: Mutability
 
     origin: DataSourceOrigin = DataSourceOrigin.SOURCE
-    metadata: Metadata
+    metadata: Optional[Metadata]
 
     @property
     def elements(self) -> List[Element]:  # noqa: D

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Sequence
 
-from metricflow.model.objects.common import Element
+from metricflow.model.objects.common import Element, Metadata
 from metricflow.model.objects.elements.dimension import Dimension
 from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.elements.measure import Measure
@@ -62,6 +62,7 @@ class DataSource(HashableBaseModel, ParseableObject):
     mutability: Mutability
 
     origin: DataSourceOrigin = DataSourceOrigin.SOURCE
+    metadata: Metadata
 
     @property
     def elements(self) -> List[Element]:  # noqa: D

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -51,4 +51,4 @@ class Measure(HashableBaseModel, ParseableObject):
     create_metric: Optional[bool]
     name: MeasureReference
     expr: Optional[str] = None
-    metadata: Metadata
+    metadata: Optional[Metadata]

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.utils import ParseableObject, HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
 from metricflow.specs import MeasureReference
@@ -50,3 +51,4 @@ class Measure(HashableBaseModel, ParseableObject):
     create_metric: Optional[bool]
     name: MeasureReference
     expr: Optional[str] = None
+    metadata: Metadata

--- a/metricflow/model/objects/materialization.py
+++ b/metricflow/model/objects/materialization.py
@@ -45,4 +45,4 @@ class Materialization(HashableBaseModel, ParseableObject):
     dimensions: List[str]
     destinations: Optional[List[MaterializationDestination]]
     destination_table: Optional[SqlTable]
-    metadata: Metadata
+    metadata: Optional[Metadata]

--- a/metricflow/model/objects/materialization.py
+++ b/metricflow/model/objects/materialization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from metricflow.dataflow.sql_table import SqlTable
+from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.utils import ParseableObject, HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
 
@@ -44,3 +45,4 @@ class Materialization(HashableBaseModel, ParseableObject):
     dimensions: List[str]
     destinations: Optional[List[MaterializationDestination]]
     destination_table: Optional[SqlTable]
+    metadata: Metadata

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -82,7 +82,7 @@ class Metric(HashableBaseModel, ParseableObject):
     type: MetricType
     type_params: MetricTypeParams
     constraint: Optional[WhereClauseConstraint]
-    metadata: Metadata
+    metadata: Optional[Metadata]
 
     @property
     def measure_names(self) -> List[MeasureReference]:  # noqa: D

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -4,6 +4,7 @@ from hashlib import sha1
 from typing import List, Optional
 
 from metricflow.errors.errors import ParsingException
+from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
 from metricflow.model.objects.utils import ParseableObject, ParseableField, HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
@@ -81,6 +82,7 @@ class Metric(HashableBaseModel, ParseableObject):
     type: MetricType
     type_params: MetricTypeParams
     constraint: Optional[WhereClauseConstraint]
+    metadata: Metadata
 
     @property
     def measure_names(self) -> List[MeasureReference]:  # noqa: D

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -187,12 +187,16 @@ def parse_config_yaml(
             document_type = next(iter(config_document.keys()))
             object_cfg = config_document[document_type]
             yaml_contents_by_line = config_yaml.contents.splitlines()
+
+            # Add filepath to the object context
+            object_cfg[PARSING_CONTEXT_KEY].filename = config_yaml.file_path
+
             if document_type == METRIC_TYPE:
-                results.append(parse(metric_class, object_cfg, config_yaml.file_path, yaml_contents_by_line))
+                results.append(parse(metric_class, object_cfg, yaml_contents_by_line))
             elif document_type == DATA_SOURCE_TYPE:
-                results.append(parse(data_source_class, object_cfg, config_yaml.file_path, yaml_contents_by_line))
+                results.append(parse(data_source_class, object_cfg, yaml_contents_by_line))
             elif document_type == MATERIALIZATION_TYPE:
-                results.append(parse(materialization_class, object_cfg, config_yaml.file_path, yaml_contents_by_line))
+                results.append(parse(materialization_class, object_cfg, yaml_contents_by_line))
             else:
                 errors.append(
                     str(
@@ -237,18 +241,18 @@ def parse_config_yaml(
 def parse(  # type: ignore[misc]
     _type: Type[Union[DataSource, Metric, Materialization]],
     yaml_dict: Dict[str, Any],
-    filename: str,
     contents_by_line: List[str],
 ) -> Any:
     """Parses a model object from (jsonschema-validated) yaml into python object"""
 
     # Add Metadata
     ctx = yaml_dict.pop(PARSING_CONTEXT_KEY)
-    ctx.filename = filename
+    filepath = ctx.filename
+    filename = os.path.split(filepath)[-1]
     yaml_dict["metadata"] = {
-        "repo_file_path": filename,
+        "repo_file_path": filepath,
         "file_slice": {
-            "filename": ctx.filename,
+            "filename": filename,
             "content": "\n".join(contents_by_line[max(0, ctx.start_line - 1) : ctx.end_line]),
             "start_line_number": ctx.start_line,
             "end_line_number": ctx.end_line,
@@ -263,10 +267,10 @@ def parse(  # type: ignore[misc]
                 if isinstance(yaml_dict[field_name], list):
                     objects = []
                     for obj in yaml_dict[field_name]:
-                        objects.append(parse(field_value.type_, obj, filename, contents_by_line))  # type: ignore
+                        objects.append(parse(field_value.type_, obj, contents_by_line))  # type: ignore
                     yaml_dict[field_name] = objects
                 else:
-                    yaml_dict[field_name] = parse(field_value.type_, yaml_dict[field_name], filename, contents_by_line)  # type: ignore
+                    yaml_dict[field_name] = parse(field_value.type_, yaml_dict[field_name], contents_by_line)  # type: ignore
             elif issubclass(field_value.type_, ParseableField):
                 if isinstance(yaml_dict[field_name], list):
                     objects = []


### PR DESCRIPTION
## Context
Metadata field was missing from the Model objects and it should be surfaced as it contains useful data about the model objects. For example, for a metric, it would show which file config it was parsed from and the sliced raw yaml block.

## Changes
- Added `Metadata` to
  - `DataSource`
  - `Metric`
  - `Materialization`
  - `Measure`
- Fixed the parser to properly parse the metadata context for each object 