### PR TITLE
Refactor Validation Issue Structuring

### DIFF
--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 from metricflow.configuration.config_handler import ConfigHandler
 from metricflow.configuration.constants import CONFIG_DWH_SCHEMA
@@ -19,7 +19,7 @@ from metricflow.engine.utils import build_user_configured_model_from_config, con
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.model.validations.validator_helpers import ValidationIssueType
+from metricflow.model.validations.validator_helpers import ModelValidationResults
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql_clients.common_client import not_empty
@@ -272,7 +272,7 @@ class MetricFlowClient:
         """
         return self.engine.drop_materialization(materialization_name=materialization_name)
 
-    def validate_configs(self) -> Optional[Tuple[ValidationIssueType, ...]]:
+    def validate_configs(self) -> ModelValidationResults:
         """Validate a model according to configured rules.
 
         Returns:

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -13,6 +13,7 @@ from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
     DimensionContext,
+    FileContext,
     MetricContext,
     ValidationContext,
     ValidationError,
@@ -99,8 +100,7 @@ class DataWarehouseTaskBuilder:
                 DataWarehouseValidationTask(
                     query_string=DataWarehouseTaskBuilder._gen_query(data_source=data_source, id=index),
                     context=DataSourceContext(
-                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source_name=data_source.name,
                     ),
                     error_message=f"Unable to access data source `{data_source.name}` in data warehouse",
@@ -134,10 +134,7 @@ class DataWarehouseTaskBuilder:
                             data_source=data_source, id=index, columns=[dim_to_query]
                         ),
                         context=DimensionContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                             dimension_name=dimension.name,
                         ),
@@ -155,8 +152,7 @@ class DataWarehouseTaskBuilder:
                         columns=data_source_columns,
                     ),
                     context=DataSourceContext(
-                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source_name=data_source.name,
                     ),
                     error_message=f"Failed to query dimensions in data warehouse for data source `{data_source.name}`",
