### PR TITLE
Add the ability to pass custom rules to ModelTransformer

### DIFF
--- a/metricflow/model/model_transformer.py
+++ b/metricflow/model/model_transformer.py
@@ -1,11 +1,14 @@
 import copy
 import logging
 
+from typing import Sequence
+
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.transformations.boolean_measure import BooleanMeasureAggregationRule
 from metricflow.model.transformations.identifiers import CompositeIdentifierExpressionRule
 from metricflow.model.transformations.names import LowerCaseNamesRule
 from metricflow.model.transformations.proxy_measure import CreateProxyMeasureRule
+from metricflow.model.transformations.transform_rule import ModelTransformRule
 
 logger = logging.getLogger(__name__)
 
@@ -16,24 +19,33 @@ class ModelTransformer:
     Generally used to make it more convenient for the user to develop their model.
     """
 
+    DEFAULT_PRE_VALIDATION_RULES: Sequence[ModelTransformRule] = (LowerCaseNamesRule(),)
+
+    DEFAULT_POST_VALIDATION_RULES: Sequence[ModelTransformRule] = (
+        CreateProxyMeasureRule(),
+        BooleanMeasureAggregationRule(),
+        CompositeIdentifierExpressionRule(),
+    )
+
     @staticmethod
-    def pre_validation_transform_model(model: UserConfiguredModel) -> UserConfiguredModel:
+    def pre_validation_transform_model(
+        model: UserConfiguredModel, rules: Sequence[ModelTransformRule] = DEFAULT_PRE_VALIDATION_RULES
+    ) -> UserConfiguredModel:
         """Transform a model according to configured rules."""
         model_copy = copy.deepcopy(model)
-        for transform_rule in (LowerCaseNamesRule(),):
+
+        for transform_rule in rules:
             model_copy = transform_rule.transform_model(model_copy)
 
         return model_copy
 
     @staticmethod
-    def post_validation_transform_model(model: UserConfiguredModel) -> UserConfiguredModel:
+    def post_validation_transform_model(
+        model: UserConfiguredModel, rules: Sequence[ModelTransformRule] = DEFAULT_POST_VALIDATION_RULES
+    ) -> UserConfiguredModel:
         """Transform a model according to configured rules."""
         model_copy = copy.deepcopy(model)
-        for transform_rule in (
-            CreateProxyMeasureRule(),
-            BooleanMeasureAggregationRule(),
-            CompositeIdentifierExpressionRule(),
-        ):
+        for transform_rule in rules:
             model_copy = transform_rule.transform_model(model_copy)
 
         return model_copy

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -231,6 +231,7 @@ def simple_model__pre_transforms(template_mapping: Dict[str, str]) -> UserConfig
         os.path.join(os.path.dirname(__file__), "model_yamls/simple_model"),
         template_mapping=template_mapping,
         apply_pre_transformations=True,
+        apply_post_transformations=False,
     )
     assert model_build_result.model
     return model_build_result.model

--- a/metricflow/test/model/transformations/test_configurable_transform_rules.py
+++ b/metricflow/test/model/transformations/test_configurable_transform_rules.py
@@ -1,0 +1,32 @@
+from metricflow.model.model_transformer import ModelTransformer
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.transformations.transform_rule import ModelTransformRule
+
+
+class SliceNamesRule(ModelTransformRule):
+    """Slice the names of data source elements in a model
+
+    NOTE: specifically for testing
+    """
+
+    @staticmethod
+    def transform_model(model: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
+        for data_source in model.data_sources:
+            data_source.name = data_source.name[:3]
+        return model
+
+
+def test_can_configure_model_transform_rules(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    pre_model = simple_model__pre_transforms
+    assert not all(len(x.name) == 3 for x in pre_model.data_sources)
+
+    # Confirms that a custom transformation works for pre-validation transform
+    pre_model = ModelTransformer.pre_validation_transform_model(pre_model, rules=[SliceNamesRule()])
+    assert all(len(x.name) == 3 for x in pre_model.data_sources)
+
+    post_model = simple_model__pre_transforms
+    assert not all(len(x.name) == 3 for x in post_model.data_sources)
+
+    # Confirms that a custom transformation works for post-validation transform
+    post_model = ModelTransformer.post_validation_transform_model(post_model, rules=[SliceNamesRule()])
+    assert all(len(x.name) == 3 for x in post_model.data_sources)


### PR DESCRIPTION
## Context
Currently, we have a set of rules that gets ran for transforming the model pre/post validation. However, this isn't extensible in a way that we can't customize it for certain scenarios. So similarly to the `ModelValidator` changes, we would want to make it so we can pass custom rules that can be ran during transformation without having to run the preset rules all the time.

## Changes
- Enable the ability to pass custom build `ModelTransformRule` into the `rules` param to run those custom rules instead of the default rules