### PR TITLE
Lint YAML Config Files before processing

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -37,9 +37,11 @@ from metricflow.cli.utils import (
 from metricflow.configuration.config_builder import YamlTemplateBuilder
 from metricflow.dataflow.dataflow_plan_to_text import dataflow_plan_as_text
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFlowExplainResult, MetricFlowQueryResult
+from metricflow.engine.utils import path_to_models
 from metricflow.model.data_warehouse_model_validator import DataWarehouseModelValidator
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.parsing.config_linter import ConfigLinter
 from metricflow.model.validations.validator_helpers import ValidationIssue, ValidationIssueLevel
 from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.telemetry.models import TelemetryLevel
@@ -694,6 +696,19 @@ def _data_warehouse_validations_runner(
 def validate_configs(cfg: CLIContext, dw_timeout: Optional[int] = None, skip_dw: bool = False) -> None:
     """Perform validations against the defined model configurations."""
     cfg.verbose = True
+
+    lint_spinner = Halo(text="Checking for YAML format issues", spinner="dots")
+    lint_spinner.start()
+
+    lint_issues = ConfigLinter().lint_dir(path_to_models(handler=cfg.config))
+    lint_errors = _filter_issues(lint_issues, [ValidationIssueLevel.ERROR, ValidationIssueLevel.FATAL])
+    if not lint_errors:
+        lint_spinner.succeed("🎉 Successfully linted config YAML files")
+        _print_issues(lint_issues)
+    else:
+        lint_spinner.fail("Breaking issues found in config YAML files")
+        _print_issues(lint_issues)
+        return
 
     build_spinner = Halo(text="Building model from configs", spinner="dots")
     build_spinner.start()

--- a/metricflow/engine/utils.py
+++ b/metricflow/engine/utils.py
@@ -11,11 +11,16 @@ from metricflow.model.parsing.dir_to_model import parse_directory_of_yaml_files_
 from metricflow.sql_clients.common_client import not_empty
 
 
+def path_to_models(handler: YamlFileHandler) -> str:
+    """Given a YamlFileHandler, return the path to the YAML model config files"""
+    return not_empty(handler.get_value(CONFIG_MODEL_PATH), CONFIG_MODEL_PATH, handler.url)
+
+
 def build_user_configured_model_from_config(handler: YamlFileHandler) -> UserConfiguredModel:
     """Given a yaml file, create a UserConfiguredModel."""
-    path_to_models = not_empty(handler.get_value(CONFIG_MODEL_PATH), CONFIG_MODEL_PATH, handler.url)
+    models_path = path_to_models(handler=handler)
     try:
-        model = parse_directory_of_yaml_files_to_model(path_to_models).model
+        model = parse_directory_of_yaml_files_to_model(models_path).model
         assert model is not None
         return model
     except Exception as e:

--- a/metricflow/model/parsing/config_linter.py
+++ b/metricflow/model/parsing/config_linter.py
@@ -1,0 +1,33 @@
+import os
+from typing import List
+from yamllint import config, linter
+
+from metricflow.model.validations.validator_helpers import ValidationContext, ValidationIssue, ValidationError
+
+
+class ConfigLinter:  # noqa: D
+    def __init__(self) -> None:  # noqa: D
+        self._config = config.YamlLintConfig("extends: default")
+
+    def lint_file(self, file_path: str, file_name: str) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
+        with open(file_path) as f:
+            for problem in linter.run(f, self._config):
+                issues.append(
+                    ValidationError(
+                        context=ValidationContext(file_name=file_name, line_number=problem.line),
+                        message=problem.desc,  # type: ignore[misc]
+                    )
+                )
+        return issues
+
+    def lint_dir(self, dir_path: str) -> List[ValidationIssue]:  # noqa: D
+        issues: List[ValidationIssue] = []
+        for root, _dirs, files in os.walk(dir_path):
+            for file in files:
+                if not (file.endswith(".yaml") or file.endswith(".yml")):
+                    continue
+                file_path = os.path.join(root, file)
+                issues += self.lint_file(file_path, file)
+
+        return issues

--- a/metricflow/model/parsing/config_linter.py
+++ b/metricflow/model/parsing/config_linter.py
@@ -1,13 +1,65 @@
 import os
-from typing import List
-from yamllint import config, linter
+from typing import List, Optional
+import yaml
+from yamllint import config, linter, rules
 
 from metricflow.model.validations.validator_helpers import ValidationContext, ValidationIssue, ValidationError
 
+WARNING = "warning"
+ERROR = "error"
+DISABLE = "disable"
+LEVEL = "level"
+
 
 class ConfigLinter:  # noqa: D
-    def __init__(self) -> None:  # noqa: D
-        self._config = config.YamlLintConfig("extends: default")
+    """A linter for checking the format of MetricFlow YAML model config files
+
+    This config linter is a custom implementation of the linter provided by
+    the yamllint package (https://pypi.org/project/yamllint/). For any problems
+    that are found, ValidationIssues are created (with the appropriate level).
+    Breaking issues will return errors. Issues that won't cause problems outside
+    of maintainability will be warnings. A custom config can be provided on
+    initialization. Please see the yamllint documentation for how that can be
+    provided (https://yamllint.readthedocs.io/en/stable/configuration.html#custom-configuration-without-a-config-file)
+    """
+
+    DEFAULT_CONFIG = {
+        "yaml-files": ["*.yaml", "*.yml"],
+        "rules": {
+            rules.braces.ID: DISABLE,
+            rules.brackets.ID: DISABLE,
+            rules.colons.ID: DISABLE,
+            rules.commas.ID: DISABLE,
+            rules.comments.ID: DISABLE,
+            rules.comments_indentation.ID: DISABLE,  # TODO: Turn on as warning once warnings are less noisy in cli
+            rules.document_start.ID: DISABLE,  # TODO: Turn on as warning once warnings are less noisy in cli
+            rules.document_end.ID: DISABLE,
+            rules.empty_lines.ID: DISABLE,
+            rules.empty_values.ID: {LEVEL: ERROR},
+            rules.hyphens.ID: DISABLE,
+            rules.indentation.ID: DISABLE,  # TODO: Turn on as warning once warnings are less noisy in cli
+            rules.key_duplicates.ID: {LEVEL: ERROR},
+            rules.key_ordering.ID: DISABLE,
+            rules.line_length.ID: DISABLE,
+            rules.new_line_at_end_of_file.ID: DISABLE,
+            rules.new_lines.ID: DISABLE,
+            rules.octal_values.ID: DISABLE,  # TODO: Turn on as warning once warnings are less noisy in cli
+            rules.quoted_strings.ID: DISABLE,
+            rules.trailing_spaces.ID: DISABLE,  # TODO: Turn on as warning once warnings are less noisy in cli
+            rules.truthy.ID: DISABLE,
+        },
+    }
+
+    def __init__(self, lint_config: Optional[str] = None) -> None:  # noqa: D
+        """Constructor for building a ConfigLinter to then use with MetricFlow YAML model config files
+
+        Args:
+            lint_config: A JSON-ified dict representing a yamllint config, see
+                https://yamllint.readthedocs.io/en/stable/configuration.html#custom-configuration-without-a-config-file
+                for details. The default config can be found as `ConfigLinter.DEFAULT_CONFIG`
+        """
+        self._lint_config = lint_config if lint_config else yaml.dump(data=self.DEFAULT_CONFIG)
+        self._config = config.YamlLintConfig(self._lint_config)
 
     def lint_file(self, file_path: str, file_name: str) -> List[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []

--- a/metricflow/model/parsing/config_linter.py
+++ b/metricflow/model/parsing/config_linter.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import yaml
 from yamllint import config, linter, rules
 
-from metricflow.model.validations.validator_helpers import ValidationContext, ValidationIssue, ValidationError
+from metricflow.model.validations.validator_helpers import ValidationContext, ValidationIssue, ValidationIssueLevel
 
 WARNING = "warning"
 ERROR = "error"
@@ -65,8 +65,10 @@ class ConfigLinter:  # noqa: D
         issues: List[ValidationIssue] = []
         with open(file_path) as f:
             for problem in linter.run(f, self._config):
+                level = ValidationIssueLevel.ERROR if problem.level == ERROR else ValidationIssueLevel.WARNING
                 issues.append(
-                    ValidationError(
+                    ValidationIssue(
+                        level=level,
                         context=ValidationContext(file_name=file_name, line_number=problem.line),
                         message=problem.desc,  # type: ignore[misc]
                     )

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -85,8 +85,9 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
             ValidationFatal(context=None, message="fatal"),  # type: ignore
         )
     )
-    with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
-        resp = cli_runner.run(validate_configs)
+    with patch("metricflow.cli.main.path_to_models", return_value=""):
+        with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
+            resp = cli_runner.run(validate_configs)
 
     assert "future_error" in resp.output
     assert resp.exit_code == 0
@@ -97,17 +98,19 @@ def test_validate_configs_data_warehouse_validations(cli_runner: MetricFlowCliRu
         ValidationError(context=None, message="Data Warehouse Error"),  # type: ignore
     ]
 
-    with patch.object(CLIContext, "sql_client", return_value=None):  # type: ignore
-        with patch("metricflow.cli.main._run_dw_validations", return_value=dw_validation_issues):
-            resp = cli_runner.run(validate_configs)
+    with patch("metricflow.cli.main.path_to_models", return_value=""):
+        with patch.object(CLIContext, "sql_client", return_value=None):  # type: ignore
+            with patch("metricflow.cli.main._run_dw_validations", return_value=dw_validation_issues):
+                resp = cli_runner.run(validate_configs)
 
     assert "Data Warehouse Error" in resp.output
     assert resp.exit_code == 0
 
 
 def test_validate_configs_skip_data_warehouse_validations(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
-    with patch.object(ModelValidator, "validate_model", return_value=MagicMock(issues=())):
-        resp = cli_runner.run(validate_configs, args=["--skip-dw"])
+    with patch("metricflow.cli.main.path_to_models", return_value=""):
+        with patch.object(ModelValidator, "validate_model", return_value=MagicMock(issues=())):
+            resp = cli_runner.run(validate_configs, args=["--skip-dw"])
 
     assert "Data Warehouse Error" not in resp.output
     assert resp.exit_code == 0

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -15,6 +15,7 @@ from metricflow.cli.main import (
     version,
 )
 from metricflow.model.model_validator import ModelValidator
+from metricflow.model.parsing.config_linter import ConfigLinter
 from metricflow.model.validations.validator_helpers import (
     ValidationError,
     ValidationFatal,
@@ -113,6 +114,16 @@ def test_validate_configs_skip_data_warehouse_validations(cli_runner: MetricFlow
             resp = cli_runner.run(validate_configs, args=["--skip-dw"])
 
     assert "Data Warehouse Error" not in resp.output
+    assert resp.exit_code == 0
+
+
+def test_validate_configs_with_lint_issues(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+    lint_issues = [ValidationError(context=None, message="YAML Lint Error")]
+    with patch("metricflow.cli.main.path_to_models", return_value=""):
+        with patch.object(ConfigLinter, "lint_dir", return_value=lint_issues):
+            resp = cli_runner.run(validate_configs)
+
+    assert "YAML Lint Error" in resp.output
     assert resp.exit_code == 0
 
 

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -263,3 +263,10 @@ def data_warehouse_validation_model(template_mapping: Dict[str, str]) -> UserCon
     )
     assert model_build_result.model
     return model_build_result.model
+
+
+@pytest.fixture(scope="session")
+def config_linter_model_path() -> str:
+    """Model path for ConfigLinter tests"""
+
+    return os.path.join(os.path.dirname(__file__), "model_yamls/config_linter_model")

--- a/metricflow/test/fixtures/model_yamls/config_linter_model/multiple_data_sources_without_divider.yml
+++ b/metricflow/test/fixtures/model_yamls/config_linter_model/multiple_data_sources_without_divider.yml
@@ -1,0 +1,44 @@
+data_source:
+  name: foo
+  description: bar buzz bazz
+  owners:
+    - support@transformdata.io
+  sql_query: "SELECT * FROM $source_schema.fct_animals"
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+    - name: is_dog
+      type: categorical
+      is_partition: True
+  measures:
+    - name: count_dogs
+      agg: sum
+      expr: 1
+      create_metric: True
+  mutability:
+    type: immutable
+data_source:
+  name: foo
+  description: bar buzz bazz
+  owners:
+    - support@transformdata.io
+  sql_query: "SELECT * FROM $source_schema.fct_animals"
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+    - name: is_dog
+      type: categorical
+      is_partition: True
+  measures:
+    - name: count_dogs
+      agg: sum
+      expr: 1
+      create_metric: True
+  mutability:
+    type: immutable

--- a/metricflow/test/model/test_config_linter.py
+++ b/metricflow/test/model/test_config_linter.py
@@ -1,0 +1,10 @@
+from metricflow.model.parsing.config_linter import ConfigLinter
+from metricflow.model.validations.validator_helpers import ValidationIssueLevel
+
+
+def test_lint_dir(config_linter_model_path: str) -> None:  # noqa: D
+    issues = ConfigLinter().lint_dir(dir_path=config_linter_model_path)
+
+    assert len(issues) == 1
+    assert issues[0].level == ValidationIssueLevel.ERROR
+    assert 'duplication of key "data_source"' in issues[0].as_readable_str()

--- a/poetry.lock
+++ b/poetry.lock
@@ -620,6 +620,14 @@ pytz = ">=2017.3"
 test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
 name = "platformdirs"
 version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -1180,10 +1188,22 @@ six = ">=1.9.0,<2"
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
+[[package]]
+name = "yamllint"
+version = "1.26.3"
+description = "A linter for YAML files."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pathspec = ">=0.5.3"
+pyyaml = "*"
+
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "88c6c3795fd0ea0f597b4ed1024cf26c655a47feaa599ea6fa2a2ab5fd9c0d55"
+content-hash = "547665abe6be43534d7845b909dbd14969751296dce948b31770ad49e61ac17a"
 
 [metadata.files]
 asn1crypto = [
@@ -1736,6 +1756,10 @@ pandas = [
     {file = "pandas-1.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:2b063d41803b6a19703b845609c0b700913593de067b552a8b24dd8eeb8c9895"},
     {file = "pandas-1.2.4.tar.gz", hash = "sha256:649ecab692fade3cbfcf967ff936496b0cfba0af00a55dfaacd82bdda5cb2279"},
 ]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
@@ -2164,4 +2188,7 @@ urllib3 = [
 virtualenv = [
     {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
     {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
+]
+yamllint = [
+    {file = "yamllint-1.26.3.tar.gz", hash = "sha256:3934dcde484374596d6b52d8db412929a169f6d9e52e20f9ade5bf3523d9b96e"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ python-Levenshtein = "^0.12.2"
 rudder-sdk-python = "^1.0.3"
 duckdb-engine = "^0.1.8"
 duckdb = "0.3.4"
+yamllint = "^1.26.3"
 
 [tool.poetry.dev-dependencies]
 pytest-mock = "^3.7.0"


### PR DESCRIPTION
There have been issues with YAML config files such as missing "---" dividers between top level object. That specific issue meant that if there were multiple metrics defined in a file, but missing the "---" dividers between them, all the metrics would be silently swallowed except the last specified in the file. The new errors people will see when validating their configs will look like the following:
```
✖ Breaking issues found in config yaml files
• ERROR: in file `opportunities.yaml` on line #84 - duplication of key "metric" in mapping. Key "metric" is a top level object. If multiple top level objects are specified in the same file, they must be separated using "---"
```