### PR TITLE
Add DuckDB Support for Local Tests

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -109,6 +109,39 @@ jobs:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
 
+  sqlite-tests:
+    environment: DW_INTEGRATION_TESTS
+    name: SQLite Tests
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.pythonLocation }}
+            ~/.cache/pypoetry
+          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+
+      - name: Install Poetry
+        run: pip install poetry && poetry config virtualenvs.create false
+
+      - name: Install Deps
+        run: cd metricflow && poetry install
+
+      - name: Run MetricFlow unit tests with SQLite configs
+        run: pytest metricflow/test/integration
+        env:
+          MF_SQL_ENGINE_URL: "sqlite://"
+
+
   slack-failure:
     environment: DW_INTEGRATION_TESTS
     needs: [ snowflake-tests, redshift-tests, bigquery-tests]

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -14,6 +14,7 @@ class SupportedSqlEngine(Enum):
     """Enumeration of DB engines currently supported by MetricFlow"""
 
     BIGQUERY = "BigQuery"
+    DUCKDB = "DuckDB"
     REDSHIFT = "Redshift"
     POSTGRES = "Postgres"
     SNOWFLAKE = "Snowflake"

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -1,0 +1,43 @@
+from metricflow.sql.render.expr_renderer import (
+    DefaultSqlExpressionRenderer,
+    SqlExpressionRenderer,
+    SqlExpressionRenderResult,
+)
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.sql_exprs import (
+    SqlTimeDeltaExpression,
+)
+from metricflow.time.time_granularity import TimeGranularity
+
+
+class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
+    """Expression renderer for the DuckDB engine."""
+
+    def visit_time_delta_expr(self, node: SqlTimeDeltaExpression) -> SqlExpressionRenderResult:  # noqa: D
+        arg_rendered = node.arg.accept(self)
+        if node.grain_to_date:
+            return SqlExpressionRenderResult(
+                sql=f"DATE_TRUNC('{node.granularity.value}', {arg_rendered.sql}::timestamp)",
+                execution_parameters=arg_rendered.execution_parameters,
+            )
+
+        count = node.count
+        granularity = node.granularity
+        if granularity == TimeGranularity.QUARTER:
+            granularity = TimeGranularity.MONTH
+            count *= 3
+
+        return SqlExpressionRenderResult(
+            sql=f"{arg_rendered.sql} - INTERVAL {count} {granularity.value}",
+            execution_parameters=arg_rendered.execution_parameters,
+        )
+
+
+class DuckDbSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+    """Plan renderer for the DuckDB engine."""
+
+    EXPR_RENDERER = DuckDbSqlExpressionRenderer()
+
+    @property
+    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa :D
+        return self.EXPR_RENDERER

--- a/metricflow/sql_clients/common_client.py
+++ b/metricflow/sql_clients/common_client.py
@@ -6,6 +6,7 @@ from metricflow.object_utils import ExtendedEnum
 class SqlDialect(ExtendedEnum):
     """All SQL dialects that MQL currently supports. Value of enum is used in URLs as the dialect."""
 
+    DUCKDB = "duckdb"
     REDSHIFT = "redshift"
     POSTGRESQL = "postgresql"
     MYSQL = "mysql"

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -21,7 +21,7 @@ class DuckDbEngineAttributes(SqlEngineAttributes):
     date_trunc_supported: ClassVar[bool] = True
     full_outer_joins_supported: ClassVar[bool] = True
     indexes_supported: ClassVar[bool] = True
-    multi_threading_supported: ClassVar[bool] = True
+    multi_threading_supported: ClassVar[bool] = False
     timestamp_type_supported: ClassVar[bool] = True
     timestamp_to_string_comparison_supported: ClassVar[bool] = True
     # Cancelling should be possible, but not yet implemented.

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -1,0 +1,60 @@
+import logging
+from typing import ClassVar, Optional
+
+import sqlalchemy
+
+from metricflow.protocols.sql_client import SupportedSqlEngine, SqlEngineAttributes
+from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql_clients.common_client import SqlDialect
+from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
+
+logger = logging.getLogger(__name__)
+
+
+class DuckDbEngineAttributes(SqlEngineAttributes):
+    """Engine-specific attributes for the DckDb query engine"""
+
+    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.DUCKDB
+
+    # SQL Engine capabilities
+    date_trunc_supported: ClassVar[bool] = True
+    full_outer_joins_supported: ClassVar[bool] = True
+    indexes_supported: ClassVar[bool] = True
+    multi_threading_supported: ClassVar[bool] = True
+    timestamp_type_supported: ClassVar[bool] = True
+    timestamp_to_string_comparison_supported: ClassVar[bool] = True
+    # Cancelling should be possible, but not yet implemented.
+    cancel_submitted_queries_supported: ClassVar[bool] = False
+
+    # SQL Dialect replacement strings
+    double_data_type_name: ClassVar[str] = "DOUBLE"
+    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
+
+    # MetricFlow attributes
+    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DuckDbSqlQueryPlanRenderer()
+
+
+class DuckDbSqlClient(SqlAlchemySqlClient):
+    """Implements Redshift."""
+
+    @staticmethod
+    def from_connection_details(url: str, password: Optional[str] = None) -> SqlAlchemySqlClient:  # noqa: D
+        expected_url = f"{SqlDialect.DUCKDB.value}://"
+        if url != expected_url:
+            raise ValueError(f"URL was '{url}' but should be '{expected_url}'")
+        if password:
+            raise ValueError("Password should be empty")
+
+        return DuckDbSqlClient()
+
+    def __init__(self) -> None:  # noqa: D
+        super().__init__(sqlalchemy.create_engine("duckdb:///:memory:"))
+
+    @property
+    def sql_engine_attributes(self) -> SqlEngineAttributes:
+        """Collection of attributes and features specific to the Snowflake SQL engine"""
+        return DuckDbEngineAttributes()
+
+    def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -18,6 +18,7 @@ from metricflow.configuration.yaml_handler import YamlFileHandler
 from metricflow.protocols.sql_client import SqlClient, SupportedSqlEngine
 from metricflow.sql_clients.big_query import BigQuerySqlClient
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
+from metricflow.sql_clients.duckdb import DuckDbSqlClient
 from metricflow.sql_clients.postgres import PostgresSqlClient
 from metricflow.sql_clients.redshift import RedshiftSqlClient
 from metricflow.sql_clients.snowflake import SnowflakeSqlClient
@@ -71,6 +72,8 @@ def make_sql_client(url: str, password: str) -> SqlClient:  # noqa: D
         return PostgresSqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.SQLITE:
         return SqliteSqlClient.from_connection_details(url, password)
+    elif dialect == SqlDialect.DUCKDB:
+        return DuckDbSqlClient.from_connection_details(url, password)
     else:
         raise ValueError(f"Unknown dialect: `{dialect}` in URL {url}")
 

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -60,8 +60,8 @@ class MetricFlowTestEnvironmentVariables:
 def mf_test_session_state(request: FixtureRequest) -> MetricFlowTestSessionState:  # noqa: D
     engine_url = MetricFlowTestEnvironmentVariables.MF_SQL_ENGINE_URL.get_optional()
     if engine_url is None:
-        logger.info(f"{MetricFlowTestEnvironmentVariables.MF_SQL_ENGINE_URL.name} has not been set, so using SQLite")
-        engine_url = "sqlite://"
+        logger.info(f"{MetricFlowTestEnvironmentVariables.MF_SQL_ENGINE_URL.name} has not been set, so using DuckDb")
+        engine_url = "duckdb://"
     engine_password = MetricFlowTestEnvironmentVariables.MF_SQL_ENGINE_PASSWORD.get_optional() or ""
 
     current_time = datetime.datetime.now().strftime("%Y_%m_%d")

--- a/metricflow/test/snapshots/test_convert_data_source.py/SqlQueryPlan/DuckDbSqlClient/test_convert_query_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_data_source.py/SqlQueryPlan/DuckDbSqlClient/test_convert_query_data_source__plan0.sql
@@ -1,0 +1,13 @@
+-- Read Elements From Data Source 'revenue'
+SELECT
+  revenue_src_10005.revenue AS txn_revenue
+  , revenue_src_10005.created_at AS ds
+  , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+  , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+  , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+  , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+  , revenue_src_10005.user_id AS user
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_revenue
+) revenue_src_10005

