### PR TITLE
Skip Hidden Directories and Files in the YAML Model Directory

### DIFF
--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -54,15 +54,23 @@ def parse_directory_of_yaml_files_to_model(
     yaml_config_files = []
 
     for root, dirs, files in os.walk(directory):
+        # Skip hidden directories. os.walk() supports mutation of dirs to skip directories.
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+
         for file in files:
             if not (file.endswith(".yaml") or file.endswith(".yml")):
                 continue
+            # Skip hidden files
+            if file.startswith("."):
+                continue
+
             file_path = os.path.join(root, file)
             with open(file_path) as f:
                 contents = Template(f.read()).substitute(template_mapping)
                 yaml_config_files.append(
                     YamlFile(file_path=file_path, contents=contents),
                 )
+
     model = parse_yaml_files_to_model(yaml_config_files)
 
     if apply_pre_transformations:


### PR DESCRIPTION
The model directory contains the YAML files that define the semantic model. Currently, it parses all YAML files in the directory, but hidden files and directories should be skipped (e.g. `.git`).