### PR TITLE
added description/owners to model objects

### DIFF
--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -51,6 +51,7 @@ class DataSource(HashableBaseModel, ParseableObject):
     """Describes a data source"""
 
     name: str
+    description: Optional[str]
     sql_table: Optional[str]
     sql_query: Optional[str]
     dbt_model: Optional[str]

--- a/metricflow/model/objects/elements/dimension.py
+++ b/metricflow/model/objects/elements/dimension.py
@@ -35,6 +35,7 @@ class Dimension(HashableBaseModel, Element, ParseableObject):
     """Describes a dimension"""
 
     name: DimensionReference
+    description: Optional[str]
     type: DimensionType
     is_partition: bool = False
     type_params: Optional[DimensionTypeParams]

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -31,6 +31,7 @@ class Identifier(HashableBaseModel, Element, ParseableObject):
     """Describes a identifier"""
 
     name: IdentifierReference
+    description: Optional[str]
     type: IdentifierType
     role: Optional[str]
     entity: Optional[str]

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -48,6 +48,7 @@ class Measure(HashableBaseModel, ParseableObject):
     """Describes a measure"""
 
     agg: AggregationType
+    description: Optional[str]
     create_metric: Optional[bool]
     name: MeasureReference
     expr: Optional[str] = None

--- a/metricflow/model/objects/materialization.py
+++ b/metricflow/model/objects/materialization.py
@@ -41,6 +41,7 @@ class Materialization(HashableBaseModel, ParseableObject):
     """Describes a materialization"""
 
     name: str
+    description: Optional[str]
     metrics: List[str]
     dimensions: List[str]
     destinations: Optional[List[MaterializationDestination]]

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -79,6 +79,7 @@ class Metric(HashableBaseModel, ParseableObject):
     """Describes a metric"""
 
     name: str
+    description: Optional[str]
     type: MetricType
     type_params: MetricTypeParams
     constraint: Optional[WhereClauseConstraint]


### PR DESCRIPTION
## Changes
Similar to https://github.com/transform-data/metricflow/pull/75 we will add addition metadata onto the model objects for extra details, specifically 
- description
- owners