### PR TITLE
replaced YamlFile -> YamlConfigFile

### DIFF
--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -1,7 +1,6 @@
 import textwrap
 from typing import Dict, Optional
 
-from metricflow.model.parsing.yaml_file import YamlFile
 from metricflow.model.parsing.yaml_loader import ParsingContext
 
 
@@ -56,10 +55,10 @@ class ConstraintParseException(Exception):  # noqa: D
 
 class ParsingException(Exception):  # noqa: D
     def __init__(  # noqa: D
-        self, message: str, ctx: Optional[ParsingContext] = None, config_yaml: Optional[YamlFile] = None
+        self, message: str, ctx: Optional[ParsingContext] = None, config_filepath: Optional[str] = None
     ) -> None:
-        if config_yaml:
-            message = f"Failed to parse YAML file '{config_yaml.file_path}' - {message}"
+        if config_filepath:
+            message = f"Failed to parse YAML file '{config_filepath}' - {message}"
         if ctx:
             message = f"{message}\nContext: {str(ctx)}"
         super().__init__(message)

--- a/metricflow/model/objects/common.py
+++ b/metricflow/model/objects/common.py
@@ -66,7 +66,7 @@ class FileSlice(HashableBaseModel):  # noqa: D
 class YamlConfigFile(HashableBaseModel):  # noqa: D
     filepath: str
     contents: str
-    url: str
+    url: Optional[str]
 
 
 class SourceContext(HashableBaseModel):  # noqa: D

--- a/metricflow/model/parsing/validation.py
+++ b/metricflow/model/parsing/validation.py
@@ -4,7 +4,7 @@ import yaml
 from jsonschema import exceptions
 
 from metricflow.errors.errors import ParsingException
-from metricflow.model.parsing.yaml_file import YamlFile
+from metricflow.model.objects.common import YamlConfigFile
 from metricflow.model.parsing.schemas_internal import (
     metric_validator,
     data_source_validator,
@@ -20,7 +20,7 @@ DOCUMENT_TYPES = [METRIC_TYPE, DATA_SOURCE_TYPE, MATERIALIZATION_TYPE]
 logger = logging.getLogger(__name__)
 
 
-def validate_config_structure(config_yaml: YamlFile) -> None:  # noqa: D
+def validate_config_structure(config_yaml: YamlConfigFile) -> None:  # noqa: D
     """Validates config shape against jsonschema
 
     catches ValidationError and raise one exception at the end so
@@ -37,7 +37,7 @@ def validate_config_structure(config_yaml: YamlFile) -> None:  # noqa: D
                 str(
                     ParsingException(
                         f"Document is not a dict. Got `{type(config_document)}`: {config_document}",
-                        config_yaml=config_yaml,
+                        config_filepath=config_yaml.filepath,
                     )
                 )
             )
@@ -55,7 +55,7 @@ def validate_config_structure(config_yaml: YamlFile) -> None:  # noqa: D
                 else:
                     raise ParsingException(
                         f"Invalid document type '{document_type}'. Valid document types are: {DOCUMENT_TYPES}",
-                        config_yaml=config_yaml,
+                        config_filepath=config_yaml.filepath,
                     )
             except exceptions.ValidationError as e:
                 errors.append(f"{e}")

--- a/metricflow/model/parsing/yaml_file.py
+++ b/metricflow/model/parsing/yaml_file.py
@@ -1,7 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class YamlFile:  # noqa: D
-    file_path: str
-    contents: str


### PR DESCRIPTION
## Context
We should be using `YamlConfigFile` instead of `YamlFile` since it is more consistent with our internal implementation. This allows us to be more consistent throughout and also it was intended to use `YamlConfigFile`, but at the time it was not migrated over yet.

## Changes
- Removed `YamlFile`
- Replaced all instances to use `YamlConfigFile`
  - fixed up some field call sites
- cleaned up `ParsingException`