### PR TITLE
Add data warehouse context provider for inference

### DIFF
--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -2,14 +2,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
-from pandas.api.types import (
-    is_datetime64_any_dtype as is_datetime_dtype,
-    is_float_dtype,
-    is_integer_dtype,
-    is_bool_dtype,
-    is_string_dtype,
-)
-
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.model.objects.utils import FrozenBaseModel
 
@@ -23,21 +15,6 @@ class SqlColumnType(str, Enum):
     FLOAT = "float"
     DATETIME = "datetime"
     UNKNOWN = "unknown"
-
-    @staticmethod
-    def from_pandas_dtype(dtype: Optional[str]) -> SqlColumnType:
-        """Get the column type from a pd.Series.dtype"""
-        if is_integer_dtype(dtype):
-            return SqlColumnType.INTEGER
-        if is_float_dtype(dtype):
-            return SqlColumnType.FLOAT
-        if is_datetime_dtype(dtype):
-            return SqlColumnType.DATETIME
-        if is_bool_dtype(dtype):
-            return SqlColumnType.BOOLEAN
-        if is_string_dtype(dtype):
-            return SqlColumnType.STRING
-        return SqlColumnType.UNKNOWN
 
 
 class SqlColumn(FrozenBaseModel):
@@ -81,3 +58,6 @@ class SqlColumn(FrozenBaseModel):
     def sql(self) -> str:
         """Return the snippet that can be used for use in SQL queries."""
         return f"{self.table.sql}.{self.column_name}"
+
+    def __repr__(self) -> str:  # noqa: D
+        return f"SqlColumn(full_name={self.sql})"

--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -1,20 +1,8 @@
 from __future__ import annotations
-from enum import Enum
 from typing import Optional
 
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.model.objects.utils import FrozenBaseModel
-
-
-class SqlColumnType(str, Enum):
-    """Represents a column type."""
-
-    STRING = "string"
-    BOOLEAN = "boolean"
-    INTEGER = "integer"
-    FLOAT = "float"
-    DATETIME = "datetime"
-    UNKNOWN = "unknown"
 
 
 class SqlColumn(FrozenBaseModel):

--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from enum import Enum
+from typing import Optional
+
+from pandas.api.types import (
+    is_datetime64_any_dtype as is_datetime_dtype,
+    is_float_dtype,
+    is_integer_dtype,
+    is_bool_dtype,
+    is_string_dtype,
+)
+
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.model.objects.utils import FrozenBaseModel, ParseableField
+
+
+class SqlColumnType(str, Enum):
+    """Represents a column type."""
+
+    STRING = "string"
+    BOOLEAN = "boolean"
+    INTEGER = "integer"
+    FLOAT = "float"
+    DATETIME = "datetime"
+    UNKNOWN = "unknown"
+
+    @staticmethod
+    def from_pandas_dtype(dtype: Optional[str]) -> SqlColumnType:
+        """Get the column type from a pd.Series.dtype"""
+        if is_integer_dtype(dtype):
+            return SqlColumnType.INTEGER
+        if is_float_dtype(dtype):
+            return SqlColumnType.FLOAT
+        if is_datetime_dtype(dtype):
+            return SqlColumnType.DATETIME
+        if is_bool_dtype(dtype):
+            return SqlColumnType.BOOLEAN
+        if is_string_dtype(dtype):
+            return SqlColumnType.STRING
+        return SqlColumnType.UNKNOWN
+
+
+class SqlColumn(FrozenBaseModel, ParseableField):
+    """Represents a reference to a SQL column."""
+
+    table: SqlTable
+    name: str
+
+    @staticmethod
+    def parse(s: str) -> SqlColumn:
+        """Implement ParseableField interface"""
+        return SqlColumn.from_string(s)
+
+    @staticmethod
+    def from_string(sql_str: str) -> SqlColumn:  # noqa: D
+        table_str, column_name = sql_str.rsplit(".", 1)
+        table = SqlTable.parse(table_str)
+        return SqlColumn(table=table, name=column_name)
+
+    @property
+    def sql(self) -> str:
+        """Return the snippet that can be used for use in SQL queries."""
+        return f"{self.table.sql}.{self.name}"

--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -23,18 +23,16 @@ class SqlColumn(FrozenBaseModel):
     table: SqlTable
     column_name: str
 
