### PR TITLE
Use DuckDB 0.3.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1183,7 +1183,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "9cd7ae2810bc56b0de2a1ce29dbc820105283e75fd3b5744ec3641b289015b96"
+content-hash = "88c6c3795fd0ea0f597b4ed1024cf26c655a47feaa599ea6fa2a2ab5fd9c0d55"
 
 [metadata.files]
 asn1crypto = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ click = "^7.1.2"
 python-Levenshtein = "^0.12.2"
 rudder-sdk-python = "^1.0.3"
 duckdb-engine = "^0.1.8"
+duckdb = "0.3.4"
 
 [tool.poetry.dev-dependencies]
 pytest-mock = "^3.7.0"


### PR DESCRIPTION
It looks like there was an update in duckdb `0.4.0` to better support multithreading: 

https://github.com/duckdb/duckdb/pull/3886

However, internal concurrency testing with `0.4.0` is throwing seg faults when removing the `check_same_thread` flag, so downgrading to the previous tested version - `0.3.4`.