### PR TITLE
Add Method to Cancel Running Queries

### DIFF
--- a/metricflow/object_utils.py
+++ b/metricflow/object_utils.py
@@ -150,7 +150,7 @@ def random_id() -> str:
     return "".join(random.choices(filtered_alphabet, k=8))
 
 
-def assert_values_exhausted(value: NoReturn) -> NoReturn:
+def assert_values_exhausted(value: Enum) -> NoReturn:
     """Helper method to allow MyPy to guarantee an exhaustive switch through an enumeration or literal
 
     See https://mypy.readthedocs.io/en/stable/literal_types.html#exhaustiveness-checks

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -137,6 +137,11 @@ class SqlClient(Protocol):
         """Close the connections / engines used by this client."""
         raise NotImplementedError
 
+    @abstractmethod
+    def cancel_submitted_queries(self) -> None:  # noqa: D
+        """Cancel queries submitted through this client (that may be still running) with best-effort."""
+        raise NotImplementedError
+
 
 class SqlEngineAttributes(Protocol):
     """Base interface for SQL engine-specific attributes and features
@@ -160,6 +165,7 @@ class SqlEngineAttributes(Protocol):
     multi_threading_supported: ClassVar[bool]
     timestamp_type_supported: ClassVar[bool]
     timestamp_to_string_comparison_supported: ClassVar[bool]
+    cancel_submitted_queries_supported: ClassVar[bool]
 
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str]

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -28,6 +28,8 @@ class BigQueryEngineAttributes:
     multi_threading_supported: ClassVar[bool] = True
     timestamp_type_supported: ClassVar[bool] = True
     timestamp_to_string_comparison_supported: ClassVar[bool] = False
+    # Cancelling should be possible, but not yet implemented.
+    cancel_submitted_queries_supported: ClassVar[bool] = False
 
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "FLOAT64"
@@ -107,3 +109,6 @@ class BigQuerySqlClient(SqlAlchemySqlClient):
             insp = sqlalchemy.inspection.inspect(conn)
             schema_dot_tables = insp.get_table_names(schema=schema_name)
             return [x.replace(schema_name + ".", "") for x in schema_dot_tables]
+
+    def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -12,7 +12,7 @@ from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 logger = logging.getLogger(__name__)
 
 
-class RedshiftEngineAttributes:
+class RedshiftEngineAttributes(SqlEngineAttributes):
     """Engine-specific attributes for the Redshift query engine
 
     This is an implementation of the SqlEngineAttributes protocol for Redshift
@@ -27,6 +27,8 @@ class RedshiftEngineAttributes:
     multi_threading_supported: ClassVar[bool] = True
     timestamp_type_supported: ClassVar[bool] = True
     timestamp_to_string_comparison_supported: ClassVar[bool] = True
+    # Cancelling should be possible, but not yet implemented.
+    cancel_submitted_queries_supported: ClassVar[bool] = False
 
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE PRECISION"
@@ -84,3 +86,6 @@ class RedshiftSqlClient(SqlAlchemySqlClient):
     def sql_engine_attributes(self) -> SqlEngineAttributes:
         """Collection of attributes and features specific to the Snowflake SQL engine"""
         return RedshiftEngineAttributes()
+
+    def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/sql_clients/sqlite.py
+++ b/metricflow/sql_clients/sqlite.py
@@ -13,7 +13,7 @@ from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 
-class SQLiteEngineAttributes:
+class SQLiteEngineAttributes(SqlEngineAttributes):
     """Engine-specific attributes for the SQLite query engine
 
     This is an implementation of the SqlEngineAttributes protocol for SQLite
@@ -28,6 +28,8 @@ class SQLiteEngineAttributes:
     multi_threading_supported: ClassVar[bool] = False
     timestamp_type_supported: ClassVar[bool] = False
     timestamp_to_string_comparison_supported: ClassVar[bool] = False
+    sleep_supported: ClassVar[bool] = False
+    cancel_submitted_queries_supported: ClassVar[bool] = False
 
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE"
@@ -105,3 +107,6 @@ class SqliteSqlClient(SqlAlchemySqlClient):
 
     def drop_schema(self, schema_name: str, cascade: bool = True) -> None:  # noqa: D
         logger.info(f"Not dropping schema '{schema_name}' since this SQLite DB is ephemeral")
+
+    def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError


### PR DESCRIPTION
This PR add a method to `SqlClient` to enable cancelling of running queries. This could be useful if a large query is submitted by mistake and the user wants to cancel running it.