-    def __init__(  # noqa: D
-        self,
+    @staticmethod
+    def from_names(
         column_name: str,
-        table_name: str = None,
-        schema_name: str = None,
-        db_name: str = None,
-        table: SqlTable = None,
+        table_name: str,
+        schema_name: str,
+        db_name: str,
     ):
-        if table is None:
-            table = SqlTable(db_name=db_name, schema_name=schema_name, table_name=table_name)
-
-        super(FrozenBaseModel, self).__init__(table=table, column_name=column_name)
+        """Helper factory method for constructing a column from database, table, schema and column names."""
+        table = SqlTable(db_name=db_name, schema_name=schema_name, table_name=table_name)
+        return SqlColumn(table=table, column_name=column_name)
 
     @staticmethod
     def from_string(sql_str: str) -> SqlColumn:  # noqa: D

--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -44,15 +44,40 @@ class SqlColumn(FrozenBaseModel):
     """Represents a reference to a SQL column."""
 
     table: SqlTable
-    name: str
+    column_name: str
+
+    def __init__(  # noqa: D
+        self,
+        column_name: str,
+        table_name: str = None,
+        schema_name: str = None,
+        db_name: str = None,
+        table: SqlTable = None,
+    ):
+        if table is None:
+            table = SqlTable(db_name=db_name, schema_name=schema_name, table_name=table_name)
+
+        super(FrozenBaseModel, self).__init__(table=table, column_name=column_name)
 
     @staticmethod
     def from_string(sql_str: str) -> SqlColumn:  # noqa: D
         table_str, column_name = sql_str.rsplit(".", 1)
         table = SqlTable.from_string(table_str)
-        return SqlColumn(table=table, name=column_name)
+        return SqlColumn(table=table, column_name=column_name)
+
+    @property
+    def db_name(self) -> Optional[str]:  # noqa: D
+        return self.table.db_name
+
+    @property
+    def schema_name(self) -> Optional[str]:  # noqa: D
+        return self.table.schema_name
+
+    @property
+    def table_name(self) -> Optional[str]:  # noqa: D
+        return self.table.table_name
 
     @property
     def sql(self) -> str:
         """Return the snippet that can be used for use in SQL queries."""
-        return f"{self.table.sql}.{self.name}"
+        return f"{self.table.sql}.{self.column_name}"

--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -11,7 +11,7 @@ from pandas.api.types import (
 )
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.model.objects.utils import FrozenBaseModel, ParseableField
+from metricflow.model.objects.utils import FrozenBaseModel
 
 
 class SqlColumnType(str, Enum):
@@ -40,21 +40,16 @@ class SqlColumnType(str, Enum):
         return SqlColumnType.UNKNOWN
 
 
-class SqlColumn(FrozenBaseModel, ParseableField):
+class SqlColumn(FrozenBaseModel):
     """Represents a reference to a SQL column."""
 
     table: SqlTable
     name: str
 
     @staticmethod
-    def parse(s: str) -> SqlColumn:
-        """Implement ParseableField interface"""
-        return SqlColumn.from_string(s)
-
-    @staticmethod
     def from_string(sql_str: str) -> SqlColumn:  # noqa: D
         table_str, column_name = sql_str.rsplit(".", 1)
-        table = SqlTable.parse(table_str)
+        table = SqlTable.from_string(table_str)
         return SqlColumn(table=table, name=column_name)
 
     @property

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -95,3 +95,7 @@ class ModelCreationException(Exception):
         super().__init__(
             "An error occurred when attempting to build the semantic model",
         )
+
+
+class InferenceError(Exception):
+    """Exception to represent errors related to inference."""

--- a/metricflow/inference/context/base.py
+++ b/metricflow/inference/context/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+
+class InferenceContext(ABC):
+    """Encapsulates information that can be used by an inference signaling rule or inference policy."""
+
+    pass
+
+
+TContext = TypeVar("TContext", bound=InferenceContext)
+
+
+class InferenceContextProvider(Generic[TContext], ABC):
+    """Provides a populated inference context from some datasource."""
+
+    @abstractmethod
+    def get_context(self) -> TContext:
+        """Fetch inference context data and return it."""
+        pass

--- a/metricflow/inference/context/data_warehouse.py
+++ b/metricflow/inference/context/data_warehouse.py
@@ -1,13 +1,30 @@
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime
+from enum import Enum
 from typing import Dict, List, Optional, TypeVar, Generic
 
-from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_column import SqlColumn
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.inference.context.base import InferenceContext, InferenceContextProvider
 
 T = TypeVar("T", str, int, float, date, datetime)
+
+
+class InferenceColumnType(str, Enum):
+    """Represents a column type that can be used for inference.
+
+    This does not provide a 1 to 1 mapping between SQL types and enum values. For example,
+    all possible floating point types (FLOAT, DOUBLE etc) are mapped to the same FLOAT
+    value. Same for datetimes and others.
+    """
+
+    STRING = "string"
+    BOOLEAN = "boolean"
+    INTEGER = "integer"
+    FLOAT = "float"
+    DATETIME = "datetime"
+    UNKNOWN = "unknown"
 
 
 @dataclass(frozen=True)
@@ -16,7 +33,7 @@ class ColumnProperties(Generic[T]):
 
     column: SqlColumn
 
-    type: SqlColumnType
+    type: InferenceColumnType
     row_count: int
     distinct_row_count: int
     is_nullable: bool

--- a/metricflow/inference/context/data_warehouse.py
+++ b/metricflow/inference/context/data_warehouse.py
@@ -1,0 +1,116 @@
+from dataclasses import InitVar, dataclass, field
+from datetime import date, datetime
+from typing import Dict, List, Optional, TypeVar, Generic
+
+from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.errors.errors import InferenceError
+from metricflow.protocols.sql_client import SqlClient
+from metricflow.inference.context.base import InferenceContext, InferenceContextProvider
+
+T = TypeVar("T", str, int, float, date, datetime)
+
+
+@dataclass(frozen=True)
+class ColumnStatistics(Generic[T]):
+    """Holds statistical data about a column."""
+
+    column: SqlColumn
+
+    dtype: InitVar[Optional[str]]
+    type: SqlColumnType = field(init=False)
+
+    row_count: int
+    distinct_row_count: int
+    null_count: int
+    min_value: Optional[T]
+    max_value: Optional[T]
+
+    def __post_init__(self, dtype: Optional[str]):  # noqa: D
+        object.__setattr__(self, "type", SqlColumnType.from_pandas_dtype(dtype))
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether the column has any rows"""
+        return self.row_count == 0
+
+    @property
+    def cardinality(self) -> float:
+        """The proportion between unique values and the row count of the column."""
+        if self.is_empty:
+            raise InferenceError("Cannot determine the cardinality of empty column.")
+
+        return self.distinct_row_count / self.row_count
+
+    @property
+    def is_nullable(self) -> bool:
+        """Whether the column is nullable or not"""
+        return self.null_count != 0
+
+
+@dataclass(frozen=True)
+class TableStatistics:
+    """Holds statistical data about a table."""
+
+    column_stats: InitVar[List[ColumnStatistics]]
+
+    table: SqlTable
+    columns: Dict[SqlColumn, ColumnStatistics] = field(default_factory=lambda: {}, init=False)
+
+    def __post_init__(self, column_stats: List[ColumnStatistics]) -> None:  # noqa: D
+        for col in column_stats:
+            self.columns[col.column] = col
+
+
+@dataclass(frozen=True)
+class DataWarehouseInferenceContext(InferenceContext):
+    """The inference context for a data warehouse. Holds statistics and metadata about each column."""
+
+    table_stats: InitVar[List[TableStatistics]]
+
+    tables: Dict[SqlTable, TableStatistics] = field(default_factory=lambda: {}, init=False)
+    columns: Dict[SqlColumn, ColumnStatistics] = field(default_factory=lambda: {}, init=False)
+
+    def __post_init__(self, table_stats: List[TableStatistics]) -> None:  # noqa: D
+        for stats in table_stats:
+            self.tables[stats.table] = stats
+            for column in stats.columns.values():
+                self.columns[column.column] = column
+
+
+@dataclass(frozen=True)
+class DataWarehouseInferenceContextProvider(InferenceContextProvider[DataWarehouseInferenceContext]):
+    """Provides inference context from a data warehouse by querying data from its tables.
+
+    client: the underlying SQL engine client that will be used for querying table data.
+    tables: an exhaustive list of all tables that should be queried.
+    max_sample_size: max number of rows to sample from each table
+    """
+
+    client: SqlClient
+    tables: List[SqlTable]
+    max_sample_size: int = 1000
+
+    def _get_table_statistics(self, table: SqlTable) -> TableStatistics:
+        """Fetch statistics about a single table by querying the warehouse."""
+
+        query = f"SELECT * FROM {table.sql} LIMIT {self.max_sample_size}"
+        df = self.client.query(query)
+        column_stats = [
+            ColumnStatistics(
+                column=SqlColumn(table=table, name=col_name),
+                dtype=str(series.dtype),
+                row_count=len(series),
+                distinct_row_count=series.nunique(dropna=False),
+                null_count=series.isnull().sum(),
+                min_value=series.min(),
+                max_value=series.max(),
+            )
+            for col_name, series in df.iteritems()
+        ]
+        return TableStatistics(table=table, column_stats=column_stats)
+
+    def get_context(self) -> DataWarehouseInferenceContext:
+        """Query the data warehouse for statistics about all tables and populate a context with it."""
+        table_stats = [self._get_table_statistics(table) for table in self.tables]
+        return DataWarehouseInferenceContext(table_stats=table_stats)

--- a/metricflow/inference/context/data_warehouse.py
+++ b/metricflow/inference/context/data_warehouse.py
@@ -83,7 +83,7 @@ class DataWarehouseInferenceContextProvider(InferenceContextProvider[DataWarehou
         df = self.client.query(query)
         column_props = [
             ColumnProperties(
-                column=SqlColumn(table=table, name=col_name),
+                column=SqlColumn(table=table, column_name=col_name),
                 type=SqlColumnType.from_pandas_dtype(str(series.dtype)),
                 row_count=len(series),
                 distinct_row_count=series.nunique(dropna=False),

--- a/metricflow/inference/context/data_warehouse.py
+++ b/metricflow/inference/context/data_warehouse.py
@@ -19,6 +19,7 @@ class ColumnProperties(Generic[T]):
     type: SqlColumnType
     row_count: int
     distinct_row_count: int
+    is_nullable: bool
     null_count: int
     min_value: Optional[T]
     max_value: Optional[T]
@@ -27,11 +28,6 @@ class ColumnProperties(Generic[T]):
     def is_empty(self) -> bool:
         """Whether the column has any rows"""
         return self.row_count == 0
-
-    @property
-    def is_nullable(self) -> bool:
-        """Whether the column is nullable or not"""
-        return self.null_count != 0
 
 
 @dataclass(frozen=True)
@@ -79,21 +75,7 @@ class DataWarehouseInferenceContextProvider(InferenceContextProvider[DataWarehou
 
     def _get_table_properties(self, table: SqlTable) -> TableProperties:
         """Fetch properties about a single table by querying the warehouse."""
-        query = f"SELECT * FROM {table.sql} LIMIT {self.max_sample_size}"
-        df = self.client.query(query)
-        column_props = [
-            ColumnProperties(
-                column=SqlColumn(table=table, column_name=col_name),
-                type=SqlColumnType.from_pandas_dtype(str(series.dtype)),
-                row_count=len(series),
-                distinct_row_count=series.nunique(dropna=False),
-                null_count=series.isnull().sum(),
-                min_value=series.min(),
-                max_value=series.max(),
-            )
-            for col_name, series in df.iteritems()
-        ]
-        return TableProperties(table=table, column_props=column_props)
+        raise NotImplementedError
 
     def get_context(self) -> DataWarehouseInferenceContext:
         """Query the data warehouse for statistics about all tables and populate a context with it."""

--- a/metricflow/inference/context/data_warehouse.py
+++ b/metricflow/inference/context/data_warehouse.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime
 from enum import Enum
@@ -77,19 +78,21 @@ class DataWarehouseInferenceContext(InferenceContext):
                 self.columns[column.column] = column
 
 
-@dataclass(frozen=True)
-class DataWarehouseInferenceContextProvider(InferenceContextProvider[DataWarehouseInferenceContext]):
-    """Provides inference context from a data warehouse by querying data from its tables.
+class DataWarehouseInferenceContextProvider(InferenceContextProvider[DataWarehouseInferenceContext], ABC):
+    """Provides inference context from a data warehouse by querying data from its tables."""
 
-    client: the underlying SQL engine client that will be used for querying table data.
-    tables: an exhaustive list of all tables that should be queried.
-    max_sample_size: max number of rows to sample from each table
-    """
+    def __init__(self, client: SqlClient, tables: List[SqlTable], max_sample_size: int = 1000) -> None:
+        """Initialize the class.
 
-    client: SqlClient
-    tables: List[SqlTable]
-    max_sample_size: int = 1000
+        client: the underlying SQL engine client that will be used for querying table data.
+        tables: an exhaustive list of all tables that should be queried.
+        max_sample_size: max number of rows to sample from each table
+        """
+        self._client = client
+        self.tables = tables
+        self.max_sample_size = max_sample_size
 
+    @abstractmethod
     def _get_table_properties(self, table: SqlTable) -> TableProperties:
         """Fetch properties about a single table by querying the warehouse."""
         raise NotImplementedError

--- a/metricflow/inference/context/snowflake.py
+++ b/metricflow/inference/context/snowflake.py
@@ -1,0 +1,102 @@
+import json
+from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.inference.context.data_warehouse import (
+    TableProperties,
+    ColumnProperties,
+    DataWarehouseInferenceContextProvider,
+)
+
+
+class SnowflakeInferenceContextProvider(DataWarehouseInferenceContextProvider):
+    """The snowflake implementation for a DataWarehouseInferenceContextProvider"""
+
+    COUNT_DISTINCT_SUFFIX = "countdistinct"
+    COUNT_NULL_SUFFIX = "countnull"
+    MIN_SUFFIX = "min"
+    MAX_SUFFIX = "max"
+
+    def _column_type_from_show_columns_data_type(self, type_str: str) -> SqlColumnType:
+        """Get the correspondent SqlColumnType from Snowflake's returned type string.
+
+        See for reference: https://docs.snowflake.com/en/sql-reference/sql/show-columns.html
+        """
+        str_dict = {
+            "FIXED": SqlColumnType.INTEGER,
+            "TEXT": SqlColumnType.STRING,
+            "REAL": SqlColumnType.FLOAT,
+            "BOOLEAN": SqlColumnType.BOOLEAN,
+            "DATE": SqlColumnType.DATETIME,
+            "TIMESTAMP_TZ": SqlColumnType.DATETIME,
+            "TIMESTAMP_LTZ": SqlColumnType.DATETIME,
+            "TIMESTAMP_NTZ": SqlColumnType.DATETIME,
+        }
+
+        return str_dict.get(type_str, SqlColumnType.UNKNOWN)
+
+    def _get_select_list_for_column_name(self, name: str, count_nulls: bool) -> str:
+        statements = [
+            f"COUNT(DISTINCT {name}) AS {name}_{SnowflakeInferenceContextProvider.COUNT_DISTINCT_SUFFIX}",
+            f"MIN({name}) AS {name}_{SnowflakeInferenceContextProvider.MIN_SUFFIX}",
+            f"MAX({name}) AS {name}_{SnowflakeInferenceContextProvider.MAX_SUFFIX}",
+            (
+                f"SUM(CASE WHEN {name} IS NULL THEN 1 ELSE 0 END) AS {name}_{SnowflakeInferenceContextProvider.COUNT_NULL_SUFFIX}"
+                if count_nulls
+                else f"0 AS {name}_{SnowflakeInferenceContextProvider.COUNT_NULL_SUFFIX}"
+            ),
+        ]
+
+        return ", ".join(statements)
+
+    def _get_table_properties(self, table: SqlTable) -> TableProperties:
+        all_columns_query = f"SHOW COLUMNS IN TABLE {table.sql}"
+        all_columns = self.client.query(all_columns_query)
+
+        sql_column_list = []
+        col_types = {}
+        col_nullable = {}
+        select_lists = []
+
+        for row in all_columns.itertuples():
+            column = SqlColumn(
+                db_name=row.database_name.lower(),
+                schema_name=row.schema_name.lower(),
+                table_name=row.table_name.lower(),
+                column_name=row.column_name.lower(),
+            )
+            sql_column_list.append(column)
+
+            type_dict = json.loads(row.data_type)
+            col_types[column] = self._column_type_from_show_columns_data_type(type_dict["type"])
+            col_nullable[column] = type_dict["nullable"]
+            select_lists.append(
+                self._get_select_list_for_column_name(
+                    name=column.column_name,
+                    count_nulls=col_nullable[column],
+                )
+            )
+
+        select_lists.append("COUNT(*) AS rowcount")
+        select_list = ", ".join(select_lists)
+        statistics_query = f"SELECT {select_list} FROM {table.sql} SAMPLE ({self.max_sample_size} ROWS)"
+        statistics_df = self.client.query(statistics_query)
+
+        column_props = [
+            ColumnProperties(
+                column=column,
+                type=col_types[column],
+                is_nullable=col_nullable[column],
+                null_count=statistics_df[f"{column.column_name}_{SnowflakeInferenceContextProvider.COUNT_NULL_SUFFIX}"][
+                    0
+                ],
+                row_count=statistics_df["rowcount"][0],
+                distinct_row_count=statistics_df[
+                    f"{column.column_name}_{SnowflakeInferenceContextProvider.COUNT_DISTINCT_SUFFIX}"
+                ][0],
+                min_value=statistics_df[f"{column.column_name}_{SnowflakeInferenceContextProvider.MIN_SUFFIX}"][0],
+                max_value=statistics_df[f"{column.column_name}_{SnowflakeInferenceContextProvider.MAX_SUFFIX}"][0],
+            )
+            for column in sql_column_list
+        ]
+
+        return TableProperties(table=table, column_props=column_props)

--- a/metricflow/inference/context/snowflake.py
+++ b/metricflow/inference/context/snowflake.py
@@ -58,7 +58,7 @@ class SnowflakeInferenceContextProvider(DataWarehouseInferenceContextProvider):
         select_lists = []
 
         for row in all_columns.itertuples():
-            column = SqlColumn(
+            column = SqlColumn.from_names(
                 db_name=row.database_name.lower(),
                 schema_name=row.schema_name.lower(),
                 table_name=row.table_name.lower(),

--- a/metricflow/inference/context/snowflake.py
+++ b/metricflow/inference/context/snowflake.py
@@ -1,9 +1,10 @@
 import json
-from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_column import SqlColumn
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.inference.context.data_warehouse import (
     TableProperties,
     ColumnProperties,
+    InferenceColumnType,
     DataWarehouseInferenceContextProvider,
 )
 
@@ -16,23 +17,23 @@ class SnowflakeInferenceContextProvider(DataWarehouseInferenceContextProvider):
     MIN_SUFFIX = "min"
     MAX_SUFFIX = "max"
 
-    def _column_type_from_show_columns_data_type(self, type_str: str) -> SqlColumnType:
-        """Get the correspondent SqlColumnType from Snowflake's returned type string.
+    def _column_type_from_show_columns_data_type(self, type_str: str) -> InferenceColumnType:
+        """Get the correspondent InferenceColumnType from Snowflake's returned type string.
 
         See for reference: https://docs.snowflake.com/en/sql-reference/sql/show-columns.html
         """
         str_dict = {
-            "FIXED": SqlColumnType.INTEGER,
-            "TEXT": SqlColumnType.STRING,
-            "REAL": SqlColumnType.FLOAT,
-            "BOOLEAN": SqlColumnType.BOOLEAN,
-            "DATE": SqlColumnType.DATETIME,
-            "TIMESTAMP_TZ": SqlColumnType.DATETIME,
-            "TIMESTAMP_LTZ": SqlColumnType.DATETIME,
-            "TIMESTAMP_NTZ": SqlColumnType.DATETIME,
+            "FIXED": InferenceColumnType.INTEGER,
+            "TEXT": InferenceColumnType.STRING,
+            "REAL": InferenceColumnType.FLOAT,
+            "BOOLEAN": InferenceColumnType.BOOLEAN,
+            "DATE": InferenceColumnType.DATETIME,
+            "TIMESTAMP_TZ": InferenceColumnType.DATETIME,
+            "TIMESTAMP_LTZ": InferenceColumnType.DATETIME,
+            "TIMESTAMP_NTZ": InferenceColumnType.DATETIME,
         }
 
-        return str_dict.get(type_str, SqlColumnType.UNKNOWN)
+        return str_dict.get(type_str, InferenceColumnType.UNKNOWN)
 
     def _get_select_list_for_column_name(self, name: str, count_nulls: bool) -> str:
         statements = [

--- a/metricflow/inference/context/snowflake.py
+++ b/metricflow/inference/context/snowflake.py
@@ -51,7 +51,7 @@ class SnowflakeInferenceContextProvider(DataWarehouseInferenceContextProvider):
 
     def _get_table_properties(self, table: SqlTable) -> TableProperties:
         all_columns_query = f"SHOW COLUMNS IN TABLE {table.sql}"
-        all_columns = self.client.query(all_columns_query)
+        all_columns = self._client.query(all_columns_query)
 
         sql_column_list = []
         col_types = {}
@@ -80,7 +80,7 @@ class SnowflakeInferenceContextProvider(DataWarehouseInferenceContextProvider):
         select_lists.append("COUNT(*) AS rowcount")
         select_list = ", ".join(select_lists)
         statistics_query = f"SELECT {select_list} FROM {table.sql} SAMPLE ({self.max_sample_size} ROWS)"
-        statistics_df = self.client.query(statistics_query)
+        statistics_df = self._client.query(statistics_query)
 
         column_props = [
             ColumnProperties(

--- a/metricflow/test/dataflow/test_sql_column.py
+++ b/metricflow/test/dataflow/test_sql_column.py
@@ -1,0 +1,55 @@
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+
+
+def test_sql_column() -> None:  # noqa: D
+    sql_column = SqlColumn(
+        table=SqlTable(db_name="test_db", schema_name="test_schema", table_name="test_table"), name="test_column"
+    )
+    column_str = "test_db.test_schema.test_table.test_column"
+
+    assert sql_column.sql == column_str
+    assert SqlColumn.from_string(column_str) == sql_column
+
+    json_serialized_column = sql_column.json()
+    deserialized_column = SqlColumn.parse_raw(json_serialized_column)
+
+    assert sql_column == deserialized_column
+
+
+def test_sql_column_type_from_pandas_dtype() -> None:  # noqa: D
+    # int
+    assert SqlColumnType.from_pandas_dtype("int") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("int8") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("int16") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("int32") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("int64") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("uint") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("uint8") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("uint16") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("uint32") == SqlColumnType.INTEGER
+    assert SqlColumnType.from_pandas_dtype("uint64") == SqlColumnType.INTEGER
+
+    # float
+    assert SqlColumnType.from_pandas_dtype("float") == SqlColumnType.FLOAT
+    assert SqlColumnType.from_pandas_dtype("float16") == SqlColumnType.FLOAT
+    assert SqlColumnType.from_pandas_dtype("float32") == SqlColumnType.FLOAT
+    assert SqlColumnType.from_pandas_dtype("float64") == SqlColumnType.FLOAT
+
+    # bool
+    assert SqlColumnType.from_pandas_dtype("bool") == SqlColumnType.BOOLEAN
+
+    # string
+    assert SqlColumnType.from_pandas_dtype("str") == SqlColumnType.STRING
+
+    # datetime
+    assert SqlColumnType.from_pandas_dtype("datetime64") == SqlColumnType.DATETIME
+
+    # unknowns
+    assert SqlColumnType.from_pandas_dtype(None) == SqlColumnType.UNKNOWN
+    assert SqlColumnType.from_pandas_dtype("complex") == SqlColumnType.UNKNOWN
+    assert SqlColumnType.from_pandas_dtype("complex64") == SqlColumnType.UNKNOWN
+    assert SqlColumnType.from_pandas_dtype("complex128") == SqlColumnType.UNKNOWN
+    assert SqlColumnType.from_pandas_dtype("asdf16") == SqlColumnType.UNKNOWN
+    assert SqlColumnType.from_pandas_dtype("test32") == SqlColumnType.UNKNOWN
+    assert SqlColumnType.from_pandas_dtype("shouldnotwork64") == SqlColumnType.UNKNOWN

--- a/metricflow/test/dataflow/test_sql_column.py
+++ b/metricflow/test/dataflow/test_sql_column.py
@@ -4,12 +4,19 @@ from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
 
 def test_sql_column() -> None:  # noqa: D
     sql_column = SqlColumn(
-        table=SqlTable(db_name="test_db", schema_name="test_schema", table_name="test_table"), name="test_column"
+        table=SqlTable(db_name="test_db", schema_name="test_schema", table_name="test_table"), column_name="test_column"
     )
     column_str = "test_db.test_schema.test_table.test_column"
 
     assert sql_column.sql == column_str
     assert SqlColumn.from_string(column_str) == sql_column
+    assert sql_column == SqlColumn(
+        db_name="test_db", schema_name="test_schema", table_name="test_table", column_name="test_column"
+    )
+
+    assert sql_column.db_name == sql_column.table.db_name
+    assert sql_column.schema_name == sql_column.table.schema_name
+    assert sql_column.table_name == sql_column.table.table_name
 
     json_serialized_column = sql_column.json()
     deserialized_column = SqlColumn.parse_raw(json_serialized_column)

--- a/metricflow/test/dataflow/test_sql_column.py
+++ b/metricflow/test/dataflow/test_sql_column.py
@@ -10,7 +10,7 @@ def test_sql_column() -> None:  # noqa: D
 
     assert sql_column.sql == column_str
     assert SqlColumn.from_string(column_str) == sql_column
-    assert sql_column == SqlColumn(
+    assert sql_column == SqlColumn.from_names(
         db_name="test_db", schema_name="test_schema", table_name="test_table", column_name="test_column"
     )
 

--- a/metricflow/test/dataflow/test_sql_column.py
+++ b/metricflow/test/dataflow/test_sql_column.py
@@ -1,5 +1,5 @@
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_column import SqlColumn
 
 
 def test_sql_column() -> None:  # noqa: D
@@ -22,41 +22,3 @@ def test_sql_column() -> None:  # noqa: D
     deserialized_column = SqlColumn.parse_raw(json_serialized_column)
 
     assert sql_column == deserialized_column
-
-
-def test_sql_column_type_from_pandas_dtype() -> None:  # noqa: D
-    # int
-    assert SqlColumnType.from_pandas_dtype("int") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("int8") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("int16") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("int32") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("int64") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("uint") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("uint8") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("uint16") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("uint32") == SqlColumnType.INTEGER
-    assert SqlColumnType.from_pandas_dtype("uint64") == SqlColumnType.INTEGER
-
-    # float
-    assert SqlColumnType.from_pandas_dtype("float") == SqlColumnType.FLOAT
-    assert SqlColumnType.from_pandas_dtype("float16") == SqlColumnType.FLOAT
-    assert SqlColumnType.from_pandas_dtype("float32") == SqlColumnType.FLOAT
-    assert SqlColumnType.from_pandas_dtype("float64") == SqlColumnType.FLOAT
-
-    # bool
-    assert SqlColumnType.from_pandas_dtype("bool") == SqlColumnType.BOOLEAN
-
-    # string
-    assert SqlColumnType.from_pandas_dtype("str") == SqlColumnType.STRING
-
-    # datetime
-    assert SqlColumnType.from_pandas_dtype("datetime64") == SqlColumnType.DATETIME
-
-    # unknowns
-    assert SqlColumnType.from_pandas_dtype(None) == SqlColumnType.UNKNOWN
-    assert SqlColumnType.from_pandas_dtype("complex") == SqlColumnType.UNKNOWN
-    assert SqlColumnType.from_pandas_dtype("complex64") == SqlColumnType.UNKNOWN
-    assert SqlColumnType.from_pandas_dtype("complex128") == SqlColumnType.UNKNOWN
-    assert SqlColumnType.from_pandas_dtype("asdf16") == SqlColumnType.UNKNOWN
-    assert SqlColumnType.from_pandas_dtype("test32") == SqlColumnType.UNKNOWN
-    assert SqlColumnType.from_pandas_dtype("shouldnotwork64") == SqlColumnType.UNKNOWN

--- a/metricflow/test/inference/context/test_data_warehouse.py
+++ b/metricflow/test/inference/context/test_data_warehouse.py
@@ -44,7 +44,7 @@ def test_table_statistics() -> None:  # noqa: D
     table = SqlTable.from_string("db.schema.table")
     col_props = [
         ColumnProperties(
-            column=SqlColumn(table=table, name="column1"),
+            column=SqlColumn(table=table, column_name="column1"),
             type=SqlColumnType.INTEGER,
             row_count=1000,
             distinct_row_count=1000,
@@ -53,7 +53,7 @@ def test_table_statistics() -> None:  # noqa: D
             max_value=999,
         ),
         ColumnProperties(
-            column=SqlColumn(table=table, name="column2"),
+            column=SqlColumn(table=table, column_name="column2"),
             type=SqlColumnType.FLOAT,
             row_count=2000,
             distinct_row_count=1000,
@@ -77,7 +77,7 @@ def test_data_warehouse_inference_context() -> None:  # noqa: D
 
     t1_cols = [
         ColumnProperties(
-            column=SqlColumn(table=t1, name="column1"),
+            column=SqlColumn(table=t1, column_name="column1"),
             type=SqlColumnType.INTEGER,
             row_count=1000,
             distinct_row_count=1000,
@@ -86,7 +86,7 @@ def test_data_warehouse_inference_context() -> None:  # noqa: D
             max_value=999,
         ),
         ColumnProperties(
-            column=SqlColumn(table=t1, name="column2"),
+            column=SqlColumn(table=t1, column_name="column2"),
             type=SqlColumnType.FLOAT,
             row_count=2000,
             distinct_row_count=1000,
@@ -99,7 +99,7 @@ def test_data_warehouse_inference_context() -> None:  # noqa: D
 
     t2_cols = [
         ColumnProperties(
-            column=SqlColumn(table=t2, name="column_a"),
+            column=SqlColumn(table=t2, column_name="column_a"),
             type=SqlColumnType.FLOAT,
             row_count=1000,
             distinct_row_count=1000,

--- a/metricflow/test/inference/context/test_data_warehouse.py
+++ b/metricflow/test/inference/context/test_data_warehouse.py
@@ -1,0 +1,229 @@
+from unittest.mock import MagicMock, call
+import pytest
+
+import pandas as pd
+
+from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.errors.errors import InferenceError
+from metricflow.inference.context.data_warehouse import (
+    ColumnStatistics,
+    DataWarehouseInferenceContext,
+    DataWarehouseInferenceContextProvider,
+    TableStatistics,
+)
+
+
+def test_column_statistics():  # noqa: D
+    stats = ColumnStatistics(
+        column=SqlColumn.from_string("db.schema.table.column"),
+        dtype="int32",
+        row_count=10000,
+        distinct_row_count=1000,
+        null_count=1,
+        min_value=0,
+        max_value=9999,
+    )
+    assert stats.type == SqlColumnType.INTEGER
+    assert not stats.is_empty
+    assert stats.is_nullable
+    assert stats.cardinality == 0.1
+
+    empty_stats = ColumnStatistics(
+        column=SqlColumn.from_string("db.schema.table.column"),
+        dtype=None,
+        row_count=0,
+        distinct_row_count=0,
+        null_count=0,
+        min_value=None,
+        max_value=None,
+    )
+    assert empty_stats.type == SqlColumnType.UNKNOWN
+    assert empty_stats.is_empty
+    assert not empty_stats.is_nullable
+    with pytest.raises(InferenceError):
+        empty_stats.cardinality
+
+
+def test_table_statistics() -> None:  # noqa: D
+    table = SqlTable.from_string("db.schema.table")
+    col_stats = [
+        ColumnStatistics(
+            column=SqlColumn(table=table, name="column1"),
+            dtype="int",
+            row_count=1000,
+            distinct_row_count=1000,
+            null_count=0,
+            min_value=0,
+            max_value=999,
+        ),
+        ColumnStatistics(
+            column=SqlColumn(table=table, name="column2"),
+            dtype="float",
+            row_count=2000,
+            distinct_row_count=1000,
+            null_count=10,
+            min_value=0,
+            max_value=1000,
+        ),
+    ]
+
+    table_stats = TableStatistics(table=table, column_stats=col_stats)
+
+    assert table_stats.columns == {
+        col_stats[0].column: col_stats[0],
+        col_stats[1].column: col_stats[1],
+    }
+
+
+def test_data_warehouse_inference_context() -> None:  # noqa: D
+    t1 = SqlTable.from_string("db.schema1.table1")
+    t2 = SqlTable.from_string("db.schema2.table1")
+
+    t1_cols = [
+        ColumnStatistics(
+            column=SqlColumn(table=t1, name="column1"),
+            dtype="int",
+            row_count=1000,
+            distinct_row_count=1000,
+            null_count=0,
+            min_value=0,
+            max_value=999,
+        ),
+        ColumnStatistics(
+            column=SqlColumn(table=t1, name="column2"),
+            dtype="float",
+            row_count=2000,
+            distinct_row_count=1000,
+            null_count=10,
+            min_value=0,
+            max_value=1000,
+        ),
+    ]
+    t1_stats = TableStatistics(table=t1, column_stats=t1_cols)
+
+    t2_cols = [
+        ColumnStatistics(
+            column=SqlColumn(table=t2, name="column_a"),
+            dtype="float",
+            row_count=1000,
+            distinct_row_count=1000,
+            null_count=0,
+            min_value=0,
+            max_value=999,
+        ),
+    ]
+    t2_stats = TableStatistics(table=t2, column_stats=t2_cols)
+
+    ctx = DataWarehouseInferenceContext(table_stats=[t1_stats, t2_stats])
+
+    assert ctx.tables == {t1: t1_stats, t2: t2_stats}
+
+    assert ctx.columns == {
+        t1_cols[0].column: t1_cols[0],
+        t1_cols[1].column: t1_cols[1],
+        t2_cols[0].column: t2_cols[0],
+    }
+
+
+def test_context_provider() -> None:  # noqa: D
+    t1_df = pd.DataFrame(
+        [[0, "lucas", 10], [1, "paul", 20], [2, "tom", 30], [3, "thomas", 30]], columns=["user_id", "name", "points"]
+    )
+
+    t2_df = pd.DataFrame(
+        [[7, "tinky winky", 4.1], [None, "gipsy", 4.2], [None, "lala", 4.1], [10, "po", 4]],
+        columns=["user_id", "name", "height"],
+    )
+    # nullable integer columns are converted by pandas to float,
+    # so we need to cast it back to nullable int
+    t2_df["user_id"] = t2_df["user_id"].astype("Int64")
+
+    client = MagicMock()
+    client.query = MagicMock()
+    client.query.side_effect = [t1_df, t2_df]
+
+    ctx_provider = DataWarehouseInferenceContextProvider(
+        client=client,
+        tables=[SqlTable.from_string("db.schema.table1"), SqlTable.from_string("db.schema.table2")],
+        max_sample_size=5,
+    )
+
+    ctx = ctx_provider.get_context()
+
+    client.query.assert_has_calls(
+        [
+            call("SELECT * FROM db.schema.table1 LIMIT 5"),
+            call("SELECT * FROM db.schema.table2 LIMIT 5"),
+        ],
+        any_order=True,
+    )
+
+    assert ctx == DataWarehouseInferenceContext(
+        [
+            TableStatistics(
+                table=SqlTable.from_string("db.schema.table1"),
+                column_stats=[
+                    ColumnStatistics(
+                        column=SqlColumn.from_string("db.schema.table1.user_id"),
+                        dtype="int",
+                        row_count=4,
+                        distinct_row_count=4,
+                        null_count=0,
+                        min_value=0,
+                        max_value=3,
+                    ),
+                    ColumnStatistics(
+                        column=SqlColumn.from_string("db.schema.table1.name"),
+                        dtype="str",
+                        row_count=4,
+                        distinct_row_count=4,
+                        null_count=0,
+                        min_value="lucas",
+                        max_value="tom",
+                    ),
+                    ColumnStatistics(
+                        column=SqlColumn.from_string("db.schema.table1.points"),
+                        dtype="int",
+                        row_count=4,
+                        distinct_row_count=3,
+                        null_count=0,
+                        min_value=10,
+                        max_value=30,
+                    ),
+                ],
+            ),
+            TableStatistics(
+                table=SqlTable.from_string("db.schema.table2"),
+                column_stats=[
+                    ColumnStatistics(
+                        column=SqlColumn.from_string("db.schema.table2.user_id"),
+                        dtype="int",
+                        row_count=4,
+                        distinct_row_count=3,
+                        null_count=2,
+                        min_value=7,
+                        max_value=10,
+                    ),
+                    ColumnStatistics(
+                        column=SqlColumn.from_string("db.schema.table2.name"),
+                        dtype="str",
+                        row_count=4,
+                        distinct_row_count=4,
+                        null_count=0,
+                        min_value="gipsy",
+                        max_value="tinky winky",
+                    ),
+                    ColumnStatistics(
+                        column=SqlColumn.from_string("db.schema.table2.height"),
+                        dtype="float",
+                        row_count=4,
+                        distinct_row_count=3,
+                        null_count=0,
+                        min_value=4,
+                        max_value=4.2,
+                    ),
+                ],
+            ),
+        ]
+    )

--- a/metricflow/test/inference/context/test_data_warehouse.py
+++ b/metricflow/test/inference/context/test_data_warehouse.py
@@ -1,7 +1,8 @@
-from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.dataflow.sql_column import SqlColumn
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.inference.context.data_warehouse import (
     ColumnProperties,
+    InferenceColumnType,
     DataWarehouseInferenceContext,
     TableProperties,
 )
@@ -11,7 +12,7 @@ def test_column_properties_is_empty():
     """Just some easy assertions to test is_empty works as intended."""
     props = ColumnProperties(
         column=SqlColumn.from_string("db.schema.table.column"),
-        type=SqlColumnType.INTEGER,
+        type=InferenceColumnType.INTEGER,
         row_count=10000,
         distinct_row_count=1000,
         is_nullable=True,
@@ -23,7 +24,7 @@ def test_column_properties_is_empty():
 
     empty_props = ColumnProperties(
         column=SqlColumn.from_string("db.schema.table.column"),
-        type=SqlColumnType.UNKNOWN,
+        type=InferenceColumnType.UNKNOWN,
         row_count=0,
         distinct_row_count=0,
         is_nullable=False,
@@ -44,7 +45,7 @@ def test_table_properties() -> None:
     col_props = [
         ColumnProperties(
             column=SqlColumn(table=table, column_name="column1"),
-            type=SqlColumnType.INTEGER,
+            type=InferenceColumnType.INTEGER,
             row_count=1000,
             distinct_row_count=1000,
             is_nullable=False,
@@ -54,7 +55,7 @@ def test_table_properties() -> None:
         ),
         ColumnProperties(
             column=SqlColumn(table=table, column_name="column2"),
-            type=SqlColumnType.FLOAT,
+            type=InferenceColumnType.FLOAT,
             row_count=2000,
             distinct_row_count=1000,
             is_nullable=True,
@@ -85,7 +86,7 @@ def test_data_warehouse_inference_context() -> None:
     t1_cols = [
         ColumnProperties(
             column=SqlColumn(table=t1, column_name="column1"),
-            type=SqlColumnType.INTEGER,
+            type=InferenceColumnType.INTEGER,
             row_count=1000,
             distinct_row_count=1000,
             is_nullable=False,
@@ -95,7 +96,7 @@ def test_data_warehouse_inference_context() -> None:
         ),
         ColumnProperties(
             column=SqlColumn(table=t1, column_name="column2"),
-            type=SqlColumnType.FLOAT,
+            type=InferenceColumnType.FLOAT,
             row_count=2000,
             distinct_row_count=1000,
             is_nullable=True,
@@ -109,7 +110,7 @@ def test_data_warehouse_inference_context() -> None:
     t2_cols = [
         ColumnProperties(
             column=SqlColumn(table=t2, column_name="column_a"),
-            type=SqlColumnType.FLOAT,
+            type=InferenceColumnType.FLOAT,
             row_count=1000,
             distinct_row_count=1000,
             is_nullable=False,

--- a/metricflow/test/inference/context/test_snowflake.py
+++ b/metricflow/test/inference/context/test_snowflake.py
@@ -4,8 +4,13 @@ from unittest.mock import MagicMock
 import pandas as pd
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
-from metricflow.inference.context.data_warehouse import TableProperties, ColumnProperties, DataWarehouseInferenceContext
+from metricflow.dataflow.sql_column import SqlColumn
+from metricflow.inference.context.data_warehouse import (
+    TableProperties,
+    ColumnProperties,
+    InferenceColumnType,
+    DataWarehouseInferenceContext,
+)
 from metricflow.inference.context.snowflake import SnowflakeInferenceContextProvider
 
 
@@ -13,18 +18,18 @@ def test_column_type_conversion() -> None:  # noqa: D
     ctx_provider = SnowflakeInferenceContextProvider(client=MagicMock(), tables=[])
 
     # known snowflake types
-    assert ctx_provider._column_type_from_show_columns_data_type("FIXED") == SqlColumnType.INTEGER
-    assert ctx_provider._column_type_from_show_columns_data_type("TEXT") == SqlColumnType.STRING
-    assert ctx_provider._column_type_from_show_columns_data_type("REAL") == SqlColumnType.FLOAT
-    assert ctx_provider._column_type_from_show_columns_data_type("BOOLEAN") == SqlColumnType.BOOLEAN
-    assert ctx_provider._column_type_from_show_columns_data_type("DATE") == SqlColumnType.DATETIME
-    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_TZ") == SqlColumnType.DATETIME
-    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_LTZ") == SqlColumnType.DATETIME
-    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_NTZ") == SqlColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("FIXED") == InferenceColumnType.INTEGER
+    assert ctx_provider._column_type_from_show_columns_data_type("TEXT") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("REAL") == InferenceColumnType.FLOAT
+    assert ctx_provider._column_type_from_show_columns_data_type("BOOLEAN") == InferenceColumnType.BOOLEAN
+    assert ctx_provider._column_type_from_show_columns_data_type("DATE") == InferenceColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_TZ") == InferenceColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_LTZ") == InferenceColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_NTZ") == InferenceColumnType.DATETIME
 
     # unknowns
-    assert ctx_provider._column_type_from_show_columns_data_type("BINARY") == SqlColumnType.UNKNOWN
-    assert ctx_provider._column_type_from_show_columns_data_type("TIME") == SqlColumnType.UNKNOWN
+    assert ctx_provider._column_type_from_show_columns_data_type("BINARY") == InferenceColumnType.UNKNOWN
+    assert ctx_provider._column_type_from_show_columns_data_type("TIME") == InferenceColumnType.UNKNOWN
 
 
 def test_context_provider() -> None:
@@ -81,7 +86,7 @@ def test_context_provider() -> None:
                 column_props=[
                     ColumnProperties(
                         column=SqlColumn.from_string("db.schema.table.intcol"),
-                        type=SqlColumnType.INTEGER,
+                        type=InferenceColumnType.INTEGER,
                         row_count=50,
                         distinct_row_count=10,
                         is_nullable=False,
@@ -91,7 +96,7 @@ def test_context_provider() -> None:
                     ),
                     ColumnProperties(
                         column=SqlColumn.from_string("db.schema.table.strcol"),
-                        type=SqlColumnType.STRING,
+                        type=InferenceColumnType.STRING,
                         row_count=50,
                         distinct_row_count=40,
                         is_nullable=True,

--- a/metricflow/test/inference/context/test_snowflake.py
+++ b/metricflow/test/inference/context/test_snowflake.py
@@ -1,0 +1,122 @@
+import json
+from unittest.mock import MagicMock, call
+
+import pandas as pd
+
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.dataflow.sql_column import SqlColumn, SqlColumnType
+from metricflow.inference.context.data_warehouse import TableProperties, ColumnProperties, DataWarehouseInferenceContext
+from metricflow.inference.context.snowflake import SnowflakeInferenceContextProvider
+
+
+def test_column_type_conversion() -> None:  # noqa: D
+    ctx_provider = SnowflakeInferenceContextProvider(client=MagicMock(), tables=[])
+
+    # known snowflake types
+    assert ctx_provider._column_type_from_show_columns_data_type("FIXED") == SqlColumnType.INTEGER
+    assert ctx_provider._column_type_from_show_columns_data_type("TEXT") == SqlColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("REAL") == SqlColumnType.FLOAT
+    assert ctx_provider._column_type_from_show_columns_data_type("BOOLEAN") == SqlColumnType.BOOLEAN
+    assert ctx_provider._column_type_from_show_columns_data_type("DATE") == SqlColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_TZ") == SqlColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_LTZ") == SqlColumnType.DATETIME
+    assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_NTZ") == SqlColumnType.DATETIME
+
+    # unknowns
+    assert ctx_provider._column_type_from_show_columns_data_type("BINARY") == SqlColumnType.UNKNOWN
+    assert ctx_provider._column_type_from_show_columns_data_type("TIME") == SqlColumnType.UNKNOWN
+
+
+def test_context_provider() -> None:  # noqa: D
+    # See for SHOW COLUMNS result dataframe spec:
+    # https://docs.snowflake.com/en/sql-reference/sql/show-columns.html
+    show_columns_result = pd.DataFrame(
+        {
+            "column_name": ["INTCOL", "STRCOL"],
+            "schema_name": ["SCHEMA", "SCHEMA"],
+            "table_name": ["TABLE", "TABLE"],
+            "database_name": ["DB", "DB"],
+            "data_type": [
+                json.dumps({"type": "FIXED", "nullable": False}),
+                json.dumps({"type": "TEXT", "nullable": True}),
+            ],
+        }
+    )
+
+    stats_result = pd.DataFrame(
+        {
+            "intcol_countdistinct": [10],
+            "intcol_min": [0],
+            "intcol_max": [10],
+            "intcol_countnull": [0],
+            "strcol_countdistinct": [40],
+            "strcol_min": ["aaaa"],
+            "strcol_max": ["zzzz"],
+            "strcol_countnull": [10],
+            "rowcount": [50],
+        }
+    )
+
+    client = MagicMock()
+    client.query = MagicMock()
+    client.query.side_effect = [show_columns_result, stats_result]
+
+    ctx_provider = SnowflakeInferenceContextProvider(
+        client=client,
+        tables=[SqlTable.from_string("db.schema.table")],
+        max_sample_size=50,
+    )
+
+    ctx = ctx_provider.get_context()
+
+    client.query.assert_has_calls(
+        [
+            call("SHOW COLUMNS IN TABLE db.schema.table"),
+            # make sure it produces correct SQL
+            call(
+                "SELECT "
+                "COUNT(DISTINCT intcol) AS intcol_countdistinct, "
+                "MIN(intcol) AS intcol_min, "
+                "MAX(intcol) AS intcol_max, "
+                # no need to query for count null if schema says it is not nullable
+                "0 AS intcol_countnull, "
+                "COUNT(DISTINCT strcol) AS strcol_countdistinct, "
+                "MIN(strcol) AS strcol_min, "
+                "MAX(strcol) AS strcol_max, "
+                "SUM(CASE WHEN strcol IS NULL THEN 1 ELSE 0 END) AS strcol_countnull, "
+                "COUNT(*) AS rowcount "
+                "FROM db.schema.table SAMPLE (50 ROWS)"
+            ),
+        ],
+        any_order=False,
+    )
+
+    assert ctx == DataWarehouseInferenceContext(
+        [
+            TableProperties(
+                table=SqlTable.from_string("db.schema.table"),
+                column_props=[
+                    ColumnProperties(
+                        column=SqlColumn.from_string("db.schema.table.intcol"),
+                        type=SqlColumnType.INTEGER,
+                        row_count=50,
+                        distinct_row_count=10,
+                        is_nullable=False,
+                        null_count=0,
+                        min_value=0,
+                        max_value=10,
+                    ),
+                    ColumnProperties(
+                        column=SqlColumn.from_string("db.schema.table.strcol"),
+                        type=SqlColumnType.STRING,
+                        row_count=50,
+                        distinct_row_count=40,
+                        is_nullable=True,
+                        null_count=10,
+                        min_value="aaaa",
+                        max_value="zzzz",
+                    ),
+                ],
+            ),
+        ]
+    )


### PR DESCRIPTION
# What does this PR do?
This PR adds an inference context provider that fetches min, max, unique and null count statistics from a given set a tables.

# Why does it do it?
This functionality will be useful for implementing inference rules about that set of tables, e.g, columns ending with "_id" are probably primary or foreign keys.

It is the first step towards data source configuration inference.

# What comes next?
For this to be in a minimally usable state, we still need to do the following (which will come on subsequent PRs):
- Implement basic inference rules such as "`_id` columns are probably IDs". Those rules will produce "signals", contextual pieces of evidence about a table or a column.
- Implement an inference policy that coerces signals about a column into some useful piece of information, such as "this column is an ID"
- Implement an `InferenceRunner` class for tying it all together in a sequence of steps (fetching context, processing rules, coercing it into inferred facts, getting user approval, writing config files)
- Surface it to end users via the CLI.