### PR TITLE
Update ModelValidator to allow for a configureable list of rules

### DIFF
--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -278,4 +278,4 @@ class MetricFlowClient:
         Returns:
             Tuple of validation issues with the model provided.
         """
-        return ModelValidator.validate_model(self.user_configured_model).issues
+        return ModelValidator().validate_model(self.user_configured_model).issues

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -587,7 +587,7 @@ def validate_configs(cfg: CLIContext) -> None:
     user_model = cfg.user_configured_model
 
     # Model validation
-    build_result = ModelValidator.validate_model(user_model)
+    build_result = ModelValidator().validate_model(user_model)
 
     if build_result.issues is None:
         click.echo("✅ Validation completed! No issues were found.")

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -55,13 +55,12 @@ class ModelValidator:
         """
         self._rules = rules
 
-    @staticmethod
-    def validate_model(model: UserConfiguredModel) -> ModelBuildResult:
+    def validate_model(self, model: UserConfiguredModel) -> ModelBuildResult:
         """Validate a model according to configured rules."""
         model_copy = copy.deepcopy(model)
 
         issues: List[ValidationIssueType] = []
-        for validation_rule in ModelValidator.DEFAULT_RULES:
+        for validation_rule in self._rules:
             issues.extend(validation_rule.validate_model(model_copy))
             # If there are any fatal errors, stop the validation process.
             if any([x.level == ValidationIssueLevel.FATAL for x in issues]):
@@ -73,11 +72,10 @@ class ModelValidator:
 
         return ModelBuildResult(model=model_copy, issues=tuple(issues))
 
-    @staticmethod
-    def checked_validations(model: UserConfiguredModel) -> UserConfiguredModel:  # chTODO: remember checked_build
+    def checked_validations(self, model: UserConfiguredModel) -> UserConfiguredModel:  # chTODO: remember checked_build
         """Similar to validate(), but throws an exception if validation fails."""
         model_copy = copy.deepcopy(model)
