### PR TITLE
Add .vscode/ entry to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # IDE
 .idea/
+.vscode/


### PR DESCRIPTION
Visual Studio Code stores a bunch of project-level IDE configuration stuff
in the .vscode directory in the local repo. We do not want these committed
to the metricflow project, so we ignore anything in that location by default.
