### PR TITLE
Add multi-threading support for DuckDB

### DIFF
--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest.mock import patch, MagicMock
-from metricflow.cli.cli_context import CLIContext
 
+from metricflow.cli.cli_context import CLIContext
 from metricflow.cli.main import (
     drop_materialization,
     get_dimension_values,
@@ -47,7 +47,8 @@ def test_list_metrics(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
 def test_get_dimension_values(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
     resp = cli_runner.run(get_dimension_values, args=["--metric-name", "bookings", "--dimension-name", "is_instant"])
 
-    assert "• 0\n• 1\n" in resp.output
+    actual_output_lines = sorted(resp.output.split("\n"))
+    assert ["", "• False", "• True"] == actual_output_lines
     assert resp.exit_code == 0
 
 


### PR DESCRIPTION
This PR adds multi-threading support for the DuckDb client. While threading is not currently used in the repo, there are dependent use case that can benefit from this.