### PR TITLE
Add Metric based Data Warehouse Validations

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -10,7 +10,7 @@ import time
 from halo import Halo
 from importlib.metadata import version as pkg_version
 from packaging.version import parse
-from typing import List, Optional, Sequence
+from typing import Callable, List, Optional, Sequence
 from update_checker import UpdateChecker
 
 from metricflow.cli import PACKAGE_NAME
@@ -33,6 +33,7 @@ from metricflow.dataflow.dataflow_plan_to_text import dataflow_plan_as_text
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFlowExplainResult, MetricFlowQueryResult
 from metricflow.model.data_warehouse_model_validator import DataWarehouseModelValidator
 from metricflow.model.model_validator import ModelValidator
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ValidationIssue, ValidationIssueLevel
 from metricflow.telemetry.models import TelemetryLevel
 from metricflow.telemetry.reporter import TelemetryReporter, log_call
@@ -589,6 +590,41 @@ def _filter_issues(
     return [issue for issue in issues if issue.level in inlcude_levels]
 
 
+def _run_dw_validations(
+    validation_func: Callable[..., List[ValidationIssue]],
+    validation_type: str,
+    model: UserConfiguredModel,
+    timeout: Optional[int],
+) -> List[ValidationIssue]:
+    """Helper handles the calling of data warehouse issue generating functions"""
+
+    spinner = Halo(text=f"Validating {validation_type} against data warehouse...", spinner="dots")
+    spinner.start()
+
+    issues = validation_func(model, timeout)
+    if issues is not None and len(issues) == 0:
+        spinner.succeed(f"🎉 Finished validating {validation_type} against data warehouse, no errors found")
+    else:
+        spinner.fail(f"Issues found when validating {validation_type} against data warehouse")
+    return issues
+
+
+def _data_warehouse_validations_runner(
+    dw_validator: DataWarehouseModelValidator, model: UserConfiguredModel, timeout: Optional[int]
+) -> None:
+    """Helper which calls the individual data warehouse validations to run and prints collected issues"""
+
+    issues: List[ValidationIssue] = []
+    issues += _run_dw_validations(
+        dw_validator.validate_data_sources, model=model, validation_type="data sources", timeout=timeout
+    )
+    issues += _run_dw_validations(
+        dw_validator.validate_metrics, model=model, validation_type="metrics", timeout=timeout
+    )
+
+    _print_issues(issues)
+
+
 @cli.command()
 @click.option(
     "--dw-timeout", required=False, type=int, help="Optional timeout for data warehouse validation steps. Default None."
@@ -629,34 +665,7 @@ def validate_configs(cfg: CLIContext, dw_timeout: Optional[int] = None, skip_dw:
 
     if not skip_dw:
         dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client, mf_engine=cfg.mf)
-
-        dw_spinner = Halo(text="Validating data source elements of model against data warehouse...", spinner="dots")
-        dw_spinner.start()
-
-        dw_issues = dw_validator.validate_data_sources(model=user_model, timeout=dw_timeout)
-        dw_errors = _filter_issues(dw_issues, [ValidationIssueLevel.ERROR, ValidationIssueLevel.FATAL])
-        if not dw_errors:
-            dw_spinner.succeed(
-                "🎉 Finished validating data source elements of model against data warehouse, no issues found"
-            )
-            dw_warnings = _filter_issues(dw_issues, [ValidationIssueLevel.FUTURE_ERROR, ValidationIssueLevel.WARNING])
-            _print_issues(dw_warnings)
-        else:
-            dw_spinner.fail("Issues found when validating data source elements of model against data warehouse")
-            _print_issues(dw_issues)
-
-        dw_spinner = Halo(text="Validating metric elements of model against data warehouse...", spinner="dots")
-        dw_spinner.start()
-
-        dw_issues = dw_validator.validate_metrics(model=user_model, timeout=dw_timeout)
-        dw_errors = _filter_issues(dw_issues, [ValidationIssueLevel.ERROR, ValidationIssueLevel.FATAL])
-        if not dw_errors:
-            dw_spinner.succeed("🎉 Finished validating metric elements of model against data warehouse, no issues found")
-            dw_warnings = _filter_issues(dw_issues, [ValidationIssueLevel.FUTURE_ERROR, ValidationIssueLevel.WARNING])
-            _print_issues(dw_warnings)
-        else:
-            dw_spinner.fail("Issues found when validating metric elements of model against data warehouse")
-            _print_issues(dw_issues)
+        _data_warehouse_validations_runner(dw_validator=dw_validator, model=user_model, timeout=dw_timeout)
 
 
 if __name__ == "__main__":

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -645,6 +645,19 @@ def validate_configs(cfg: CLIContext, dw_timeout: Optional[int] = None, skip_dw:
             dw_spinner.fail("Issues found when validating data source elements of model against data warehouse")
             _print_issues(dw_issues)
 
+        dw_spinner = Halo(text="Validating metric elements of model against data warehouse...", spinner="dots")
+        dw_spinner.start()
+
+        dw_issues = dw_validator.validate_metrics(model=user_model, timeout=dw_timeout)
+        dw_errors = _filter_issues(dw_issues, [ValidationIssueLevel.ERROR, ValidationIssueLevel.FATAL])
+        if not dw_errors:
+            dw_spinner.succeed("🎉 Finished validating metric elements of model against data warehouse, no issues found")
+            dw_warnings = _filter_issues(dw_issues, [ValidationIssueLevel.FUTURE_ERROR, ValidationIssueLevel.WARNING])
+            _print_issues(dw_warnings)
+        else:
+            dw_spinner.fail("Issues found when validating metric elements of model against data warehouse")
+            _print_issues(dw_issues)
+
 
 if __name__ == "__main__":
     cli()

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -628,7 +628,7 @@ def validate_configs(cfg: CLIContext, dw_timeout: Optional[int] = None, skip_dw:
         return
 
     if not skip_dw:
-        dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client)
+        dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client, mf_engine=cfg.mf)
 
         dw_spinner = Halo(text="Validating data source elements of model against data warehouse...", spinner="dots")
         dw_spinner.start()

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from time import perf_counter
 from typing import List, Optional, OrderedDict as ODType
+from metricflow.engine.metricflow_engine import MetricFlowEngine
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -94,8 +95,9 @@ class DataWarehouseModelValidator:
     them (assuming the model has passed these validations before use).
     """
 
-    def __init__(self, sql_client: SqlClient) -> None:  # noqa: D
+    def __init__(self, sql_client: SqlClient, mf_engine: MetricFlowEngine) -> None:  # noqa: D
         self._sql_client = sql_client
+        self._mf_engine = mf_engine
 
     def run_tasks(
         self, tasks: List[DataWarehouseValidationTask], timeout: Optional[int] = None

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -2,12 +2,14 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from time import perf_counter
 from typing import List, Optional, OrderedDict as ODType
-from metricflow.engine.metricflow_engine import MetricFlowEngine
+from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowExplainResult, MetricFlowQueryRequest
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.validations.validator_helpers import ValidationError, ValidationIssue, ValidationWarning
 from metricflow.protocols.sql_client import SqlClient
+from metricflow.sql.sql_bind_parameters import SqlBindParameters
 
 
 @dataclass
@@ -17,6 +19,7 @@ class DataWarehouseValidationTask:
     query_string: str
     error_message: str
     object_ref: ODType = field(default_factory=lambda: OrderedDict())
+    query_params: SqlBindParameters = field(default_factory=lambda: SqlBindParameters())
 
 
 class DataWarehouseTaskBuilder:
@@ -85,6 +88,28 @@ class DataWarehouseTaskBuilder:
             )
         return tasks
 
+    @staticmethod
+    def gen_metric_tasks(model: UserConfiguredModel, mf_engine: MetricFlowEngine) -> List[DataWarehouseValidationTask]:
+        """Generates a list of tasks for validating the metrics of the model"""
+        primary_time_dim = SemanticModel(
+            user_configured_model=model
+        ).data_source_semantics.primary_time_dimension_reference
+        tasks: List[DataWarehouseValidationTask] = []
+        for metric in model.metrics:
+            mf_query = MetricFlowQueryRequest.create_with_random_request_id(
+                metric_names=[metric.name], group_by_names=[primary_time_dim.element_name]
+            )
+            explain_result: MetricFlowExplainResult = mf_engine.explain(mf_request=mf_query)
+            tasks.append(
+                DataWarehouseValidationTask(
+                    query_string=explain_result.rendered_sql.sql_query,
+                    query_params=explain_result.rendered_sql.bind_parameters,
+                    object_ref=ValidationIssue.make_object_reference(metric_name=metric.name),
+                    error_message=f"Unable to query metric `{metric.name}`.",
+                )
+            )
+        return tasks
+
 
 class DataWarehouseModelValidator:
     """A Validator for checking specific tasks for the model against the Data Warehouse
@@ -123,7 +148,7 @@ class DataWarehouseModelValidator:
                 )
                 break
             try:
-                self._sql_client.dry_run(stmt=task.query_string)
+                self._sql_client.dry_run(stmt=task.query_string, sql_bind_parameters=task.query_params)
             except Exception as e:
                 issues.append(
                     ValidationError(
@@ -140,4 +165,18 @@ class DataWarehouseModelValidator:
         :param timeout int: An optional timeout. Default is None. When the timeout is hit, function will return early.
         """
         tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(model=model)
+        return self.run_tasks(tasks=tasks, timeout=timeout)
+
+    def validate_metrics(self, model: UserConfiguredModel, timeout: Optional[int] = None) -> List[ValidationIssue]:
+        """Generates a list of tasks for validating the metrics of the model and then runs them
+
+        Args:
+            model: Model which to run data warehouse validations on
+            timeout: An optional timeout. Default is None. When the timeout is hit, function will return early.
+
+        Returns:
+            A list of validation issues. If there are no validation issues, an empty list is returned.
+        """
+
+        tasks = DataWarehouseTaskBuilder.gen_metric_tasks(model=model, mf_engine=self._mf_engine)
         return self.run_tasks(tasks=tasks, timeout=timeout)

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -12,6 +12,11 @@ from metricflow.cli.cli_context import CLIContext
 from metricflow.engine.models import Dimension, Materialization, Metric
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFlowQueryResult
+from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
+from metricflow.model.objects.elements.dimension import Dimension as DimensionObj, DimensionType, DimensionTypeParams
+from metricflow.model.objects.metric import Metric as MetricObj
+from metricflow.specs import DimensionReference
+from metricflow.time.time_granularity import TimeGranularity
 
 
 class MockMetricFlowEngine:
@@ -70,7 +75,31 @@ class MockSemanticModel:
 class MockUserConfiguredModel:
     """Mock UserConfiguredModel class as only integration is needed to be tested."""
 
-    pass
+    @property
+    def data_sources(self) -> List[DataSource]:  # noqa: D
+        return [
+            DataSource(
+                name="animals",
+                sql_query="SELECT true as foo, '2022-06-01' as ds",
+                measures=[],
+                dimensions=[
+                    DimensionObj(
+                        name=DimensionReference(element_name="ds"),
+                        type=DimensionType.TIME,
+                        type_params=DimensionTypeParams(
+                            is_primary=True,
+                            time_granularity=TimeGranularity.DAY,
+                        ),
+                    ),
+                    DimensionObj(name=DimensionReference(element_name="foo"), type=DimensionType.CATEGORICAL),
+                ],
+                mutability=Mutability(type=MutabilityType.IMMUTABLE),
+            )
+        ]
+
+    @property
+    def metrics(self) -> List[MetricObj]:  # noqa: D
+        return []
 
 
 class MetricFlowCliRunner(CliRunner):

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -249,3 +249,15 @@ def extended_date_semantic_model(mf_test_session_state: MetricFlowTestSessionSta
     )
     assert model_build_result.model
     return SemanticModel(model_build_result.model)
+
+
+@pytest.fixture(scope="session")
+def data_warehouse_validation_model(template_mapping: Dict[str, str]) -> UserConfiguredModel:
+    """Model used for data warehouse validation tests"""
+
+    model_build_result = parse_directory_of_yaml_files_to_model(
+        os.path.join(os.path.dirname(__file__), "model_yamls/data_warehouse_validation_model"),
+        template_mapping=template_mapping,
+    )
+    assert model_build_result.model
+    return model_build_result.model

--- a/metricflow/test/fixtures/model_yamls/data_warehouse_validation_model/data_sources/data_source1.yml
+++ b/metricflow/test/fixtures/model_yamls/data_warehouse_validation_model/data_sources/data_source1.yml
@@ -1,0 +1,25 @@
+---
+data_source:
+  name: animals
+  description: If a user is a company / business, this defines the mapping.
+  owners:
+    - support@transformdata.io
+
+  sql_query: "SELECT true AS is_dog, '2022-06-01' AS ds"
+
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+    - name: is_dog
+      type: categorical
+      is_partition: True
+  measures:
+    - name: count_dogs
+      agg: sum
+      expr: is_dog
+      create_metric: True
+  mutability:
+    type: immutable

--- a/metricflow/test/model/validations/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/validations/test_data_warehouse_tasks.py
@@ -1,56 +1,60 @@
+from copy import deepcopy
+import pytest
+from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.model.data_warehouse_model_validator import (
     DataWarehouseModelValidator,
     DataWarehouseTaskBuilder,
     DataWarehouseValidationTask,
 )
+from metricflow.model.model_transformer import ModelTransformer
 
 from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
-from metricflow.model.objects.elements.dimension import Dimension, DimensionType
+from metricflow.model.objects.elements.measure import AggregationType, Measure
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.validations.validator_helpers import ValidationIssueLevel
+from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
+from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.specs import DimensionReference
+from metricflow.specs import MeasureReference
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.test_utils import as_datetime
+from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 
-def test_build_data_source_tasks() -> None:  # noqa:D
-    dim_ref_1 = DimensionReference(element_name="dim1")
-    dim_ref_2 = DimensionReference(element_name="dim1")
-
-    model = UserConfiguredModel(
-        data_sources=[
-            DataSource(
-                name="test_data_source",
-                sql_table="test.data_source",
-                dimensions=[
-                    Dimension(name=dim_ref_1, type=DimensionType.CATEGORICAL, is_partition=True),
-                    Dimension(
-                        name=dim_ref_2,
-                        type=DimensionType.CATEGORICAL,
-                        is_partition=True,
-                        expr="animal in ('cat', 'dog', 'platypus')",
-                    ),
-                ],
-                mutability=Mutability(type=MutabilityType.IMMUTABLE),
-            ),
-        ],
-        metrics=[],
-        materializations=[],
+@pytest.fixture(scope="module")
+def mf_engine(  # noqa: D
+    data_warehouse_validation_model: UserConfiguredModel,
+    sql_client: SqlClient,
+    time_spine_source: TimeSpineSource,
+    mf_test_session_state: MetricFlowTestSessionState,
+) -> MetricFlowEngine:
+    semantic_model = SemanticModel(data_warehouse_validation_model)
+    return MetricFlowEngine(
+        semantic_model=semantic_model,
+        sql_client=sql_client,
+        column_association_resolver=DefaultColumnAssociationResolver(semantic_model=semantic_model),
+        time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
+        time_spine_source=time_spine_source,
+        system_schema=mf_test_session_state.mf_system_schema,
     )
 
-    tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(model=model)
-    assert len(tasks) == 1
+
+def test_build_data_source_tasks(data_warehouse_validation_model: UserConfiguredModel) -> None:  # noqa:D
+    tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(model=data_warehouse_validation_model)
+    assert len(tasks) == len(data_warehouse_validation_model.data_sources)
     assert (
         tasks[0].query_string
-        == "SELECT (true) AS col0 FROM test.data_source WHERE dim1 IS NOT NULL AND (animal in ('cat', 'dog', 'platypus')) IS NOT NULL"
+        == "SELECT (true) AS col0 FROM (SELECT true AS is_dog, '2022-06-01' AS ds) WHERE is_dog IS NOT NULL"
     )
 
 
-def test_task_runner(sql_client: SqlClient) -> None:  # noqa: D
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
+def test_task_runner(sql_client: SqlClient, mf_engine: MetricFlowEngine) -> None:  # noqa: D
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=mf_engine)
 
     tasks = [
         DataWarehouseValidationTask(query_string="SELECT 'foo' AS foo", error_message="Could not select foo"),
-        DataWarehouseValidationTask(query_string="SELECT 'bar' as bar", error_message="Could not select bar"),
+        DataWarehouseValidationTask(query_string="SELECT 'bar' AS bar", error_message="Could not select bar"),
     ]
 
     issues = dw_validator.run_tasks(tasks=tasks)
@@ -68,21 +72,12 @@ def test_task_runner(sql_client: SqlClient) -> None:  # noqa: D
     assert err_msg_bad in issues[0].message
 
 
-def test_validate_data_sources(sql_client: SqlClient) -> None:  # noqa: D
-    model = UserConfiguredModel(
-        data_sources=[
-            DataSource(
-                name="test_data_source",
-                sql_query="SELECT 'foo' as foo",
-                dimensions=[],
-                mutability=Mutability(type=MutabilityType.IMMUTABLE),
-            ),
-        ],
-        metrics=[],
-        materializations=[],
-    )
+def test_validate_data_sources(  # noqa: D
+    data_warehouse_validation_model: UserConfiguredModel, sql_client: SqlClient, mf_engine: MetricFlowEngine
+) -> None:
+    model = deepcopy(data_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
+    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=mf_engine)
 
     issues = dw_validator.validate_data_sources(model)
     assert len(issues) == 0

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/test_build_metric_tasks__query0.sql
@@ -1,0 +1,19 @@
+-- Read Elements From Data Source 'animals'
+-- Constrain Time Range to [2000-01-01T00:00:00, 2040-12-31T00:00:00]
+-- Pass Only Elements:
+--   ['count_dogs', 'ds']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(is_dog) AS count_dogs
+  , ds
+FROM (
+  SELECT true AS is_dog, '2022-06-01' AS ds
+) animals_src_0
+WHERE (
+  ds >= CAST('2000-01-01' AS TEXT)
+) AND (
+  ds <= CAST('2040-12-31' AS TEXT)
+)
+GROUP BY
+  ds


### PR DESCRIPTION
Perhaps the most important data warehouse validation is ensuring all metrics defined in the model will run in the data warehouse. This PR adds metric based data warehouse validations to the `DataWarhouseModelValidator`. Additionally, these validations are now run as part of `validate-configs`