### PR TITLE
Make validate-configs print success message when there are no issues

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -589,7 +589,7 @@ def validate_configs(cfg: CLIContext) -> None:
     # Model validation
     build_result = ModelValidator().validate_model(user_model)
 
-    if build_result.issues is None:
+    if not build_result.issues:
         click.echo("✅ Validation completed! No issues were found.")
     else:
         for issue in build_result.issues:


### PR DESCRIPTION
Previously the validate-configs command only printed the success message if the 'build_result.issues' was 'None'. However, the current implementation of the ModelValidator returns an empty tuple for the issues when there are no issues. Thus the validate-configs command never printed the success message. This change checks the boolean value of 'build_result.issues' which evaluates to 'False' for 'None' and empty sequences.

Previously this was the appearance of running `validate-configs` when there are no issues:
```
$ mf validate-configs
```
This is now the appearance of running `validate-configs` when there are no issues:
```
$ mf validate-configs
✅ Validation completed! No issues were found.
```