-        build_result = ModelValidator.validate_model(model_copy)
+        build_result = self.validate_model(model_copy)
         if build_result.issues is not None:
             if any(
                 [

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import List
+from typing import List, Sequence
 
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class ModelValidator:
     """A Validator that acts on UserConfiguredModel"""
 
-    DEFAULT_RULES: List[ModelValidationRule] = [
+    DEFAULT_RULES = (
         DataSourceMeasuresUniqueRule(),
         DataSourceTimeDimensionWarningsRule(),
         DimensionConsistencyRule(),
@@ -45,9 +45,9 @@ class ModelValidator:
         NonEmptyRule(),
         UniqueAndValidNameRule(),
         ValidMaterializationRule(),
-    ]
+    )
 
-    def __init__(self, rules: List[ModelValidationRule] = DEFAULT_RULES) -> None:
+    def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES) -> None:
         """Constructor.
 
         Args:

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -53,6 +53,11 @@ class ModelValidator:
         Args:
             rules: List of validation rules to run. Defaults to DEFAULT_RULES
         """
+
+        # Raises an error if 'rules' is an empty sequence or None
+        if not rules:
+            raise ValueError("ModelValidator 'rules' must be a sequence with at least one ModelValidationRule.")
+
         self._rules = rules
 
     def validate_model(self, model: UserConfiguredModel) -> ModelBuildResult:

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class ModelValidator:
     """A Validator that acts on UserConfiguredModel"""
 
-    VALIDATION_RULES: List[ModelValidationRule] = [
+    DEFAULT_RULES: List[ModelValidationRule] = [
         DataSourceMeasuresUniqueRule(),
         DataSourceTimeDimensionWarningsRule(),
         DimensionConsistencyRule(),
@@ -47,13 +47,21 @@ class ModelValidator:
         ValidMaterializationRule(),
     ]
 
+    def __init__(self, rules: List[ModelValidationRule] = DEFAULT_RULES) -> None:
+        """Constructor.
+
+        Args:
+            rules: List of validation rules to run. Defaults to DEFAULT_RULES
+        """
+        self._rules = rules
+
     @staticmethod
     def validate_model(model: UserConfiguredModel) -> ModelBuildResult:
         """Validate a model according to configured rules."""
         model_copy = copy.deepcopy(model)
 
         issues: List[ValidationIssueType] = []
-        for validation_rule in ModelValidator.VALIDATION_RULES:
+        for validation_rule in ModelValidator.DEFAULT_RULES:
             issues.extend(validation_rule.validate_model(model_copy))
             # If there are any fatal errors, stop the validation process.
             if any([x.level == ValidationIssueLevel.FATAL for x in issues]):

--- a/metricflow/test/model/validations/test_common_identifiers.py
+++ b/metricflow/test/model/validations/test_common_identifiers.py
@@ -18,7 +18,7 @@ def test_lonely_identifier_raises_issue(simple_model__pre_transforms: UserConfig
     func: Callable[[DataSource], bool] = lambda data_source: len(data_source.identifiers) > 0
     data_source_with_identifiers, _ = find_data_source_with(model, func)
     data_source_with_identifiers.identifiers[0].name = IdentifierSpec.parse(lonely_identifier_name)
-    build = ModelValidator.validate_model(model)
+    build = ModelValidator().validate_model(model)
 
     found_warning = False
     warning = f"Identifier `{lonely_identifier_name}` only found in one data source `{data_source_with_identifiers.name}` which means it will be unused in joins."

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -1,3 +1,4 @@
+import pytest
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.materialization import Materialization
 from metricflow.model.validations.materializations import ValidMaterializationRule
@@ -21,11 +22,18 @@ def test_can_configure_model_validator_rules(simple_model__pre_transforms: UserC
     issues = ModelValidator().validate_model(model).issues
     assert len(issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
 
-    # confirm that with an empty configuration, no issue is raised
-    issues = ModelValidator(rules=[]).validate_model(model).issues
-    assert len(issues) == 0, f"Empty rules list configured ModelValidator returned issues {issues}"
-
     # confirm that a custom configuration excluding DataSourceMeasuresUniqueRule, no issue is raised
     rules = [rule for rule in ModelValidator.DEFAULT_RULES if rule.__class__ is not ValidMaterializationRule]
     issues = ModelValidator(rules=rules).validate_model(model).issues
     assert len(issues) == 0, f"ModelValidator without ValidMaterializationRule returned issues {issues}"
+
+
+def test_cant_configure_model_validator_without_rules() -> None:  # noqa: D
+    with pytest.raises(ValueError):
+        ModelValidator(rules=[])
+
+    with pytest.raises(ValueError):
+        ModelValidator(rules=())
+
+    with pytest.raises(ValueError):
+        ModelValidator(rules=None)  # type: ignore

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -1,0 +1,31 @@
+from metricflow.model.model_validator import ModelValidator
+from metricflow.model.objects.materialization import Materialization
+from metricflow.model.validations.materializations import ValidMaterializationRule
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.test.test_utils import model_with_materialization
+
+
+def test_can_configure_model_validator_rules(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    model = model_with_materialization(
+        simple_model__pre_transforms,
+        [
+            Materialization(
+                name="foobar",
+                metrics=["invalid_bookings"],
+                dimensions=["ds"],
+            )
+        ],
+    )
+
+    # confirm that with the default configuration, an issue is raised
+    issues = ModelValidator().validate_model(model).issues
+    assert len(issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
+
+    # confirm that with an empty configuration, no issue is raised
+    issues = ModelValidator(rules=[]).validate_model(model).issues
+    assert len(issues) == 0, f"Empty rules list configured ModelValidator returned issues {issues}"
+
+    # confirm that a custom configuration excluding DataSourceMeasuresUniqueRule, no issue is raised
+    rules = [rule for rule in ModelValidator.DEFAULT_RULES if rule.__class__ is not ValidMaterializationRule]
+    issues = ModelValidator(rules=rules).validate_model(model).issues
+    assert len(issues) == 0, f"ModelValidator without ValidMaterializationRule returned issues {issues}"

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -16,7 +16,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
     with pytest.raises(ModelValidationException, match=r"type conflict for dimension"):
         dim_reference = DimensionReference(element_name="dim")
         measure_reference = MeasureReference(element_name="measure")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -59,7 +59,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
         dimension_reference = DimensionReference(element_name=DEFAULT_DS)
         dimension_reference2 = DimensionReference(element_name="not_ds")
         measure_reference = MeasureReference(element_name="measure")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -110,7 +110,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
     with pytest.raises(ModelValidationException, match=r"conflicting is_partition attribute for dimension"):
         dim_ref1 = DimensionReference(element_name="dim1")
         measure_reference = MeasureReference(element_name="measure")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -16,7 +16,7 @@ def test_inconsistent_elements() -> None:  # noqa:D
     dim_reference = DimensionReference(element_name="ename")
     measure_reference = MeasureReference(element_name="ename")
     with pytest.raises(ModelValidationException):
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -32,7 +32,7 @@ def test_data_source_cant_have_more_than_one_primary_identifier(
         identifier.type = IdentifierType.PRIMARY
         identifier_names.add(identifier.name)
 
-    build = ModelValidator.validate_model(model)
+    build = ModelValidator().validate_model(model)
 
     future_issue = (
         f"Data sources can have only one primary identifier. The data source"
@@ -56,7 +56,7 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
         measure2_reference = MeasureReference(element_name="metric_with_no_time_dim")
         identifier_reference = IdentifierReference(element_name="thorium")
         foreign_identifier_reference = IdentifierReference(element_name="composite_thorium")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -105,7 +105,7 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
         measure2_reference = MeasureReference(element_name="metric_with_no_time_dim")
         identifier_reference = IdentifierReference(element_name="thorium")
         foreign_identifier_reference = IdentifierReference(element_name="composite_thorium")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -155,7 +155,7 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
         identifier_reference = IdentifierReference(element_name="thorium")
         foreign_identifier_reference = IdentifierReference(element_name="composite_thorium")
         foreign_identifier2_reference = IdentifierReference(element_name="shouldnt_have_both")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -230,7 +230,7 @@ def test_mismatched_identifier(simple_model__pre_transforms: UserConfiguredModel
     )
     listings_latest.identifiers = flatten_nested_sequence([listings_latest.identifiers, [identifier_listings]])
 
-    build = ModelValidator.validate_model(model)
+    build = ModelValidator().validate_model(model)
 
     expected_error_message_fragment = "does not have consistent sub-identifiers"
     error_count = len([issue for issue in build.issues if re.search(expected_error_message_fragment, issue.message)])

--- a/metricflow/test/model/validations/test_measures.py
+++ b/metricflow/test/model/validations/test_measures.py
@@ -10,7 +10,7 @@ from metricflow.test.test_utils import find_data_source_with
 def test_measures_only_exist_in_one_data_source(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
     model = copy.deepcopy(simple_model__pre_transforms)
 
-    build = ModelValidator.validate_model(model)
+    build = ModelValidator().validate_model(model)
     duplicate_measure_message = "Found measure with name .* in multiple data sources with names"
     found_issue = False
 
@@ -33,7 +33,7 @@ def test_measures_only_exist_in_one_data_source(simple_model__pre_transforms: Us
     measure = first_data_source.measures[0]
     second_data_source.measures = list(flatten_nested_sequence([second_data_source.measures, [measure]]))
 
-    build = ModelValidator.validate_model(model)
+    build = ModelValidator().validate_model(model)
 
     if build.issues is not None:
         for issue in build.issues:

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -18,7 +18,7 @@ def test_metric_missing_measure() -> None:  # noqa:D
     with pytest.raises(ModelValidationException):
         measure_reference = MeasureReference(element_name="my_measure")
         measure2_reference = MeasureReference(element_name="nonexistent_measure")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -43,7 +43,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
     dim_reference = DimensionReference(element_name="country")
     dim2_reference = DimensionReference(element_name="ename")
     measure_reference = MeasureReference(element_name="foo")
-    ModelValidator.checked_validations(
+    ModelValidator().checked_validations(
         UserConfiguredModel(
             data_sources=[
                 DataSource(
@@ -87,7 +87,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
     with pytest.raises(ModelValidationException):
         dim_reference = DimensionReference(element_name="country")
         measure_reference = MeasureReference(element_name="foo")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -120,7 +120,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
         dim_reference = DimensionReference(element_name="date_created")
         dim2_reference = DimensionReference(element_name="date_deleted")
         measure_reference = MeasureReference(element_name="foo")
-        ModelValidator.checked_validations(
+        ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
                     DataSource(
@@ -185,7 +185,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
     )
     data_source.measures[0].create_metric = True
 
-    ModelValidator.checked_validations(
+    ModelValidator().checked_validations(
         UserConfiguredModel(
             data_sources=[data_source],
             metrics=[],

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -42,7 +42,7 @@ def test_duplicate_data_source_name(simple_model__pre_transforms: UserConfigured
         ModelValidationException,
         match=rf"Can't use name `{duplicated_data_source.name}` for a data source when it was already used for a data source",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 def test_duplicate_metric_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
@@ -53,7 +53,7 @@ def test_duplicate_metric_name(simple_model__pre_transforms: UserConfiguredModel
         ModelValidationException,
         match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for a metric",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 def test_duplicate_materalization_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
@@ -64,7 +64,7 @@ def test_duplicate_materalization_name(simple_model__pre_transforms: UserConfigu
         ModelValidationException,
         match=rf"Can't use name `{duplicated_materialization.name}` for a materialization when it was already used for a materialization",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(
@@ -78,8 +78,8 @@ def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(
     model_data_source.data_sources[0].name = metric_name
     model_materialization.materializations[0].name = model_data_source.metrics[0].name
 
-    ModelValidator.checked_validations(model_data_source)
-    ModelValidator.checked_validations(model_materialization)
+    ModelValidator().checked_validations(model_data_source)
+    ModelValidator().checked_validations(model_materialization)
 
 
 def test_top_level_elements_cant_share_names_except_with_metrics(
@@ -93,7 +93,7 @@ def test_top_level_elements_cant_share_names_except_with_metrics(
         ModelValidationException,
         match=rf"Can't use name `{data_source_name}` for a materialization when it was already used for a data source",
     ):
-        ModelValidator.checked_validations(model_ds_and_mat)
+        ModelValidator().checked_validations(model_ds_and_mat)
 
 
 """
@@ -138,21 +138,21 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
         ModelValidationException,
         match=rf"can't use name `{measure_reference.element_name}` for a dimension when it was already used for a measure",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
     model.data_sources[usable_ds_index] = ds_measure_x_identifier
     with pytest.raises(
         ModelValidationException,
         match=rf"can't use name `{measure_reference.element_name}` for a identifier when it was already used for a measure",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
     model.data_sources[usable_ds_index] = ds_dimension_x_identifier
     with pytest.raises(
         ModelValidationException,
         match=rf"can't use name `{dimension_reference.element_name}` for a dimension when it was already used for a identifier",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 def test_duplicate_measure_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
@@ -169,7 +169,7 @@ def test_duplicate_measure_name(simple_model__pre_transforms: UserConfiguredMode
         ModelValidationException,
         match=rf"can't use name `{duplicated_measure.name.element_name}` for a measure when it was already used for a measure",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 def test_duplicate_dimension_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
@@ -187,7 +187,7 @@ def test_duplicate_dimension_name(simple_model__pre_transforms: UserConfiguredMo
         match=rf"can't use name `{duplicated_dimension.name.element_name}` for a "
         rf"dimension when it was already used for a dimension",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 def test_duplicate_identifier_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
@@ -204,7 +204,7 @@ def test_duplicate_identifier_name(simple_model__pre_transforms: UserConfiguredM
         ModelValidationException,
         match=rf"can't use name `{duplicated_identifier.name.element_name}` for a identifier when it was already used for a identifier",
     ):
-        ModelValidator.checked_validations(model)
+        ModelValidator().checked_validations(model)
 
 
 """


### PR DESCRIPTION
This PR makes the ModelValidator configurable. Specifically it makes it so that the lists of rules that are run is configurable. This is important because it powers two important use cases. There are times when people only want to run a subset of rules (for instance when the only thing that was changed were the dimensions in a metric) or where custom validations are needed (for instance if someone extends the parsing schema so that all data sources have owners and they want to validate all data sources have owners).

# Example uses:
## Run validator with default rules
```
from metricflow.model.model_validator import ModelValidator

ModelValidator().validate_model(your_model)
```

## Run validator with only MetricMeasuresRule
```
from metricflow.model.model_validator import ModelValidator
from metricflow.model.validations.metrics import MetricMeasuresRule

ModelValidator(rules=[MetricMeasuresRule]).validate_model(your_model)
```

## Run the validator with default rules and custom DataSourceOwnersRule
```
from metricflow.model.model_validator import ModelValidator
from path.to.custom.rule.module import DataSourceOwnersRule

ModelValidator(rules=list(ModelValidator.DEFAULT_RULES) + [DataSourceOwnersRule]).validate_model(your_model)
```