@@ -179,8 +175,7 @@ class DataWarehouseTaskBuilder:
                     query_string=explain_result.rendered_sql.sql_query,
                     query_params=explain_result.rendered_sql.bind_parameters,
                     context=MetricContext(
-                        file_name=metric.metadata.file_slice.filename if metric.metadata else None,
-                        line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=metric.metadata),
                         metric_name=metric.name,
                     ),
                     error_message=f"Unable to query metric `{metric.name}`.",

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -21,6 +21,7 @@ from metricflow.model.validations.metrics import MetricMeasuresRule, CumulativeM
 from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
 from metricflow.model.validations.validator_helpers import (
+    ModelValidationResults,
     ValidationIssueType,
     ModelValidationRule,
     ValidationIssueLevel,
@@ -73,7 +74,7 @@ class ModelValidator:
             if any([x.level == ValidationIssueLevel.FATAL for x in issues]):
                 break
 
-        return ModelBuildResult(model=model_copy, issues=tuple(issues))
+        return ModelBuildResult(model=model_copy, issues=ModelValidationResults.from_issues_sequence(issues))
 
     def checked_validations(self, model: UserConfiguredModel) -> UserConfiguredModel:  # chTODO: remember checked_build
         """Similar to validate(), but throws an exception if validation fails."""

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -80,20 +80,8 @@ class ModelValidator:
         """Similar to validate(), but throws an exception if validation fails."""
         model_copy = copy.deepcopy(model)
         build_result = self.validate_model(model_copy)
-        if build_result.issues is not None:
-            if any(
-                [
-                    x.level == ValidationIssueLevel.WARNING or x.level == ValidationIssueLevel.FUTURE_ERROR
-                    for x in build_result.issues
-                ]
-            ):
-                issues_str = "\n".join([x.as_readable_str() for x in build_result.issues])
-                logger.warning(f"Found some validation warnings in the model:\n{issues_str}")
-            if any(
-                [
-                    x.level == ValidationIssueLevel.ERROR or x.level == ValidationIssueLevel.FATAL
-                    for x in build_result.issues
-                ]
-            ):
-                raise ModelValidationException(issues=build_result.issues)
+
+        if build_result.issues.has_blocking_issues:
+            raise ModelValidationException(issues=tuple(build_result.issues.all_issues))
+
         return model

--- a/metricflow/model/parsing/config_linter.py
+++ b/metricflow/model/parsing/config_linter.py
@@ -6,6 +6,7 @@ from metricflow.model.parsing.validation import METRIC_TYPE, DATA_SOURCE_TYPE, M
 
 from metricflow.model.validations.validator_helpers import (
     FileContext,
+    ModelValidationResults,
     ValidationError,
     ValidationIssue,
     ValidationWarning,
@@ -102,7 +103,7 @@ class ConfigLinter:  # noqa: D
 
         return issues
 
-    def lint_dir(self, dir_path: str) -> List[ValidationIssue]:  # noqa: D
+    def lint_dir(self, dir_path: str) -> ModelValidationResults:  # noqa: D
         issues: List[ValidationIssue] = []
         for root, _dirs, files in os.walk(dir_path):
             for file in files:
@@ -111,4 +112,4 @@ class ConfigLinter:  # noqa: D
                 file_path = os.path.join(root, file)
                 issues += self.lint_file(file_path, file)
 
-        return issues
+        return ModelValidationResults.from_issues_sequence(issues)

--- a/metricflow/model/parsing/config_linter.py
+++ b/metricflow/model/parsing/config_linter.py
@@ -4,7 +4,12 @@ import yaml
 from yamllint import config, linter, rules
 from metricflow.model.parsing.validation import METRIC_TYPE, DATA_SOURCE_TYPE, MATERIALIZATION_TYPE
 
-from metricflow.model.validations.validator_helpers import ValidationContext, ValidationIssue, ValidationIssueLevel
+from metricflow.model.validations.validator_helpers import (
+    FileContext,
+    ValidationError,
+    ValidationIssue,
+    ValidationWarning,
+)
 
 WARNING = "warning"
 ERROR = "error"
@@ -80,14 +85,21 @@ class ConfigLinter:  # noqa: D
                 if problem.rule == rules.key_duplicates.ID:
                     self.add_additional_key_duplicates_info(problem=problem)
 
-                level = ValidationIssueLevel.ERROR if problem.level == ERROR else ValidationIssueLevel.WARNING
-                issues.append(
-                    ValidationIssue(
-                        level=level,
-                        context=ValidationContext(file_name=file_name, line_number=problem.line),
-                        message=problem.desc,  # type: ignore[misc]
+                if problem.level == ERROR:
+                    issues.append(
+                        ValidationError(
+                            context=FileContext(file_name=file_name, line_number=problem.line),
+                            message=problem.desc,  # type: ignore[misc]
+                        )
                     )
-                )
+                else:
+                    issues.append(
+                        ValidationWarning(
+                            context=FileContext(file_name=file_name, line_number=problem.line),
+                            message=problem.desc,  # type: ignore[misc]
+                        )
+                    )
+
         return issues
 
     def lint_dir(self, dir_path: str) -> List[ValidationIssue]:  # noqa: D

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -4,7 +4,7 @@ import os.path
 import textwrap
 from dataclasses import dataclass
 from string import Template
-from typing import Optional, Dict, List, Union, Type, Any, Tuple
+from typing import Optional, Dict, List, Union, Type, Any
 
 import yaml
 from jsonschema import exceptions
@@ -27,7 +27,7 @@ from metricflow.model.parsing.validation import (
     DOCUMENT_TYPES,
 )
 from metricflow.model.parsing.yaml_loader import ParsingContext, SafeLineLoader, PARSING_CONTEXT_KEY
-from metricflow.model.validations.validator_helpers import ValidationIssueType
+from metricflow.model.validations.validator_helpers import ModelValidationResults
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class ModelBuildResult:  # noqa: D
     model: Optional[UserConfiguredModel] = None
     # Issues found in the model.
-    issues: Tuple[ValidationIssueType, ...] = tuple()
+    issues: ModelValidationResults = ModelValidationResults()
 
 
 def parse_directory_of_yaml_files_to_model(

--- a/metricflow/model/validations/common_identifiers.py
+++ b/metricflow/model/validations/common_identifiers.py
@@ -4,6 +4,7 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
+    FileContext,
     IdentifierContext,
     ModelValidationRule,
     ValidationWarning,
@@ -45,8 +46,7 @@ class CommonIdentifiersRule(ModelValidationRule):
             issues.append(
                 ValidationWarning(
                     context=IdentifierContext(
-                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source_name=data_source.name,
                         identifier_name=identifier.name,
                     ),

--- a/metricflow/model/validations/common_identifiers.py
+++ b/metricflow/model/validations/common_identifiers.py
@@ -1,11 +1,13 @@
 from typing import Dict, List, Set
+from metricflow.instances import DataSourceElementReference
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
+    DataSourceElementContext,
+    DataSourceElementType,
     FileContext,
-    IdentifierContext,
     ModelValidationRule,
     ValidationWarning,
     validate_safely,
@@ -45,10 +47,12 @@ class CommonIdentifiersRule(ModelValidationRule):
         ):
             issues.append(
                 ValidationWarning(
-                    context=IdentifierContext(
+                    context=DataSourceElementContext(
                         file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                        data_source_name=data_source.name,
-                        identifier_name=identifier.name,
+                        data_source_element=DataSourceElementReference(
+                            data_source_name=data_source.name, element_name=identifier.name
+                        ),
+                        element_type=DataSourceElementType.IDENTIFIER,
                     ),
                     message=f"Identifier `{identifier.reference.element_name}` "
                     f"only found in one data source `{data_source.name}` "

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -8,6 +8,7 @@ from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
     DimensionContext,
+    FileContext,
     MeasureContext,
     ModelValidationRule,
     ValidationIssueType,
@@ -37,10 +38,7 @@ class DataSourceMeasuresUniqueRule(ModelValidationRule):
                     issues.append(
                         ValidationError(
                             context=MeasureContext(
-                                file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                                line_number=data_source.metadata.file_slice.start_line_number
-                                if data_source.metadata
-                                else None,
+                                file_context=FileContext.from_metadata(metadata=data_source.metadata),
                                 data_source_name=data_source.name,
                                 measure_name=measure.reference.element_name,
                             ),
@@ -74,8 +72,7 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
 
         for dim in data_source.dimensions:
             context = DimensionContext(
-                file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                file_context=FileContext.from_metadata(metadata=data_source.metadata),
                 data_source_name=data_source.name,
                 dimension_name=dim.name,
             )
@@ -99,8 +96,7 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
             issues.append(
                 ValidationError(
                     context=DataSourceContext(
-                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source_name=data_source.name,
                     ),
                     message=f"No primary time dimension in data source with name ({data_source.name}). Please add one",

--- a/metricflow/model/validations/dimension_const.py
+++ b/metricflow/model/validations/dimension_const.py
@@ -1,9 +1,11 @@
 from typing import Dict, List
+from metricflow.instances import DataSourceElementReference
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.validations.validator_helpers import (
-    DimensionContext,
+    DataSourceElementContext,
+    DataSourceElementType,
     FileContext,
     ModelValidationRule,
     DimensionInvariants,
@@ -62,10 +64,12 @@ class DimensionConsistencyRule(ModelValidationRule):
         Throws: MdoValidationError if there is an inconsistent dimension in the data source.
         """
         issues: List[ValidationIssueType] = []
-        context = DimensionContext(
+        context = DataSourceElementContext(
             file_context=FileContext.from_metadata(metadata=data_source.metadata),
-            data_source_name=data_source.name,
-            dimension_name=dimension.name,
+            data_source_element=DataSourceElementReference(
+                data_source_name=data_source.name, element_name=dimension.name
+            ),
+            element_type=DataSourceElementType.DIMENSION,
         )
 
         if dimension.type == DimensionType.TIME:
@@ -124,10 +128,12 @@ class DimensionConsistencyRule(ModelValidationRule):
             # is_partition might not be specified in the configs, so default to False.
             is_partition = dimension.is_partition or False
 
-            context = DimensionContext(
+            context = DataSourceElementContext(
                 file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                data_source_name=data_source.name,
-                dimension_name=dimension.name,
+                data_source_element=DataSourceElementReference(
+                    data_source_name=data_source.name, element_name=dimension.name
+                ),
+                element_type=DataSourceElementType.DIMENSION,
             )
 
             if dimension_invariant.type != dimension.type:

--- a/metricflow/model/validations/dimension_const.py
+++ b/metricflow/model/validations/dimension_const.py
@@ -4,6 +4,7 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.validations.validator_helpers import (
     DimensionContext,
+    FileContext,
     ModelValidationRule,
     DimensionInvariants,
     ValidationIssueType,
@@ -62,8 +63,7 @@ class DimensionConsistencyRule(ModelValidationRule):
         """
         issues: List[ValidationIssueType] = []
         context = DimensionContext(
-            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-            line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+            file_context=FileContext.from_metadata(metadata=data_source.metadata),
             data_source_name=data_source.name,
             dimension_name=dimension.name,
         )
@@ -125,8 +125,7 @@ class DimensionConsistencyRule(ModelValidationRule):
             is_partition = dimension.is_partition or False
 
             context = DimensionContext(
-                file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                file_context=FileContext.from_metadata(metadata=data_source.metadata),
                 data_source_name=data_source.name,
                 dimension_name=dimension.name,
             )

--- a/metricflow/model/validations/element_const.py
+++ b/metricflow/model/validations/element_const.py
@@ -4,6 +4,7 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
+    FileContext,
     ModelValidationRule,
     ModelObjectType,
     ValidationError,
@@ -47,10 +48,7 @@ class ElementConsistencyRule(ModelValidationRule):
                 issues.append(
                     ValidationError(
                         context=DataSourceContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                         ),
                         message=f"In data source {data_source.name}, element `{element_name}` is of type "
@@ -66,10 +64,7 @@ class ElementConsistencyRule(ModelValidationRule):
                 issues.append(
                     ValidationError(
                         context=DataSourceContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                         ),
                         message=f"In data source {data_source.name}, the element named {element_name} "

--- a/metricflow/model/validations/identifiers.py
+++ b/metricflow/model/validations/identifiers.py
@@ -11,6 +11,7 @@ from metricflow.model.objects.elements.identifier import Identifier, IdentifierT
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
+    FileContext,
     IdentifierContext,
     ModelValidationRule,
     ValidationIssue,
@@ -44,8 +45,7 @@ class IdentifierConfigRule(ModelValidationRule):
         for ident in data_source.identifiers:
             if ident.identifiers:
                 context = IdentifierContext(
-                    file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                    line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                    file_context=FileContext.from_metadata(metadata=data_source.metadata),
                     data_source_name=data_source.name,
                     identifier_name=ident.name,
                 )
@@ -107,8 +107,7 @@ class OnePrimaryIdentifierPerDataSourceRule(ModelValidationRule):
             return [
                 ValidationFutureError(
                     context=DataSourceContext(
-                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source_name=data_source.name,
                     ),
                     message=f"Data sources can have only one primary identifier. The data source"
@@ -198,8 +197,7 @@ class IdentifierConsistencyRule(ModelValidationRule):
             issues.append(
                 ValidationWarning(
                     context=IdentifierContext(
-                        file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                        line_number=data_source.metadata.file_slice.start_line_number if data_source.metadata else None,
+                        file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source_name=data_source.name,
                         identifier_name=identifier_name,
                     ),

--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -11,6 +11,7 @@ from metricflow.model.objects.materialization import Materialization
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.validations.validator_helpers import (
+    FileContext,
     MaterializationContext,
     ModelValidationRule,
     ValidationError,
@@ -43,8 +44,7 @@ class ValidMaterializationRule(ModelValidationRule):
         issues: List[ValidationIssueType] = []
 
         context = MaterializationContext(
-            file_name=materialization.metadata.file_slice.filename if materialization.metadata else None,
-            line_number=materialization.metadata.file_slice.start_line_number if materialization.metadata else None,
+            file_context=FileContext.from_metadata(metadata=materialization.metadata),
             materialization_name=materialization.name,
         )
 

--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from typing import List
+from metricflow.instances import MaterializationModelReference
 
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.builder.source_node import SourceNodeBuilder
@@ -45,7 +46,7 @@ class ValidMaterializationRule(ModelValidationRule):
 
         context = MaterializationContext(
             file_context=FileContext.from_metadata(metadata=materialization.metadata),
-            materialization_name=materialization.name,
+            materialization=MaterializationModelReference(materialization_name=materialization.name),
         )
 
         if not materialization.dimensions:

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -5,6 +5,7 @@ from metricflow.errors.errors import ParsingException
 from metricflow.model.objects.metric import Metric, MetricType, CumulativeMetricWindow
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
+    FileContext,
     MetricContext,
     ModelValidationRule,
     ValidationIssueType,
@@ -38,8 +39,7 @@ class MetricMeasuresRule(ModelValidationRule):
                 issues.append(
                     ValidationFatal(
                         context=MetricContext(
-                            file_name=metric.metadata.file_slice.filename if metric.metadata else None,
-                            line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                            file_context=FileContext.from_metadata(metadata=metric.metadata),
                             metric_name=metric.name,
                         ),
                         message=f"Invalid measure {measure_in_metric} in metric {metric.name}",
@@ -76,8 +76,7 @@ class CumulativeMetricRule(ModelValidationRule):
                 issues.append(
                     ValidationError(
                         context=MetricContext(
-                            file_name=metric.metadata.file_slice.filename if metric.metadata else None,
-                            line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                            file_context=FileContext.from_metadata(metadata=metric.metadata),
                             metric_name=metric.name,
                         ),
                         message="Both window and grain_to_date set for cumulative metric. Please set one or the other",
@@ -91,8 +90,7 @@ class CumulativeMetricRule(ModelValidationRule):
                     issues.append(
                         ValidationError(
                             context=MetricContext(
-                                file_name=metric.metadata.file_slice.filename if metric.metadata else None,
-                                line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                                file_context=FileContext.from_metadata(metadata=metric.metadata),
                                 metric_name=metric.name,
                             ),
                             message=traceback.format_exc(),

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -2,6 +2,7 @@ import traceback
 from typing import List
 
 from metricflow.errors.errors import ParsingException
+from metricflow.instances import MetricModelReference
 from metricflow.model.objects.metric import Metric, MetricType, CumulativeMetricWindow
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
@@ -40,7 +41,7 @@ class MetricMeasuresRule(ModelValidationRule):
                     ValidationFatal(
                         context=MetricContext(
                             file_context=FileContext.from_metadata(metadata=metric.metadata),
-                            metric_name=metric.name,
+                            metric=MetricModelReference(metric_name=metric.name),
                         ),
                         message=f"Invalid measure {measure_in_metric} in metric {metric.name}",
                     )
@@ -77,7 +78,7 @@ class CumulativeMetricRule(ModelValidationRule):
                     ValidationError(
                         context=MetricContext(
                             file_context=FileContext.from_metadata(metadata=metric.metadata),
-                            metric_name=metric.name,
+                            metric=MetricModelReference(metric_name=metric.name),
                         ),
                         message="Both window and grain_to_date set for cumulative metric. Please set one or the other",
                     )
@@ -91,7 +92,7 @@ class CumulativeMetricRule(ModelValidationRule):
                         ValidationError(
                             context=MetricContext(
                                 file_context=FileContext.from_metadata(metadata=metric.metadata),
-                                metric_name=metric.name,
+                                metric=MetricModelReference(metric_name=metric.name),
                             ),
                             message=traceback.format_exc(),
                         )

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -1,15 +1,20 @@
 import re
 from typing import Dict, Tuple, List, Optional
+from metricflow.instances import (
+    DataSourceElementReference,
+    DataSourceReference,
+    MaterializationModelReference,
+    MetricModelReference,
+)
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
-    DimensionContext,
+    DataSourceElementContext,
+    DataSourceElementType,
     FileContext,
-    IdentifierContext,
     MaterializationContext,
-    MeasureContext,
     MetricContext,
     ModelValidationRule,
     ValidationContext,
@@ -69,10 +74,12 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     (
                         measure.reference,
                         "measure",
-                        MeasureContext(
+                        DataSourceElementContext(
                             file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                            data_source_name=data_source.name,
-                            measure_name=measure.reference.element_name,
+                            data_source_element=DataSourceElementReference(
+                                data_source_name=data_source.name, element_name=measure.name
+                            ),
+                            element_type=DataSourceElementType.MEASURE,
                         ),
                     )
                 )
@@ -82,10 +89,12 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     (
                         identifier.reference,
                         "identifier",
-                        IdentifierContext(
+                        DataSourceElementContext(
                             file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                            data_source_name=data_source.name,
-                            identifier_name=identifier.name,
+                            data_source_element=DataSourceElementReference(
+                                data_source_name=data_source.name, element_name=identifier.name
+                            ),
+                            element_type=DataSourceElementType.IDENTIFIER,
                         ),
                     )
                 )
@@ -95,10 +104,12 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     (
                         dimension.reference,
                         "dimension",
-                        DimensionContext(
+                        DataSourceElementContext(
                             file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                            data_source_name=data_source.name,
-                            dimension_name=dimension.name,
+                            data_source_element=DataSourceElementReference(
+                                data_source_name=data_source.name, element_name=dimension.name
+                            ),
+                            element_type=DataSourceElementType.DIMENSION,
                         ),
                     )
                 )
@@ -134,7 +145,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         "data source",
                         DataSourceContext(
                             file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                            data_source_name=data_source.name,
+                            data_source=DataSourceReference(data_source_name=data_source.name),
                         ),
                     )
                 )
@@ -146,7 +157,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         "materialization",
                         MaterializationContext(
                             file_context=FileContext.from_metadata(metadata=materialization.metadata),
-                            materialization_name=materialization.name,
+                            materialization=MaterializationModelReference(materialization_name=materialization.name),
                         ),
                     )
                 )
@@ -175,7 +186,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         ValidationFatal(
                             context=MetricContext(
                                 file_context=FileContext.from_metadata(metadata=metric.metadata),
-                                metric_name=metric.name,
+                                metric=MetricModelReference(metric_name=metric.name),
                             ),
                             message=f"Can't use name `{metric.name}` for a metric when it was already used for a metric",
                         )

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -6,6 +6,7 @@ from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
     DimensionContext,
+    FileContext,
     IdentifierContext,
     MaterializationContext,
     MeasureContext,
@@ -69,10 +70,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         measure.reference,
                         "measure",
                         MeasureContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                             measure_name=measure.reference.element_name,
                         ),
@@ -85,10 +83,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         identifier.reference,
                         "identifier",
                         IdentifierContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                             identifier_name=identifier.name,
                         ),
@@ -101,10 +96,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         dimension.reference,
                         "dimension",
                         DimensionContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                             dimension_name=dimension.name,
                         ),
@@ -141,10 +133,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         data_source.name,
                         "data source",
                         DataSourceContext(
-                            file_name=data_source.metadata.file_slice.filename if data_source.metadata else None,
-                            line_number=data_source.metadata.file_slice.start_line_number
-                            if data_source.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_name=data_source.name,
                         ),
                     )
@@ -156,12 +145,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                         materialization.name,
                         "materialization",
                         MaterializationContext(
-                            file_name=materialization.metadata.file_slice.filename
-                            if materialization.metadata
-                            else None,
-                            line_number=materialization.metadata.file_slice.start_line_number
-                            if materialization.metadata
-                            else None,
+                            file_context=FileContext.from_metadata(metadata=materialization.metadata),
                             materialization_name=materialization.name,
                         ),
                     )
@@ -190,8 +174,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     issues.append(
                         ValidationFatal(
                             context=MetricContext(
-                                file_name=metric.metadata.file_slice.filename if metric.metadata else None,
-                                line_number=metric.metadata.file_slice.start_line_number if metric.metadata else None,
+                                file_context=FileContext.from_metadata(metadata=metric.metadata),
                                 metric_name=metric.name,
                             ),
                             message=f"Can't use name `{metric.name}` for a metric when it was already used for a metric",

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -8,6 +8,7 @@ from datetime import date
 from enum import Enum
 from pydantic import BaseModel, Extra
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from metricflow.model.objects.common import Metadata
 
 from metricflow.model.objects.elements.dimension import DimensionType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -65,6 +66,15 @@ class FileContext(BaseModel):
                 context_string += f" on line #{self.line_number}"
 
         return context_string
+
+    @classmethod
+    def from_metadata(cls, metadata: Optional[Metadata] = None) -> FileContext:
+        """Creates a FileContext instance from a Metadata object"""
+
+        return cls(
+            file_name=metadata.file_slice.filename if metadata else None,
+            line_number=metadata.file_slice.start_line_number if metadata else None,
+        )
 
 
 class MaterializationContext(BaseModel):

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -8,6 +8,12 @@ from datetime import date
 from enum import Enum
 from pydantic import BaseModel, Extra
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from metricflow.instances import (
+    DataSourceElementReference,
+    DataSourceReference,
+    MaterializationModelReference,
+    MetricModelReference,
+)
 from metricflow.model.objects.common import Metadata
 
 from metricflow.model.objects.elements.dimension import DimensionType
@@ -33,15 +39,12 @@ class ValidationIssueLevel(Enum):
     FATAL = 3
 
 
-class ModelObjectType(Enum):
-    """Maps object types in the models to a readable string."""
+class DataSourceElementType(Enum):
+    """Maps data source element types to a readable string."""
 
-    DATA_SOURCE = "data_source"
-    MATERIALIZATION = "materialization"
     MEASURE = "measure"
     DIMENSION = "dimension"
     IDENTIFIER = "identifier"
-    METRIC = "metric"
 
 
 class FileContext(BaseModel):
@@ -81,79 +84,53 @@ class MaterializationContext(BaseModel):
     """The context class for validation issues involving materializations"""
 
     file_context: FileContext
-    materialization_name: str
+    materialization: MaterializationModelReference
 
     def context_str(self) -> str:
         """Human readable stringified representation of the context"""
-        return f"with materialization `{self.materialization_name}` {self.file_context.context_str()}"
+        return f"with materialization `{self.materialization.materialization_name}` {self.file_context.context_str()}"
 
 
 class MetricContext(BaseModel):
     """The context class for validation issues involving metrics"""
 
     file_context: FileContext
-    metric_name: str
+    metric: MetricModelReference
 
     def context_str(self) -> str:
         """Human readable stringified representation of the context"""
-        return f"with metric `{self.metric_name}` {self.file_context.context_str()}"
+        return f"with metric `{self.metric.metric_name}` {self.file_context.context_str()}"
 
 
 class DataSourceContext(BaseModel):
     """The context class for validation issues involving data sources"""
 
     file_context: FileContext
-    data_source_name: str
+    data_source: DataSourceReference
 
     def context_str(self) -> str:
         """Human readable stringified representation of the context"""
-        return f"with data source `{self.data_source_name}` {self.file_context.context_str()}"
+        return f"with data source `{self.data_source.data_source_name}` {self.file_context.context_str()}"
 
 
-class DimensionContext(BaseModel):
+class DataSourceElementContext(BaseModel):
     """The context class for validation issues involving dimensions"""
 
     file_context: FileContext
-    data_source_name: str
-    dimension_name: str
+    data_source_element: DataSourceElementReference
+    element_type: DataSourceElementType
 
     def context_str(self) -> str:
         """Human readable stringified representation of the context"""
-        return f"with dimension `{self.dimension_name}` in data source `{self.data_source_name}` {DataSourceContext.context_str(self)}"
-
-
-class IdentifierContext(BaseModel):
-    """The context class for validation issues involving indentifiers"""
-
-    file_context: FileContext
-    data_source_name: str
-    identifier_name: str
-
-    def context_str(self) -> str:
-        """Human readable stringified representation of the context"""
-        return f"with identifier `{self.identifier_name}` in data source `{self.data_source_name}` {DataSourceContext.context_str(self)}"
-
-
-class MeasureContext(BaseModel):
-    """The context class for validation issues involving measures"""
-
-    file_context: FileContext
-    data_source_name: str
-    measure_name: str
-
-    def context_str(self) -> str:
-        """Human readable stringified representation of the context"""
-        return f"with measure `{self.measure_name}` in data source `{self.data_source_name}` {DataSourceContext.context_str(self)}"
+        return f"with {self.element_type.value} `{self.data_source_element.element_name}` in data source `{self.data_source_element.data_source_name}` {self.file_context.context_str()}"
 
 
 ValidationContext = Union[
     FileContext,
     MaterializationContext,
     MetricContext,
-    DimensionContext,
-    MeasureContext,
-    IdentifierContext,
     DataSourceContext,
+    DataSourceElementContext,
 ]
 
 

--- a/metricflow/test/api/test_metricflow_client.py
+++ b/metricflow/test/api/test_metricflow_client.py
@@ -1,6 +1,7 @@
 from metricflow.api.metricflow_client import MetricFlowClient
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.engine.models import Dimension, Materialization, Metric
+from metricflow.model.validations.validator_helpers import ModelValidationResults
 from metricflow.object_utils import random_id
 
 
@@ -100,4 +101,4 @@ def test_materializations(mf_client: MetricFlowClient) -> None:  # noqa: D
 
 def test_validate_configs(mf_client: MetricFlowClient) -> None:  # noqa: D
     issues = mf_client.validate_configs()
-    assert isinstance(issues, tuple)
+    assert isinstance(issues, ModelValidationResults)

--- a/metricflow/test/model/test_config_linter.py
+++ b/metricflow/test/model/test_config_linter.py
@@ -1,10 +1,9 @@
 from metricflow.model.parsing.config_linter import ConfigLinter
-from metricflow.model.validations.validator_helpers import ValidationIssueLevel
 
 
 def test_lint_dir(config_linter_model_path: str) -> None:  # noqa: D
     issues = ConfigLinter().lint_dir(dir_path=config_linter_model_path)
 
-    assert len(issues) == 1
-    assert issues[0].level == ValidationIssueLevel.ERROR
-    assert 'duplication of key "data_source"' in issues[0].as_readable_str()
+    assert len(issues.all_issues) == 1
+    assert len(issues.errors) == 1
+    assert 'duplication of key "data_source"' in issues.errors[0].as_readable_str()

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -22,12 +22,12 @@ def test_can_configure_model_validator_rules(simple_model__pre_transforms: UserC
 
     # confirm that with the default configuration, an issue is raised
     issues = ModelValidator().validate_model(model).issues
-    assert len(issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
+    assert len(issues.all_issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
 
     # confirm that a custom configuration excluding DataSourceMeasuresUniqueRule, no issue is raised
     rules = [rule for rule in ModelValidator.DEFAULT_RULES if rule.__class__ is not ValidMaterializationRule]
     issues = ModelValidator(rules=rules).validate_model(model).issues
-    assert len(issues) == 0, f"ModelValidator without ValidMaterializationRule returned issues {issues}"
+    assert len(issues.all_issues) == 0, f"ModelValidator without ValidMaterializationRule returned issues {issues}"
 
 
 def test_cant_configure_model_validator_without_rules() -> None:  # noqa: D

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -42,7 +42,7 @@ def test_data_source_cant_have_more_than_one_primary_identifier(
     found_future_issue = False
 
     if build.issues is not None:
-        for issue in build.issues:
+        for issue in build.issues.all_issues:
             if re.search(future_issue, issue.message):
                 found_future_issue = True
 
@@ -236,6 +236,8 @@ def test_mismatched_identifier(simple_model__pre_transforms: UserConfiguredModel
     build = ModelValidator().validate_model(model)
 
     expected_error_message_fragment = "does not have consistent sub-identifiers"
-    error_count = len([issue for issue in build.issues if re.search(expected_error_message_fragment, issue.message)])
+    error_count = len(
+        [issue for issue in build.issues.all_issues if re.search(expected_error_message_fragment, issue.message)]
+    )
 
     assert error_count == 1

--- a/metricflow/test/model/validations/test_measures.py
+++ b/metricflow/test/model/validations/test_measures.py
@@ -15,7 +15,7 @@ def test_measures_only_exist_in_one_data_source(simple_model__pre_transforms: Us
     found_issue = False
 
     if build.issues is not None:
-        for issue in build.issues:
+        for issue in build.issues.all_issues:
             if re.search(duplicate_measure_message, issue.message):
                 found_issue = True
 
@@ -36,7 +36,7 @@ def test_measures_only_exist_in_one_data_source(simple_model__pre_transforms: Us
     build = ModelValidator().validate_model(model)
 
     if build.issues is not None:
-        for issue in build.issues:
+        for issue in build.issues.all_issues:
             if re.search(duplicate_measure_message, issue.message):
                 found_issue = True
 

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -137,8 +137,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     with pytest.raises(
         ModelValidationException,
         match=(
-            f"element `{measure_reference.element_name}` is of type ModelObjectType.MEASURE, but it was previously "
-            f"used earlier in the model as ModelObjectType.DIMENSION"
+            f"element `{measure_reference.element_name}` is of type DataSourceElementType.MEASURE, but it was previously "
+            f"used earlier in the model as DataSourceElementType.DIMENSION"
         ),
     ):
         ModelValidator().checked_validations(model)
@@ -147,8 +147,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     with pytest.raises(
         ModelValidationException,
         match=(
-            f"element `{measure_reference.element_name}` is of type ModelObjectType.MEASURE, but it was previously "
-            f"used earlier in the model as ModelObjectType.IDENTIFIER"
+            f"element `{measure_reference.element_name}` is of type DataSourceElementType.MEASURE, but it was previously "
+            f"used earlier in the model as DataSourceElementType.IDENTIFIER"
         ),
     ):
         ModelValidator().checked_validations(model)
@@ -157,8 +157,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     with pytest.raises(
         ModelValidationException,
         match=(
-            f"element `{dimension_reference.element_name}` is of type ModelObjectType.DIMENSION, but it was previously "
-            f"used earlier in the model as ModelObjectType.IDENTIFIER"
+            f"element `{dimension_reference.element_name}` is of type DataSourceElementType.DIMENSION, but it was previously "
+            f"used earlier in the model as DataSourceElementType.IDENTIFIER"
         ),
     ):
         ModelValidator().checked_validations(model)

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -1,6 +1,5 @@
 from datetime import date
-import json
-from typing import Any, Dict, List, Union
+from typing import List
 
 import pytest
 
@@ -13,12 +12,9 @@ from metricflow.model.validations.validator_helpers import (
     MeasureContext,
     MetricContext,
     ModelValidationResults,
-    ValidationContextJSON,
     ValidationError,
     ValidationFatal,
     ValidationFutureError,
-    ValidationIssue,
-    ValidationIssueJSON,
     ValidationIssueLevel,
     ValidationIssueType,
     ValidationWarning,
@@ -26,228 +22,56 @@ from metricflow.model.validations.validator_helpers import (
 
 
 @pytest.fixture
-def file_context_dict() -> Dict[str, Union[str, int]]:  # noqa: D
-    return {
-        "file_name": "foo.py",
-        "line_number": 1337,
-    }
+def list_of_issues() -> List[ValidationIssueType]:  # noqa: D
+    file_context = FileContext(file_name="foo", line_number=1337)
+    data_source_name = "My data source"
 
-
-@pytest.fixture
-def data_source_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
-    return {
-        "file_context": file_context_dict,
-        "data_source_name": "data source alpha",
-    }
-
-
-@pytest.fixture
-def dimension_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
-    return {
-        "file_context": file_context_dict,
-        "data_source_name": "data source alpha",
-        "dimension_name": "dimension beta",
-    }
-
-
-@pytest.fixture
-def identifier_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
-    return {
-        "file_context": file_context_dict,
-        "data_source_name": "data source alpha",
-        "identifier_name": "identifer omega",
-    }
-
-
-@pytest.fixture
-def measure_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
-    return {
-        "file_context": file_context_dict,
-        "data_source_name": "data source alpha",
-        "measure_name": "measure delta",
-    }
-
-
-@pytest.fixture
-def materialization_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
-    return {
-        "file_context": file_context_dict,
-        "materialization_name": "materialization epsilon",
-    }
-
-
-@pytest.fixture
-def metric_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
-    return {
-        "file_context": file_context_dict,
-        "metric_name": "metric cappa",
-    }
-
-
-@pytest.fixture
-def base_issue_dict(file_context_dict: ValidationContextJSON) -> ValidationIssueJSON:  # noqa: D
-    return {
-        "message": "An issue occured",
-        "context": file_context_dict,
-    }
-
-
-@pytest.fixture
-def list_of_issues(  # noqa: D
-    file_context_dict: Dict[str, Union[str, int]],
-    data_source_context_dict: Dict[str, Any],
-    dimension_context_dict: Dict[str, Any],
-    identifier_context_dict: Dict[str, Any],
-    measure_context_dict: Dict[str, Any],
-    materialization_context_dict: Dict[str, Any],
-    metric_context_dict: Dict[str, Any],
-) -> List[ValidationIssueType]:
     issues: List[ValidationIssueType] = []
     issues.append(
         ValidationWarning(
-            context=DataSourceContext.parse_obj(data_source_context_dict),
+            context=DataSourceContext(file_context=file_context, data_source_name=data_source_name),
             message="Something caused a warning, problem #1",
         )
     )
     issues.append(
         ValidationWarning(
-            context=DimensionContext.parse_obj(dimension_context_dict), message="Something caused a warning, problem #2"
+            context=DimensionContext(
+                file_context=file_context, data_source_name=data_source_name, dimension_name="My dimension"
+            ),
+            message="Something caused a warning, problem #2",
         )
     )
     issues.append(
         ValidationFutureError(
-            context=IdentifierContext.parse_obj(identifier_context_dict),
+            context=IdentifierContext(
+                file_context=file_context, data_source_name=data_source_name, identifier_name="My identifier"
+            ),
             message="Something caused a future error, problem #3",
             error_date=date(2022, 6, 13),
         )
     )
     issues.append(
         ValidationError(
-            context=MeasureContext.parse_obj(measure_context_dict), message="Something caused an error, problem #4"
+            context=MeasureContext(
+                file_context=file_context, data_source_name=data_source_name, measure_name="My measure"
+            ),
+            message="Something caused an error, problem #4",
         )
     )
     issues.append(
         ValidationError(
-            context=MaterializationContext.parse_obj(materialization_context_dict),
+            context=MaterializationContext(file_context=file_context, materialization_name="My materialization"),
             message="Something caused an error, problem #5",
         )
     )
     issues.append(
         ValidationFatal(
-            context=MetricContext.parse_obj(metric_context_dict), message="Something caused a fatal, problem #6"
+            context=MetricContext(file_context=file_context, metric_name="My metric"),
+            message="Something caused a fatal, problem #6",
         )
     )
-    issues.append(
-        ValidationFatal(
-            context=FileContext.parse_obj(file_context_dict), message="Something caused a fatal, probelm #7"
-        )
-    )
+    issues.append(ValidationFatal(context=file_context, message="Something caused a fatal, probelm #7"))
     return issues
-
-
-def test_load_validation_context(file_context_dict: Dict[str, Union[str, int]]) -> None:  # noqa: D
-    context = FileContext.parse_obj({})
-    assert isinstance(context, FileContext)
-    assert context.line_number is None
-    assert context.file_name is None
-    assert context.context_str() == ""
-
-    context = FileContext.parse_obj(file_context_dict)
-    assert isinstance(context, FileContext)
-    assert context.line_number == file_context_dict["line_number"]
-    assert context.file_name == file_context_dict["file_name"]
-    assert context.context_str()
-
-
-def test_load_data_source_context(data_source_context_dict: Dict[str, Any]) -> None:  # noqa: D
-    context = DataSourceContext.parse_obj(data_source_context_dict)
-
-    assert isinstance(context, DataSourceContext)
-    assert context.data_source_name == data_source_context_dict["data_source_name"]
-    assert context.context_str()
-
-
-def test_load_dimension_context(dimension_context_dict: Dict[str, Any]) -> None:  # noqa: D
-    context = DimensionContext.parse_obj(dimension_context_dict)
-
-    assert isinstance(context, DimensionContext)
-    assert context.data_source_name == dimension_context_dict["data_source_name"]
-    assert context.dimension_name == dimension_context_dict["dimension_name"]
-    assert context.context_str()
-
-
-def test_load_identifier_context(identifier_context_dict: Dict[str, Any]) -> None:  # noqa: D
-    context = IdentifierContext.parse_obj(identifier_context_dict)
-
-    assert isinstance(context, IdentifierContext)
-    assert context.data_source_name == identifier_context_dict["data_source_name"]
-    assert context.identifier_name == identifier_context_dict["identifier_name"]
-    assert context.context_str()
-
-
-def test_load_measure_context(measure_context_dict: Dict[str, Any]) -> None:  # noqa: D
-    context = MeasureContext.parse_obj(measure_context_dict)
-
-    assert isinstance(context, MeasureContext)
-    assert context.data_source_name == measure_context_dict["data_source_name"]
-    assert context.measure_name == measure_context_dict["measure_name"]
-    assert context.context_str()
-
-
-def test_load_materialization_context(materialization_context_dict: Dict[str, Any]) -> None:  # noqa: D
-    context = MaterializationContext.parse_obj(materialization_context_dict)
-
-    assert isinstance(context, MaterializationContext)
-    assert context.materialization_name == materialization_context_dict["materialization_name"]
-    assert context.context_str()
-
-
-def test_load_metric_context(metric_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    context = MetricContext.parse_obj(metric_context_dict)
-
-    assert isinstance(context, MetricContext)
-    assert context.metric_name == metric_context_dict["metric_name"]
-    assert context.context_str()
-
-
-def test_load_validation_fatal(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
-    issue = ValidationFatal.parse_raw(json.dumps(base_issue_dict))
-
-    assert isinstance(issue, ValidationIssue)
-    assert issue.level == ValidationIssueLevel.FATAL
-    assert issue.message == base_issue_dict["message"]
-    assert isinstance(issue.context, FileContext)
-
-
-def test_load_validation_error(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
-    issue = ValidationError.parse_raw(json.dumps(base_issue_dict))
-
-    assert isinstance(issue, ValidationIssue)
-    assert issue.level == ValidationIssueLevel.ERROR
-    assert issue.message == base_issue_dict["message"]
-    assert isinstance(issue.context, FileContext)
-
-
-def test_load_validation_future_error(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
-    error_date = date(2022, 6, 13)
-    base_issue_dict["error_date"] = error_date.isoformat()
-
-    issue = ValidationFutureError.parse_raw(json.dumps(base_issue_dict))
-
-    assert isinstance(issue, ValidationFutureError)
-    assert issue.level == ValidationIssueLevel.FUTURE_ERROR
-    assert issue.message == base_issue_dict["message"]
-    assert issue.error_date == error_date
-    assert isinstance(issue.context, FileContext)
-
-
-def test_load_validation_warning(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
-    issue = ValidationWarning.parse_raw(json.dumps(base_issue_dict))
-
-    assert isinstance(issue, ValidationIssue)
-    assert issue.level == ValidationIssueLevel.WARNING
-    assert issue.message == base_issue_dict["message"]
-    assert isinstance(issue.context, FileContext)
 
 
 def test_creating_model_validation_results_from_issue_list(  # noqa: D

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -1,6 +1,6 @@
 from datetime import date
 import json
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 import pytest
 
@@ -12,6 +12,7 @@ from metricflow.model.validations.validator_helpers import (
     MaterializationContext,
     MeasureContext,
     MetricContext,
+    ModelValidationResults,
     ValidationContextJSON,
     ValidationError,
     ValidationFatal,
@@ -19,6 +20,7 @@ from metricflow.model.validations.validator_helpers import (
     ValidationIssue,
     ValidationIssueJSON,
     ValidationIssueLevel,
+    ValidationIssueType,
     ValidationWarning,
 )
 
@@ -88,6 +90,59 @@ def base_issue_dict(file_context_dict: ValidationContextJSON) -> ValidationIssue
         "message": "An issue occured",
         "context": file_context_dict,
     }
+
+
+@pytest.fixture
+def list_of_issues(  # noqa: D
+    file_context_dict: Dict[str, Union[str, int]],
+    data_source_context_dict: Dict[str, Any],
+    dimension_context_dict: Dict[str, Any],
+    identifier_context_dict: Dict[str, Any],
+    measure_context_dict: Dict[str, Any],
+    materialization_context_dict: Dict[str, Any],
+    metric_context_dict: Dict[str, Any],
+) -> List[ValidationIssueType]:
+    issues: List[ValidationIssueType] = []
+    issues.append(
+        ValidationWarning(
+            context=DataSourceContext.parse_obj(data_source_context_dict),
+            message="Something caused a warning, problem #1",
+        )
+    )
+    issues.append(
+        ValidationWarning(
+            context=DimensionContext.parse_obj(dimension_context_dict), message="Something caused a warning, problem #2"
+        )
+    )
+    issues.append(
+        ValidationFutureError(
+            context=IdentifierContext.parse_obj(identifier_context_dict),
+            message="Something caused a future error, problem #3",
+            error_date=date(2022, 6, 13),
+        )
+    )
+    issues.append(
+        ValidationError(
+            context=MeasureContext.parse_obj(measure_context_dict), message="Something caused an error, problem #4"
+        )
+    )
+    issues.append(
+        ValidationError(
+            context=MaterializationContext.parse_obj(materialization_context_dict),
+            message="Something caused an error, problem #5",
+        )
+    )
+    issues.append(
+        ValidationFatal(
+            context=MetricContext.parse_obj(metric_context_dict), message="Something caused a fatal, problem #6"
+        )
+    )
+    issues.append(
+        ValidationFatal(
+            context=FileContext.parse_obj(file_context_dict), message="Something caused a fatal, probelm #7"
+        )
+    )
+    return issues
 
 
 def test_load_validation_context(file_context_dict: Dict[str, Union[str, int]]) -> None:  # noqa: D
@@ -193,3 +248,53 @@ def test_load_validation_warning(base_issue_dict: ValidationIssueJSON) -> None: 
     assert issue.level == ValidationIssueLevel.WARNING
     assert issue.message == base_issue_dict["message"]
     assert isinstance(issue.context, FileContext)
+
+
+def test_creating_model_validation_results_from_issue_list(  # noqa: D
+    list_of_issues: List[ValidationIssueType],
+) -> None:
+    warnings = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.WARNING]
+    future_errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.FUTURE_ERROR]
+    errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.ERROR]
+    fatals = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.FATAL]
+
+    model_validation_issues = ModelValidationResults.from_issues_sequence(list_of_issues)
+    assert len(model_validation_issues.warnings) == len(warnings)
+    assert len(model_validation_issues.future_errors) == len(future_errors)
+    assert len(model_validation_issues.errors) == len(errors)
+    assert len(model_validation_issues.fatals) == len(fatals)
+    assert model_validation_issues.has_blocking_issues
+
+    model_validation_issues = ModelValidationResults(warnings=warnings, future_errors=future_errors)
+    assert not model_validation_issues.has_blocking_issues
+
+
+def test_jsonifying_and_reloading_model_validation_results_is_equal(  # noqa: D
+    list_of_issues: List[ValidationIssueType],
+) -> None:
+    warnings = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.WARNING]
+    errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.ERROR]
+    set_context_types = set([issue.context.__class__ for issue in list_of_issues])
+
+    model_validation_issues = ModelValidationResults.from_issues_sequence(list_of_issues)
+    model_validation_issues_new = ModelValidationResults.parse_raw(model_validation_issues.json())
+    assert model_validation_issues_new == model_validation_issues
+    assert model_validation_issues_new != ModelValidationResults(warnings=warnings, errors=errors)
+
+    # ensure ValidationContexts were properly parsed into the differen subclasses
+    new_context_types = [issue.context.__class__ for issue in model_validation_issues_new.warnings]
+    new_context_types += [issue.context.__class__ for issue in model_validation_issues_new.future_errors]
+    new_context_types += [issue.context.__class__ for issue in model_validation_issues_new.errors]
+    new_context_types += [issue.context.__class__ for issue in model_validation_issues_new.fatals]
+    assert set_context_types == set(new_context_types)
+
+
+def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssueType]) -> None:  # noqa: D
+    validation_results = ModelValidationResults.from_issues_sequence(list_of_issues)
+    validation_results_dup = ModelValidationResults.from_issues_sequence(list_of_issues)
+    merged = ModelValidationResults.merge([validation_results, validation_results_dup])
+
+    assert merged.warnings == validation_results.warnings + validation_results_dup.warnings
+    assert merged.future_errors == validation_results.future_errors + validation_results_dup.future_errors
+    assert merged.errors == validation_results.errors + validation_results_dup.errors
+    assert merged.fatals == validation_results.fatals + validation_results_dup.fatals

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -2,14 +2,19 @@ from datetime import date
 from typing import List
 
 import pytest
+from metricflow.instances import (
+    DataSourceElementReference,
+    DataSourceReference,
+    MaterializationModelReference,
+    MetricModelReference,
+)
 
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
-    DimensionContext,
+    DataSourceElementContext,
+    DataSourceElementType,
     FileContext,
-    IdentifierContext,
     MaterializationContext,
-    MeasureContext,
     MetricContext,
     ModelValidationResults,
     ValidationError,
@@ -29,22 +34,33 @@ def list_of_issues() -> List[ValidationIssueType]:  # noqa: D
     issues: List[ValidationIssueType] = []
     issues.append(
         ValidationWarning(
-            context=DataSourceContext(file_context=file_context, data_source_name=data_source_name),
+            context=DataSourceContext(
+                file_context=file_context,
+                data_source=DataSourceReference(data_source_name=data_source_name),
+            ),
             message="Something caused a warning, problem #1",
         )
     )
     issues.append(
         ValidationWarning(
-            context=DimensionContext(
-                file_context=file_context, data_source_name=data_source_name, dimension_name="My dimension"
+            context=DataSourceElementContext(
+                file_context=file_context,
+                data_source_element=DataSourceElementReference(
+                    data_source_name=data_source_name, element_name="My dimension"
+                ),
+                element_type=DataSourceElementType.DIMENSION,
             ),
             message="Something caused a warning, problem #2",
         )
     )
     issues.append(
         ValidationFutureError(
-            context=IdentifierContext(
-                file_context=file_context, data_source_name=data_source_name, identifier_name="My identifier"
+            context=DataSourceElementContext(
+                file_context=file_context,
+                data_source_element=DataSourceElementReference(
+                    data_source_name=data_source_name, element_name="My identifier"
+                ),
+                element_type=DataSourceElementType.IDENTIFIER,
             ),
             message="Something caused a future error, problem #3",
             error_date=date(2022, 6, 13),
@@ -52,21 +68,32 @@ def list_of_issues() -> List[ValidationIssueType]:  # noqa: D
     )
     issues.append(
         ValidationError(
-            context=MeasureContext(
-                file_context=file_context, data_source_name=data_source_name, measure_name="My measure"
+            context=DataSourceElementContext(
+                file_context=file_context,
+                data_source_name=data_source_name,
+                data_source_element=DataSourceElementReference(
+                    data_source_name=data_source_name, element_name="My measure"
+                ),
+                element_type=DataSourceElementType.MEASURE,
             ),
             message="Something caused an error, problem #4",
         )
     )
     issues.append(
         ValidationError(
-            context=MaterializationContext(file_context=file_context, materialization_name="My materialization"),
+            context=MaterializationContext(
+                file_context=file_context,
+                materialization=MaterializationModelReference(materialization_name="My materialization"),
+            ),
             message="Something caused an error, problem #5",
         )
     )
     issues.append(
         ValidationFatal(
-            context=MetricContext(file_context=file_context, metric_name="My metric"),
+            context=MetricContext(
+                file_context=file_context,
+                metric=MetricModelReference(metric_name="My metric"),
+            ),
             message="Something caused a fatal, problem #6",
         )
     )

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -1,13 +1,176 @@
 from datetime import date
+import json
 
-from metricflow.model.validations.validator_helpers import ValidationContext, ValidationFutureError
+import pytest
+
+from metricflow.model.validations.validator_helpers import (
+    DataSourceContext,
+    DimensionContext,
+    IdentifierContext,
+    MaterializationContext,
+    MeasureContext,
+    MetricContext,
+    ValidationContext,
+    ValidationContextJSON,
+    ValidationFutureError,
+    ValidationIssue,
+    ValidationIssueJSON,
+    ValidationIssueLevel,
+)
 
 
-def test_validaiton_issue_to_json() -> None:  # noqa: D
+@pytest.fixture
+def base_context_dict() -> ValidationContextJSON:  # noqa: D
+    return {
+        "file_name": "foo.py",
+        "line_number": 1337,
+    }
+
+
+@pytest.fixture
+def base_issue_dict(base_context_dict: ValidationContextJSON) -> ValidationIssueJSON:  # noqa: D
+    return {
+        "message": "An issue occured",
+        "level": ValidationIssueLevel.ERROR.value,
+        "context": base_context_dict,
+    }
+
+
+def test_can_load_issue_from_jsonified_issue() -> None:  # noqa: D
     issue = ValidationFutureError(
         context=ValidationContext(file_name="foo.yaml", line_number=1337),
         message="A issue was found that will be an error",
         error_date=date(2022, 6, 13),
     )
 
-    assert issue.json(), f"Failed to jsonify issue: {issue}"
+    jsonified_issue = issue.json()
+    new_issue = ValidationIssue.from_json(jsonified_issue)
+
+    assert isinstance(new_issue, ValidationFutureError)
+    assert new_issue == issue
+
+
+def test_load_validation_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    context = ValidationContext.from_dict({})
+    assert isinstance(context, ValidationContext)
+    assert context.line_number is None
+    assert context.file_name is None
+
+    context = ValidationContext.from_dict(base_context_dict)
+    assert isinstance(context, ValidationContext)
+    assert context.line_number == base_context_dict["line_number"]
+    assert context.file_name == base_context_dict["file_name"]
+
+
+def test_load_data_source_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    data_source_name = "data source alpha"
+    base_context_dict["data_source_name"] = data_source_name
+
+    context = ValidationContext.from_dict(base_context_dict)
+
+    assert isinstance(context, DataSourceContext)
+    assert context.data_source_name == data_source_name
+
+
+def test_load_dimension_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    data_source_name = "data source alpha"
+    dimension_name = "dimension beta"
+    base_context_dict["data_source_name"] = data_source_name
+    base_context_dict["dimension_name"] = dimension_name
+
+    context = ValidationContext.from_dict(base_context_dict)
+
+    assert isinstance(context, DimensionContext)
+    assert context.data_source_name == data_source_name
+    assert context.dimension_name == dimension_name
+
+
+def test_load_identifier_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    data_source_name = "data source alpha"
+    identifier_name = "identifer omega"
+    base_context_dict["data_source_name"] = data_source_name
+    base_context_dict["identifier_name"] = identifier_name
+
+    context = ValidationContext.from_dict(base_context_dict)
+
+    assert isinstance(context, IdentifierContext)
+    assert context.data_source_name == data_source_name
+    assert context.identifier_name == identifier_name
+
+
+def test_load_measure_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    data_source_name = "data source alpha"
+    measure_name = "measure delta"
+    base_context_dict["data_source_name"] = data_source_name
+    base_context_dict["measure_name"] = measure_name
+
+    context = ValidationContext.from_dict(base_context_dict)
+
+    assert isinstance(context, MeasureContext)
+    assert context.data_source_name == data_source_name
+    assert context.measure_name == measure_name
+
+
+def test_load_materialization_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    materialization_name = "materialization epsilon"
+    base_context_dict["materialization_name"] = materialization_name
+
+    context = ValidationContext.from_dict(base_context_dict)
+
+    assert isinstance(context, MaterializationContext)
+    assert context.materialization_name == materialization_name
+
+
+def test_load_metric_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    metric_name = "metric cappa"
+    base_context_dict["metric_name"] = metric_name
+
+    context = ValidationContext.from_dict(base_context_dict)
+
+    assert isinstance(context, MetricContext)
+    assert context.metric_name == metric_name
+
+
+def test_load_validation_fatal(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
+    base_issue_dict["level"] = ValidationIssueLevel.FATAL.value
+
+    issue = ValidationIssue.from_json(json.dumps(base_issue_dict))
+
+    assert isinstance(issue, ValidationIssue)
+    assert issue.level == ValidationIssueLevel.FATAL
+    assert issue.message == base_issue_dict["message"]
+    assert isinstance(issue.context, ValidationContext)
+
+
+def test_load_validation_error(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
+    issue = ValidationIssue.from_json(json.dumps(base_issue_dict))
+
+    assert isinstance(issue, ValidationIssue)
+    assert issue.level == ValidationIssueLevel.ERROR
+    assert issue.message == base_issue_dict["message"]
+    assert isinstance(issue.context, ValidationContext)
+
+
+def test_load_validation_future_error(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
+    error_date = date(2022, 6, 13)
+    base_issue_dict["level"] = ValidationIssueLevel.FUTURE_ERROR.value
+    base_issue_dict["error_date"] = error_date.isoformat()
+
+    issue = ValidationIssue.from_json(json.dumps(base_issue_dict))
+
+    assert isinstance(issue, ValidationFutureError)
+    assert issue.level == ValidationIssueLevel.FUTURE_ERROR
+    assert issue.message == base_issue_dict["message"]
+    assert issue.error_date == error_date
+    assert isinstance(issue.context, ValidationContext)
+
+
+def test_load_validation_warning(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
+    base_issue_dict["level"] = ValidationIssueLevel.WARNING.value
+
+    issue = ValidationIssue.from_json(json.dumps(base_issue_dict))
+
+    assert isinstance(issue, ValidationIssue)
+    assert issue.level == ValidationIssueLevel.WARNING
+    assert issue.message == base_issue_dict["message"]
+    assert isinstance(issue.context, ValidationContext)

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -1,16 +1,17 @@
 from datetime import date
 import json
+from typing import Any, Dict, Union
 
 import pytest
 
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
     DimensionContext,
+    FileContext,
     IdentifierContext,
     MaterializationContext,
     MeasureContext,
     MetricContext,
-    ValidationContext,
     ValidationContextJSON,
     ValidationFutureError,
     ValidationIssue,
@@ -20,7 +21,7 @@ from metricflow.model.validations.validator_helpers import (
 
 
 @pytest.fixture
-def base_context_dict() -> ValidationContextJSON:  # noqa: D
+def file_context_dict() -> Dict[str, Union[str, int]]:  # noqa: D
     return {
         "file_name": "foo.py",
         "line_number": 1337,
@@ -28,17 +29,68 @@ def base_context_dict() -> ValidationContextJSON:  # noqa: D
 
 
 @pytest.fixture
-def base_issue_dict(base_context_dict: ValidationContextJSON) -> ValidationIssueJSON:  # noqa: D
+def data_source_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
+    return {
+        "file_context": file_context_dict,
+        "data_source_name": "data source alpha",
+    }
+
+
+@pytest.fixture
+def dimension_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
+    return {
+        "file_context": file_context_dict,
+        "data_source_name": "data source alpha",
+        "dimension_name": "dimension beta",
+    }
+
+
+@pytest.fixture
+def identifier_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
+    return {
+        "file_context": file_context_dict,
+        "data_source_name": "data source alpha",
+        "identifier_name": "identifer omega",
+    }
+
+
+@pytest.fixture
+def measure_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
+    return {
+        "file_context": file_context_dict,
+        "data_source_name": "data source alpha",
+        "measure_name": "measure delta",
+    }
+
+
+@pytest.fixture
+def materialization_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
+    return {
+        "file_context": file_context_dict,
+        "materialization_name": "materialization epsilon",
+    }
+
+
+@pytest.fixture
+def metric_context_dict(file_context_dict: Dict[str, Union[str, int]]) -> Dict[str, Any]:  # noqa: D
+    return {
+        "file_context": file_context_dict,
+        "metric_name": "metric cappa",
+    }
+
+
+@pytest.fixture
+def base_issue_dict(file_context_dict: ValidationContextJSON) -> ValidationIssueJSON:  # noqa: D
     return {
         "message": "An issue occured",
         "level": ValidationIssueLevel.ERROR.value,
-        "context": base_context_dict,
+        "context": file_context_dict,
     }
 
 
 def test_can_load_issue_from_jsonified_issue() -> None:  # noqa: D
     issue = ValidationFutureError(
-        context=ValidationContext(file_name="foo.yaml", line_number=1337),
+        context=FileContext(file_name="foo.yaml", line_number=1337),
         message="A issue was found that will be an error",
         error_date=date(2022, 6, 13),
     )
@@ -50,85 +102,69 @@ def test_can_load_issue_from_jsonified_issue() -> None:  # noqa: D
     assert new_issue == issue
 
 
-def test_load_validation_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    context = ValidationContext.from_dict({})
-    assert isinstance(context, ValidationContext)
+def test_load_validation_context(file_context_dict: Dict[str, Union[str, int]]) -> None:  # noqa: D
+    context = FileContext.parse_obj({})
+    assert isinstance(context, FileContext)
     assert context.line_number is None
     assert context.file_name is None
+    assert context.context_str() == ""
 
-    context = ValidationContext.from_dict(base_context_dict)
-    assert isinstance(context, ValidationContext)
-    assert context.line_number == base_context_dict["line_number"]
-    assert context.file_name == base_context_dict["file_name"]
+    context = FileContext.parse_obj(file_context_dict)
+    assert isinstance(context, FileContext)
+    assert context.line_number == file_context_dict["line_number"]
+    assert context.file_name == file_context_dict["file_name"]
+    assert context.context_str()
 
 
-def test_load_data_source_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    data_source_name = "data source alpha"
-    base_context_dict["data_source_name"] = data_source_name
-
-    context = ValidationContext.from_dict(base_context_dict)
+def test_load_data_source_context(data_source_context_dict: Dict[str, Any]) -> None:  # noqa: D
+    context = DataSourceContext.parse_obj(data_source_context_dict)
 
     assert isinstance(context, DataSourceContext)
-    assert context.data_source_name == data_source_name
+    assert context.data_source_name == data_source_context_dict["data_source_name"]
+    assert context.context_str()
 
 
-def test_load_dimension_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    data_source_name = "data source alpha"
-    dimension_name = "dimension beta"
-    base_context_dict["data_source_name"] = data_source_name
-    base_context_dict["dimension_name"] = dimension_name
-
-    context = ValidationContext.from_dict(base_context_dict)
+def test_load_dimension_context(dimension_context_dict: Dict[str, Any]) -> None:  # noqa: D
+    context = DimensionContext.parse_obj(dimension_context_dict)
 
     assert isinstance(context, DimensionContext)
-    assert context.data_source_name == data_source_name
-    assert context.dimension_name == dimension_name
+    assert context.data_source_name == dimension_context_dict["data_source_name"]
+    assert context.dimension_name == dimension_context_dict["dimension_name"]
+    assert context.context_str()
 
 
-def test_load_identifier_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    data_source_name = "data source alpha"
-    identifier_name = "identifer omega"
-    base_context_dict["data_source_name"] = data_source_name
-    base_context_dict["identifier_name"] = identifier_name
-
-    context = ValidationContext.from_dict(base_context_dict)
+def test_load_identifier_context(identifier_context_dict: Dict[str, Any]) -> None:  # noqa: D
+    context = IdentifierContext.parse_obj(identifier_context_dict)
 
     assert isinstance(context, IdentifierContext)
-    assert context.data_source_name == data_source_name
-    assert context.identifier_name == identifier_name
+    assert context.data_source_name == identifier_context_dict["data_source_name"]
+    assert context.identifier_name == identifier_context_dict["identifier_name"]
+    assert context.context_str()
 
 
-def test_load_measure_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    data_source_name = "data source alpha"
-    measure_name = "measure delta"
-    base_context_dict["data_source_name"] = data_source_name
-    base_context_dict["measure_name"] = measure_name
-
-    context = ValidationContext.from_dict(base_context_dict)
+def test_load_measure_context(measure_context_dict: Dict[str, Any]) -> None:  # noqa: D
+    context = MeasureContext.parse_obj(measure_context_dict)
 
     assert isinstance(context, MeasureContext)
-    assert context.data_source_name == data_source_name
-    assert context.measure_name == measure_name
+    assert context.data_source_name == measure_context_dict["data_source_name"]
+    assert context.measure_name == measure_context_dict["measure_name"]
+    assert context.context_str()
 
 
-def test_load_materialization_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    materialization_name = "materialization epsilon"
-    base_context_dict["materialization_name"] = materialization_name
-
-    context = ValidationContext.from_dict(base_context_dict)
+def test_load_materialization_context(materialization_context_dict: Dict[str, Any]) -> None:  # noqa: D
+    context = MaterializationContext.parse_obj(materialization_context_dict)
 
     assert isinstance(context, MaterializationContext)
-    assert context.materialization_name == materialization_name
+    assert context.materialization_name == materialization_context_dict["materialization_name"]
+    assert context.context_str()
 
 
-def test_load_metric_context(base_context_dict: ValidationContextJSON) -> None:  # noqa: D
-    metric_name = "metric cappa"
-    base_context_dict["metric_name"] = metric_name
-
-    context = ValidationContext.from_dict(base_context_dict)
+def test_load_metric_context(metric_context_dict: ValidationContextJSON) -> None:  # noqa: D
+    context = MetricContext.parse_obj(metric_context_dict)
 
     assert isinstance(context, MetricContext)
-    assert context.metric_name == metric_name
+    assert context.metric_name == metric_context_dict["metric_name"]
+    assert context.context_str()
 
 
 def test_load_validation_fatal(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
@@ -139,7 +175,7 @@ def test_load_validation_fatal(base_issue_dict: ValidationIssueJSON) -> None:  #
     assert isinstance(issue, ValidationIssue)
     assert issue.level == ValidationIssueLevel.FATAL
     assert issue.message == base_issue_dict["message"]
-    assert isinstance(issue.context, ValidationContext)
+    assert isinstance(issue.context, FileContext)
 
 
 def test_load_validation_error(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
@@ -148,7 +184,7 @@ def test_load_validation_error(base_issue_dict: ValidationIssueJSON) -> None:  #
     assert isinstance(issue, ValidationIssue)
     assert issue.level == ValidationIssueLevel.ERROR
     assert issue.message == base_issue_dict["message"]
-    assert isinstance(issue.context, ValidationContext)
+    assert isinstance(issue.context, FileContext)
 
 
 def test_load_validation_future_error(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
@@ -162,7 +198,7 @@ def test_load_validation_future_error(base_issue_dict: ValidationIssueJSON) -> N
     assert issue.level == ValidationIssueLevel.FUTURE_ERROR
     assert issue.message == base_issue_dict["message"]
     assert issue.error_date == error_date
-    assert isinstance(issue.context, ValidationContext)
+    assert isinstance(issue.context, FileContext)
 
 
 def test_load_validation_warning(base_issue_dict: ValidationIssueJSON) -> None:  # noqa: D
@@ -173,4 +209,4 @@ def test_load_validation_warning(base_issue_dict: ValidationIssueJSON) -> None: 
     assert isinstance(issue, ValidationIssue)
     assert issue.level == ValidationIssueLevel.WARNING
     assert issue.message == base_issue_dict["message"]
-    assert isinstance(issue.context, ValidationContext)
+    assert isinstance(issue.context, FileContext)


### PR DESCRIPTION
This PR started as the second half to #133, in that we wanted to be able to deserialize JSON-ified ValidationIssues into ValidationIssue objeccts. In doing this work we found blocking problems with the structure of `ValidationIssues` and `ValidationContext` which stopped the magical parsing of Pydantic `BaseModel` from working. This in turn lead to a refactor to the structure of`ValidationIssues` and `ValidationContexts` so that both serialization and de-serialization of `ValidationIssues` is simple.

# Highlights
• The different `ValidationContexts` now contain a `FileContext` instead of inheriting from `FileContext`.
• `ValidationIssue` is now an `ABC` which the different issue types implement, making them distinct.
• There is a new `ModelValidationResults` class which should be the primary source of serialization and deserialization for validation issues
• The different Validators `ModelValiator`, `DataWarehouseModelValidator`, `ConfigLinter` now return `ModelValidationResults` instead of a list/tuple of ValidationIssues

# Good to knows

## Serialization and de-serialization
Serialization and de-serialization should primarily happen with `ModelValidationResults` objects.
```Python
# serialization
serialized = model_validation_results.json()

# de-serialization
deserialized_mvr = ModelValidationResults.parse_raw(serialized)
```

## ModelValidationResults creation and helpers
```Python
# Create a ModelValidationResults instance from a sequence of issues
new_mvr = ModelValidationResults.from_issue_sequence(list_of_issues)

# Get a list of issues from a ModelValidationResults instance
validation_issues_list = new_mvr.all_issues

# Check if a ModelValidationResults has blocking issues
new_mvr.has_blocking_issues # True if object has errors or fatals, otherwise false

# Merge multiple ModelValidationResults objects together
big_mvr = ModelValidationResults.merge(mvr1, mvr2, mvr3, ...)
```



