### PR TITLE
Test CLI without mock MF engine

### DIFF
--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -1,119 +1,60 @@
 from __future__ import annotations
 
 import click
-import datetime
-import pandas as pd
 import pytest
 
 from click.testing import CliRunner, Result
-from typing import List, Optional, Sequence
+from typing import Sequence
 
 from metricflow.cli.cli_context import CLIContext
-from metricflow.engine.models import Dimension, Materialization, Metric
-from metricflow.dataflow.sql_table import SqlTable
-from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFlowQueryResult
-from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
-from metricflow.model.objects.elements.dimension import Dimension as DimensionObj, DimensionType, DimensionTypeParams
-from metricflow.model.objects.metric import Metric as MetricObj
-from metricflow.specs import DimensionReference
-from metricflow.time.time_granularity import TimeGranularity
-
-
-class MockMetricFlowEngine:
-    """Mock MetricFlowEngine class as only integration is needed to be tested."""
-
-    def query(self, mf_request: MetricFlowQueryRequest) -> MetricFlowQueryResult:  # noqa: D
-        data = {"metric1": [123, 5123, 23, 5123], "ds": [1, 2, 3, 4]}
-        return MetricFlowQueryResult(
-            query_spec=None,  # type: ignore
-            dataflow_plan=None,  # type: ignore
-            sql="SELECT * FROM hello",
-            result_df=pd.DataFrame(data),
-            result_table=None,
-        )
-
-    def simple_dimensions_for_metrics(self, metric_names: List[str]) -> List[Dimension]:  # noqa: D
-        dimensions = ["dim1", "dim2", "dim3"]
-        return [Dimension(name) for name in dimensions]
-
-    def list_metrics(self) -> List[Metric]:  # noqa: D
-        return [Metric(name="metric1", dimensions=self.simple_dimensions_for_metrics(metric_names=[]))]
-
-    def get_dimension_values(  # noqa: D
-        self,
-        metric_name: str,
-        get_group_by_values: str,
-        time_constraint_start: Optional[datetime.datetime] = None,
-        time_constraint_end: Optional[datetime.datetime] = None,
-    ) -> List[str]:
-        return ["dim_val1", "dim_val2", "dim_val3"]
-
-    def list_materializations(self) -> List[Materialization]:  # noqa: D
-        return [Materialization(name="mat1", metrics=["metric1"], dimensions=["dim1", "dim2"], destination_table=None)]
-
-    def materialize(  # noqa: D
-        self,
-        materialization_name: str,
-        time_constraint_start: Optional[datetime.datetime] = None,
-        time_constraint_end: Optional[datetime.datetime] = None,
-    ) -> SqlTable:
-        return SqlTable.from_string("test.table")
-
-    def drop_materialization(self, materialization_name: str) -> bool:  # noqa: D
-        return True
-
-
-class MockSemanticModel:
-    """Mock SemanticModel class as only integration is needed to be tested."""
-
-    @property
-    def user_configured_model(self) -> str:  # type: ignore
-        """Mocked UserConfiguredModel."""
-        return "Should build a mocked model if needed in the future"
-
-
-class MockUserConfiguredModel:
-    """Mock UserConfiguredModel class as only integration is needed to be tested."""
-
-    @property
-    def data_sources(self) -> List[DataSource]:  # noqa: D
-        return [
-            DataSource(
-                name="animals",
-                sql_query="SELECT true as foo, '2022-06-01' as ds",
-                measures=[],
-                dimensions=[
-                    DimensionObj(
-                        name=DimensionReference(element_name="ds"),
-                        type=DimensionType.TIME,
-                        type_params=DimensionTypeParams(
-                            is_primary=True,
-                            time_granularity=TimeGranularity.DAY,
-                        ),
-                    ),
-                    DimensionObj(name=DimensionReference(element_name="foo"), type=DimensionType.CATEGORICAL),
-                ],
-                mutability=Mutability(type=MutabilityType.IMMUTABLE),
-            )
-        ]
-
-    @property
-    def metrics(self) -> List[MetricObj]:  # noqa: D
-        return []
-
-
-class MetricFlowCliRunner(CliRunner):
-    """Custom CliRunner class to handle mocks."""
-
-    def run(self, cli: click.BaseCommand, args: Sequence[str] = None) -> Result:  # noqa: D
-        # Mock the metricflow engine
-        cli_context = CLIContext()
-        cli_context._mf = MockMetricFlowEngine()  # type: ignore
-        cli_context._semantic_model = MockSemanticModel()  # type: ignore
-        cli_context._user_configured_model = MockUserConfiguredModel()  # type: ignore
-        return super().invoke(cli, args, obj=cli_context)
+from metricflow.engine.metricflow_engine import MetricFlowEngine
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantic_model import SemanticModel
+from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
+from metricflow.plan_conversion.time_spine import TimeSpineSource
+from metricflow.protocols.sql_client import SqlClient
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.test_utils import as_datetime
+from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 
 @pytest.fixture
-def cli_runner() -> MetricFlowCliRunner:  # noqa: D
-    return MetricFlowCliRunner()
+def cli_context(  # noqa: D
+    sql_client: SqlClient,
+    simple_user_configured_model: UserConfiguredModel,
+    time_spine_source: TimeSpineSource,
+    mf_test_session_state: MetricFlowTestSessionState,
+    create_simple_model_tables: bool,
+) -> CLIContext:
+    semantic_model = SemanticModel(simple_user_configured_model)
+    mf_engine = MetricFlowEngine(
+        semantic_model=semantic_model,
+        sql_client=sql_client,
+        column_association_resolver=DefaultColumnAssociationResolver(semantic_model=semantic_model),
+        time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
+        time_spine_source=time_spine_source,
+        system_schema=mf_test_session_state.mf_system_schema,
+    )
+    context = CLIContext()
+    context._mf = mf_engine
+    context._sql_client = sql_client
+    context._user_configured_model = simple_user_configured_model
+    context._semantic_model = semantic_model
+    context._mf_system_schema = mf_test_session_state.mf_system_schema
+    return context
+
+
+class MetricFlowCliRunner(CliRunner):
+    """Custom CliRunner class to handle passing context."""
+
+    def __init__(self, cli_context: CLIContext) -> None:  # noqa: D
+        self.cli_context = cli_context
+        super().__init__()
+
+    def run(self, cli: click.BaseCommand, args: Sequence[str] = None) -> Result:  # noqa: D
+        return super().invoke(cli, args, obj=self.cli_context)
+
+
+@pytest.fixture
+def cli_runner(cli_context: CLIContext) -> MetricFlowCliRunner:  # noqa: D
+    return MetricFlowCliRunner(cli_context=cli_context)


### PR DESCRIPTION
## Context
Currently, we test the CLI without any integration with the MF engine as we mock all the returned results and just check that the CLI returns properly and displays the proper results. This is an _okay_ approach, but we would like to test with the real thing rather than mocking an integral component to the CLI engine.

## Changes
- removed the mocked `MetricFlowEngine`, `SemanticModel`, `UserConfiguredModel`
- Test the CLI with the `simple_user_configured_model` model
- Added a test for `health_checks` command