### PR TITLE
docs(sql-client): add instructions to run tests against local postgres

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ Welcome to the MetricFlow developer community, we're thrilled to have you aboard
         - Mac users might prefer to use Homebrew: `brew install postgresql`
     - SQLite:
         - You likely have this installed already, but if it is missing [SQLite provides pre-built packages for download and installation](https://www.sqlite.org/download.html)
+    - Docker:
+        - This is only required if you are developing with Postgres.
+        - Follow the [instructions from Docker](https://docs.docker.com/get-docker/)
 3. [Create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of the [MetricFlow repo](https://github.com/transform-data/metricflow) and [clone it locally](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository). 
 4. Activate a [Python virtual environment](https://docs.python.org/3/library/venv.html). While this is not required, it is *strongly* encouraged.
     - We provide `make venv` and `make remove_venv` helpers for creating/deleting standard Python virtual envs. You may pass `VENV_NAME=your_custom_name` to override the default `venv` location.
@@ -56,6 +59,7 @@ You're ready to start! Note all `make` and `poetry` commands should be run from 
         - `export MF_SQL_ENGINE_URL=<YOUR_WAREHOUSE_CONNECTION_URL>`
         - `export MF_SQL_ENGINE_PASSWORD=<YOUR_WAREHOUSE_PASSWORD>`
     - Run `make test` to execute the entire test suite against the target engine.
+    - By default, without `MF_SQL_ENGINE_URL` and `MF_SQL_ENGINE_PASSWORD` set, your tests will run against SQLite. 
 4. Run the linters with `make lint` at any time, but especially before submitting a PR. We use:
     - `Black` for formatting
     - `Flake8` for general Python linting

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ VENV_NAME?=venv
 .PHONY: venv
 venv:
 	python3 -m venv $(VENV_NAME) && echo "To activate your new virtual environment, run:\nsource $(VENV_NAME)/bin/activate"
+
 .PHONY: remove_venv
 remove_venv:
 	rm -rf $(VENV_NAME) && echo "If $(VENV_NAME) was active when you ran this command you will need to run deactivate"
@@ -16,10 +17,21 @@ remove_venv:
 .PHONY: install
 install:
 	poetry install
+
 # Testing and linting
 .PHONY: test
 test:
 	poetry run pytest metricflow/test/
+
+.PHONY: test-postgresql
+test-postgresql:
+	MF_SQL_ENGINE_URL="postgresql://metricflow@localhost:5432/metricflow" MF_SQL_ENGINE_PASSWORD="metricflowing" poetry run pytest metricflow/test/
+
 .PHONY: lint
 lint:
 	pre-commit run --all-files
+
+# Running data warehouses locally
+.PHONY: postgresql
+postgresql:
+	make -C local-data-warehouses postgresql

--- a/local-data-warehouses/Makefile
+++ b/local-data-warehouses/Makefile
@@ -1,0 +1,7 @@
+#
+# Local Data Warehouse Setup
+#
+
+.PHONY: postgresql
+postgresql:
+	docker-compose -f postgresql/docker-compose.yaml up

--- a/local-data-warehouses/README.md
+++ b/local-data-warehouses/README.md
@@ -1,0 +1,28 @@
+# Local Data Warehouses
+
+This folder includes utilities to run data warehouses for local development. See the [Contributing guide](../CONTRIBUTING.md)
+to ensure your environment is setup properly.
+
+## SQLite
+
+We assume that you have SQLite installed in your environment. By default, tests will run with SQLite.
+
+## PostgreSQL
+
+We assume that you have PostgreSQL and Docker installed in your environment.
+
+In a separate terminal window, run PostgreSQL in the background.
+
+```sh
+make postgres
+```
+
+Then, when running `pytest`, ensure that `MF_SQL_ENGINE_URL` and `MF_SQL_ENGINE_PASSWORD` are setup
+to access the PostgreSQL instance.
+
+```sh
+export MF_SQL_ENGINE_URL="postgresql://metricflow@localhost:5432/metricflow"
+export MF_SQL_ENGINE_PASSWORD="metricflowing"
+
+poetry run pytest metricflow/test/
+```

--- a/local-data-warehouses/postgresql/docker-compose.yaml
+++ b/local-data-warehouses/postgresql/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3.7"
+
+services:
+  postgres:
+    container_name: postgres
+    image: postgres
+    expose:
+      - "5432"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: "metricflow"
+      POSTGRES_PASSWORD: "metricflowing"
+      POSTGRES_DB: "metricflow"


### PR DESCRIPTION
As the title. 

#### Test Plan
In a separate window:

```
make postgresql
```

In the main window:

```
make test-postgresql
```

All tests fail until #99 lands.