### PR TITLE
Removing extra space in the MetricFlow tutorial in Step 7 of the README.md file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For reference, the tutorial steps are below:
     4.  Check out dimensions for your metric `mf list-dimensions --metric-names transactions`
     5.  Query your first metric: `mf query --metrics transactions --dimensions ds --order ds`
     6.  Show the SQL MetricFlow generates: `mf query --metrics transactions --dimensions ds --order ds --explain`
-    7.  Visualize the plan: `mf query --metrics transactions --dimensions ds --order ds --explain -- display-plans`
+    7.  Visualize the plan: `mf query --metrics transactions --dimensions ds --order ds --explain --display-plans`
         * This only works if you have graphviz installed - see README.
         * Aesthetic improvements to the visualization are TBD.
     8.  Add another dimension: `mf query --metrics transactions --dimensions ds,customer__country --order ds`


### PR DESCRIPTION
**Issue opened here**: https://github.com/transform-data/metricflow/issues/56 

**Why:** The tutorial section has a Step 7 with the original code `mf query --metrics transactions --dimensions ds --order ds --explain -- display-plans` (note the extra space prior to the `display-plans`). This was throwing an error. 

**What was changed:** Removing the space prior to `display-plans` to fix the command, now showing up as `mf query --metrics transactions --dimensions ds --order ds --explain --display-plans`