--- a/metricflow/test/snapshots/test_convert_data_source.py/SqlQueryPlan/DuckDbSqlClient/test_convert_table_data_source_with_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_data_source.py/SqlQueryPlan/DuckDbSqlClient/test_convert_table_data_source_with_measures__plan0.sql
@@ -1,0 +1,29 @@
+-- Read Elements From Data Source 'id_verifications'
+SELECT
+  1 AS identity_verifications
+  , id_verifications_src_10002.ds
+  , DATE_TRUNC('week', id_verifications_src_10002.ds) AS ds__week
+  , DATE_TRUNC('month', id_verifications_src_10002.ds) AS ds__month
+  , DATE_TRUNC('quarter', id_verifications_src_10002.ds) AS ds__quarter
+  , DATE_TRUNC('year', id_verifications_src_10002.ds) AS ds__year
+  , id_verifications_src_10002.ds_partitioned
+  , DATE_TRUNC('week', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__week
+  , DATE_TRUNC('month', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__month
+  , DATE_TRUNC('quarter', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__quarter
+  , DATE_TRUNC('year', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__year
+  , id_verifications_src_10002.verification_type
+  , id_verifications_src_10002.ds AS verification__ds
+  , DATE_TRUNC('week', id_verifications_src_10002.ds) AS verification__ds__week
+  , DATE_TRUNC('month', id_verifications_src_10002.ds) AS verification__ds__month
+  , DATE_TRUNC('quarter', id_verifications_src_10002.ds) AS verification__ds__quarter
+  , DATE_TRUNC('year', id_verifications_src_10002.ds) AS verification__ds__year
+  , id_verifications_src_10002.ds_partitioned AS verification__ds_partitioned
+  , DATE_TRUNC('week', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__week
+  , DATE_TRUNC('month', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__month
+  , DATE_TRUNC('quarter', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__quarter
+  , DATE_TRUNC('year', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__year
+  , id_verifications_src_10002.verification_type AS verification__verification_type
+  , id_verifications_src_10002.verification_id AS verification
+  , id_verifications_src_10002.user_id AS user
+  , id_verifications_src_10002.user_id AS verification__user
+FROM ***************************.fct_id_verifications id_verifications_src_10002

--- a/metricflow/test/snapshots/test_convert_data_source.py/SqlQueryPlan/DuckDbSqlClient/test_convert_table_data_source_without_measures__plan0.sql
+++ b/metricflow/test/snapshots/test_convert_data_source.py/SqlQueryPlan/DuckDbSqlClient/test_convert_table_data_source_without_measures__plan0.sql
@@ -1,0 +1,16 @@
+-- Read Elements From Data Source 'users_latest'
+SELECT
+  users_latest_src_10007.ds
+  , DATE_TRUNC('week', users_latest_src_10007.ds) AS ds__week
+  , DATE_TRUNC('month', users_latest_src_10007.ds) AS ds__month
+  , DATE_TRUNC('quarter', users_latest_src_10007.ds) AS ds__quarter
+  , DATE_TRUNC('year', users_latest_src_10007.ds) AS ds__year
+  , users_latest_src_10007.home_state_latest
+  , users_latest_src_10007.ds AS user__ds
+  , DATE_TRUNC('week', users_latest_src_10007.ds) AS user__ds__week
+  , DATE_TRUNC('month', users_latest_src_10007.ds) AS user__ds__month
+  , DATE_TRUNC('quarter', users_latest_src_10007.ds) AS user__ds__quarter
+  , DATE_TRUNC('year', users_latest_src_10007.ds) AS user__ds__year
+  , users_latest_src_10007.home_state_latest AS user__home_state_latest
+  , users_latest_src_10007.user_id AS user
+FROM ***************************.dim_users_latest users_latest_src_10007

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/DuckDbSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/DuckDbSqlClient/test_build_metric_tasks__query0.sql
@@ -1,0 +1,24 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(count_dogs) AS count_dogs
+  , ds
+FROM (
+  -- Read Elements From Data Source 'animals'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2040-12-31T00:00:00]
+  -- Pass Only Elements:
+  --   ['count_dogs', 'ds']
+  SELECT
+    1 AS count_dogs
+    , ds
+  FROM (
+    SELECT * FROM ***************************.fct_animals
+  ) animals_src_0
+  WHERE (
+    ds >= CAST('2000-01-01' AS TIMESTAMP)
+  ) AND (
+    ds <= CAST('2040-12-31' AS TIMESTAMP)
+  )
+) subq_2
+GROUP BY
+  ds

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -1,0 +1,92 @@
+<ExecutionPlan>
+    <SelectSqlQueryToDataFrameTask>
+        <!-- description = Run a query and write the results to a data frame -->
+        <!-- node_id = rsq_0 -->
+        <!-- sql_query =                                                                              -->
+        <!--   -- Combine Metrics                                                                     -->
+        <!--   SELECT                                                                                 -->
+        <!--     subq_9.bookings AS bookings                                                          -->
+        <!--     , subq_10.instant_bookings AS instant_bookings                                       -->
+        <!--     , subq_11.booking_value AS booking_value                                             -->
+        <!--     , COALESCE(subq_9.is_instant, subq_10.is_instant, subq_11.is_instant) AS is_instant  -->
+        <!--     , COALESCE(subq_9.ds, subq_10.ds, subq_11.ds) AS ds                                  -->
+        <!--   FROM (                                                                                 -->
+        <!--     -- Aggregate Measures                                                                -->
+        <!--     -- Compute Metrics via Expressions                                                   -->
+        <!--     SELECT                                                                               -->
+        <!--       SUM(bookings) AS bookings                                                          -->
+        <!--       , is_instant                                                                       -->
+        <!--       , ds                                                                               -->
+        <!--     FROM (                                                                               -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                                -->
+        <!--       -- Pass Only Elements:                                                             -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                              -->
+        <!--       SELECT                                                                             -->
+        <!--         1 AS bookings                                                                    -->
+        <!--         , is_instant                                                                     -->
+        <!--         , ds                                                                             -->
+        <!--       FROM (                                                                             -->
+        <!--         -- User Defined SQL Query                                                        -->
+        <!--         SELECT * FROM ***************************.fct_bookings                           -->
+        <!--       ) bookings_source_src_10000                                                        -->
+        <!--     ) subq_1                                                                             -->
+        <!--     GROUP BY                                                                             -->
+        <!--       is_instant                                                                         -->
+        <!--       , ds                                                                               -->
+        <!--   ) subq_9                                                                               -->
+        <!--   FULL OUTER JOIN (                                                                      -->
+        <!--     -- Aggregate Measures                                                                -->
+        <!--     -- Compute Metrics via Expressions                                                   -->
+        <!--     SELECT                                                                               -->
+        <!--       SUM(instant_bookings) AS instant_bookings                                          -->
+        <!--       , is_instant                                                                       -->
+        <!--       , ds                                                                               -->
+        <!--     FROM (                                                                               -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                                -->
+        <!--       -- Pass Only Elements:                                                             -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                      -->
+        <!--       SELECT                                                                             -->
+        <!--         CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                       -->
+        <!--         , is_instant                                                                     -->
+        <!--         , ds                                                                             -->
+        <!--       FROM (                                                                             -->
+        <!--         -- User Defined SQL Query                                                        -->
+        <!--         SELECT * FROM ***************************.fct_bookings                           -->
+        <!--       ) bookings_source_src_10000                                                        -->
+        <!--     ) subq_4                                                                             -->
+        <!--     GROUP BY                                                                             -->
+        <!--       is_instant                                                                         -->
+        <!--       , ds                                                                               -->
+        <!--   ) subq_10                                                                              -->
+        <!--   ON                                                                                     -->
+        <!--     (                                                                                    -->
+        <!--       subq_9.is_instant = subq_10.is_instant                                             -->
+        <!--     ) AND (                                                                              -->
+        <!--       subq_9.ds = subq_10.ds                                                             -->
+        <!--     )                                                                                    -->
+        <!--   FULL OUTER JOIN (                                                                      -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                  -->
+        <!--     -- Pass Only Elements:                                                               -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                           -->
+        <!--     -- Aggregate Measures                                                                -->
+        <!--     -- Compute Metrics via Expressions                                                   -->
+        <!--     SELECT                                                                               -->
+        <!--       SUM(booking_value) AS booking_value                                                -->
+        <!--       , is_instant                                                                       -->
+        <!--       , ds                                                                               -->
+        <!--     FROM (                                                                               -->
+        <!--       -- User Defined SQL Query                                                          -->
+        <!--       SELECT * FROM ***************************.fct_bookings                             -->
+        <!--     ) bookings_source_src_10000                                                          -->
+        <!--     GROUP BY                                                                             -->
+        <!--       is_instant                                                                         -->
+        <!--       , ds                                                                               -->
+        <!--   ) subq_11                                                                              -->
+        <!--   ON                                                                                     -->
+        <!--     (                                                                                    -->
+        <!--       COALESCE(subq_9.is_instant, subq_10.is_instant) = subq_11.is_instant               -->
+        <!--     ) AND (                                                                              -->
+        <!--       COALESCE(subq_9.ds, subq_10.ds) = subq_11.ds                                       -->
+        <!--     )                                                                                    -->
+    </SelectSqlQueryToDataFrameTask>
+</ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_joined_plan__ep_0.xml
@@ -1,0 +1,36 @@
+<ExecutionPlan>
+    <SelectSqlQueryToDataFrameTask>
+        <!-- description = Run a query and write the results to a data frame -->
+        <!-- node_id = rsq_0 -->
+        <!-- sql_query =                                                                    -->
+        <!--   -- Join Standard Outputs                                                     -->
+        <!--   -- Pass Only Elements:                                                       -->
+        <!--   --   ['bookings', 'is_instant', 'listing__country_latest']                   -->
+        <!--   -- Aggregate Measures                                                        -->
+        <!--   -- Compute Metrics via Expressions                                           -->
+        <!--   SELECT                                                                       -->
+        <!--     SUM(subq_1.bookings) AS bookings                                           -->
+        <!--     , subq_1.is_instant AS is_instant                                          -->
+        <!--     , listings_latest_src_10003.country AS listing__country_latest             -->
+        <!--   FROM (                                                                       -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                        -->
+        <!--     -- Pass Only Elements:                                                     -->
+        <!--     --   ['bookings', 'is_instant', 'listing']                                 -->
+        <!--     SELECT                                                                     -->
+        <!--       1 AS bookings                                                            -->
+        <!--       , is_instant                                                             -->
+        <!--       , listing_id AS listing                                                  -->
+        <!--     FROM (                                                                     -->
+        <!--       -- User Defined SQL Query                                                -->
+        <!--       SELECT * FROM ***************************.fct_bookings                   -->
+        <!--     ) bookings_source_src_10000                                                -->
+        <!--   ) subq_1                                                                     -->
+        <!--   LEFT OUTER JOIN                                                              -->
+        <!--     ***************************.dim_listings_latest listings_latest_src_10003  -->
+        <!--   ON                                                                           -->
+        <!--     subq_1.listing = listings_latest_src_10003.listing_id                      -->
+        <!--   GROUP BY                                                                     -->
+        <!--     subq_1.is_instant                                                          -->
+        <!--     , listings_latest_src_10003.country                                        -->
+    </SelectSqlQueryToDataFrameTask>
+</ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -1,0 +1,42 @@
+<ExecutionPlan>
+    <SelectSqlQueryToDataFrameTask>
+        <!-- description = Run a query and write the results to a data frame -->
+        <!-- node_id = rsq_0 -->
+        <!-- sql_query =                                                                        -->
+        <!--   -- Join Standard Outputs                                                         -->
+        <!--   -- Pass Only Elements:                                                           -->
+        <!--   --   ['txn_count', 'account_id__customer_id__customer_name']                     -->
+        <!--   -- Aggregate Measures                                                            -->
+        <!--   -- Compute Metrics via Expressions                                               -->
+        <!--   SELECT                                                                           -->
+        <!--     SUM(account_month_txns_src_0.txn_count) AS txn_count                           -->
+        <!--     , subq_6.customer_id__customer_name AS account_id__customer_id__customer_name  -->
+        <!--   FROM ***************************.account_month_txns account_month_txns_src_0     -->
+        <!--   LEFT OUTER JOIN (                                                                -->
+        <!--     -- Join Standard Outputs                                                       -->
+        <!--     -- Pass Only Elements:                                                         -->
+        <!--     --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']            -->
+        <!--     SELECT                                                                         -->
+        <!--       customer_table_src_3.customer_name AS customer_id__customer_name             -->
+        <!--       , bridge_table_src_1.ds_partitioned AS ds_partitioned                        -->
+        <!--       , bridge_table_src_1.account_id AS account_id                                -->
+        <!--     FROM ***************************.bridge_table bridge_table_src_1               -->
+        <!--     LEFT OUTER JOIN                                                                -->
+        <!--       ***************************.customer_table customer_table_src_3              -->
+        <!--     ON                                                                             -->
+        <!--       (                                                                            -->
+        <!--         bridge_table_src_1.customer_id = customer_table_src_3.customer_id          -->
+        <!--       ) AND (                                                                      -->
+        <!--         bridge_table_src_1.ds_partitioned = customer_table_src_3.ds_partitioned    -->
+        <!--       )                                                                            -->
+        <!--   ) subq_6                                                                         -->
+        <!--   ON                                                                               -->
+        <!--     (                                                                              -->
+        <!--       account_month_txns_src_0.account_id = subq_6.account_id                      -->
+        <!--     ) AND (                                                                        -->
+        <!--       account_month_txns_src_0.ds_partitioned = subq_6.ds_partitioned              -->
+        <!--     )                                                                              -->
+        <!--   GROUP BY                                                                         -->
+        <!--     subq_6.customer_id__customer_name                                              -->
+    </SelectSqlQueryToDataFrameTask>
+</ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -1,0 +1,51 @@
+<ExecutionPlan>
+    <SelectSqlQueryToDataFrameTask>
+        <!-- description = Run a query and write the results to a data frame -->
+        <!-- node_id = rsq_0 -->
+        <!-- sql_query =                                                         -->
+        <!--   -- Combine Metrics                                                -->
+        <!--   SELECT                                                            -->
+        <!--     subq_6.bookings AS bookings                                     -->
+        <!--     , subq_7.booking_value AS booking_value                         -->
+        <!--     , COALESCE(subq_6.is_instant, subq_7.is_instant) AS is_instant  -->
+        <!--   FROM (                                                            -->
+        <!--     -- Aggregate Measures                                           -->
+        <!--     -- Compute Metrics via Expressions                              -->
+        <!--     SELECT                                                          -->
+        <!--       SUM(bookings) AS bookings                                     -->
+        <!--       , is_instant                                                  -->
+        <!--     FROM (                                                          -->
+        <!--       -- Read Elements From Data Source 'bookings_source'           -->
+        <!--       -- Pass Only Elements:                                        -->
+        <!--       --   ['bookings', 'is_instant']                               -->
+        <!--       SELECT                                                        -->
+        <!--         1 AS bookings                                               -->
+        <!--         , is_instant                                                -->
+        <!--       FROM (                                                        -->
+        <!--         -- User Defined SQL Query                                   -->
+        <!--         SELECT * FROM ***************************.fct_bookings      -->
+        <!--       ) bookings_source_src_10000                                   -->
+        <!--     ) subq_1                                                        -->
+        <!--     GROUP BY                                                        -->
+        <!--       is_instant                                                    -->
+        <!--   ) subq_6                                                          -->
+        <!--   FULL OUTER JOIN (                                                 -->
+        <!--     -- Read Elements From Data Source 'bookings_source'             -->
+        <!--     -- Pass Only Elements:                                          -->
+        <!--     --   ['booking_value', 'is_instant']                            -->
+        <!--     -- Aggregate Measures                                           -->
+        <!--     -- Compute Metrics via Expressions                              -->
+        <!--     SELECT                                                          -->
+        <!--       SUM(booking_value) AS booking_value                           -->
+        <!--       , is_instant                                                  -->
+        <!--     FROM (                                                          -->
+        <!--       -- User Defined SQL Query                                     -->
+        <!--       SELECT * FROM ***************************.fct_bookings        -->
+        <!--     ) bookings_source_src_10000                                     -->
+        <!--     GROUP BY                                                        -->
+        <!--       is_instant                                                    -->
+        <!--   ) subq_7                                                          -->
+        <!--   ON                                                                -->
+        <!--     subq_6.is_instant = subq_7.is_instant                           -->
+    </SelectSqlQueryToDataFrameTask>
+</ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0.sql
@@ -1,0 +1,46 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_2.messages
+  , subq_2.user_team___team_id
+  , subq_2.user_team___user_id
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_1.messages) AS messages
+    , subq_1.user_team___team_id
+    , subq_1.user_team___user_id
+  FROM (
+    -- Pass Only Elements:
+    --   ['messages', 'user_team']
+    SELECT
+      subq_0.messages
+      , subq_0.user_team___team_id
+      , subq_0.user_team___user_id
+    FROM (
+      -- Read Elements From Data Source 'messages_source'
+      SELECT
+        1 AS messages
+        , messages_source_src_10014.ds
+        , DATE_TRUNC('week', messages_source_src_10014.ds) AS ds__week
+        , DATE_TRUNC('month', messages_source_src_10014.ds) AS ds__month
+        , DATE_TRUNC('quarter', messages_source_src_10014.ds) AS ds__quarter
+        , DATE_TRUNC('year', messages_source_src_10014.ds) AS ds__year
+        , messages_source_src_10014.team_id
+        , messages_source_src_10014.ds AS user_id__ds
+        , DATE_TRUNC('week', messages_source_src_10014.ds) AS user_id__ds__week
+        , DATE_TRUNC('month', messages_source_src_10014.ds) AS user_id__ds__month
+        , DATE_TRUNC('quarter', messages_source_src_10014.ds) AS user_id__ds__quarter
+        , DATE_TRUNC('year', messages_source_src_10014.ds) AS user_id__ds__year
+        , messages_source_src_10014.team_id AS user_id__team_id
+        , messages_source_src_10014.user_id
+        , messages_source_src_10014.team_id AS user_team___team_id
+        , messages_source_src_10014.user_id AS user_team___user_id
+        , messages_source_src_10014.team_id AS user_id__user_team___team_id
+        , messages_source_src_10014.user_id AS user_id__user_team___user_id
+      FROM ***************************.fct_messages messages_source_src_10014
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.user_team___team_id
+    , subq_1.user_team___user_id
+) subq_2

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -1,0 +1,19 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(messages) AS messages
+  , user_team___team_id
+  , user_team___user_id
+FROM (
+  -- Read Elements From Data Source 'messages_source'
+  -- Pass Only Elements:
+  --   ['messages', 'user_team']
+  SELECT
+    1 AS messages
+    , team_id AS user_team___team_id
+    , user_id AS user_team___user_id
+  FROM ***************************.fct_messages messages_source_src_10014
+) subq_4
+GROUP BY
+  user_team___team_id
+  , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,0 +1,128 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.messages
+  , subq_6.user_team__country
+  , subq_6.user_team___team_id
+  , subq_6.user_team___user_id
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.messages) AS messages
+    , subq_5.user_team__country
+    , subq_5.user_team___team_id
+    , subq_5.user_team___user_id
+  FROM (
+    -- Pass Only Elements:
+    --   ['messages', 'user_team__country', 'user_team']
+    SELECT
+      subq_4.messages
+      , subq_4.user_team__country
+      , subq_4.user_team___team_id
+      , subq_4.user_team___user_id
+    FROM (
+      -- Join Standard Outputs
+      SELECT
+        subq_1.messages AS messages
+        , subq_3.country AS user_team__country
+        , subq_1.user_team___team_id AS user_team___team_id
+        , subq_1.user_team___user_id AS user_team___user_id
+      FROM (
+        -- Pass Only Elements:
+        --   ['messages', 'user_team', 'user_team']
+        SELECT
+          subq_0.messages
+          , subq_0.user_team___team_id
+          , subq_0.user_team___user_id
+        FROM (
+          -- Read Elements From Data Source 'messages_source'
+          SELECT
+            1 AS messages
+            , messages_source_src_10014.ds
+            , DATE_TRUNC('week', messages_source_src_10014.ds) AS ds__week
+            , DATE_TRUNC('month', messages_source_src_10014.ds) AS ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10014.ds) AS ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10014.ds) AS ds__year
+            , messages_source_src_10014.team_id
+            , messages_source_src_10014.ds AS user_id__ds
+            , DATE_TRUNC('week', messages_source_src_10014.ds) AS user_id__ds__week
+            , DATE_TRUNC('month', messages_source_src_10014.ds) AS user_id__ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10014.ds) AS user_id__ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10014.ds) AS user_id__ds__year
+            , messages_source_src_10014.team_id AS user_id__team_id
+            , messages_source_src_10014.user_id
+            , messages_source_src_10014.team_id AS user_team___team_id
+            , messages_source_src_10014.user_id AS user_team___user_id
+            , messages_source_src_10014.team_id AS user_id__user_team___team_id
+            , messages_source_src_10014.user_id AS user_id__user_team___user_id
+          FROM ***************************.fct_messages messages_source_src_10014
+        ) subq_0
+      ) subq_1
+      LEFT OUTER JOIN (
+        -- Pass Only Elements:
+        --   ['user_team', 'country']
+        SELECT
+          subq_2.country
+          , subq_2.user_team___team_id
+          , subq_2.user_team___user_id
+        FROM (
+          -- Read Elements From Data Source 'users_source'
+          SELECT
+            users_source_src_10016.created_at AS ds
+            , DATE_TRUNC('week', users_source_src_10016.created_at) AS ds__week
+            , DATE_TRUNC('month', users_source_src_10016.created_at) AS ds__month
+            , DATE_TRUNC('quarter', users_source_src_10016.created_at) AS ds__quarter
+            , DATE_TRUNC('year', users_source_src_10016.created_at) AS ds__year
+            , users_source_src_10016.team_id
+            , users_source_src_10016.country
+            , users_source_src_10016.created_at AS user_id__ds
+            , DATE_TRUNC('week', users_source_src_10016.created_at) AS user_id__ds__week
+            , DATE_TRUNC('month', users_source_src_10016.created_at) AS user_id__ds__month
+            , DATE_TRUNC('quarter', users_source_src_10016.created_at) AS user_id__ds__quarter
+            , DATE_TRUNC('year', users_source_src_10016.created_at) AS user_id__ds__year
+            , users_source_src_10016.team_id AS user_id__team_id
+            , users_source_src_10016.country AS user_id__country
+            , users_source_src_10016.created_at AS user_composite_ident_2__ds
+            , DATE_TRUNC('week', users_source_src_10016.created_at) AS user_composite_ident_2__ds__week
+            , DATE_TRUNC('month', users_source_src_10016.created_at) AS user_composite_ident_2__ds__month
+            , DATE_TRUNC('quarter', users_source_src_10016.created_at) AS user_composite_ident_2__ds__quarter
+            , DATE_TRUNC('year', users_source_src_10016.created_at) AS user_composite_ident_2__ds__year
+            , users_source_src_10016.team_id AS user_composite_ident_2__team_id
+            , users_source_src_10016.country AS user_composite_ident_2__country
+            , users_source_src_10016.created_at AS user_team__ds
+            , DATE_TRUNC('week', users_source_src_10016.created_at) AS user_team__ds__week
+            , DATE_TRUNC('month', users_source_src_10016.created_at) AS user_team__ds__month
+            , DATE_TRUNC('quarter', users_source_src_10016.created_at) AS user_team__ds__quarter
+            , DATE_TRUNC('year', users_source_src_10016.created_at) AS user_team__ds__year
+            , users_source_src_10016.team_id AS user_team__team_id
+            , users_source_src_10016.country AS user_team__country
+            , users_source_src_10016.id AS user_id
+            , users_source_src_10016.ident_2 AS user_composite_ident_2___ident_2
+            , users_source_src_10016.id AS user_composite_ident_2___user_id
+            , users_source_src_10016.team_id AS user_team___team_id
+            , users_source_src_10016.id AS user_team___user_id
+            , users_source_src_10016.ident_2 AS user_id__user_composite_ident_2___ident_2
+            , users_source_src_10016.id AS user_id__user_composite_ident_2___user_id
+            , users_source_src_10016.team_id AS user_id__user_team___team_id
+            , users_source_src_10016.id AS user_id__user_team___user_id
+            , users_source_src_10016.id AS user_composite_ident_2__user_id
+            , users_source_src_10016.team_id AS user_composite_ident_2__user_team___team_id
+            , users_source_src_10016.id AS user_composite_ident_2__user_team___user_id
+            , users_source_src_10016.id AS user_team__user_id
+            , users_source_src_10016.ident_2 AS user_team__user_composite_ident_2___ident_2
+            , users_source_src_10016.id AS user_team__user_composite_ident_2___user_id
+          FROM ***************************.fct_users users_source_src_10016
+        ) subq_2
+      ) subq_3
+      ON
+        (
+          subq_1.user_team___team_id = subq_3.user_team___team_id
+        ) AND (
+          subq_1.user_team___user_id = subq_3.user_team___user_id
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.user_team__country
+    , subq_5.user_team___team_id
+    , subq_5.user_team___user_id
+) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Join Standard Outputs
+-- Pass Only Elements:
+--   ['messages', 'user_team__country', 'user_team']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(subq_8.messages) AS messages
+  , users_source_src_10016.country AS user_team__country
+  , subq_8.user_team___team_id AS user_team___team_id
+  , subq_8.user_team___user_id AS user_team___user_id
+FROM (
+  -- Read Elements From Data Source 'messages_source'
+  -- Pass Only Elements:
+  --   ['messages', 'user_team', 'user_team']
+  SELECT
+    1 AS messages
+    , team_id AS user_team___team_id
+    , user_id AS user_team___user_id
+  FROM ***************************.fct_messages messages_source_src_10014
+) subq_8
+LEFT OUTER JOIN
+  ***************************.fct_users users_source_src_10016
+ON
+  (
+    subq_8.user_team___team_id = users_source_src_10016.team_id
+  ) AND (
+    subq_8.user_team___user_id = users_source_src_10016.id
+  )
+GROUP BY
+  users_source_src_10016.country
+  , subq_8.user_team___team_id
+  , subq_8.user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -1,0 +1,54 @@
+-- Order By ['user_team']
+SELECT
+  subq_3.messages
+  , subq_3.user_team___team_id
+  , subq_3.user_team___user_id
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_2.messages
+    , subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      SUM(subq_1.messages) AS messages
+      , subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+    FROM (
+      -- Pass Only Elements:
+      --   ['messages', 'user_team']
+      SELECT
+        subq_0.messages
+        , subq_0.user_team___team_id
+        , subq_0.user_team___user_id
+      FROM (
+        -- Read Elements From Data Source 'messages_source'
+        SELECT
+          1 AS messages
+          , messages_source_src_10014.ds
+          , DATE_TRUNC('week', messages_source_src_10014.ds) AS ds__week
+          , DATE_TRUNC('month', messages_source_src_10014.ds) AS ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10014.ds) AS ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10014.ds) AS ds__year
+          , messages_source_src_10014.team_id
+          , messages_source_src_10014.ds AS user_id__ds
+          , DATE_TRUNC('week', messages_source_src_10014.ds) AS user_id__ds__week
+          , DATE_TRUNC('month', messages_source_src_10014.ds) AS user_id__ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10014.ds) AS user_id__ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10014.ds) AS user_id__ds__year
+          , messages_source_src_10014.team_id AS user_id__team_id
+          , messages_source_src_10014.user_id
+          , messages_source_src_10014.team_id AS user_team___team_id
+          , messages_source_src_10014.user_id AS user_team___user_id
+          , messages_source_src_10014.team_id AS user_id__user_team___team_id
+          , messages_source_src_10014.user_id AS user_id__user_team___user_id
+        FROM ***************************.fct_messages messages_source_src_10014
+      ) subq_0
+    ) subq_1
+    GROUP BY
+      subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+  ) subq_2
+) subq_3
+ORDER BY subq_3.user_team___team_id DESC, subq_3.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
@@ -1,0 +1,21 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+-- Order By ['user_team']
+SELECT
+  SUM(messages) AS messages
+  , user_team___team_id
+  , user_team___user_id
+FROM (
+  -- Read Elements From Data Source 'messages_source'
+  -- Pass Only Elements:
+  --   ['messages', 'user_team']
+  SELECT
+    1 AS messages
+    , team_id AS user_team___team_id
+    , user_id AS user_team___user_id
+  FROM ***************************.fct_messages messages_source_src_10014
+) subq_5
+GROUP BY
+  user_team___team_id
+  , user_team___user_id
+ORDER BY user_team___team_id DESC, user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0.sql
@@ -1,0 +1,119 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_5.bookings
+  , subq_5.listing__country_latest
+  , subq_5.listing
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_4.bookings) AS bookings
+    , subq_4.listing__country_latest
+    , subq_4.listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_1.bookings AS bookings
+      , subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'listing']
+      SELECT
+        subq_0.bookings
+        , subq_0.listing
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        SELECT
+          1 AS bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+          , bookings_source_src_10000.booking_value
+          , bookings_source_src_10000.booking_value AS max_booking_value
+          , bookings_source_src_10000.booking_value AS min_booking_value
+          , bookings_source_src_10000.guest_id AS bookers
+          , bookings_source_src_10000.booking_value AS average_booking_value
+          , bookings_source_src_10000.is_instant
+          , bookings_source_src_10000.ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+          , bookings_source_src_10000.ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+          , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+          , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+          , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , bookings_source_src_10000.listing_id AS listing
+          , bookings_source_src_10000.guest_id AS guest
+          , bookings_source_src_10000.host_id AS host
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+          , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+          , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10000
+      ) subq_0
+    ) subq_1
+    LEFT OUTER JOIN (
+      -- Pass Only Elements:
+      --   ['listing', 'country_latest']
+      SELECT
+        subq_2.country_latest
+        , subq_2.listing
+      FROM (
+        -- Read Elements From Data Source 'listings_latest'
+        SELECT
+          1 AS listings
+          , listings_latest_src_10003.capacity AS largest_listing
+          , listings_latest_src_10003.capacity AS smallest_listing
+          , listings_latest_src_10003.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+          , listings_latest_src_10003.created_at
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+          , listings_latest_src_10003.country AS country_latest
+          , listings_latest_src_10003.is_lux AS is_lux_latest
+          , listings_latest_src_10003.capacity AS capacity_latest
+          , listings_latest_src_10003.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+          , listings_latest_src_10003.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+          , listings_latest_src_10003.country AS listing__country_latest
+          , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10003.capacity AS listing__capacity_latest
+          , listings_latest_src_10003.listing_id AS listing
+          , listings_latest_src_10003.user_id AS user
+          , listings_latest_src_10003.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10003
+      ) subq_2
+    ) subq_3
+    ON
+      subq_1.listing = subq_3.listing
+  ) subq_4
+  GROUP BY
+    subq_4.listing__country_latest
+    , subq_4.listing
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Join Standard Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(subq_7.bookings) AS bookings
+  , listings_latest_src_10003.country AS listing__country_latest
+  , subq_7.listing AS listing
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Pass Only Elements:
+  --   ['bookings', 'listing']
+  SELECT
+    1 AS bookings
+    , listing_id AS listing
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_7
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_10003
+ON
+  subq_7.listing = listings_latest_src_10003.listing_id
+GROUP BY
+  listings_latest_src_10003.country
+  , subq_7.listing

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,0 +1,278 @@
+-- Compute Metrics via Expressions
+SELECT
+  CAST(subq_15.bookings AS DOUBLE) / CAST(NULLIF(subq_15.views, 0) AS DOUBLE) AS bookings_per_view
+  , subq_15.listing__country_latest
+  , subq_15.ds
+FROM (
+  -- Pass Only Elements:
+  --   ['listing__country_latest', 'ds', 'bookings', 'views']
+  SELECT
+    subq_14.bookings
+    , subq_14.views
+    , subq_14.listing__country_latest
+    , subq_14.ds
+  FROM (
+    -- Join Aggregated Measures with Standard Outputs
+    SELECT
+      subq_6.bookings AS bookings
+      , subq_13.views AS views
+      , subq_6.listing__country_latest AS listing__country_latest
+      , subq_6.ds AS ds
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        SUM(subq_5.bookings) AS bookings
+        , subq_5.listing__country_latest
+        , subq_5.ds
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'listing__country_latest', 'ds']
+        SELECT
+          subq_4.bookings
+          , subq_4.listing__country_latest
+          , subq_4.ds
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_1.bookings AS bookings
+            , subq_3.country_latest AS listing__country_latest
+            , subq_1.ds AS ds
+            , subq_1.listing AS listing
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'ds', 'listing']
+            SELECT
+              subq_0.bookings
+              , subq_0.ds
+              , subq_0.listing
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10000.booking_value
+                , bookings_source_src_10000.booking_value AS max_booking_value
+                , bookings_source_src_10000.booking_value AS min_booking_value
+                , bookings_source_src_10000.guest_id AS bookers
+                , bookings_source_src_10000.booking_value AS average_booking_value
+                , bookings_source_src_10000.is_instant
+                , bookings_source_src_10000.ds
+                , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+                , bookings_source_src_10000.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10000.listing_id AS listing
+                , bookings_source_src_10000.guest_id AS guest
+                , bookings_source_src_10000.host_id AS host
+                , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10000
+            ) subq_0
+          ) subq_1
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_2.country_latest
+              , subq_2.listing
+            FROM (
+              -- Read Elements From Data Source 'listings_latest'
+              SELECT
+                1 AS listings
+                , listings_latest_src_10003.capacity AS largest_listing
+                , listings_latest_src_10003.capacity AS smallest_listing
+                , listings_latest_src_10003.created_at AS ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+                , listings_latest_src_10003.created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+                , listings_latest_src_10003.country AS country_latest
+                , listings_latest_src_10003.is_lux AS is_lux_latest
+                , listings_latest_src_10003.capacity AS capacity_latest
+                , listings_latest_src_10003.created_at AS listing__ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+                , listings_latest_src_10003.created_at AS listing__created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+                , listings_latest_src_10003.country AS listing__country_latest
+                , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+                , listings_latest_src_10003.capacity AS listing__capacity_latest
+                , listings_latest_src_10003.listing_id AS listing
+                , listings_latest_src_10003.user_id AS user
+                , listings_latest_src_10003.user_id AS listing__user
+              FROM ***************************.dim_listings_latest listings_latest_src_10003
+            ) subq_2
+          ) subq_3
+          ON
+            subq_1.listing = subq_3.listing
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.listing__country_latest
+        , subq_5.ds
+    ) subq_6
+    INNER JOIN (
+      -- Aggregate Measures
+      SELECT
+        SUM(subq_12.views) AS views
+        , subq_12.listing__country_latest
+        , subq_12.ds
+      FROM (
+        -- Pass Only Elements:
+        --   ['views', 'listing__country_latest', 'ds']
+        SELECT
+          subq_11.views
+          , subq_11.listing__country_latest
+          , subq_11.ds
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_8.views AS views
+            , subq_10.country_latest AS listing__country_latest
+            , subq_8.ds AS ds
+            , subq_8.listing AS listing
+          FROM (
+            -- Pass Only Elements:
+            --   ['views', 'ds', 'listing']
+            SELECT
+              subq_7.views
+              , subq_7.ds
+              , subq_7.listing
+            FROM (
+              -- Read Elements From Data Source 'views_source'
+              SELECT
+                1 AS views
+                , views_source_src_10008.ds
+                , DATE_TRUNC('week', views_source_src_10008.ds) AS ds__week
+                , DATE_TRUNC('month', views_source_src_10008.ds) AS ds__month
+                , DATE_TRUNC('quarter', views_source_src_10008.ds) AS ds__quarter
+                , DATE_TRUNC('year', views_source_src_10008.ds) AS ds__year
+                , views_source_src_10008.ds_partitioned
+                , DATE_TRUNC('week', views_source_src_10008.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', views_source_src_10008.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', views_source_src_10008.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', views_source_src_10008.ds_partitioned) AS ds_partitioned__year
+                , views_source_src_10008.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', views_source_src_10008.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', views_source_src_10008.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', views_source_src_10008.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', views_source_src_10008.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , views_source_src_10008.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', views_source_src_10008.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', views_source_src_10008.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', views_source_src_10008.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', views_source_src_10008.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , views_source_src_10008.listing_id AS listing
+                , views_source_src_10008.user_id AS user
+                , views_source_src_10008.user_id AS create_a_cycle_in_the_join_graph
+                , views_source_src_10008.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , views_source_src_10008.user_id AS create_a_cycle_in_the_join_graph__user
+              FROM (
+                -- User Defined SQL Query
+                SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+              ) views_source_src_10008
+            ) subq_7
+          ) subq_8
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_9.country_latest
+              , subq_9.listing
+            FROM (
+              -- Read Elements From Data Source 'listings_latest'
+              SELECT
+                1 AS listings
+                , listings_latest_src_10003.capacity AS largest_listing
+                , listings_latest_src_10003.capacity AS smallest_listing
+                , listings_latest_src_10003.created_at AS ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+                , listings_latest_src_10003.created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+                , listings_latest_src_10003.country AS country_latest
+                , listings_latest_src_10003.is_lux AS is_lux_latest
+                , listings_latest_src_10003.capacity AS capacity_latest
+                , listings_latest_src_10003.created_at AS listing__ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+                , listings_latest_src_10003.created_at AS listing__created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+                , listings_latest_src_10003.country AS listing__country_latest
+                , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+                , listings_latest_src_10003.capacity AS listing__capacity_latest
+                , listings_latest_src_10003.listing_id AS listing
+                , listings_latest_src_10003.user_id AS user
+                , listings_latest_src_10003.user_id AS listing__user
+              FROM ***************************.dim_listings_latest listings_latest_src_10003
+            ) subq_9
+          ) subq_10
+          ON
+            subq_8.listing = subq_10.listing
+        ) subq_11
+      ) subq_12
+      GROUP BY
+        subq_12.listing__country_latest
+        , subq_12.ds
+    ) subq_13
+    ON
+      (
+        (
+          subq_6.listing__country_latest = subq_13.listing__country_latest
+        ) OR (
+          (
+            subq_6.listing__country_latest IS NULL
+          ) AND (
+            subq_13.listing__country_latest IS NULL
+          )
+        )
+      ) AND (
+        (
+          subq_6.ds = subq_13.ds
+        ) OR (
+          (subq_6.ds IS NULL) AND (subq_13.ds IS NULL)
+        )
+      )
+  ) subq_14
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -1,0 +1,86 @@
+-- Join Aggregated Measures with Standard Outputs
+-- Pass Only Elements:
+--   ['listing__country_latest', 'ds', 'bookings', 'views']
+-- Compute Metrics via Expressions
+SELECT
+  CAST(subq_22.bookings AS DOUBLE) / CAST(NULLIF(subq_29.views, 0) AS DOUBLE) AS bookings_per_view
+  , subq_22.listing__country_latest AS listing__country_latest
+  , subq_22.ds AS ds
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements:
+  --   ['bookings', 'listing__country_latest', 'ds']
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_17.bookings) AS bookings
+    , listings_latest_src_10003.country AS listing__country_latest
+    , subq_17.ds AS ds
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    -- Pass Only Elements:
+    --   ['bookings', 'ds', 'listing']
+    SELECT
+      1 AS bookings
+      , ds
+      , listing_id AS listing
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_17
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10003
+  ON
+    subq_17.listing = listings_latest_src_10003.listing_id
+  GROUP BY
+    listings_latest_src_10003.country
+    , subq_17.ds
+) subq_22
+INNER JOIN (
+  -- Join Standard Outputs
+  -- Pass Only Elements:
+  --   ['views', 'listing__country_latest', 'ds']
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_24.views) AS views
+    , listings_latest_src_10003.country AS listing__country_latest
+    , subq_24.ds AS ds
+  FROM (
+    -- Read Elements From Data Source 'views_source'
+    -- Pass Only Elements:
+    --   ['views', 'ds', 'listing']
+    SELECT
+      1 AS views
+      , ds
+      , listing_id AS listing
+    FROM (
+      -- User Defined SQL Query
+      SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+    ) views_source_src_10008
+  ) subq_24
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10003
+  ON
+    subq_24.listing = listings_latest_src_10003.listing_id
+  GROUP BY
+    listings_latest_src_10003.country
+    , subq_24.ds
+) subq_29
+ON
+  (
+    (
+      subq_22.listing__country_latest = subq_29.listing__country_latest
+    ) OR (
+      (
+        subq_22.listing__country_latest IS NULL
+      ) AND (
+        subq_29.listing__country_latest IS NULL
+      )
+    )
+  ) AND (
+    (
+      subq_22.ds = subq_29.ds
+    ) OR (
+      (subq_22.ds IS NULL) AND (subq_29.ds IS NULL)
+    )
+  )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -1,0 +1,122 @@
+-- Compute Metrics via Expressions
+SELECT
+  CAST(subq_5.bookings AS DOUBLE) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE) AS bookings_per_booker
+  , subq_5.listing__country_latest
+  , subq_5.listing
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_4.bookings) AS bookings
+    , COUNT(DISTINCT subq_4.bookers) AS bookers
+    , subq_4.listing__country_latest
+    , subq_4.listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_1.bookings AS bookings
+      , subq_1.bookers AS bookers
+      , subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'bookers', 'listing']
+      SELECT
+        subq_0.bookings
+        , subq_0.bookers
+        , subq_0.listing
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        SELECT
+          1 AS bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+          , bookings_source_src_10000.booking_value
+          , bookings_source_src_10000.booking_value AS max_booking_value
+          , bookings_source_src_10000.booking_value AS min_booking_value
+          , bookings_source_src_10000.guest_id AS bookers
+          , bookings_source_src_10000.booking_value AS average_booking_value
+          , bookings_source_src_10000.is_instant
+          , bookings_source_src_10000.ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+          , bookings_source_src_10000.ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+          , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+          , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+          , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , bookings_source_src_10000.listing_id AS listing
+          , bookings_source_src_10000.guest_id AS guest
+          , bookings_source_src_10000.host_id AS host
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+          , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+          , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10000
+      ) subq_0
+    ) subq_1
+    LEFT OUTER JOIN (
+      -- Pass Only Elements:
+      --   ['listing', 'country_latest']
+      SELECT
+        subq_2.country_latest
+        , subq_2.listing
+      FROM (
+        -- Read Elements From Data Source 'listings_latest'
+        SELECT
+          1 AS listings
+          , listings_latest_src_10003.capacity AS largest_listing
+          , listings_latest_src_10003.capacity AS smallest_listing
+          , listings_latest_src_10003.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+          , listings_latest_src_10003.created_at
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+          , listings_latest_src_10003.country AS country_latest
+          , listings_latest_src_10003.is_lux AS is_lux_latest
+          , listings_latest_src_10003.capacity AS capacity_latest
+          , listings_latest_src_10003.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+          , listings_latest_src_10003.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+          , listings_latest_src_10003.country AS listing__country_latest
+          , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10003.capacity AS listing__capacity_latest
+          , listings_latest_src_10003.listing_id AS listing
+          , listings_latest_src_10003.user_id AS user
+          , listings_latest_src_10003.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10003
+      ) subq_2
+    ) subq_3
+    ON
+      subq_1.listing = subq_3.listing
+  ) subq_4
+  GROUP BY
+    subq_4.listing__country_latest
+    , subq_4.listing
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  CAST(bookings AS DOUBLE) / CAST(NULLIF(bookers, 0) AS DOUBLE) AS bookings_per_booker
+  , listing__country_latest
+  , listing
+FROM (
+  -- Join Standard Outputs
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_7.bookings) AS bookings
+    , COUNT(DISTINCT subq_7.bookers) AS bookers
+    , listings_latest_src_10003.country AS listing__country_latest
+    , subq_7.listing AS listing
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    -- Pass Only Elements:
+    --   ['bookings', 'bookers', 'listing']
+    SELECT
+      1 AS bookings
+      , guest_id AS bookers
+      , listing_id AS listing
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_7
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10003
+  ON
+    subq_7.listing = listings_latest_src_10003.listing_id
+  GROUP BY
+    listings_latest_src_10003.country
+    , subq_7.listing
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -1,0 +1,119 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking_value * 0.05 AS booking_fees
+  , subq_5.listing__country_latest
+  , subq_5.listing
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_4.booking_value) AS booking_value
+    , subq_4.listing__country_latest
+    , subq_4.listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_1.booking_value AS booking_value
+      , subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
+    FROM (
+      -- Pass Only Elements:
+      --   ['booking_value', 'listing']
+      SELECT
+        subq_0.booking_value
+        , subq_0.listing
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        SELECT
+          1 AS bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+          , bookings_source_src_10000.booking_value
+          , bookings_source_src_10000.booking_value AS max_booking_value
+          , bookings_source_src_10000.booking_value AS min_booking_value
+          , bookings_source_src_10000.guest_id AS bookers
+          , bookings_source_src_10000.booking_value AS average_booking_value
+          , bookings_source_src_10000.is_instant
+          , bookings_source_src_10000.ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+          , bookings_source_src_10000.ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+          , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+          , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+          , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , bookings_source_src_10000.listing_id AS listing
+          , bookings_source_src_10000.guest_id AS guest
+          , bookings_source_src_10000.host_id AS host
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+          , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+          , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10000
+      ) subq_0
+    ) subq_1
+    LEFT OUTER JOIN (
+      -- Pass Only Elements:
+      --   ['listing', 'country_latest']
+      SELECT
+        subq_2.country_latest
+        , subq_2.listing
+      FROM (
+        -- Read Elements From Data Source 'listings_latest'
+        SELECT
+          1 AS listings
+          , listings_latest_src_10003.capacity AS largest_listing
+          , listings_latest_src_10003.capacity AS smallest_listing
+          , listings_latest_src_10003.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+          , listings_latest_src_10003.created_at
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+          , listings_latest_src_10003.country AS country_latest
+          , listings_latest_src_10003.is_lux AS is_lux_latest
+          , listings_latest_src_10003.capacity AS capacity_latest
+          , listings_latest_src_10003.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+          , listings_latest_src_10003.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+          , listings_latest_src_10003.country AS listing__country_latest
+          , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10003.capacity AS listing__capacity_latest
+          , listings_latest_src_10003.listing_id AS listing
+          , listings_latest_src_10003.user_id AS user
+          , listings_latest_src_10003.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10003
+      ) subq_2
+    ) subq_3
+    ON
+      subq_1.listing = subq_3.listing
+  ) subq_4
+  GROUP BY
+    subq_4.listing__country_latest
+    , subq_4.listing
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
@@ -1,0 +1,24 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking_value * 0.05 AS booking_fees
+  , listing__country_latest
+  , listing
+FROM (
+  -- Join Standard Outputs
+  -- Aggregate Measures
+  SELECT
+    SUM(bookings_source_src_10000.booking_value) AS booking_value
+    , listings_latest_src_10003.country AS listing__country_latest
+    , bookings_source_src_10000.listing_id AS listing
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10003
+  ON
+    bookings_source_src_10000.listing_id = listings_latest_src_10003.listing_id
+  GROUP BY
+    listings_latest_src_10003.country
+    , bookings_source_src_10000.listing_id
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_constrain_primary_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_constrain_primary_time_dimension__plan0.sql
@@ -1,0 +1,60 @@
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+SELECT
+  subq_1.bookings
+  , subq_1.ds
+FROM (
+  -- Pass Only Elements:
+  --   ['bookings', 'ds']
+  SELECT
+    subq_0.bookings
+    , subq_0.ds
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    SELECT
+      1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+      , bookings_source_src_10000.booking_value
+      , bookings_source_src_10000.booking_value AS max_booking_value
+      , bookings_source_src_10000.booking_value AS min_booking_value
+      , bookings_source_src_10000.guest_id AS bookers
+      , bookings_source_src_10000.booking_value AS average_booking_value
+      , bookings_source_src_10000.is_instant
+      , bookings_source_src_10000.ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+      , bookings_source_src_10000.ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+      , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+      , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+      , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+      , bookings_source_src_10000.listing_id AS listing
+      , bookings_source_src_10000.guest_id AS guest
+      , bookings_source_src_10000.host_id AS host
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+      , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+      , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_0
+) subq_1
+WHERE (
+  subq_1.ds >= CAST('2020-01-01' AS TIMESTAMP)
+) AND (
+  subq_1.ds <= CAST('2020-01-02' AS TIMESTAMP)
+)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_constrain_primary_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_constrain_primary_time_dimension__plan0_optimized.sql
@@ -1,0 +1,16 @@
+-- Read Elements From Data Source 'bookings_source'
+-- Pass Only Elements:
+--   ['bookings', 'ds']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+SELECT
+  1 AS bookings
+  , ds
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_bookings
+) bookings_source_src_10000
+WHERE (
+  ds >= CAST('2020-01-01' AS TIMESTAMP)
+) AND (
+  ds <= CAST('2020-01-02' AS TIMESTAMP)
+)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0.sql
@@ -1,0 +1,54 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_5.txn_revenue AS trailing_2_months_revenue
+  , subq_5.ds__month
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_4.txn_revenue) AS txn_revenue
+    , subq_4.ds__month
+  FROM (
+    -- Join Self Over Time Range
+    SELECT
+      subq_1.txn_revenue AS txn_revenue
+      , subq_2.ds__month AS ds__month
+    FROM (
+      -- Date Spine
+      SELECT
+        DATE_TRUNC('month', subq_3.ds) AS ds__month
+      FROM ***************************.mf_time_spine subq_3
+      GROUP BY
+        DATE_TRUNC('month', subq_3.ds)
+    ) subq_2
+    INNER JOIN (
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'ds__month']
+      SELECT
+        subq_0.txn_revenue
+        , subq_0.ds__month
+      FROM (
+        -- Read Elements From Data Source 'revenue'
+        SELECT
+          revenue_src_10005.revenue AS txn_revenue
+          , revenue_src_10005.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+          , revenue_src_10005.user_id AS user
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10005
+      ) subq_0
+    ) subq_1
+    ON
+      (
+        subq_1.ds__month <= subq_2.ds__month
+      ) AND (
+        subq_1.ds__month > subq_2.ds__month - INTERVAL 2 month
+      )
+  ) subq_4
+  GROUP BY
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Join Self Over Time Range
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(revenue_src_10005.revenue) AS trailing_2_months_revenue
+  , subq_8.ds__month AS ds__month
+FROM (
+  -- Date Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS ds__month
+  FROM ***************************.mf_time_spine subq_9
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_8
+INNER JOIN (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_revenue
+) revenue_src_10005
+ON
+  (
+    DATE_TRUNC('month', revenue_src_10005.created_at) <= subq_8.ds__month
+  ) AND (
+    DATE_TRUNC('month', revenue_src_10005.created_at) > subq_8.ds__month - INTERVAL 2 month
+  )
+GROUP BY
+  subq_8.ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,0 +1,54 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_5.txn_revenue AS revenue_mtd
+  , subq_5.ds__month
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_4.txn_revenue) AS txn_revenue
+    , subq_4.ds__month
+  FROM (
+    -- Join Self Over Time Range
+    SELECT
+      subq_1.txn_revenue AS txn_revenue
+      , subq_2.ds__month AS ds__month
+    FROM (
+      -- Date Spine
+      SELECT
+        DATE_TRUNC('month', subq_3.ds) AS ds__month
+      FROM ***************************.mf_time_spine subq_3
+      GROUP BY
+        DATE_TRUNC('month', subq_3.ds)
+    ) subq_2
+    INNER JOIN (
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'ds__month']
+      SELECT
+        subq_0.txn_revenue
+        , subq_0.ds__month
+      FROM (
+        -- Read Elements From Data Source 'revenue'
+        SELECT
+          revenue_src_10005.revenue AS txn_revenue
+          , revenue_src_10005.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+          , revenue_src_10005.user_id AS user
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10005
+      ) subq_0
+    ) subq_1
+    ON
+      (
+        subq_1.ds__month <= subq_2.ds__month
+      ) AND (
+        subq_1.ds__month >= DATE_TRUNC('month', subq_2.ds__month::timestamp)
+      )
+  ) subq_4
+  GROUP BY
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Join Self Over Time Range
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(revenue_src_10005.revenue) AS revenue_mtd
+  , subq_8.ds__month AS ds__month
+FROM (
+  -- Date Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS ds__month
+  FROM ***************************.mf_time_spine subq_9
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_8
+INNER JOIN (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_revenue
+) revenue_src_10005
+ON
+  (
+    DATE_TRUNC('month', revenue_src_10005.created_at) <= subq_8.ds__month
+  ) AND (
+    DATE_TRUNC('month', revenue_src_10005.created_at) >= DATE_TRUNC('month', subq_8.ds__month::timestamp)
+  )
+GROUP BY
+  subq_8.ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0.sql
@@ -1,0 +1,29 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_3.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_2.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements:
+    --   ['txn_revenue']
+    SELECT
+      subq_0.txn_revenue
+    FROM (
+      -- Read Elements From Data Source 'revenue'
+      SELECT
+        revenue_src_10005.revenue AS txn_revenue
+        , revenue_src_10005.created_at AS ds
+        , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+        , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+        , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+        , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+        , revenue_src_10005.user_id AS user
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_revenue
+      ) revenue_src_10005
+    ) subq_0
+  ) subq_2
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -1,0 +1,11 @@
+-- Read Elements From Data Source 'revenue'
+-- Pass Only Elements:
+--   ['txn_revenue']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(revenue) AS trailing_2_months_revenue
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_revenue
+) revenue_src_10005

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_5.txn_revenue AS revenue_all_time
+  , subq_5.ds__month
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_4.txn_revenue) AS txn_revenue
+    , subq_4.ds__month
+  FROM (
+    -- Join Self Over Time Range
+    SELECT
+      subq_1.txn_revenue AS txn_revenue
+      , subq_2.ds__month AS ds__month
+    FROM (
+      -- Date Spine
+      SELECT
+        DATE_TRUNC('month', subq_3.ds) AS ds__month
+      FROM ***************************.mf_time_spine subq_3
+      GROUP BY
+        DATE_TRUNC('month', subq_3.ds)
+    ) subq_2
+    INNER JOIN (
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'ds__month']
+      SELECT
+        subq_0.txn_revenue
+        , subq_0.ds__month
+      FROM (
+        -- Read Elements From Data Source 'revenue'
+        SELECT
+          revenue_src_10005.revenue AS txn_revenue
+          , revenue_src_10005.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+          , revenue_src_10005.user_id AS user
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10005
+      ) subq_0
+    ) subq_1
+    ON
+      subq_1.ds__month <= subq_2.ds__month
+  ) subq_4
+  GROUP BY
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -1,0 +1,22 @@
+-- Join Self Over Time Range
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(revenue_src_10005.revenue) AS revenue_all_time
+  , subq_8.ds__month AS ds__month
+FROM (
+  -- Date Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS ds__month
+  FROM ***************************.mf_time_spine subq_9
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_8
+INNER JOIN (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_revenue
+) revenue_src_10005
+ON
+  DATE_TRUNC('month', revenue_src_10005.created_at) <= subq_8.ds__month
+GROUP BY
+  subq_8.ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,0 +1,82 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.txn_revenue AS revenue_all_time
+  , subq_7.ds__month
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_6.txn_revenue) AS txn_revenue
+    , subq_6.ds__month
+  FROM (
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
+    SELECT
+      subq_5.txn_revenue
+      , subq_5.ds__month
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.txn_revenue AS txn_revenue
+        , subq_3.ds__month AS ds__month
+      FROM (
+        -- Date Spine
+        SELECT
+          DATE_TRUNC('month', subq_4.ds) AS ds__month
+        FROM ***************************.mf_time_spine subq_4
+        WHERE (
+          subq_4.ds >= CAST('2020-01-01' AS TIMESTAMP)
+        ) AND (
+          subq_4.ds <= CAST('2020-01-01' AS TIMESTAMP)
+        )
+        GROUP BY
+          DATE_TRUNC('month', subq_4.ds)
+      ) subq_3
+      INNER JOIN (
+        -- Pass Only Elements:
+        --   ['txn_revenue', 'ds__month']
+        SELECT
+          subq_1.txn_revenue
+          , subq_1.ds__month
+        FROM (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_0.txn_revenue
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user
+          FROM (
+            -- Read Elements From Data Source 'revenue'
+            SELECT
+              revenue_src_10005.revenue AS txn_revenue
+              , revenue_src_10005.created_at AS ds
+              , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+              , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+              , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+              , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+              , revenue_src_10005.user_id AS user
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_revenue
+            ) revenue_src_10005
+          ) subq_0
+          WHERE (
+            subq_0.ds >= CAST('2000-01-01' AS TIMESTAMP)
+          ) AND (
+            subq_0.ds <= CAST('2020-01-01' AS TIMESTAMP)
+          )
+        ) subq_1
+      ) subq_2
+      ON
+        subq_2.ds__month <= subq_3.ds__month
+    ) subq_5
+    WHERE (
+      subq_5.ds__month >= CAST('2020-01-01' AS TIMESTAMP)
+    ) AND (
+      subq_5.ds__month <= CAST('2020-01-01' AS TIMESTAMP)
+    )
+  ) subq_6
+  GROUP BY
+    subq_6.ds__month
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,47 @@
+-- Join Self Over Time Range
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(subq_10.txn_revenue) AS revenue_all_time
+  , subq_11.ds__month AS ds__month
+FROM (
+  -- Date Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS ds__month
+  FROM ***************************.mf_time_spine subq_12
+  WHERE (
+    ds >= CAST('2020-01-01' AS TIMESTAMP)
+  ) AND (
+    ds <= CAST('2020-01-01' AS TIMESTAMP)
+  )
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_11
+INNER JOIN (
+  -- Read Elements From Data Source 'revenue'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  -- Pass Only Elements:
+  --   ['txn_revenue', 'ds__month']
+  SELECT
+    revenue AS txn_revenue
+    , DATE_TRUNC('month', created_at) AS ds__month
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_revenue
+  ) revenue_src_10005
+  WHERE (
+    created_at >= CAST('2000-01-01' AS TIMESTAMP)
+  ) AND (
+    created_at <= CAST('2020-01-01' AS TIMESTAMP)
+  )
+) subq_10
+ON
+  subq_10.ds__month <= subq_11.ds__month
+WHERE (
+  subq_11.ds__month >= CAST('2020-01-01' AS TIMESTAMP)
+) AND (
+  subq_11.ds__month <= CAST('2020-01-01' AS TIMESTAMP)
+)
+GROUP BY
+  subq_11.ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,86 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.txn_revenue AS trailing_2_months_revenue
+  , subq_7.ds__month
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_6.txn_revenue) AS txn_revenue
+    , subq_6.ds__month
+  FROM (
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
+    SELECT
+      subq_5.txn_revenue
+      , subq_5.ds__month
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.txn_revenue AS txn_revenue
+        , subq_3.ds__month AS ds__month
+      FROM (
+        -- Date Spine
+        SELECT
+          DATE_TRUNC('month', subq_4.ds) AS ds__month
+        FROM ***************************.mf_time_spine subq_4
+        WHERE (
+          subq_4.ds >= CAST('2020-01-01' AS TIMESTAMP)
+        ) AND (
+          subq_4.ds <= CAST('2020-01-01' AS TIMESTAMP)
+        )
+        GROUP BY
+          DATE_TRUNC('month', subq_4.ds)
+      ) subq_3
+      INNER JOIN (
+        -- Pass Only Elements:
+        --   ['txn_revenue', 'ds__month']
+        SELECT
+          subq_1.txn_revenue
+          , subq_1.ds__month
+        FROM (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_0.txn_revenue
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user
+          FROM (
+            -- Read Elements From Data Source 'revenue'
+            SELECT
+              revenue_src_10005.revenue AS txn_revenue
+              , revenue_src_10005.created_at AS ds
+              , DATE_TRUNC('week', revenue_src_10005.created_at) AS ds__week
+              , DATE_TRUNC('month', revenue_src_10005.created_at) AS ds__month
+              , DATE_TRUNC('quarter', revenue_src_10005.created_at) AS ds__quarter
+              , DATE_TRUNC('year', revenue_src_10005.created_at) AS ds__year
+              , revenue_src_10005.user_id AS user
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_revenue
+            ) revenue_src_10005
+          ) subq_0
+          WHERE (
+            subq_0.ds >= CAST('2019-12-01' AS TIMESTAMP)
+          ) AND (
+            subq_0.ds <= CAST('2020-01-01' AS TIMESTAMP)
+          )
+        ) subq_1
+      ) subq_2
+      ON
+        (
+          subq_2.ds__month <= subq_3.ds__month
+        ) AND (
+          subq_2.ds__month > subq_3.ds__month - INTERVAL 2 month
+        )
+    ) subq_5
+    WHERE (
+      subq_5.ds__month >= CAST('2020-01-01' AS TIMESTAMP)
+    ) AND (
+      subq_5.ds__month <= CAST('2020-01-01' AS TIMESTAMP)
+    )
+  ) subq_6
+  GROUP BY
+    subq_6.ds__month
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,51 @@
+-- Join Self Over Time Range
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(subq_10.txn_revenue) AS trailing_2_months_revenue
+  , subq_11.ds__month AS ds__month
+FROM (
+  -- Date Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS ds__month
+  FROM ***************************.mf_time_spine subq_12
+  WHERE (
+    ds >= CAST('2020-01-01' AS TIMESTAMP)
+  ) AND (
+    ds <= CAST('2020-01-01' AS TIMESTAMP)
+  )
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_11
+INNER JOIN (
+  -- Read Elements From Data Source 'revenue'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  -- Pass Only Elements:
+  --   ['txn_revenue', 'ds__month']
+  SELECT
+    revenue AS txn_revenue
+    , DATE_TRUNC('month', created_at) AS ds__month
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_revenue
+  ) revenue_src_10005
+  WHERE (
+    created_at >= CAST('2019-12-01' AS TIMESTAMP)
+  ) AND (
+    created_at <= CAST('2020-01-01' AS TIMESTAMP)
+  )
+) subq_10
+ON
+  (
+    subq_10.ds__month <= subq_11.ds__month
+  ) AND (
+    subq_10.ds__month > subq_11.ds__month - INTERVAL 2 month
+  )
+WHERE (
+  subq_11.ds__month >= CAST('2020-01-01' AS TIMESTAMP)
+) AND (
+  subq_11.ds__month <= CAST('2020-01-01' AS TIMESTAMP)
+)
+GROUP BY
+  subq_11.ds__month

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0.sql
@@ -1,0 +1,136 @@
+-- Order By ['listing__country_latest'] Limit 100
+SELECT
+  subq_8.listing__country_latest
+FROM (
+  -- Pass Only Elements:
+  --   ['listing__country_latest']
+  SELECT
+    subq_7.listing__country_latest
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.bookings
+      , subq_6.listing__country_latest
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        SUM(subq_5.bookings) AS bookings
+        , subq_5.listing__country_latest
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'listing__country_latest']
+        SELECT
+          subq_4.bookings
+          , subq_4.listing__country_latest
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_1.bookings AS bookings
+            , subq_3.country_latest AS listing__country_latest
+            , subq_1.listing AS listing
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'listing']
+            SELECT
+              subq_0.bookings
+              , subq_0.listing
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10000.booking_value
+                , bookings_source_src_10000.booking_value AS max_booking_value
+                , bookings_source_src_10000.booking_value AS min_booking_value
+                , bookings_source_src_10000.guest_id AS bookers
+                , bookings_source_src_10000.booking_value AS average_booking_value
+                , bookings_source_src_10000.is_instant
+                , bookings_source_src_10000.ds
+                , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+                , bookings_source_src_10000.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10000.listing_id AS listing
+                , bookings_source_src_10000.guest_id AS guest
+                , bookings_source_src_10000.host_id AS host
+                , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10000
+            ) subq_0
+          ) subq_1
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_2.country_latest
+              , subq_2.listing
+            FROM (
+              -- Read Elements From Data Source 'listings_latest'
+              SELECT
+                1 AS listings
+                , listings_latest_src_10003.capacity AS largest_listing
+                , listings_latest_src_10003.capacity AS smallest_listing
+                , listings_latest_src_10003.created_at AS ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+                , listings_latest_src_10003.created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+                , listings_latest_src_10003.country AS country_latest
+                , listings_latest_src_10003.is_lux AS is_lux_latest
+                , listings_latest_src_10003.capacity AS capacity_latest
+                , listings_latest_src_10003.created_at AS listing__ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+                , listings_latest_src_10003.created_at AS listing__created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+                , listings_latest_src_10003.country AS listing__country_latest
+                , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+                , listings_latest_src_10003.capacity AS listing__capacity_latest
+                , listings_latest_src_10003.listing_id AS listing
+                , listings_latest_src_10003.user_id AS user
+                , listings_latest_src_10003.user_id AS listing__user
+              FROM ***************************.dim_listings_latest listings_latest_src_10003
+            ) subq_2
+          ) subq_3
+          ON
+            subq_1.listing = subq_3.listing
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.listing__country_latest
+    ) subq_6
+  ) subq_7
+) subq_8
+ORDER BY subq_8.listing__country_latest
+LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0_optimized.sql
@@ -1,0 +1,22 @@
+-- Join Standard Outputs
+-- Pass Only Elements:
+--   ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+-- Pass Only Elements:
+--   ['listing__country_latest']
+-- Order By ['listing__country_latest'] Limit 100
+SELECT
+  listings_latest_src_10003.country AS listing__country_latest
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_bookings
+) bookings_source_src_10000
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_10003
+ON
+  bookings_source_src_10000.listing_id = listings_latest_src_10003.listing_id
+GROUP BY
+  listings_latest_src_10003.country
+ORDER BY listing__country_latest
+LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_node__plan0.sql
@@ -1,0 +1,48 @@
+-- Pass Only Elements:
+--   ['bookings']
+SELECT
+  subq_0.bookings
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , bookings_source_src_10000.booking_value
+    , bookings_source_src_10000.booking_value AS max_booking_value
+    , bookings_source_src_10000.booking_value AS min_booking_value
+    , bookings_source_src_10000.guest_id AS bookers
+    , bookings_source_src_10000.booking_value AS average_booking_value
+    , bookings_source_src_10000.is_instant
+    , bookings_source_src_10000.ds
+    , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+    , bookings_source_src_10000.ds_partitioned
+    , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+    , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+    , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+    , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+    , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+    , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+    , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+    , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+    , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+    , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+    , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+    , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+    , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+    , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+    , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+    , bookings_source_src_10000.listing_id AS listing
+    , bookings_source_src_10000.guest_id AS guest
+    , bookings_source_src_10000.host_id AS host
+    , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+    , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+    , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+    , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_0

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_node__plan0_optimized.sql
@@ -1,0 +1,9 @@
+-- Read Elements From Data Source 'bookings_source'
+-- Pass Only Elements:
+--   ['bookings']
+SELECT
+  1 AS bookings
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_bookings
+) bookings_source_src_10000

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_node__plan0.sql
@@ -1,0 +1,56 @@
+-- Constrain Output with WHERE
+SELECT
+  subq_1.bookings
+  , subq_1.ds
+FROM (
+  -- Pass Only Elements:
+  --   ['bookings', 'ds']
+  SELECT
+    subq_0.bookings
+    , subq_0.ds
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    SELECT
+      1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+      , bookings_source_src_10000.booking_value
+      , bookings_source_src_10000.booking_value AS max_booking_value
+      , bookings_source_src_10000.booking_value AS min_booking_value
+      , bookings_source_src_10000.guest_id AS bookers
+      , bookings_source_src_10000.booking_value AS average_booking_value
+      , bookings_source_src_10000.is_instant
+      , bookings_source_src_10000.ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+      , bookings_source_src_10000.ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+      , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+      , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+      , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+      , bookings_source_src_10000.listing_id AS listing
+      , bookings_source_src_10000.guest_id AS guest
+      , bookings_source_src_10000.host_id AS host
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+      , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+      , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_0
+) subq_1
+WHERE ds = '2020-01-01'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -1,0 +1,17 @@
+-- Constrain Output with WHERE
+SELECT
+  bookings
+  , ds
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Pass Only Elements:
+  --   ['bookings', 'ds']
+  SELECT
+    1 AS bookings
+    , ds
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_3
+WHERE ds = '2020-01-01'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,0 +1,141 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.bookings
+  , subq_8.is_instant
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_7.bookings) AS bookings
+    , subq_7.is_instant
+  FROM (
+    -- Pass Only Elements:
+    --   ['bookings', 'is_instant']
+    SELECT
+      subq_6.bookings
+      , subq_6.is_instant
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_5.bookings
+        , subq_5.is_instant
+        , subq_5.listing__country_latest
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'is_instant', 'listing__country_latest']
+        SELECT
+          subq_4.bookings
+          , subq_4.is_instant
+          , subq_4.listing__country_latest
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_1.bookings AS bookings
+            , subq_1.is_instant AS is_instant
+            , subq_3.country_latest AS listing__country_latest
+            , subq_1.listing AS listing
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'is_instant', 'listing']
+            SELECT
+              subq_0.bookings
+              , subq_0.is_instant
+              , subq_0.listing
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10000.booking_value
+                , bookings_source_src_10000.booking_value AS max_booking_value
+                , bookings_source_src_10000.booking_value AS min_booking_value
+                , bookings_source_src_10000.guest_id AS bookers
+                , bookings_source_src_10000.booking_value AS average_booking_value
+                , bookings_source_src_10000.is_instant
+                , bookings_source_src_10000.ds
+                , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+                , bookings_source_src_10000.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10000.listing_id AS listing
+                , bookings_source_src_10000.guest_id AS guest
+                , bookings_source_src_10000.host_id AS host
+                , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10000
+            ) subq_0
+          ) subq_1
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_2.country_latest
+              , subq_2.listing
+            FROM (
+              -- Read Elements From Data Source 'listings_latest'
+              SELECT
+                1 AS listings
+                , listings_latest_src_10003.capacity AS largest_listing
+                , listings_latest_src_10003.capacity AS smallest_listing
+                , listings_latest_src_10003.created_at AS ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+                , listings_latest_src_10003.created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+                , listings_latest_src_10003.country AS country_latest
+                , listings_latest_src_10003.is_lux AS is_lux_latest
+                , listings_latest_src_10003.capacity AS capacity_latest
+                , listings_latest_src_10003.created_at AS listing__ds
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+                , listings_latest_src_10003.created_at AS listing__created_at
+                , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+                , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+                , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+                , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+                , listings_latest_src_10003.country AS listing__country_latest
+                , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+                , listings_latest_src_10003.capacity AS listing__capacity_latest
+                , listings_latest_src_10003.listing_id AS listing
+                , listings_latest_src_10003.user_id AS user
+                , listings_latest_src_10003.user_id AS listing__user
+              FROM ***************************.dim_listings_latest listings_latest_src_10003
+            ) subq_2
+          ) subq_3
+          ON
+            subq_1.listing = subq_3.listing
+        ) subq_4
+      ) subq_5
+      WHERE listing__country_latest = 'us'
+    ) subq_6
+  ) subq_7
+  GROUP BY
+    subq_7.is_instant
+) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -1,0 +1,37 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements:
+--   ['bookings', 'is_instant']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(bookings) AS bookings
+  , is_instant
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements:
+  --   ['bookings', 'is_instant', 'listing__country_latest']
+  SELECT
+    subq_10.bookings AS bookings
+    , subq_10.is_instant AS is_instant
+    , listings_latest_src_10003.country AS listing__country_latest
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    -- Pass Only Elements:
+    --   ['bookings', 'is_instant', 'listing']
+    SELECT
+      1 AS bookings
+      , is_instant
+      , listing_id AS listing
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_10
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10003
+  ON
+    subq_10.listing = listings_latest_src_10003.listing_id
+) subq_14
+WHERE listing__country_latest = 'us'
+GROUP BY
+  is_instant

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0.sql
@@ -1,0 +1,70 @@
+-- Order By [] Limit 1
+SELECT
+  subq_3.bookings
+  , subq_3.ds
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_2.bookings
+    , subq_2.ds
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      SUM(subq_1.bookings) AS bookings
+      , subq_1.ds
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'ds']
+      SELECT
+        subq_0.bookings
+        , subq_0.ds
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        SELECT
+          1 AS bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+          , bookings_source_src_10000.booking_value
+          , bookings_source_src_10000.booking_value AS max_booking_value
+          , bookings_source_src_10000.booking_value AS min_booking_value
+          , bookings_source_src_10000.guest_id AS bookers
+          , bookings_source_src_10000.booking_value AS average_booking_value
+          , bookings_source_src_10000.is_instant
+          , bookings_source_src_10000.ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+          , bookings_source_src_10000.ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+          , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+          , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+          , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , bookings_source_src_10000.listing_id AS listing
+          , bookings_source_src_10000.guest_id AS guest
+          , bookings_source_src_10000.host_id AS host
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+          , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+          , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10000
+      ) subq_0
+    ) subq_1
+    GROUP BY
+      subq_1.ds
+  ) subq_2
+) subq_3
+LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0_optimized.sql
@@ -1,0 +1,21 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+-- Order By [] Limit 1
+SELECT
+  SUM(bookings) AS bookings
+  , ds
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Pass Only Elements:
+  --   ['bookings', 'ds']
+  SELECT
+    1 AS bookings
+    , ds
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_5
+GROUP BY
+  ds
+LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,0 +1,56 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_2.listings
+  , subq_2.listing__country_latest
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_1.listings) AS listings
+    , subq_1.listing__country_latest
+  FROM (
+    -- Pass Only Elements:
+    --   ['listings', 'listing__country_latest']
+    SELECT
+      subq_0.listings
+      , subq_0.listing__country_latest
+    FROM (
+      -- Read Elements From Data Source 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_10003.capacity AS largest_listing
+        , listings_latest_src_10003.capacity AS smallest_listing
+        , listings_latest_src_10003.created_at AS ds
+        , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+        , listings_latest_src_10003.created_at
+        , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+        , listings_latest_src_10003.country AS country_latest
+        , listings_latest_src_10003.is_lux AS is_lux_latest
+        , listings_latest_src_10003.capacity AS capacity_latest
+        , listings_latest_src_10003.created_at AS listing__ds
+        , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+        , listings_latest_src_10003.created_at AS listing__created_at
+        , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+        , listings_latest_src_10003.country AS listing__country_latest
+        , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+        , listings_latest_src_10003.capacity AS listing__capacity_latest
+        , listings_latest_src_10003.listing_id AS listing
+        , listings_latest_src_10003.user_id AS user
+        , listings_latest_src_10003.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_10003
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.listing__country_latest
+) subq_2

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -1,0 +1,16 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(listings) AS listings
+  , listing__country_latest
+FROM (
+  -- Read Elements From Data Source 'listings_latest'
+  -- Pass Only Elements:
+  --   ['listings', 'listing__country_latest']
+  SELECT
+    1 AS listings
+    , country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_10003
+) subq_4
+GROUP BY
+  listing__country_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_aggregation_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_aggregation_node__plan0.sql
@@ -1,0 +1,59 @@
+-- Aggregate Measures
+SELECT
+  SUM(subq_1.bookings) AS bookings
+  , SUM(subq_1.instant_bookings) AS instant_bookings
+  , COUNT(DISTINCT subq_1.bookers) AS bookers
+  , AVG(subq_1.average_booking_value) AS average_booking_value
+FROM (
+  -- Pass Only Elements:
+  --   ['bookings', 'instant_bookings', 'average_booking_value', 'bookers']
+  SELECT
+    subq_0.bookings
+    , subq_0.instant_bookings
+    , subq_0.bookers
+    , subq_0.average_booking_value
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    SELECT
+      1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+      , bookings_source_src_10000.booking_value
+      , bookings_source_src_10000.booking_value AS max_booking_value
+      , bookings_source_src_10000.booking_value AS min_booking_value
+      , bookings_source_src_10000.guest_id AS bookers
+      , bookings_source_src_10000.booking_value AS average_booking_value
+      , bookings_source_src_10000.is_instant
+      , bookings_source_src_10000.ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+      , bookings_source_src_10000.ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+      , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+      , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+      , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+      , bookings_source_src_10000.listing_id AS listing
+      , bookings_source_src_10000.guest_id AS guest
+      , bookings_source_src_10000.host_id AS host
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+      , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+      , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_0
+) subq_1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_aggregation_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_aggregation_node__plan0_optimized.sql
@@ -1,0 +1,13 @@
+-- Read Elements From Data Source 'bookings_source'
+-- Pass Only Elements:
+--   ['bookings', 'instant_bookings', 'average_booking_value', 'bookers']
+-- Aggregate Measures
+SELECT
+  SUM(1) AS bookings
+  , SUM(CASE WHEN is_instant THEN 1 ELSE 0 END) AS instant_bookings
+  , COUNT(DISTINCT guest_id) AS bookers
+  , AVG(booking_value) AS average_booking_value
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_bookings
+) bookings_source_src_10000

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_join_node__plan0.sql
@@ -1,0 +1,149 @@
+-- Join Standard Outputs
+SELECT
+  subq_1.bookings AS bookings
+  , subq_3.country_latest AS listing__country_latest
+  , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
+FROM (
+  -- Pass Only Elements:
+  --   ['bookings', 'listing']
+  SELECT
+    subq_0.bookings
+    , subq_0.listing
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    SELECT
+      1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+      , bookings_source_src_10000.booking_value
+      , bookings_source_src_10000.booking_value AS max_booking_value
+      , bookings_source_src_10000.booking_value AS min_booking_value
+      , bookings_source_src_10000.guest_id AS bookers
+      , bookings_source_src_10000.booking_value AS average_booking_value
+      , bookings_source_src_10000.is_instant
+      , bookings_source_src_10000.ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+      , bookings_source_src_10000.ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+      , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+      , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+      , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+      , bookings_source_src_10000.listing_id AS listing
+      , bookings_source_src_10000.guest_id AS guest
+      , bookings_source_src_10000.host_id AS host
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+      , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+      , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_0
+) subq_1
+LEFT OUTER JOIN (
+  -- Pass Only Elements:
+  --   ['listing', 'country_latest']
+  SELECT
+    subq_2.country_latest
+    , subq_2.listing
+  FROM (
+    -- Read Elements From Data Source 'listings_latest'
+    SELECT
+      1 AS listings
+      , listings_latest_src_10003.capacity AS largest_listing
+      , listings_latest_src_10003.capacity AS smallest_listing
+      , listings_latest_src_10003.created_at AS ds
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+      , listings_latest_src_10003.created_at
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+      , listings_latest_src_10003.country AS country_latest
+      , listings_latest_src_10003.is_lux AS is_lux_latest
+      , listings_latest_src_10003.capacity AS capacity_latest
+      , listings_latest_src_10003.created_at AS listing__ds
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+      , listings_latest_src_10003.created_at AS listing__created_at
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+      , listings_latest_src_10003.country AS listing__country_latest
+      , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+      , listings_latest_src_10003.capacity AS listing__capacity_latest
+      , listings_latest_src_10003.listing_id AS listing
+      , listings_latest_src_10003.user_id AS user
+      , listings_latest_src_10003.user_id AS listing__user
+    FROM ***************************.dim_listings_latest listings_latest_src_10003
+  ) subq_2
+) subq_3
+ON
+  subq_1.listing = subq_3.listing
+LEFT OUTER JOIN (
+  -- Pass Only Elements:
+  --   ['listing', 'country_latest']
+  SELECT
+    subq_4.country_latest
+    , subq_4.listing
+  FROM (
+    -- Read Elements From Data Source 'listings_latest'
+    SELECT
+      1 AS listings
+      , listings_latest_src_10003.capacity AS largest_listing
+      , listings_latest_src_10003.capacity AS smallest_listing
+      , listings_latest_src_10003.created_at AS ds
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+      , listings_latest_src_10003.created_at
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+      , listings_latest_src_10003.country AS country_latest
+      , listings_latest_src_10003.is_lux AS is_lux_latest
+      , listings_latest_src_10003.capacity AS capacity_latest
+      , listings_latest_src_10003.created_at AS listing__ds
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+      , listings_latest_src_10003.created_at AS listing__created_at
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+      , listings_latest_src_10003.country AS listing__country_latest
+      , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+      , listings_latest_src_10003.capacity AS listing__capacity_latest
+      , listings_latest_src_10003.listing_id AS listing
+      , listings_latest_src_10003.user_id AS user
+      , listings_latest_src_10003.user_id AS listing__user
+    FROM ***************************.dim_listings_latest listings_latest_src_10003
+  ) subq_4
+) subq_5
+ON
+  subq_1.listing = subq_5.listing

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_join_node__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Join Standard Outputs
+SELECT
+  subq_7.bookings AS bookings
+  , subq_9.country_latest AS listing__country_latest
+  , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Pass Only Elements:
+  --   ['bookings', 'listing']
+  SELECT
+    1 AS bookings
+    , listing_id AS listing
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_7
+LEFT OUTER JOIN (
+  -- Read Elements From Data Source 'listings_latest'
+  -- Pass Only Elements:
+  --   ['listing', 'country_latest']
+  SELECT
+    country AS country_latest
+    , listing_id AS listing
+  FROM ***************************.dim_listings_latest listings_latest_src_10003
+) subq_9
+ON
+  subq_7.listing = subq_9.listing
+LEFT OUTER JOIN (
+  -- Read Elements From Data Source 'listings_latest'
+  -- Pass Only Elements:
+  --   ['listing', 'country_latest']
+  SELECT
+    country AS country_latest
+    , listing_id AS listing
+  FROM ***************************.dim_listings_latest listings_latest_src_10003
+) subq_11
+ON
+  subq_7.listing = subq_11.listing

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0.sql
@@ -1,0 +1,185 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.txn_count
+  , subq_9.account_id__customer_id__customer_name
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_8.txn_count) AS txn_count
+    , subq_8.account_id__customer_id__customer_name
+  FROM (
+    -- Pass Only Elements:
+    --   ['txn_count', 'account_id__customer_id__customer_name']
+    SELECT
+      subq_7.txn_count
+      , subq_7.account_id__customer_id__customer_name
+    FROM (
+      -- Join Standard Outputs
+      SELECT
+        subq_1.txn_count AS txn_count
+        , subq_6.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_1.ds_partitioned AS ds_partitioned
+        , subq_6.ds_partitioned AS account_id__ds_partitioned
+        , subq_1.account_id AS account_id
+      FROM (
+        -- Pass Only Elements:
+        --   ['txn_count', 'account_id', 'ds_partitioned']
+        SELECT
+          subq_0.txn_count
+          , subq_0.ds_partitioned
+          , subq_0.account_id
+        FROM (
+          -- Read Elements From Data Source 'account_month_txns'
+          SELECT
+            account_month_txns_src_0.txn_count
+            , account_month_txns_src_0.ds_partitioned
+            , DATE_TRUNC('week', account_month_txns_src_0.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', account_month_txns_src_0.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', account_month_txns_src_0.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', account_month_txns_src_0.ds_partitioned) AS ds_partitioned__year
+            , account_month_txns_src_0.ds
+            , DATE_TRUNC('week', account_month_txns_src_0.ds) AS ds__week
+            , DATE_TRUNC('month', account_month_txns_src_0.ds) AS ds__month
+            , DATE_TRUNC('quarter', account_month_txns_src_0.ds) AS ds__quarter
+            , DATE_TRUNC('year', account_month_txns_src_0.ds) AS ds__year
+            , account_month_txns_src_0.account_month
+            , account_month_txns_src_0.ds_partitioned AS account_id__ds_partitioned
+            , DATE_TRUNC('week', account_month_txns_src_0.ds_partitioned) AS account_id__ds_partitioned__week
+            , DATE_TRUNC('month', account_month_txns_src_0.ds_partitioned) AS account_id__ds_partitioned__month
+            , DATE_TRUNC('quarter', account_month_txns_src_0.ds_partitioned) AS account_id__ds_partitioned__quarter
+            , DATE_TRUNC('year', account_month_txns_src_0.ds_partitioned) AS account_id__ds_partitioned__year
+            , account_month_txns_src_0.ds AS account_id__ds
+            , DATE_TRUNC('week', account_month_txns_src_0.ds) AS account_id__ds__week
+            , DATE_TRUNC('month', account_month_txns_src_0.ds) AS account_id__ds__month
+            , DATE_TRUNC('quarter', account_month_txns_src_0.ds) AS account_id__ds__quarter
+            , DATE_TRUNC('year', account_month_txns_src_0.ds) AS account_id__ds__year
+            , account_month_txns_src_0.account_month AS account_id__account_month
+            , account_month_txns_src_0.account_id
+          FROM ***************************.account_month_txns account_month_txns_src_0
+        ) subq_0
+      ) subq_1
+      LEFT OUTER JOIN (
+        -- Pass Only Elements:
+        --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
+        SELECT
+          subq_5.customer_id__customer_name
+          , subq_5.ds_partitioned
+          , subq_5.account_id
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.extra_dim AS extra_dim
+            , subq_2.account_id__extra_dim AS account_id__extra_dim
+            , subq_4.customer_name AS customer_id__customer_name
+            , subq_4.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_2.ds_partitioned AS ds_partitioned
+            , subq_2.ds_partitioned__week AS ds_partitioned__week
+            , subq_2.ds_partitioned__month AS ds_partitioned__month
+            , subq_2.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_2.ds_partitioned__year AS ds_partitioned__year
+            , subq_2.account_id__ds_partitioned AS account_id__ds_partitioned
+            , subq_2.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_2.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_2.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_2.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_4.ds_partitioned AS customer_id__ds_partitioned
+            , subq_4.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_4.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_2.account_id AS account_id
+            , subq_2.customer_id AS customer_id
+            , subq_2.account_id__customer_id AS account_id__customer_id
+          FROM (
+            -- Read Elements From Data Source 'bridge_table'
+            SELECT
+              bridge_table_src_1.extra_dim
+              , bridge_table_src_1.ds_partitioned
+              , DATE_TRUNC('week', bridge_table_src_1.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bridge_table_src_1.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bridge_table_src_1.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bridge_table_src_1.ds_partitioned) AS ds_partitioned__year
+              , bridge_table_src_1.extra_dim AS account_id__extra_dim
+              , bridge_table_src_1.ds_partitioned AS account_id__ds_partitioned
+              , DATE_TRUNC('week', bridge_table_src_1.ds_partitioned) AS account_id__ds_partitioned__week
+              , DATE_TRUNC('month', bridge_table_src_1.ds_partitioned) AS account_id__ds_partitioned__month
+              , DATE_TRUNC('quarter', bridge_table_src_1.ds_partitioned) AS account_id__ds_partitioned__quarter
+              , DATE_TRUNC('year', bridge_table_src_1.ds_partitioned) AS account_id__ds_partitioned__year
+              , bridge_table_src_1.account_id
+              , bridge_table_src_1.customer_id
+              , bridge_table_src_1.customer_id AS account_id__customer_id
+            FROM ***************************.bridge_table bridge_table_src_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['customer_name',
+            --    'customer_atomic_weight',
+            --    'customer_id__customer_name',
+            --    'customer_id__customer_atomic_weight',
+            --    'customer_id',
+            --    'ds_partitioned',
+            --    'ds_partitioned__week',
+            --    'ds_partitioned__month',
+            --    'ds_partitioned__quarter',
+            --    'ds_partitioned__year',
+            --    'customer_id__ds_partitioned',
+            --    'customer_id__ds_partitioned__week',
+            --    'customer_id__ds_partitioned__month',
+            --    'customer_id__ds_partitioned__quarter',
+            --    'customer_id__ds_partitioned__year']
+            SELECT
+              subq_3.customer_name
+              , subq_3.customer_atomic_weight
+              , subq_3.customer_id__customer_name
+              , subq_3.customer_id__customer_atomic_weight
+              , subq_3.ds_partitioned
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.customer_id__ds_partitioned
+              , subq_3.customer_id__ds_partitioned__week
+              , subq_3.customer_id__ds_partitioned__month
+              , subq_3.customer_id__ds_partitioned__quarter
+              , subq_3.customer_id__ds_partitioned__year
+              , subq_3.customer_id
+            FROM (
+              -- Read Elements From Data Source 'customer_table'
+              SELECT
+                customer_table_src_3.customer_name
+                , customer_table_src_3.customer_atomic_weight
+                , customer_table_src_3.ds_partitioned
+                , DATE_TRUNC('week', customer_table_src_3.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', customer_table_src_3.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', customer_table_src_3.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', customer_table_src_3.ds_partitioned) AS ds_partitioned__year
+                , customer_table_src_3.customer_name AS customer_id__customer_name
+                , customer_table_src_3.customer_atomic_weight AS customer_id__customer_atomic_weight
+                , customer_table_src_3.ds_partitioned AS customer_id__ds_partitioned
+                , DATE_TRUNC('week', customer_table_src_3.ds_partitioned) AS customer_id__ds_partitioned__week
+                , DATE_TRUNC('month', customer_table_src_3.ds_partitioned) AS customer_id__ds_partitioned__month
+                , DATE_TRUNC('quarter', customer_table_src_3.ds_partitioned) AS customer_id__ds_partitioned__quarter
+                , DATE_TRUNC('year', customer_table_src_3.ds_partitioned) AS customer_id__ds_partitioned__year
+                , customer_table_src_3.customer_id
+              FROM ***************************.customer_table customer_table_src_3
+            ) subq_3
+          ) subq_4
+          ON
+            (
+              subq_2.customer_id = subq_4.customer_id
+            ) AND (
+              subq_2.ds_partitioned = subq_4.ds_partitioned
+            )
+        ) subq_5
+      ) subq_6
+      ON
+        (
+          subq_1.account_id = subq_6.account_id
+        ) AND (
+          subq_1.ds_partitioned = subq_6.ds_partitioned
+        )
+    ) subq_7
+  ) subq_8
+  GROUP BY
+    subq_8.account_id__customer_id__customer_name
+) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Join Standard Outputs
+-- Pass Only Elements:
+--   ['txn_count', 'account_id__customer_id__customer_name']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(account_month_txns_src_0.txn_count) AS txn_count
+  , subq_16.customer_id__customer_name AS account_id__customer_id__customer_name
+FROM ***************************.account_month_txns account_month_txns_src_0
+LEFT OUTER JOIN (
+  -- Join Standard Outputs
+  -- Pass Only Elements:
+  --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
+  SELECT
+    customer_table_src_3.customer_name AS customer_id__customer_name
+    , bridge_table_src_1.ds_partitioned AS ds_partitioned
+    , bridge_table_src_1.account_id AS account_id
+  FROM ***************************.bridge_table bridge_table_src_1
+  LEFT OUTER JOIN
+    ***************************.customer_table customer_table_src_3
+  ON
+    (
+      bridge_table_src_1.customer_id = customer_table_src_3.customer_id
+    ) AND (
+      bridge_table_src_1.ds_partitioned = customer_table_src_3.ds_partitioned
+    )
+) subq_16
+ON
+  (
+    account_month_txns_src_0.account_id = subq_16.account_id
+  ) AND (
+    account_month_txns_src_0.ds_partitioned = subq_16.ds_partitioned
+  )
+GROUP BY
+  subq_16.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_order_by_node__plan0.sql
@@ -1,0 +1,75 @@
+-- Order By ['ds', 'bookings']
+SELECT
+  subq_3.bookings
+  , subq_3.is_instant
+  , subq_3.ds
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_2.bookings
+    , subq_2.is_instant
+    , subq_2.ds
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      SUM(subq_1.bookings) AS bookings
+      , subq_1.is_instant
+      , subq_1.ds
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'is_instant', 'ds']
+      SELECT
+        subq_0.bookings
+        , subq_0.is_instant
+        , subq_0.ds
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        SELECT
+          1 AS bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+          , bookings_source_src_10000.booking_value
+          , bookings_source_src_10000.booking_value AS max_booking_value
+          , bookings_source_src_10000.booking_value AS min_booking_value
+          , bookings_source_src_10000.guest_id AS bookers
+          , bookings_source_src_10000.booking_value AS average_booking_value
+          , bookings_source_src_10000.is_instant
+          , bookings_source_src_10000.ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+          , bookings_source_src_10000.ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+          , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+          , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+          , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+          , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+          , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , bookings_source_src_10000.listing_id AS listing
+          , bookings_source_src_10000.guest_id AS guest
+          , bookings_source_src_10000.host_id AS host
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+          , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+          , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+          , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10000
+      ) subq_0
+    ) subq_1
+    GROUP BY
+      subq_1.is_instant
+      , subq_1.ds
+  ) subq_2
+) subq_3
+ORDER BY subq_3.ds, subq_3.bookings DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_order_by_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_order_by_node__plan0_optimized.sql
@@ -1,0 +1,24 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+-- Order By ['ds', 'bookings']
+SELECT
+  SUM(bookings) AS bookings
+  , is_instant
+  , ds
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Pass Only Elements:
+  --   ['bookings', 'is_instant', 'ds']
+  SELECT
+    1 AS bookings
+    , is_instant
+    , ds
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_5
+GROUP BY
+  is_instant
+  , ds
+ORDER BY ds, bookings DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0.sql
@@ -1,0 +1,119 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.identity_verifications
+  , subq_6.user__home_state
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.identity_verifications) AS identity_verifications
+    , subq_5.user__home_state
+  FROM (
+    -- Pass Only Elements:
+    --   ['identity_verifications', 'user__home_state']
+    SELECT
+      subq_4.identity_verifications
+      , subq_4.user__home_state
+    FROM (
+      -- Join Standard Outputs
+      SELECT
+        subq_1.identity_verifications AS identity_verifications
+        , subq_3.home_state AS user__home_state
+        , subq_1.ds_partitioned AS ds_partitioned
+        , subq_3.ds_partitioned AS user__ds_partitioned
+        , subq_1.user AS user
+      FROM (
+        -- Pass Only Elements:
+        --   ['identity_verifications', 'user', 'ds_partitioned']
+        SELECT
+          subq_0.identity_verifications
+          , subq_0.ds_partitioned
+          , subq_0.user
+        FROM (
+          -- Read Elements From Data Source 'id_verifications'
+          SELECT
+            1 AS identity_verifications
+            , id_verifications_src_10002.ds
+            , DATE_TRUNC('week', id_verifications_src_10002.ds) AS ds__week
+            , DATE_TRUNC('month', id_verifications_src_10002.ds) AS ds__month
+            , DATE_TRUNC('quarter', id_verifications_src_10002.ds) AS ds__quarter
+            , DATE_TRUNC('year', id_verifications_src_10002.ds) AS ds__year
+            , id_verifications_src_10002.ds_partitioned
+            , DATE_TRUNC('week', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', id_verifications_src_10002.ds_partitioned) AS ds_partitioned__year
+            , id_verifications_src_10002.verification_type
+            , id_verifications_src_10002.ds AS verification__ds
+            , DATE_TRUNC('week', id_verifications_src_10002.ds) AS verification__ds__week
+            , DATE_TRUNC('month', id_verifications_src_10002.ds) AS verification__ds__month
+            , DATE_TRUNC('quarter', id_verifications_src_10002.ds) AS verification__ds__quarter
+            , DATE_TRUNC('year', id_verifications_src_10002.ds) AS verification__ds__year
+            , id_verifications_src_10002.ds_partitioned AS verification__ds_partitioned
+            , DATE_TRUNC('week', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__week
+            , DATE_TRUNC('month', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__month
+            , DATE_TRUNC('quarter', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__quarter
+            , DATE_TRUNC('year', id_verifications_src_10002.ds_partitioned) AS verification__ds_partitioned__year
+            , id_verifications_src_10002.verification_type AS verification__verification_type
+            , id_verifications_src_10002.verification_id AS verification
+            , id_verifications_src_10002.user_id AS user
+            , id_verifications_src_10002.user_id AS verification__user
+          FROM ***************************.fct_id_verifications id_verifications_src_10002
+        ) subq_0
+      ) subq_1
+      LEFT OUTER JOIN (
+        -- Pass Only Elements:
+        --   ['user', 'ds_partitioned', 'home_state']
+        SELECT
+          subq_2.home_state
+          , subq_2.ds_partitioned
+          , subq_2.user
+        FROM (
+          -- Read Elements From Data Source 'users_ds_source'
+          SELECT
+            users_ds_source_src_10006.ds
+            , DATE_TRUNC('week', users_ds_source_src_10006.ds) AS ds__week
+            , DATE_TRUNC('month', users_ds_source_src_10006.ds) AS ds__month
+            , DATE_TRUNC('quarter', users_ds_source_src_10006.ds) AS ds__quarter
+            , DATE_TRUNC('year', users_ds_source_src_10006.ds) AS ds__year
+            , users_ds_source_src_10006.created_at
+            , DATE_TRUNC('week', users_ds_source_src_10006.created_at) AS created_at__week
+            , DATE_TRUNC('month', users_ds_source_src_10006.created_at) AS created_at__month
+            , DATE_TRUNC('quarter', users_ds_source_src_10006.created_at) AS created_at__quarter
+            , DATE_TRUNC('year', users_ds_source_src_10006.created_at) AS created_at__year
+            , users_ds_source_src_10006.ds_partitioned
+            , DATE_TRUNC('week', users_ds_source_src_10006.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', users_ds_source_src_10006.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', users_ds_source_src_10006.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', users_ds_source_src_10006.ds_partitioned) AS ds_partitioned__year
+            , users_ds_source_src_10006.home_state
+            , users_ds_source_src_10006.ds AS user__ds
+            , DATE_TRUNC('week', users_ds_source_src_10006.ds) AS user__ds__week
+            , DATE_TRUNC('month', users_ds_source_src_10006.ds) AS user__ds__month
+            , DATE_TRUNC('quarter', users_ds_source_src_10006.ds) AS user__ds__quarter
+            , DATE_TRUNC('year', users_ds_source_src_10006.ds) AS user__ds__year
+            , users_ds_source_src_10006.created_at AS user__created_at
+            , DATE_TRUNC('week', users_ds_source_src_10006.created_at) AS user__created_at__week
+            , DATE_TRUNC('month', users_ds_source_src_10006.created_at) AS user__created_at__month
+            , DATE_TRUNC('quarter', users_ds_source_src_10006.created_at) AS user__created_at__quarter
+            , DATE_TRUNC('year', users_ds_source_src_10006.created_at) AS user__created_at__year
+            , users_ds_source_src_10006.ds_partitioned AS user__ds_partitioned
+            , DATE_TRUNC('week', users_ds_source_src_10006.ds_partitioned) AS user__ds_partitioned__week
+            , DATE_TRUNC('month', users_ds_source_src_10006.ds_partitioned) AS user__ds_partitioned__month
+            , DATE_TRUNC('quarter', users_ds_source_src_10006.ds_partitioned) AS user__ds_partitioned__quarter
+            , DATE_TRUNC('year', users_ds_source_src_10006.ds_partitioned) AS user__ds_partitioned__year
+            , users_ds_source_src_10006.home_state AS user__home_state
+            , users_ds_source_src_10006.user_id AS user
+          FROM ***************************.dim_users users_ds_source_src_10006
+        ) subq_2
+      ) subq_3
+      ON
+        (
+          subq_1.user = subq_3.user
+        ) AND (
+          subq_1.ds_partitioned = subq_3.ds_partitioned
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.user__home_state
+) subq_6

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Join Standard Outputs
+-- Pass Only Elements:
+--   ['identity_verifications', 'user__home_state']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(subq_8.identity_verifications) AS identity_verifications
+  , users_ds_source_src_10006.home_state AS user__home_state
+FROM (
+  -- Read Elements From Data Source 'id_verifications'
+  -- Pass Only Elements:
+  --   ['identity_verifications', 'user', 'ds_partitioned']
+  SELECT
+    1 AS identity_verifications
+    , ds_partitioned
+    , user_id AS user
+  FROM ***************************.fct_id_verifications id_verifications_src_10002
+) subq_8
+LEFT OUTER JOIN
+  ***************************.dim_users users_ds_source_src_10006
+ON
+  (
+    subq_8.user = users_ds_source_src_10006.user_id
+  ) AND (
+    subq_8.ds_partitioned = users_ds_source_src_10006.ds_partitioned
+  )
+GROUP BY
+  users_ds_source_src_10006.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_single_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_single_join_node__plan0.sql
@@ -1,0 +1,102 @@
+-- Join Standard Outputs
+SELECT
+  subq_1.bookings AS bookings
+  , subq_3.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
+FROM (
+  -- Pass Only Elements:
+  --   ['bookings', 'listing']
+  SELECT
+    subq_0.bookings
+    , subq_0.listing
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    SELECT
+      1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+      , bookings_source_src_10000.booking_value
+      , bookings_source_src_10000.booking_value AS max_booking_value
+      , bookings_source_src_10000.booking_value AS min_booking_value
+      , bookings_source_src_10000.guest_id AS bookers
+      , bookings_source_src_10000.booking_value AS average_booking_value
+      , bookings_source_src_10000.is_instant
+      , bookings_source_src_10000.ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+      , bookings_source_src_10000.ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+      , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+      , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+      , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+      , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+      , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+      , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+      , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+      , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+      , bookings_source_src_10000.listing_id AS listing
+      , bookings_source_src_10000.guest_id AS guest
+      , bookings_source_src_10000.host_id AS host
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+      , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+      , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+      , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_10000
+  ) subq_0
+) subq_1
+LEFT OUTER JOIN (
+  -- Pass Only Elements:
+  --   ['listing', 'country_latest']
+  SELECT
+    subq_2.country_latest
+    , subq_2.listing
+  FROM (
+    -- Read Elements From Data Source 'listings_latest'
+    SELECT
+      1 AS listings
+      , listings_latest_src_10003.capacity AS largest_listing
+      , listings_latest_src_10003.capacity AS smallest_listing
+      , listings_latest_src_10003.created_at AS ds
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS ds__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS ds__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS ds__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS ds__year
+      , listings_latest_src_10003.created_at
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS created_at__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS created_at__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS created_at__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS created_at__year
+      , listings_latest_src_10003.country AS country_latest
+      , listings_latest_src_10003.is_lux AS is_lux_latest
+      , listings_latest_src_10003.capacity AS capacity_latest
+      , listings_latest_src_10003.created_at AS listing__ds
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__ds__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__ds__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__ds__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__ds__year
+      , listings_latest_src_10003.created_at AS listing__created_at
+      , DATE_TRUNC('week', listings_latest_src_10003.created_at) AS listing__created_at__week
+      , DATE_TRUNC('month', listings_latest_src_10003.created_at) AS listing__created_at__month
+      , DATE_TRUNC('quarter', listings_latest_src_10003.created_at) AS listing__created_at__quarter
+      , DATE_TRUNC('year', listings_latest_src_10003.created_at) AS listing__created_at__year
+      , listings_latest_src_10003.country AS listing__country_latest
+      , listings_latest_src_10003.is_lux AS listing__is_lux_latest
+      , listings_latest_src_10003.capacity AS listing__capacity_latest
+      , listings_latest_src_10003.listing_id AS listing
+      , listings_latest_src_10003.user_id AS user
+      , listings_latest_src_10003.user_id AS listing__user
+    FROM ***************************.dim_listings_latest listings_latest_src_10003
+  ) subq_2
+) subq_3
+ON
+  subq_1.listing = subq_3.listing

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_single_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_single_join_node__plan0_optimized.sql
@@ -1,0 +1,21 @@
+-- Join Standard Outputs
+SELECT
+  subq_5.bookings AS bookings
+  , listings_latest_src_10003.country AS listing__country_latest
+  , subq_5.listing AS listing
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Pass Only Elements:
+  --   ['bookings', 'listing']
+  SELECT
+    1 AS bookings
+    , listing_id AS listing
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_10000
+) subq_5
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_10003
+ON
+  subq_5.listing = listings_latest_src_10003.listing_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_source_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_source_node__plan0.sql
@@ -1,0 +1,42 @@
+-- Read Elements From Data Source 'bookings_source'
+SELECT
+  1 AS bookings
+  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  , bookings_source_src_10000.booking_value
+  , bookings_source_src_10000.booking_value AS max_booking_value
+  , bookings_source_src_10000.booking_value AS min_booking_value
+  , bookings_source_src_10000.guest_id AS bookers
+  , bookings_source_src_10000.booking_value AS average_booking_value
+  , bookings_source_src_10000.is_instant
+  , bookings_source_src_10000.ds
+  , DATE_TRUNC('week', bookings_source_src_10000.ds) AS ds__week
+  , DATE_TRUNC('month', bookings_source_src_10000.ds) AS ds__month
+  , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS ds__quarter
+  , DATE_TRUNC('year', bookings_source_src_10000.ds) AS ds__year
+  , bookings_source_src_10000.ds_partitioned
+  , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__week
+  , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__month
+  , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__quarter
+  , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS ds_partitioned__year
+  , bookings_source_src_10000.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+  , bookings_source_src_10000.ds AS create_a_cycle_in_the_join_graph__ds
+  , DATE_TRUNC('week', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__week
+  , DATE_TRUNC('month', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__month
+  , DATE_TRUNC('quarter', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+  , DATE_TRUNC('year', bookings_source_src_10000.ds) AS create_a_cycle_in_the_join_graph__ds__year
+  , bookings_source_src_10000.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+  , DATE_TRUNC('week', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+  , DATE_TRUNC('month', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+  , DATE_TRUNC('quarter', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+  , DATE_TRUNC('year', bookings_source_src_10000.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+  , bookings_source_src_10000.listing_id AS listing
+  , bookings_source_src_10000.guest_id AS guest
+  , bookings_source_src_10000.host_id AS host
+  , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph
+  , bookings_source_src_10000.listing_id AS create_a_cycle_in_the_join_graph__listing
+  , bookings_source_src_10000.guest_id AS create_a_cycle_in_the_join_graph__guest
+  , bookings_source_src_10000.host_id AS create_a_cycle_in_the_join_graph__host
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_bookings
+) bookings_source_src_10000

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_source_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_source_node__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Read Elements From Data Source 'bookings_source'
+SELECT
+  1 AS bookings
+  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  , booking_value
+  , booking_value AS max_booking_value
+  , booking_value AS min_booking_value
+  , guest_id AS bookers
+  , booking_value AS average_booking_value
+  , is_instant
+  , ds
+  , DATE_TRUNC('week', ds) AS ds__week
+  , DATE_TRUNC('month', ds) AS ds__month
+  , DATE_TRUNC('quarter', ds) AS ds__quarter
+  , DATE_TRUNC('year', ds) AS ds__year
+  , ds_partitioned
+  , DATE_TRUNC('week', ds_partitioned) AS ds_partitioned__week
+  , DATE_TRUNC('month', ds_partitioned) AS ds_partitioned__month
+  , DATE_TRUNC('quarter', ds_partitioned) AS ds_partitioned__quarter
+  , DATE_TRUNC('year', ds_partitioned) AS ds_partitioned__year
+  , is_instant AS create_a_cycle_in_the_join_graph__is_instant
+  , ds AS create_a_cycle_in_the_join_graph__ds
+  , DATE_TRUNC('week', ds) AS create_a_cycle_in_the_join_graph__ds__week
+  , DATE_TRUNC('month', ds) AS create_a_cycle_in_the_join_graph__ds__month
+  , DATE_TRUNC('quarter', ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+  , DATE_TRUNC('year', ds) AS create_a_cycle_in_the_join_graph__ds__year
+  , ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+  , DATE_TRUNC('week', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+  , DATE_TRUNC('month', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+  , DATE_TRUNC('quarter', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+  , DATE_TRUNC('year', ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+  , listing_id AS listing
+  , guest_id AS guest
+  , host_id AS host
+  , guest_id AS create_a_cycle_in_the_join_graph
+  , listing_id AS create_a_cycle_in_the_join_graph__listing
+  , guest_id AS create_a_cycle_in_the_join_graph__guest
+  , host_id AS create_a_cycle_in_the_join_graph__host
+FROM (
+  -- User Defined SQL Query
+  SELECT * FROM ***************************.fct_bookings
+) bookings_source_src_10000

--- a/metricflow/test/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/DuckDbSqlClient/test_cast_to_timestamp__plan0.sql
+++ b/metricflow/test/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/DuckDbSqlClient/test_cast_to_timestamp__plan0.sql
@@ -1,0 +1,4 @@
+-- Test Cast to Timestamp Expression
+SELECT
+  CAST('2020-01-01' AS TIMESTAMP) AS col0
+FROM foo.bar a

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_query__query0.sql
@@ -1,0 +1,25 @@
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  SUM(bookings) AS bookings
+  , ds
+FROM (
+  -- Read Elements From Data Source 'bookings_source'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2040-12-31T00:00:00]
+  -- Pass Only Elements:
+  --   ['bookings', 'ds']
+  SELECT
+    1 AS bookings
+    , ds
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_bookings
+  ) bookings_source_src_0
+  WHERE (
+    ds >= CAST('2000-01-01' AS TIMESTAMP)
+  ) AND (
+    ds <= CAST('2040-12-31' AS TIMESTAMP)
+  )
+) subq_2
+GROUP BY
+  ds

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_write_to_table_query__query0.sql
@@ -1,0 +1,27 @@
+CREATE TABLE ***************************.test_table AS (
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    SUM(bookings) AS bookings
+    , ds
+  FROM (
+    -- Read Elements From Data Source 'bookings_source'
+    -- Constrain Time Range to [2000-01-01T00:00:00, 2040-12-31T00:00:00]
+    -- Pass Only Elements:
+    --   ['bookings', 'ds']
+    SELECT
+      1 AS bookings
+      , ds
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_bookings
+    ) bookings_source_src_0
+    WHERE (
+      ds >= CAST('2000-01-01' AS TIMESTAMP)
+    ) AND (
+      ds <= CAST('2040-12-31' AS TIMESTAMP)
+    )
+  ) subq_2
+  GROUP BY
+    ds
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan0.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan0.sql
@@ -1,0 +1,4 @@
+-- test0
+SELECT
+  SUM(1) AS bookings
+FROM demo.fct_bookings a

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan1.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan1.sql
@@ -1,0 +1,6 @@
+-- test1
+SELECT
+  SUM(1) AS bookings
+  , b.country AS user__country
+  , c.country AS listing__country
+FROM demo.fct_bookings a

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan2.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan2.sql
@@ -1,0 +1,10 @@
+-- test2
+SELECT
+  SUM(1) AS bookings
+  , b.country AS user__country
+  , c.country AS listing__country
+FROM demo.fct_bookings a
+LEFT OUTER JOIN
+  demo.dim_users b
+ON
+  a.user_id = b.user_id

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan3.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan3.sql
@@ -1,0 +1,14 @@
+-- test3
+SELECT
+  SUM(1) AS bookings
+  , b.country AS user__country
+  , c.country AS listing__country
+FROM demo.fct_bookings a
+LEFT OUTER JOIN
+  demo.dim_users b
+ON
+  a.user_id = b.user_id
+LEFT OUTER JOIN
+  demo.dim_listings c
+ON
+  a.user_id = c.user_id

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan4.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan4.sql
@@ -1,0 +1,16 @@
+-- test4
+SELECT
+  SUM(1) AS bookings
+  , b.country AS user__country
+  , c.country AS listing__country
+FROM demo.fct_bookings a
+LEFT OUTER JOIN
+  demo.dim_users b
+ON
+  a.user_id = b.user_id
+LEFT OUTER JOIN
+  demo.dim_listings c
+ON
+  a.user_id = c.user_id
+GROUP BY
+  b.country

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan5.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_component_rendering__plan5.sql
@@ -1,0 +1,17 @@
+-- test5
+SELECT
+  SUM(1) AS bookings
+  , b.country AS user__country
+  , c.country AS listing__country
+FROM demo.fct_bookings a
+LEFT OUTER JOIN
+  demo.dim_users b
+ON
+  a.user_id = b.user_id
+LEFT OUTER JOIN
+  demo.dim_listings c
+ON
+  a.user_id = c.user_id
+GROUP BY
+  b.country
+  , c.country

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_render_limit__plan0.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_render_limit__plan0.sql
@@ -1,0 +1,5 @@
+-- test0
+SELECT
+  a.bookings
+FROM demo.fct_bookings a
+LIMIT 1

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_render_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_render_order_by__plan0.sql
@@ -1,0 +1,6 @@
+-- test0
+SELECT
+  a.booking_value
+  , a.bookings
+FROM demo.fct_bookings a
+ORDER BY a.booking_value, a.bookings DESC

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_render_where__plan0.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDbSqlClient/test_render_where__plan0.sql
@@ -1,0 +1,5 @@
+-- test0
+SELECT
+  a.booking_value
+FROM demo.fct_bookings a
+WHERE a.booking_value > 100

--- a/poetry.lock
+++ b/poetry.lock
@@ -137,6 +137,29 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "duckdb"
+version = "0.3.4"
+description = "DuckDB embedded database"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = ">=1.14"
+
+[[package]]
+name = "duckdb-engine"
+version = "0.1.8"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+duckdb = ">=0.2.8"
+sqlalchemy = ">=1.3.19,<2.0.0"
+
+[[package]]
 name = "filelock"
 version = "3.7.1"
 description = "A platform independent file lock."
@@ -1160,7 +1183,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "fe9c62165eab354d9eb2813178cabb10e40ff468863ba54499cb93a19f2b0ca3"
+content-hash = "9cd7ae2810bc56b0de2a1ce29dbc820105283e75fd3b5744ec3641b289015b96"
 
 [metadata.files]
 asn1crypto = [
@@ -1284,6 +1307,50 @@ cryptography = [
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
+duckdb = [
+    {file = "duckdb-0.3.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4ecfa5e8c6bde61efead473b05b35ed989dc08fe76c7ab1c931e4c16e082b10b"},
+    {file = "duckdb-0.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7bda539e070d08391b36370e847122350c66d90d9fdf20727b23cde86847fa39"},
+    {file = "duckdb-0.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6d913ea8d59c4004508ed2a21b70dcf7c5cd5d667e7a48efac01e0453627aadc"},
+    {file = "duckdb-0.3.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eeab0867e5194e14ea39dbe1d14164c058c9d9fff1328b120361fa6da87aa622"},
+    {file = "duckdb-0.3.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0695ee38ad8b2fa4390507ef75c491c93bb508dbe636fec4d08f66bc20b2f911"},
+    {file = "duckdb-0.3.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:b4a743dc8f1e78539070295be548dfbb7a01c1625d2e37f2414068378a11c3d5"},
+    {file = "duckdb-0.3.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6202a9f611aa6526db9699ba625ee0518ca3e269642d6955b995375285f38a7e"},
+    {file = "duckdb-0.3.4-cp310-cp310-win32.whl", hash = "sha256:f3452e6780756508f07cd45b696dd92a08adac02d032442ffb4146578c31ff19"},
+    {file = "duckdb-0.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:e27f5a6e486785797afc109204dffc81982e6eb0af2001e1e1709dd25c0c203d"},
+    {file = "duckdb-0.3.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6e0b88fd0a905e23efb5555f22b980952494c9b94f103c14ea3b613019522095"},
+    {file = "duckdb-0.3.4-cp36-cp36m-win32.whl", hash = "sha256:99ba0cdfbbaee22828cb936c4c324617476970359ff6a9e80b5b7daf4269c500"},
+    {file = "duckdb-0.3.4-cp36-cp36m-win_amd64.whl", hash = "sha256:03020e992d6093a68ab597e11da2e34587863f238bcc317690e1fec1e93bca41"},
+    {file = "duckdb-0.3.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d6280debb6c10a44b1efa073ba07fb067911f3e11d7f5ae9db715478a819a67d"},
+    {file = "duckdb-0.3.4-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b2107da403605bf68692ed5b9194e5692290bd73fa9abdd48fde82be0d6457d"},
+    {file = "duckdb-0.3.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e47ab2f2112a258f2e8fae66321009bb51253d674fadf7dd964be0886514684c"},
+    {file = "duckdb-0.3.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9df6867017644f016cde47da37de57065540d3cfa410e50b943bd90f42d96110"},
+    {file = "duckdb-0.3.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0da2cadcdfbf9aa2e34eba9cc4413ed7c635aaa0bb4cafef7eb37d951f205223"},
+    {file = "duckdb-0.3.4-cp37-cp37m-win32.whl", hash = "sha256:672645773abbe32801bf543d12a1189dbc67122db4da6b90a57f3acecd525dbf"},
+    {file = "duckdb-0.3.4-cp37-cp37m-win_amd64.whl", hash = "sha256:6fa14f1d3cf225f788ad7f055e25b98d99c06d3a379df4b788fdf66ebe7f9b98"},
+    {file = "duckdb-0.3.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:155f6717ad9fe1aa99d8d631508d2577b06519661b7e30cb14cff46a0446558c"},
+    {file = "duckdb-0.3.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:013a65ddac424d2d778dff37d5b1e91c2f68365436cc8ec76ea45a906313e0bf"},
+    {file = "duckdb-0.3.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ba1d627a913154c651daca5ca168b8fa49caa6792a61f069f30eae645a8d52cd"},
+    {file = "duckdb-0.3.4-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8d4e960945955b19ba051e5bb0d6b17c3bcea3d29f9114bb94faaa7585df8c5"},
+    {file = "duckdb-0.3.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56ecd82eb31d89ff349059fd909e02906efa1971faeec1a0f7a81357d09d1ad9"},
+    {file = "duckdb-0.3.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:78c8d2c6629e14140fd038402bf3cbb8c2017ba68148c29c66f8142ffa8f3a39"},
+    {file = "duckdb-0.3.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4811c3fd101d1561d46b5d6c7b9915c3b2adbc8a6270e7cddc63411c6a4b4a0c"},
+    {file = "duckdb-0.3.4-cp38-cp38-win32.whl", hash = "sha256:aa42d850cf2dd3f5f664f7a9c8be548f8618064ca6260808fa4e361a334ce2b1"},
+    {file = "duckdb-0.3.4-cp38-cp38-win_amd64.whl", hash = "sha256:6ec0be5153a35e3a7462c014a90bba81964f63f114af3f25384b97b0bf5fcae7"},
+    {file = "duckdb-0.3.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e35d92606c34cfb56f084eca2540db6573b260f974245465f6dae9dbcdbe6434"},
+    {file = "duckdb-0.3.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54cf2d11ea8e8a9d474a83137ea654a66b2ac7ea26f615ef4498b9e3fb5091f1"},
+    {file = "duckdb-0.3.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8762917c1349c1517487500d5975c2788f3544b82ae341d79984eaa836e20a"},
+    {file = "duckdb-0.3.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:60a163e65a1afdf410b2b9cbecd124875a53e53ad9271bdd66ed98ae42034778"},
+    {file = "duckdb-0.3.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f552592ac977d368ea02c6a89b62373fb53a49a36aa8e7d3b3c89999ee420010"},
+    {file = "duckdb-0.3.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a1c355929e06f22f35a2d3a74c16721d7b2ecd35e5088bf9722f1ca574ff5a2b"},
+    {file = "duckdb-0.3.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f5c65d6a4afa8c313c612d6bc92bca055f1cbcc81646640d5dde797c745b7876"},
+    {file = "duckdb-0.3.4-cp39-cp39-win32.whl", hash = "sha256:79256b5521c3945f540dd4ccfcc7658d18e98a42ba619c5571eb075fc234b5a1"},
+    {file = "duckdb-0.3.4-cp39-cp39-win_amd64.whl", hash = "sha256:f38cdf5a55a4a4f18c30d2ad73055d4531679fa3282cb08cacf2646f0a0150be"},
+    {file = "duckdb-0.3.4.tar.gz", hash = "sha256:ab94cfc9e4c25f93d4a7be2063879475c308d771d53588bfd6198a89a8c2bcd2"},
+]
+duckdb-engine = [
+    {file = "duckdb_engine-0.1.8-py3-none-any.whl", hash = "sha256:308c1318b1b526a5d89be2c7b3da748a4189aae4916151fd3ade65611377fbec"},
+    {file = "duckdb_engine-0.1.8.tar.gz", hash = "sha256:08688e92e0c872e498f4f7bddec252fc0368bbc5b67028fab608ffdcd3d9197a"},
 ]
 filelock = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ click = "^7.1.2"
 "ruamel.yaml" = "^0.17.21"
 python-Levenshtein = "^0.12.2"
 rudder-sdk-python = "^1.0.3"
+duckdb-engine = "^0.1.8"
 
 [tool.poetry.dev-dependencies]
 pytest-mock = "^3.7.0"


### PR DESCRIPTION
This PR adds support to use DuckDB for running local unit tests. Currently, SQLite is used, but this presents limitations as queries that use full outer joins or date functions can't be tested. DuckDB has support for those features, so now all tests can be run without remote connections. 