### PR TITLE
Improve Validation Issue Context

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -611,7 +611,7 @@ def drop_materialization(cfg: CLIContext, materialization_name: str) -> None:
 def _print_issues(issues: Sequence[ValidationIssue]) -> None:  # noqa: D
     for issue in issues:
         header = build_validation_header_msg(issue.level)
-        click.echo(f"• {header}: {issue.message}")
+        click.echo(f"• {header}: {issue.as_readable_str(with_level=False)}")
 
 
 def _filter_issues(

--- a/metricflow/model/validations/common_identifiers.py
+++ b/metricflow/model/validations/common_identifiers.py
@@ -4,8 +4,8 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
+    IdentifierContext,
     ModelValidationRule,
-    ValidationIssue,
     ValidationWarning,
     validate_safely,
     ValidationIssueType,
@@ -44,8 +44,11 @@ class CommonIdentifiersRule(ModelValidationRule):
         ):
             issues.append(
                 ValidationWarning(
-                    model_object_reference=ValidationIssue.make_object_reference(
-                        data_source_name=data_source.name, identifier_name=identifier.name.element_name
+                    context=IdentifierContext(
+                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
+                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        data_source_name=data_source.name,
+                        identifier_name=identifier.name.element_name,
                     ),
                     message=f"Identifier `{identifier.name.element_name}` "
                     f"only found in one data source `{data_source.name}` "

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -5,12 +5,11 @@ from metricflow.errors.errors import ParsingException
 from metricflow.model.objects.metric import Metric, MetricType, CumulativeMetricWindow
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
+    MetricContext,
     ModelValidationRule,
-    ValidationIssue,
     ValidationIssueType,
     ValidationError,
     ValidationFatal,
-    ModelObjectType,
     validate_safely,
 )
 
@@ -38,7 +37,9 @@ class MetricMeasuresRule(ModelValidationRule):
             if measure_in_metric.element_name not in valid_measure_names:
                 issues.append(
                     ValidationFatal(
-                        model_object_reference=ValidationIssue.make_object_reference(
+                        context=MetricContext(
+                            file_name=metric.metadata.file_slice.filename if metric.metadata else None,
+                            line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
                             metric_name=metric.name,
                         ),
                         message=f"Invalid measure {measure_in_metric.element_name} in metric {metric.name}",
@@ -74,9 +75,10 @@ class CumulativeMetricRule(ModelValidationRule):
             if metric.type_params.window and metric.type_params.grain_to_date:
                 issues.append(
                     ValidationError(
-                        model_object_reference=ValidationIssue.make_object_reference(
-                            object_type=ModelObjectType.METRIC,
-                            object_name=metric.name,
+                        context=MetricContext(
+                            file_name=metric.metadata.file_slice.filename if metric.metadata else None,
+                            line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                            metric_name=metric.name,
                         ),
                         message="Both window and grain_to_date set for cumulative metric. Please set one or the other",
                     )
@@ -88,7 +90,9 @@ class CumulativeMetricRule(ModelValidationRule):
                 except ParsingException:
                     issues.append(
                         ValidationError(
-                            model_object_reference=ValidationIssue.make_object_reference(
+                            context=MetricContext(
+                                file_name=metric.metadata.file_slice.filename if metric.metadata else None,
+                                line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
                                 metric_name=metric.name,
                             ),
                             message=traceback.format_exc(),

--- a/metricflow/model/validations/non_empty.py
+++ b/metricflow/model/validations/non_empty.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import List
 
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -20,7 +19,6 @@ class NonEmptyRule(ModelValidationRule):
         if not model.data_sources:
             issues.append(
                 ValidationError(
-                    model_object_reference=OrderedDict(),
                     message="No data sources present in the model.",
                 )
             )
@@ -42,7 +40,6 @@ class NonEmptyRule(ModelValidationRule):
         if not model.metrics and not create_measure_proxy_metrics:
             issues.append(
                 ValidationError(
-                    model_object_reference=OrderedDict(),
                     message="No metrics present in the model.",
                 )
             )

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -1,13 +1,21 @@
 import re
-from collections import OrderedDict
 from typing import Dict, Tuple, List, Optional
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
+    DataSourceContext,
+    DimensionContext,
+    IdentifierContext,
+    MaterializationContext,
+    MeasureContext,
+    MetricContext,
     ModelValidationRule,
-    ValidationIssue,
+    ValidationContext,
+    ValidationError,
+    ValidationFatal,
     ValidationIssueLevel,
+    ValidationIssueType,
     validate_safely,
 )
 from metricflow.specs import ElementReference
@@ -24,17 +32,15 @@ class UniqueAndValidNameRule(ModelValidationRule):
     NAME_REGEX = re.compile(r"\A[a-z][a-z0-9_]*[a-z0-9]\Z")
 
     @staticmethod
-    def check_valid_name(name: str, data_source_name: Optional[str] = None) -> List[ValidationIssue]:  # noqa: D
-        issues = []
+    def check_valid_name(  # noqa: D
+        name: str, context: Optional[ValidationContext] = None
+    ) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+
         if not UniqueAndValidNameRule.NAME_REGEX.match(name):
             issues.append(
-                ValidationIssue(
-                    level=ValidationIssueLevel.ERROR,
-                    model_object_reference=ValidationIssue.make_object_reference(
-                        data_source_name=data_source_name,
-                    )
-                    if data_source_name
-                    else OrderedDict(),
+                ValidationError(
+                    context=context,
                     message=f"Invalid name `{name}` - names should only consist of lower case letters, numbers, "
                     f"and underscores. In addition, names should start with a lower case letter, and should not end "
                     f"with an underscore, and they must be at least 2 characters long.",
@@ -42,13 +48,8 @@ class UniqueAndValidNameRule(ModelValidationRule):
             )
         if name.upper() in TimeGranularity.list_names():
             issues.append(
-                ValidationIssue(
-                    level=ValidationIssueLevel.ERROR,
-                    model_object_reference=ValidationIssue.make_object_reference(
-                        data_source_name=data_source_name,
-                    )
-                    if data_source_name
-                    else OrderedDict(),
+                ValidationError(
+                    context=context,
                     message=f"Invalid name `{name}` - names cannot match reserved time granularity keywords "
                     f"({TimeGranularity.list_names()})",
                 )
@@ -57,30 +58,66 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking data source sub element names are unique")
-    def _validate_data_source_elements(data_source: DataSource) -> List[ValidationIssue]:
-        issues = []
-        name_and_type_tuples: List[Tuple[ElementReference, str]] = []
+    def _validate_data_source_elements(data_source: DataSource) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+        element_info_tuples: List[Tuple[ElementReference, str, ValidationContext]] = []
 
         if data_source.measures:
             for measure in data_source.measures:
-                name_and_type_tuples.append((measure.name, "measure"))
+                element_info_tuples.append(
+                    (
+                        measure.name,
+                        "measure",
+                        MeasureContext(
+                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
+                            line_number=data_source.metadata.file_slice.start_line_number
+                            if data_source.metadata
+                            else None,
+                            data_source_name=data_source.name,
+                            measure_name=measure.name.element_name,
+                        ),
+                    )
+                )
         if data_source.identifiers:
             for identifier in data_source.identifiers:
-                name_and_type_tuples.append((identifier.name, "identifier"))
+                element_info_tuples.append(
+                    (
+                        identifier.name,
+                        "identifier",
+                        IdentifierContext(
+                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
+                            line_number=data_source.metadata.file_slice.start_line_number
+                            if data_source.metadata
+                            else None,
+                            data_source_name=data_source.name,
+                            identifier_name=identifier.name.element_name,
+                        ),
+                    )
+                )
         if data_source.dimensions:
             for dimension in data_source.dimensions:
-                name_and_type_tuples.append((dimension.name, "dimension"))
+                element_info_tuples.append(
+                    (
+                        dimension.name,
+                        "dimension",
+                        DimensionContext(
+                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
+                            line_number=data_source.metadata.file_slice.start_line_number
+                            if data_source.metadata
+                            else None,
+                            data_source_name=data_source.name,
+                            dimension_name=dimension.name.element_name,
+                        ),
+                    )
+                )
 
         name_to_type: Dict[ElementReference, str] = {}
 
-        for name, _type in name_and_type_tuples:
+        for name, _type, context in element_info_tuples:
             if name in name_to_type:
                 issues.append(
-                    ValidationIssue(
-                        level=ValidationIssueLevel.FATAL,
-                        model_object_reference=ValidationIssue.make_object_reference(
-                            data_source_name=data_source.name,
-                        ),
+                    ValidationFatal(
+                        context=context,
                         message=f"In data source `{data_source.name}`, can't use name `{name.element_name}` for a "
                         f"{_type} when it was already used for a {name_to_type[name]}",
                     )
@@ -88,33 +125,58 @@ class UniqueAndValidNameRule(ModelValidationRule):
             else:
                 name_to_type[name] = _type
 
-        for name, _ in name_and_type_tuples:
-            issues += UniqueAndValidNameRule.check_valid_name(data_source_name=data_source.name, name=name.element_name)
+        for name, _, context in element_info_tuples:
+            issues += UniqueAndValidNameRule.check_valid_name(name=name.element_name, context=context)
 
         return issues
 
     @staticmethod
     @validate_safely(whats_being_done="checking model top level element names are sufficiently unique")
-    def _validate_top_level_objects(model: UserConfiguredModel) -> List[ValidationIssue]:
+    def _validate_top_level_objects(model: UserConfiguredModel) -> List[ValidationIssueType]:
         """Checks names of objects that are not nested."""
-        name_and_type_tuples = []
+        object_info_tuples = []
         if model.data_sources:
             for data_source in model.data_sources:
-                name_and_type_tuples.append((data_source.name, "data source"))
+                object_info_tuples.append(
+                    (
+                        data_source.name,
+                        "data source",
+                        DataSourceContext(
+                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
+                            line_number=data_source.metadata.file_slice.start_line_number
+                            if data_source.metadata
+                            else None,
+                            data_source_name=data_source.name,
+                        ),
+                    )
+                )
         if model.materializations:
             for materialization in model.materializations:
-                name_and_type_tuples.append((materialization.name, "materialization"))
+                object_info_tuples.append(
+                    (
+                        materialization.name,
+                        "materialization",
+                        MaterializationContext(
+                            file_name=materialization.metadata.file_slice.filename
+                            if materialization.metadata
+                            else None,
+                            line_number=materialization.metadata.file_slice.start_line_number
+                            if materialization.metadata
+                            else None,
+                            materialization_name=materialization.name,
+                        ),
+                    )
+                )
 
         name_to_type: Dict[str, str] = {}
 
-        issues = []
+        issues: List[ValidationIssueType] = []
 
-        for name, type_ in name_and_type_tuples:
+        for name, type_, context in object_info_tuples:
             if name in name_to_type:
                 issues.append(
-                    ValidationIssue(
-                        level=ValidationIssueLevel.FATAL,
-                        model_object_reference=OrderedDict(),
+                    ValidationFatal(
+                        context=context,
                         message=f"Can't use name `{name}` for a {type_} when it was already used for a "
                         f"{name_to_type[name]}",
                     )
@@ -127,9 +189,12 @@ class UniqueAndValidNameRule(ModelValidationRule):
             for metric in model.metrics:
                 if metric.name in metric_names:
                     issues.append(
-                        ValidationIssue(
-                            level=ValidationIssueLevel.FATAL,
-                            model_object_reference=OrderedDict(),
+                        ValidationFatal(
+                            context=MetricContext(
+                                file_name=metric.metadata.file_slice.filename if metric.metadata else None,
+                                line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                                metric_name=metric.name,
+                            ),
                             message=f"Can't use name `{metric.name}` for a metric when it was already used for a metric",
                         )
                     )
@@ -139,14 +204,14 @@ class UniqueAndValidNameRule(ModelValidationRule):
         if any([x.level == ValidationIssueLevel.FATAL for x in issues]):
             return issues
 
-        for name, _ in name_and_type_tuples:
-            issues += UniqueAndValidNameRule.check_valid_name(name)
+        for name, _, context in object_info_tuples:
+            issues += UniqueAndValidNameRule.check_valid_name(name=name, context=context)
 
         return issues
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssue]:  # noqa: D
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
         issues = []
         issues += UniqueAndValidNameRule._validate_top_level_objects(model=model)
 

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import functools
 import traceback
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple, Union
+
+from pydantic import BaseModel, Extra
 
 from metricflow.model.objects.elements.dimension import DimensionType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -39,82 +40,111 @@ class ModelObjectType(Enum):
     METRIC = "metric"
 
 
+class ValidationContext(BaseModel):
+    """The base context class for validation issues"""
+
+    file_name: Optional[str]
+    line_number: Optional[int]
+
+    class Config:
+        """Pydantic class configuration options"""
+
+        extra = Extra.forbid
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+
+        context_string = ""
+
+        if self.file_name:
+            context_string += f"in file `{self.file_name}`"
+            if self.line_number:
+                context_string += f" on line #{self.line_number}"
+
+        return context_string
+
+
+class MaterializationContext(ValidationContext):
+    """The context class for vaidation issues involving materializations"""
+
+    materialization_name: str
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+        return f"with materialization `{self.materialization_name}` {ValidationContext.context_str(self)}"
+
+
+class MetricContext(ValidationContext):
+    """The context class for vaidation issues involving metrics"""
+
+    metric_name: str
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+        return f"with metric `{self.metric_name}` {ValidationContext.context_str(self)}"
+
+
+class DataSourceContext(ValidationContext):
+    """The context class for vaidation issues involving data sources"""
+
+    data_source_name: str
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+        return f"with data source `{self.data_source_name}` {ValidationContext.context_str(self)}"
+
+
+class DimensionContext(DataSourceContext):
+    """The context class for vaidation issues involving dimensions"""
+
+    dimension_name: str
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+        return f"with dimension `{self.dimension_name}` in data source `{self.data_source_name}` {ValidationContext.context_str(self)}"
+
+
+class IdentifierContext(DataSourceContext):
+    """The context class for vaidation issues involving indentifiers"""
+
+    identifier_name: str
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+        return f"with identifier `{self.identifier_name}` in data source `{self.data_source_name}` {ValidationContext.context_str(self)}"
+
+
+class MeasureContext(DataSourceContext):
+    """The context class for vaidation issues involving measures"""
+
+    measure_name: str
+
+    def context_str(self) -> str:
+        """Human readable stringified representation of the context"""
+        return f"with measure `{self.measure_name}` in data source `{self.data_source_name}` {ValidationContext.context_str(self)}"
+
+
 @dataclass(unsafe_hash=True)
 class ValidationIssue:
     """An issue that was found while validating the MetricFlow model."""
 
     level: ValidationIssueLevel
-    # Need a better way to represent the object, but right now this is a dict to the type of object to the name,
-    # inserted in hierarchical order.
-    # e.g. {"data_source": "example_data_source", "measure": "example_measure"}
-    model_object_reference: OrderedDict[ModelObjectType, str]
     message: str
+    context: Optional[ValidationContext]
     # Consider adding a enum here that categories the type of validation issue and standardize the error messages.
 
     def as_readable_str(self) -> str:
         """Return a easily readable string that can be used to log the issue."""
-        object_str = "{" + ", ".join([f"{k.value}: {v}" for k, v in self.model_object_reference.items()]) + "}"
-        return f"[{self.level.name}] Object: {object_str} - {self.message}"
-
-    @staticmethod
-    def make_object_reference(
-        data_source_name: Optional[str] = None,
-        materialization_name: Optional[str] = None,
-        dimension_name: Optional[str] = None,
-        identifier_name: Optional[str] = None,
-        measure_name: Optional[str] = None,
-        metric_name: Optional[str] = None,
-        object_type: Optional[ModelObjectType] = None,
-        object_name: Optional[str] = None,
-    ) -> OrderedDict[ModelObjectType, str]:
-        """Convenience function for making the object reference dict."""
-
-        model_object: OrderedDict[ModelObjectType, str] = OrderedDict()
-        if data_source_name:
-            if object_type == ModelObjectType.DATA_SOURCE:
-                raise RuntimeError("Conflicting object types - multiple data sources")
-            model_object[ModelObjectType.DATA_SOURCE] = data_source_name
-        if materialization_name:
-            if object_type == ModelObjectType.MATERIALIZATION:
-                raise RuntimeError("Conflicting object types - multiple materializations")
-            model_object[ModelObjectType.MATERIALIZATION] = materialization_name
-        if metric_name:
-            if object_type == ModelObjectType.METRIC:
-                raise RuntimeError("Conflicting object types - multiple metrics")
-            model_object[ModelObjectType.METRIC] = metric_name
-        if dimension_name:
-            if object_type == ModelObjectType.DIMENSION:
-                raise RuntimeError("Conflicting object types - multiple dimensions")
-            model_object[ModelObjectType.DIMENSION] = dimension_name
-        if identifier_name:
-            if object_type == ModelObjectType.IDENTIFIER:
-                raise RuntimeError("Conflicting object types - multiple dimensions")
-            model_object[ModelObjectType.IDENTIFIER] = identifier_name
-        if measure_name:
-            if object_type == ModelObjectType.MEASURE:
-                raise RuntimeError("Conflicting object types - multiple dimensions")
-            model_object[ModelObjectType.MEASURE] = measure_name
-
-        if object_type:
-            if not object_name:
-                raise RuntimeError("Object name must be specified with object type.")
-            model_object[object_type] = object_name
-
-        if len(model_object) == 0:
-            raise RuntimeError("No object parameters were passed in.")
-
-        return model_object
+        return f"{self.level.name} {self.context.context_str if self.context else ''} - {self.message}"
 
 
 @dataclass(unsafe_hash=True)
 class ValidationWarning(ValidationIssue):
     """A warning that was found while validation the model."""
 
-    def __init__(self, model_object_reference: OrderedDict[ModelObjectType, str], message: str):
+    def __init__(self, message: str, context: Optional[ValidationContext] = None):
         """Initializes with super (ValidationIssue) with hardcoded level of WARNING"""
-        super().__init__(
-            level=ValidationIssueLevel.WARNING, model_object_reference=model_object_reference, message=message
-        )
+        super().__init__(level=ValidationIssueLevel.WARNING, context=context, message=message)
 
 
 @dataclass(unsafe_hash=True)
@@ -123,21 +153,16 @@ class ValidationFutureError(ValidationIssue):
 
     error_date: date
 
-    def __init__(self, model_object_reference: OrderedDict[ModelObjectType, str], message: str, error_date: date):
+    def __init__(self, message: str, error_date: date, context: Optional[ValidationContext] = None):
         """Calls super (ValidationIssue) with hardcoded level of FUTURE_ERROR"""
         # Special way to set error_date because we're in a frozen dataclass
         object.__setattr__(self, "error_date", error_date)
-        super().__init__(
-            level=ValidationIssueLevel.FUTURE_ERROR,
-            model_object_reference=model_object_reference,
-            message=message,
-        )
+        super().__init__(level=ValidationIssueLevel.FUTURE_ERROR, context=context, message=message)
 
     def as_readable_str(self) -> str:
         """Return a easily readable string that can be used to log the issue."""
-        object_str = "{" + ", ".join([f"{k.value}: {v}" for k, v in self.model_object_reference.items()]) + "}"
         return (
-            f"[{self.level.name}] Object: {object_str} - {self.message}. "
+            f"{ValidationIssue.as_readable_str(self)}"
             f"IMPORTANT: this error will break your model starting {self.error_date.strftime('%b %d, %Y')}. "
         )
 
@@ -146,35 +171,31 @@ class ValidationFutureError(ValidationIssue):
 class ValidationError(ValidationIssue):
     """An error that was found while validating the model."""
 
-    def __init__(self, model_object_reference: OrderedDict[ModelObjectType, str], message: str):
+    def __init__(self, message: str, context: Optional[ValidationContext] = None):
         """Calls super (ValidationIssue) with hardcoded level of ERROR"""
-        super().__init__(
-            level=ValidationIssueLevel.ERROR, model_object_reference=model_object_reference, message=message
-        )
+        super().__init__(level=ValidationIssueLevel.ERROR, context=context, message=message)
 
 
 @dataclass(unsafe_hash=True)
 class ValidationFatal(ValidationIssue):
     """A fatal issue that was found while validation the model."""
 
-    def __init__(self, model_object_reference: OrderedDict[ModelObjectType, str], message: str):
+    def __init__(self, message: str, context: Optional[ValidationContext] = None):
         """Calls super (ValidationIssue) with hardcoded level of FATAL"""
-        super().__init__(
-            level=ValidationIssueLevel.FATAL, model_object_reference=model_object_reference, message=message
-        )
+        super().__init__(level=ValidationIssueLevel.FATAL, context=context, message=message)
 
 
 ValidationIssueType = Union[ValidationIssue, ValidationWarning, ValidationFutureError, ValidationError, ValidationFatal]
 
 
 def generate_exception_issue(
-    obj_ref: OrderedDict[ModelObjectType, str],
     what_was_being_done: str,
     e: Exception,
+    context: Optional[ValidationContext] = None,
 ) -> ValidationIssue:
     """Generates a validation issue for exceptions"""
     return ValidationError(
-        model_object_reference=obj_ref,
+        context=context,
         message=f"An error occured while {what_was_being_done} - {''.join(traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__))}",
     )
 
@@ -197,7 +218,6 @@ def validate_safely(whats_being_done: str) -> Callable:
                 arguments_str = _func_args_to_string(*args, **kwargs)
                 issues = [
                     generate_exception_issue(
-                        obj_ref=OrderedDict(),
                         what_was_being_done=whats_being_done
                         + VALIDATE_SAFELY_ERROR_STR_TMPLT.format(
                             method_name=func.__name__, arguments_str=arguments_str

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -133,9 +133,13 @@ class ValidationIssue:
     context: Optional[ValidationContext]
     # Consider adding a enum here that categories the type of validation issue and standardize the error messages.
 
-    def as_readable_str(self) -> str:
+    def as_readable_str(self, with_level: bool = True) -> str:
         """Return a easily readable string that can be used to log the issue."""
-        return f"{self.level.name} {self.context.context_str if self.context else ''} - {self.message}"
+        msg_base = f"{self.level.name} " if with_level else ""
+        msg_base += self.context.context_str() if self.context else ""
+        if msg_base:
+            msg_base += " - "
+        return msg_base + self.message
 
 
 @dataclass(unsafe_hash=True)
@@ -159,10 +163,10 @@ class ValidationFutureError(ValidationIssue):
         object.__setattr__(self, "error_date", error_date)
         super().__init__(level=ValidationIssueLevel.FUTURE_ERROR, context=context, message=message)
 
-    def as_readable_str(self) -> str:
+    def as_readable_str(self, with_level: bool = True) -> str:
         """Return a easily readable string that can be used to log the issue."""
         return (
-            f"{ValidationIssue.as_readable_str(self)}"
+            f"{ValidationIssue.as_readable_str(self, with_level=with_level)}"
             f"IMPORTANT: this error will break your model starting {self.error_date.strftime('%b %d, %Y')}. "
         )
 

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -79,10 +79,10 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
     # Mock validation errors in validate_model function
     mocked_build_result = MagicMock(
         issues=(
-            ValidationWarning(None, "warning"),  # type: ignore
-            ValidationFutureError(None, "future_error", datetime.now()),  # type: ignore
-            ValidationError(None, "error"),  # type: ignore
-            ValidationFatal(None, "fatal"),  # type: ignore
+            ValidationWarning(context=None, message="warning"),  # type: ignore
+            ValidationFutureError(context=None, message="future_error", error_date=datetime.now()),  # type: ignore
+            ValidationError(context=None, message="error"),  # type: ignore
+            ValidationFatal(context=None, message="fatal"),  # type: ignore
         )
     )
     with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
@@ -94,7 +94,7 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
 
 def test_validate_configs_data_warehouse_validations(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
     dw_validation_issues = [
-        ValidationError(None, "Data Warehouse Error"),  # type: ignore
+        ValidationError(context=None, message="Data Warehouse Error"),  # type: ignore
     ]
 
     with patch.object(CLIContext, "sql_client", return_value=None):  # type: ignore

--- a/metricflow/test/model/validations/helpers.py
+++ b/metricflow/test/model/validations/helpers.py
@@ -1,0 +1,97 @@
+from typing import List, Optional, Sequence
+
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.engine.models import Dimension
+from metricflow.model.objects.common import FileSlice, Metadata
+from metricflow.model.objects.constraints.where import WhereClauseConstraint
+from metricflow.model.objects.data_source import DataSource, DataSourceOrigin, Mutability
+from metricflow.model.objects.elements.identifier import Identifier
+from metricflow.model.objects.elements.measure import Measure
+from metricflow.model.objects.materialization import Materialization, MaterializationDestination
+from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+
+
+def default_meta() -> Metadata:
+    """Returns a Metadata object with the required information"""
+
+    return Metadata(
+        repo_file_path="/not/from/a/repo",
+        file_slice=FileSlice(
+            filename="not_from_file.py",
+            content="N/A",
+            start_line_number=0,
+            end_line_number=0,
+        ),
+    )
+
+
+def materialization_with_guaranteed_meta(
+    name: str,
+    metrics: List[str],
+    dimensions: List[str],
+    description: str = "adhoc materialization",
+    metadata: Metadata = default_meta(),
+    destinations: List[MaterializationDestination] = [],
+    destination_table: Optional[SqlTable] = None,
+) -> Materialization:
+    """Creates a materialization with the given input. If a metadata object is not supplied, a default metadata object is used"""
+
+    return Materialization(
+        name=name,
+        description=description,
+        metrics=metrics,
+        dimensions=dimensions,
+        destinations=destinations,
+        destination_table=destination_table,
+        metadata=metadata,
+    )
+
+
+def metric_with_guaranteed_meta(
+    name: str,
+    type: MetricType,
+    type_params: MetricTypeParams,
+    constraint: Optional[WhereClauseConstraint] = None,
+    metadata: Metadata = default_meta(),
+    description: str = "adhoc metric",
+) -> Metric:
+    """Creates a metric with the given input. If a metadata object is not supplied, a default metadata object is used"""
+
+    return Metric(
+        name=name,
+        description=description,
+        type=type,
+        type_params=type_params,
+        constraint=constraint,
+        metadata=metadata,
+    )
+
+
+def data_source_with_guaranteed_meta(
+    name: str,
+    mutability: Mutability,
+    description: Optional[str] = None,
+    sql_table: Optional[str] = None,
+    sql_query: Optional[str] = None,
+    dbt_model: Optional[str] = None,
+    metadata: Metadata = default_meta(),
+    identifiers: Sequence[Identifier] = [],
+    measures: Sequence[Measure] = [],
+    dimensions: Sequence[Dimension] = [],
+    origin: DataSourceOrigin = DataSourceOrigin.SOURCE,
+) -> DataSource:
+    """Creates a data source with the given input. If a metadata object is not supplied, a default metadata object is used"""
+
+    return DataSource(
+        name=name,
+        mutability=mutability,
+        description=description,
+        sql_table=sql_table,
+        sql_query=sql_query,
+        dbt_model=dbt_model,
+        identifiers=identifiers,
+        measures=measures,
+        dimensions=dimensions,
+        origin=origin,
+        metadata=metadata,
+    )

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -1,8 +1,8 @@
 import pytest
 from metricflow.model.model_validator import ModelValidator
-from metricflow.model.objects.materialization import Materialization
 from metricflow.model.validations.materializations import ValidMaterializationRule
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.test.model.validations.helpers import materialization_with_guaranteed_meta
 from metricflow.test.test_utils import model_with_materialization
 
 
@@ -10,7 +10,7 @@ def test_can_configure_model_validator_rules(simple_model__pre_transforms: UserC
     model = model_with_materialization(
         simple_model__pre_transforms,
         [
-            Materialization(
+            materialization_with_guaranteed_meta(
                 name="foobar",
                 metrics=["invalid_bookings"],
                 dimensions=["ds"],

--- a/metricflow/test/model/validations/test_data_sources.py
+++ b/metricflow/test/model/validations/test_data_sources.py
@@ -1,9 +1,10 @@
 import pytest
 
-from metricflow.model.objects.data_source import DataSource, MutabilityType, Mutability
+from metricflow.model.objects.data_source import MutabilityType, Mutability
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.specs import DimensionReference
+from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity
 
 
@@ -11,7 +12,7 @@ from metricflow.time.time_granularity import TimeGranularity
 def test_data_source_invalid_sql() -> None:  # noqa:D
     dimension_reference = DimensionReference(element_name="ds")
     with pytest.raises(ModelValidationException, match=r"Invalid SQL"):
-        DataSource(
+        data_source_with_guaranteed_meta(
             name="invalid_sql_source",
             sql_query="SELECT foo FROM bar;",
             dimensions=[

--- a/metricflow/test/model/validations/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/validations/test_data_warehouse_tasks.py
@@ -9,7 +9,7 @@ from metricflow.model.data_warehouse_model_validator import (
     DataWarehouseValidationTask,
 )
 from metricflow.model.model_transformer import ModelTransformer
-from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
+from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.elements.measure import AggregationType, Measure
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -20,6 +20,7 @@ from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs import DimensionReference, MeasureReference
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta
 from metricflow.test.plan_utils import assert_snapshot_text_equal, make_schema_replacement_function
 from metricflow.test.test_utils import as_datetime
 from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
@@ -92,7 +93,7 @@ def test_validate_data_sources(  # noqa: D
     assert len(issues) == 0
 
     model.data_sources.append(
-        DataSource(
+        data_source_with_guaranteed_meta(
             name="test_data_source2",
             sql_table="doesnt_exist",
             dimensions=[],

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -1,12 +1,13 @@
 import pytest
 
 from metricflow.model.model_validator import ModelValidator
-from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
+from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.elements.measure import Measure, AggregationType
-from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.specs import MeasureReference, DimensionReference
+from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.test.fixtures.table_fixtures import DEFAULT_DS
@@ -19,7 +20,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name} FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -35,7 +36,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                         ],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     ),
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="categoricaldim",
                         sql_query="SELECT foo FROM bar",
                         dimensions=[Dimension(name=dim_reference, type=DimensionType.CATEGORICAL)],
@@ -43,7 +44,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),
@@ -62,7 +63,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim1",
                         sql_query=f"SELECT ds, {measure_reference.element_name} FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -78,7 +79,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                         ],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     ),
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim2",
                         sql_query="SELECT foo1 FROM bar",
                         dimensions=[
@@ -95,7 +96,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),
@@ -113,7 +114,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim1",
                         sql_query=f"SELECT {dim_ref1.element_name}, {measure_reference.element_name} FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -130,7 +131,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                         ],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     ),
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim2",
                         sql_query="SELECT foo1 FROM bar",
                         dimensions=[
@@ -147,7 +148,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -1,12 +1,13 @@
 import pytest
 
 from metricflow.model.model_validator import ModelValidator
-from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
+from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.elements.measure import Measure, AggregationType
-from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.specs import MeasureReference, DimensionReference
+from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.model.validations.validator_helpers import ModelValidationException
 
@@ -19,7 +20,7 @@ def test_inconsistent_elements() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="s1",
                         sql_query="SELECT foo FROM bar",
                         dimensions=[
@@ -33,7 +34,7 @@ def test_inconsistent_elements() -> None:  # noqa:D
                         ],
                         mutability=Mutability(type=MutabilityType.IMMUTABLE),
                     ),
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="s2",
                         sql_query="SELECT foo FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -41,7 +42,7 @@ def test_inconsistent_elements() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -10,10 +10,11 @@ from metricflow.model.objects.data_source import DataSource, Mutability, Mutabil
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.elements.identifier import IdentifierType, Identifier, CompositeSubIdentifier
 from metricflow.model.objects.elements.measure import Measure, AggregationType
-from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.specs import DimensionReference, MeasureReference, IdentifierReference
+from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.test.test_utils import find_data_source_with
 
@@ -59,7 +60,7 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name}, thorium_id FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -87,7 +88,7 @@ def test_invalid_composite_identifiers() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure2_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),
@@ -108,7 +109,7 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name}, thorium_id FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -136,7 +137,7 @@ def test_composite_identifiers_nonexistent_ref() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure2_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),
@@ -158,7 +159,7 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="dim1",
                         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name}, thorium_id FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -188,7 +189,7 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name=measure2_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),

--- a/metricflow/test/model/validations/test_materializations.py
+++ b/metricflow/test/model/validations/test_materializations.py
@@ -1,8 +1,8 @@
 import logging
 
-from metricflow.model.objects.materialization import Materialization
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.materializations import ValidMaterializationRule
+from metricflow.test.model.validations.helpers import materialization_with_guaranteed_meta
 from metricflow.test.test_utils import (
     model_with_materialization,
 )
@@ -21,7 +21,7 @@ def test_identifier(simple_model__pre_transforms: UserConfiguredModel) -> None: 
                 model_with_materialization(
                     simple_model__pre_transforms,
                     [
-                        Materialization(
+                        materialization_with_guaranteed_meta(
                             name="foobar",
                             metrics=["bookings"],
                             dimensions=["ds", "listing"],
@@ -41,7 +41,7 @@ def test_invalid_metric_name(simple_model__pre_transforms: UserConfiguredModel) 
                 model_with_materialization(
                     simple_model__pre_transforms,
                     [
-                        Materialization(
+                        materialization_with_guaranteed_meta(
                             name="foobar",
                             metrics=["invalid_bookings"],
                             dimensions=["ds"],
@@ -61,7 +61,7 @@ def test_invalid_dimension_name(simple_model__pre_transforms: UserConfiguredMode
                 model_with_materialization(
                     simple_model__pre_transforms,
                     [
-                        Materialization(
+                        materialization_with_guaranteed_meta(
                             name="foobar",
                             metrics=["bookings"],
                             dimensions=["ds", "invalid_dimension_name"],
@@ -82,7 +82,7 @@ def test_missing_primary_time_dimension(simple_model__pre_transforms: UserConfig
                 model_with_materialization(
                     simple_model__pre_transforms,
                     [
-                        Materialization(
+                        materialization_with_guaranteed_meta(
                             name="foobar",
                             metrics=["bookings"],
                             dimensions=["is_instant"],
@@ -102,7 +102,7 @@ def test_valid_time_granularity(simple_model__pre_transforms: UserConfiguredMode
                 model_with_materialization(
                     simple_model__pre_transforms,
                     [
-                        Materialization(
+                        materialization_with_guaranteed_meta(
                             name="materialization_test_case",
                             metrics=["bookings"],
                             dimensions=["ds__day"],
@@ -122,7 +122,7 @@ def test_invalid_time_granularity(simple_model__pre_transforms: UserConfiguredMo
                 model_with_materialization(
                     simple_model__pre_transforms,
                     [
-                        Materialization(
+                        materialization_with_guaranteed_meta(
                             name="materialization_test_case",
                             metrics=["revenue"],
                             dimensions=["ds__hour"],

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -1,14 +1,15 @@
 import pytest
 
 from metricflow.model.model_validator import ModelValidator
-from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
+from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.elements.identifier import Identifier, IdentifierType
 from metricflow.model.objects.elements.measure import Measure, AggregationType
-from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.specs import MeasureReference, DimensionReference, IdentifierReference
+from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.test.fixtures.table_fixtures import DEFAULT_DS
 
@@ -21,7 +22,7 @@ def test_metric_missing_measure() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="sum_measure",
                         sql_query="SELECT foo FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -29,7 +30,7 @@ def test_metric_missing_measure() -> None:  # noqa:D
                     )
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name="metric_with_nonexistent_measure",
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure2_reference]),
@@ -46,14 +47,14 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
     ModelValidator().checked_validations(
         UserConfiguredModel(
             data_sources=[
-                DataSource(
+                data_source_with_guaranteed_meta(
                     name="sum_measure",
                     sql_query="SELECT foo, country FROM bar",
                     measures=[],
                     dimensions=[Dimension(name=dim_reference, type=DimensionType.CATEGORICAL)],
                     mutability=Mutability(type=MutabilityType.IMMUTABLE),
                 ),
-                DataSource(
+                data_source_with_guaranteed_meta(
                     name="sum_measure2",
                     sql_query="SELECT foo, country FROM bar",
                     measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -72,7 +73,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                 ),
             ],
             metrics=[
-                Metric(
+                metric_with_guaranteed_meta(
                     name="metric_with_no_time_dim",
                     type=MetricType.MEASURE_PROXY,
                     type_params=MetricTypeParams(measures=[measure_reference]),
@@ -90,7 +91,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="sum_measure",
                         sql_query="SELECT foo, country FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -104,7 +105,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                     )
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name="metric_with_no_time_dim",
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),
@@ -123,7 +124,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
         ModelValidator().checked_validations(
             UserConfiguredModel(
                 data_sources=[
-                    DataSource(
+                    data_source_with_guaranteed_meta(
                         name="sum_measure",
                         sql_query="SELECT foo, date_created, date_deleted FROM bar",
                         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],
@@ -147,7 +148,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                     )
                 ],
                 metrics=[
-                    Metric(
+                    metric_with_guaranteed_meta(
                         name="foo",
                         type=MetricType.MEASURE_PROXY,
                         type_params=MetricTypeParams(measures=[measure_reference]),
@@ -163,7 +164,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
     dim2_reference = DimensionReference(element_name=DEFAULT_DS)
     measure_reference = MeasureReference(element_name="measure")
     identifier_reference = IdentifierReference(element_name="primary")
-    data_source = DataSource(
+    data_source = data_source_with_guaranteed_meta(
         name="dim1",
         sql_query=f"SELECT {dim_reference.element_name}, {measure_reference.element_name} FROM bar",
         measures=[Measure(name=measure_reference, agg=AggregationType.SUM)],


### PR DESCRIPTION
Historically we have used model_object_reference (an OrderedDict) to give context to ValidationIssues. However, this has some drawbacks. First the OrderedDict could be over specified (i.e. what if both a dimension and a measure name are specified?). Second it's not easily JSON serializable. Thus we've moved to something more concrete, ValidationContext and sub-classes thereof. This new class, and sub-classes, provides a hierarchy of contexts which all provide the same interface for generating human readable context strings. Additionally, ValidationContexts are of our specifically JSON serializable 'BaseModel' class. The one hickup is that in most cases we want to generate the ValidaitonContext from an available 'Metadata' object for 'DataSources', 'Metrics', and 'Materializations'. It'd be useful at some point to guarantee the 'Metadata' object on these objects to simply the code somewhat.

From a CLI prospective, `mf validate-configs` with errors used to look like:
```
mf validate-configs
✖ Errors found when building model from configs
• ERROR: Found measure with name MeasureReference(element_name='amount') in multiple data sources with names (['salesforce_oppportunities'])
• FATAL: In data source `salesforce_oppportunities`, can't use name `amount` for a measure when it was already used for a measure
```


and now they look like:
```
$ mf validate-configs                                               
✖ Errors found when building model from configs
• ERROR: with measure `amount` in data source `salesforce_oppportunities` in file `opportunities.yaml` on line #2 - Found measure with name MeasureReference(element_name='amount') in multiple data sources with names (['salesforce_oppportunities'])
• FATAL: with measure `amount` in data source `salesforce_oppportunities` in file `opportunities.yaml` on line #2 - In data source `salesforce_oppportunities`, can't use name `amount` for a measure when it was already used for a measure
```