### PR TITLE
Validate Aggregation Time Dimension for Measures

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -4,6 +4,7 @@ from typing import List, Sequence
 
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
+from metricflow.model.validations.agg_time_dimension import AggregationTimeDimensionRule
 from metricflow.model.validations.data_sources import (
     DataSourceMeasuresUniqueRule,
     DataSourceTimeDimensionWarningsRule,
@@ -45,6 +46,7 @@ class ModelValidator:
         NonEmptyRule(),
         UniqueAndValidNameRule(),
         ValidMaterializationRule(),
+        AggregationTimeDimensionRule(),
     )
 
     def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES) -> None:

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.utils import ParseableObject, HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
 from metricflow.specs import MeasureReference, TimeDimensionReference
@@ -51,6 +52,7 @@ class Measure(HashableBaseModel, ParseableObject):
     description: Optional[str]
     create_metric: Optional[bool]
     expr: Optional[str] = None
+    metadata: Optional[Metadata]
 
     # Defines the time dimension to aggregate this measure by. If not specified, it means to use the primary time
     # dimension in the data source.

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -184,10 +184,6 @@ class DataSourceSemantics:
         """Retrieves a full dimension object by name"""
         dimension_reference = time_dimension_reference.dimension_reference()
 
-        logger.info(f"Dimension reference is {dimension_reference}")
-        for key in self._dimension_index.keys():
-            logger.error(f"Key is {key}")
-
         if dimension_reference not in self._dimension_index:
             raise ValueError(
                 f"Could not find dimension with name ({dimension_reference.element_name}) in configured data sources"
@@ -295,6 +291,7 @@ class DataSourceSemantics:
             self._entity_index[ident.entity].append(data_source)
             self._linkable_reference_index[ident.reference].append(data_source)
 
+    @property
     def data_source_references(self) -> Sequence[DataSourceReference]:  # noqa: D
         data_source_names_sorted = sorted(self._data_source_names)
         return tuple(DataSourceReference(data_source_name=x) for x in data_source_names_sorted)

--- a/metricflow/model/validations/agg_time_dimension.py
+++ b/metricflow/model/validations/agg_time_dimension.py
@@ -1,0 +1,66 @@
+from typing import List
+
+from metricflow.model.objects.data_source import DataSource
+from metricflow.model.objects.elements.dimension import DimensionType
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.validator_helpers import (
+    ModelValidationRule,
+    ValidationIssueType,
+    validate_safely,
+    ValidationError,
+    ValidationIssue,
+)
+from metricflow.specs import TimeDimensionReference
+
+
+class AggregationTimeDimensionRule(ModelValidationRule):
+    """Checks that the aggregation time dimension for a measure points to a valid time dimension in the data source."""
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking aggregation time dimension for data sources in the model")
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+        issues: List[ValidationIssueType] = []
+        for data_source in model.data_sources:
+            issues.extend(AggregationTimeDimensionRule._validate_data_source(data_source))
+
+        return issues
+
+    @staticmethod
+    def _time_dimension_in_model(time_dimension_reference: TimeDimensionReference, data_source: DataSource) -> bool:
+        for dimension in data_source.dimensions:
+            if dimension.type == DimensionType.TIME and dimension.name == time_dimension_reference.element_name:
+                return True
+        return False
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking aggregation time dimension for a data source")
+    def _validate_data_source(data_source: DataSource) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+
+        for measure in data_source.measures:
+            model_object_reference = ValidationIssue.make_object_reference(
+                data_source_name=data_source.name, measure_name=measure.name
+            )
+            if not measure.agg_time_dimension:
+                issues.append(
+                    ValidationError(
+                        model_object_reference=model_object_reference,
+                        message=f"In data source '{data_source.name}', measure '{measure.name}' does not have an "
+                        f"aggregation time dimension set",
+                    )
+                )
+                continue
+            agg_time_dimension_reference = measure.checked_agg_time_dimension
+            if not AggregationTimeDimensionRule._time_dimension_in_model(
+                time_dimension_reference=agg_time_dimension_reference, data_source=data_source
+            ):
+                issues.append(
+                    ValidationError(
+                        model_object_reference=model_object_reference,
+                        message=f"In data source '{data_source.name}', measure '{measure.name}' has the aggregation "
+                        f"time dimension is set to '{agg_time_dimension_reference.element_name}', "
+                        f"which not a valid time dimension in the data source",
+                    )
+                )
+
+        return issues

--- a/metricflow/test/model/validations/test_agg_time_dimension.py
+++ b/metricflow/test/model/validations/test_agg_time_dimension.py
@@ -1,0 +1,27 @@
+import pytest
+
+from metricflow.model.model_validator import ModelValidator
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.validator_helpers import ModelValidationException
+from metricflow.test.model.validations.test_unique_valid_name import copied_model
+from metricflow.test.test_utils import find_data_source_with
+
+
+def test_invalid_aggregation_time_dimension(simple_user_configured_model: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(simple_user_configured_model)
+    data_source_with_measures, _ = find_data_source_with(
+        model,
+        lambda data_source: len(data_source.measures) > 0,
+    )
+
+    data_source_with_measures.measures[0].agg_time_dimension = "invalid_time_dimension"
+
+    with pytest.raises(
+        ModelValidationException,
+        match=(
+            "has the aggregation time dimension is set to 'invalid_time_dimension', which not a valid time dimension "
+            "in the data source"
+        ),
+    ):
+        model_validator = ModelValidator()
+        model_validator.checked_validations(model)

--- a/metricflow/test/plan_utils.py
+++ b/metricflow/test/plan_utils.py
@@ -207,9 +207,7 @@ def assert_snapshot_text_equal(
         if snapshot_text != expected_snapshot_text:
             differ = difflib.Differ()
             diff = differ.compare(expected_snapshot_text.splitlines(), snapshot_text.splitlines())
-            logger.error(f"Snapshot from {file_path} does not match. Diff from expected to actual:\n" + "\n".join(diff))
-            logger.error(snapshot_text)
-            assert False
+            assert False, f"Snapshot from {file_path} does not match. Diff from expected to actual:\n" + "\n".join(diff)
 
 
 def assert_execution_plan_text_equal(  # noqa: D


### PR DESCRIPTION
This PR adds a validation rule that ensures that the aggregation time dimension set for a measure in a data source references a valid time dimension in the same data source.