### PR TITLE
Clean up docstrings to ensure all follow google docstring formatting

### DIFF
--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -64,8 +64,11 @@ class DataWarehouseTaskBuilder:
         query would be "SELECT (dim2) as col1, (dim3) as col2 FROM table1 WHERE
         dim1 IS NOT NULL".
 
-        :param data_source DataSource: The data source to gen the query for
-        :param columns List[str]: Column strings to select
+        Args:
+            data_source: The data source to generate the query for
+            columns: Column strings to select
+        Returns:
+            A string representing the query for the passed in arguments.
         """
         data_source_str = data_source.sql_table if data_source.sql_table else f"({data_source.sql_query})"
 
@@ -178,8 +181,12 @@ class DataWarehouseModelValidator:
     ) -> List[ValidationIssue]:
         """Runs the list of tasks as queries agains the data warehouse, returning any found issues
 
-        :param tasks List[DataWarehouseValidationTask]: A list of tasks to run
-        :param timeout int: An optional timeout. Default is None. When the timeout is hit, function will return early.
+        Args:
+            tasks: A list of tasks to run against the data warehouse
+            timeout: An optional timeout. Default is None. When the timeout is hit, function will return early.
+
+        Returns:
+            A list of validation issues discovered when running the passed in tasks against the data warehosue
         """
 
         # Used for keeping track if we go past the max time
@@ -214,8 +221,12 @@ class DataWarehouseModelValidator:
     def validate_data_sources(self, model: UserConfiguredModel, timeout: Optional[int] = None) -> List[ValidationIssue]:
         """Generates a list of tasks for validating the data sources of the model and then runs them
 
-        :param model UserConfiguredModel: Model which to run data warehouse validations on
-        :param timeout int: An optional timeout. Default is None. When the timeout is hit, function will return early.
+        Args:
+            model: Model which to run data warehouse validations on
+            timeout: An optional timeout. Default is None. When the timeout is hit, function will return early.
+
+        Returns:
+            A list of validation issues discovered when running the passed in tasks against the data warehosue
         """
         tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(model=model)
         return self.run_tasks(tasks=tasks, timeout=timeout)

--- a/metricflow/model/validations/element_const.py
+++ b/metricflow/model/validations/element_const.py
@@ -99,9 +99,13 @@ class ElementConsistencyRule(ModelValidationRule):
     ) -> List[ValidationIssueType]:  # noqa: D
         """Check if the elements in the data source matches the expected type.
 
-        :param model: UserConfiguredModel to check
-        :param data_source: the data source to check
-        :param add_to_dict: if the given element does not exist in the dictionary, whether to add it.
+        Args:
+            model: UserConfiguredModel to check
+            data_source: the data source to check
+            add_to_dict: if the given element does not exist in the dictionary, whether to add it.
+
+        Returns:
+            A list of validation issues found with elements of data sources for the model
         """
         measure_name_tuples = [(x.name, ModelObjectType.MEASURE) for x in data_source.measures or []]
         dimension_name_tuples = [(x.name, ModelObjectType.DIMENSION) for x in data_source.dimensions or []]

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -46,10 +46,10 @@ class SqlClient(Protocol):
     ) -> None:
         """Method for creating a table from the provided select query
 
-        :param SqlTable sql_table: - the SqlTable metadata of the table to create
-        :param str select_query: - the query to use to populate the table
-        :param SqlBindParameters sql_bind_parameters: map of values to substitute in to
-        parameterized sql query strings
+        Args:
+            sql_table: The SqlTable metadata of the table to create
+            select_query: The query to use to populate the table
+            sql_bind_parameters: Map of values to substitute in to parameterized sql query strings
         """
         raise NotImplementedError
 
@@ -62,9 +62,10 @@ class SqlClient(Protocol):
     ) -> None:
         """Creates a table and populates it with the contents of the dataframe
 
-        :param SqlTable sql_table: - The SqlTable metadata of the table to create
-        :param DataFrame df: - the Pandas DataFrame with the contents of the target table
-        :param Optional[int] chunk_size: - the number of rows to write per query
+        Args:
+            sql_table: The SqlTable metadata of the table to create
+            df: The Pandas DataFrame with the contents of the target table
+            chunk_size: The number of rows to write per query
         """
         raise NotImplementedError
 

--- a/metricflow/sql_clients/base_sql_client_implementation.py
+++ b/metricflow/sql_clients/base_sql_client_implementation.py
@@ -73,9 +73,10 @@ class BaseSqlClientImplementation(ABC, SqlClient):
     ) -> pd.DataFrame:
         """Query statement; result expected to be data which will be returned as a DataFrame
 
-        :param stmt str:  - The SQL query statement to run. This should produce output via a SELECT
-        :param sql_bind_parameters SqlQueryExecutionParameters: - The parameter replacement mapping for filling in
-        concrete values for SQL query parameters.
+        Args:
+            stmt: The SQL query statement to run. This should produce output via a SELECT
+            sql_bind_parameters: The parameter replacement mapping for filling in
+                concrete values for SQL query parameters.
         """
         start = time.time()
         logger.info(
@@ -113,9 +114,10 @@ class BaseSqlClientImplementation(ABC, SqlClient):
     ) -> None:
         """Dry run statement; checks that the 'stmt' is queryable. Returns None. Raises an exception if the 'stmt' isn't queryable.
 
-        :param stmt str:  - The SQL query statement to dry run.
-        :param sql_bind_parameters SqlQueryExecutionParameters: - The parameter replacement mapping for filling in
-        concrete values for SQL query parameters.
+        Args:
+            stmt: The SQL query statement to dry run.
+            sql_bind_parameters: The parameter replacement mapping for filling in
+                concrete values for SQL query parameters.
         """
         start = time.time()
         logger.info(


### PR DESCRIPTION
We used to use a lot of reST style doc strings in our infrastructure. After cutting things over to metricflow we started using google style docstrings for documenting classes / methods / etc. However, not everything got converted over, there were still some stragglers. This PR simply makes sure any docstrings following the old reST style now follow the google style.