### PR TITLE
add `filepath` to method signature instead of getting from ParsingContext

### DIFF
--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -192,11 +192,11 @@ def parse_config_yaml(
             object_cfg[PARSING_CONTEXT_KEY].filename = config_yaml.file_path
 
             if document_type == METRIC_TYPE:
-                results.append(parse(metric_class, object_cfg, yaml_contents_by_line))
+                results.append(parse(metric_class, object_cfg, config_yaml.file_path, yaml_contents_by_line))
             elif document_type == DATA_SOURCE_TYPE:
-                results.append(parse(data_source_class, object_cfg, yaml_contents_by_line))
+                results.append(parse(data_source_class, object_cfg, config_yaml.file_path, yaml_contents_by_line))
             elif document_type == MATERIALIZATION_TYPE:
-                results.append(parse(materialization_class, object_cfg, yaml_contents_by_line))
+                results.append(parse(materialization_class, object_cfg, config_yaml.file_path, yaml_contents_by_line))
             else:
                 errors.append(
                     str(
@@ -241,13 +241,13 @@ def parse_config_yaml(
 def parse(  # type: ignore[misc]
     _type: Type[Union[DataSource, Metric, Materialization]],
     yaml_dict: Dict[str, Any],
+    filepath: str,
     contents_by_line: List[str],
 ) -> Any:
     """Parses a model object from (jsonschema-validated) yaml into python object"""
 
     # Add Metadata
     ctx = yaml_dict.pop(PARSING_CONTEXT_KEY)
-    filepath = ctx.filename
     filename = os.path.split(filepath)[-1]
     yaml_dict["metadata"] = {
         "repo_file_path": filepath,
@@ -267,10 +267,10 @@ def parse(  # type: ignore[misc]
                 if isinstance(yaml_dict[field_name], list):
                     objects = []
                     for obj in yaml_dict[field_name]:
-                        objects.append(parse(field_value.type_, obj, contents_by_line))  # type: ignore
+                        objects.append(parse(field_value.type_, obj, filepath, contents_by_line))  # type: ignore
                     yaml_dict[field_name] = objects
                 else:
-                    yaml_dict[field_name] = parse(field_value.type_, yaml_dict[field_name], contents_by_line)  # type: ignore
+                    yaml_dict[field_name] = parse(field_value.type_, yaml_dict[field_name], filepath, contents_by_line)  # type: ignore
             elif issubclass(field_value.type_, ParseableField):
                 if isinstance(yaml_dict[field_name], list):
                     objects = []


### PR DESCRIPTION
## Context
`ParsingContext` is loaded via the yaml loader, but I can't think of a good way to pass the filepath to the custom Loader. In the custom Loader we just put the filename as a literal string `'<unicode string>'` [here](https://github.com/transform-data/metricflow/blob/main/metricflow/model/parsing/yaml_loader.py#L33) listed as `node.start_mark.name`. This causes the parser to use `'<unicode string>'` as the filename/filepath.

## Changes
Originally, it was done this way where we pass the filepath through the `parse` method, but it was a bit janky so I removed it. Now I realized we actually needed it in order to retrieve the filepath for each object we parse or else we'll just have the filepath correct on the first node and the rest of the child nodes will have `'<unicode string>'` 