### PR TITLE
Enable struct parsing for metric measures

### DIFF
--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -47,7 +47,7 @@ class MetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
         elif isinstance(input, str):
             return MetricInputMeasure(name=input)
         elif isinstance(input, dict):
-            raise NotImplementedError("Support for object-type parsing for metric measure inputs coming soon!")
+            return MetricInputMeasure(**input)
         else:
             raise ValueError(
                 f"MetricInputMeasure inputs from model configs are expected to be of either type string or "

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -22,6 +22,44 @@ class MetricType(ExtendedEnum):
     CUMULATIVE = "cumulative"
 
 
+class MetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
+    """Provides a pointer to a measure along with metric-specific processing directives"""
+
+    name: str
+    # TODO add constraint handling property
+
+    @classmethod
+    def _from_yaml_value(cls, input: Any):
+        """Parses a MetricInputMeasure from a string (name only) or object (struct spec) input
+
+        Internally, we will pass fully formed instnace of a MetricInputMeasure through in any case where
+        the Measure object defined in the DataSource has `create_metric` set to True. For these cases, we
+        do not need to do further parsing.
+
+        For user input cases, the original YAML spec for a Metric included measure(s) specified as string names
+        or lists of string names. As such, configs pre-dating the addition of this model type will only provide the
+        base name for this object. The addition of new properties requires a key/value input for each
+        entry, which would need to be handled by object (dict) type parsing logic.
+        """
+        if isinstance(input, MetricInputMeasure):
+            # Internally constructed, pass it through and ignore this case in error messaging
+            return input
+        elif isinstance(input, str):
+            return MetricInputMeasure(name=input)
+        elif isinstance(input, dict):
+            raise NotImplementedError("Support for object-type parsing for metric measure inputs coming soon!")
+        else:
+            raise ValueError(
+                f"MetricInputMeasure inputs from model configs are expected to be of either type string or "
+                f"object (key/value pairs), but got type {type(input)} with value: {input}"
+            )
+
+    @property
+    def measure_reference(self) -> MeasureReference:
+        """Property accessor to get the MeasureReference associated with this metric input measure"""
+        return MeasureReference(element_name=self.name)
+
+
 class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
     """Describes the window of time the metric should be accumulated over. ie '1 day', '2 weeks', etc"""
 
@@ -84,21 +122,23 @@ class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
 class MetricTypeParams(HashableBaseModel):
     """Type params add additional context to certain metric types (the context depends on the metric type)"""
 
-    measure: Optional[str]
-    measures: Optional[List[str]]
-    numerator: Optional[str]
-    denominator: Optional[str]
+    measure: Optional[MetricInputMeasure]
+    measures: Optional[List[MetricInputMeasure]]
+    numerator: Optional[MetricInputMeasure]
+    denominator: Optional[MetricInputMeasure]
     expr: Optional[str]
     window: Optional[CumulativeMetricWindow]
     grain_to_date: Optional[TimeGranularity]
 
     @property
-    def numerator_measure_reference(self) -> Optional[MeasureReference]:  # noqa: D
-        return MeasureReference(element_name=self.numerator) if self.numerator else None
+    def numerator_measure_reference(self) -> Optional[MeasureReference]:
+        """Return the measure reference, if any, associated with the metric input measure defined as the numerator"""
+        return self.numerator.measure_reference if self.numerator else None
 
     @property
-    def denominator_measure_reference(self) -> Optional[MeasureReference]:  # noqa: D
-        return MeasureReference(element_name=self.denominator) if self.denominator else None
+    def denominator_measure_reference(self) -> Optional[MeasureReference]:
+        """Return the measure reference, if any, associated with the metric input measure defined as the denominator"""
+        return self.denominator.measure_reference if self.denominator else None
 
 
 class Metric(HashableBaseModel):
@@ -111,7 +151,8 @@ class Metric(HashableBaseModel):
     metadata: Optional[Metadata]
 
     @property
-    def measure_references(self) -> List[MeasureReference]:  # noqa: D
+    def input_measures(self) -> List[MetricInputMeasure]:
+        """Return the complete list of input measure configurations for this metric"""
         tp = self.type_params
         res = tp.measures or []
         if tp.measure:
@@ -121,7 +162,12 @@ class Metric(HashableBaseModel):
         if tp.denominator:
             res.append(tp.denominator)
 
-        return [MeasureReference(element_name=x) for x in res]
+        return res
+
+    @property
+    def measure_references(self) -> List[MeasureReference]:
+        """Return the measure references associated with all input measure configurations for this metric"""
+        return [x.measure_reference for x in self.input_measures]
 
     @property
     def definition_hash(self) -> str:  # noqa: D

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -63,16 +63,30 @@ materialization_destination_schema = {
     "additionalProperties": False,
 }
 
+metric_input_measure_schema = {
+    "$id": "metric_input_measure_schema",
+    "oneOf": [
+        {"type": "string"},
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+    ],
+}
+
 metric_type_params_schema = {
     "$id": "metric_type_params",
     "type": "object",
     "properties": {
-        "numerator": {"type": "string"},
-        "denominator": {"type": "string"},
-        "measure": {"type": "string"},
+        "numerator": {"$ref": "metric_input_measure_schema"},
+        "denominator": {"$ref": "metric_input_measure_schema"},
+        "measure": {"$ref": "metric_input_measure_schema"},
         "measures": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {"$ref": "metric_input_measure_schema"},
         },
         "expr": {"type": ["string", "boolean"]},
         "window": {"type": "string"},
@@ -287,6 +301,7 @@ schema_store = {
     derived_group_by_element_schema["$id"]: derived_group_by_element_schema,
     materialization_schema["$id"]: materialization_schema,
     # Sub-object schemas
+    metric_input_measure_schema["$id"]: metric_input_measure_schema,
     metric_type_params_schema["$id"]: metric_type_params_schema,
     identifier_schema["$id"]: identifier_schema,
     measure_schema["$id"]: measure_schema,

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -7,6 +7,7 @@ from metricflow.model.parsing.schemas import (
     data_source_schema,
     materialization_schema,
     derived_group_by_element_schema,
+    metric_input_measure_schema,
     metric_type_params_schema,
     identifier_schema,
     measure_schema,
@@ -88,6 +89,7 @@ schema_store = {
     derived_group_by_element_schema["$id"]: derived_group_by_element_schema,
     materialization_schema["$id"]: materialization_schema,
     # Sub-object schemas
+    metric_input_measure_schema["$id"]: metric_input_measure_schema,
     metric_type_params_schema["$id"]: metric_type_params_schema,
     locked_metadata_schema["$id"]: locked_metadata_schema,
     identifier_schema["$id"]: identifier_schema,

--- a/metricflow/model/transformations/proxy_measure.py
+++ b/metricflow/model/transformations/proxy_measure.py
@@ -1,6 +1,6 @@
 import logging
 
-from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+from metricflow.model.objects.metric import Metric, MetricInputMeasure, MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.transformations.transform_rule import ModelTransformRule
 
@@ -44,7 +44,10 @@ class CreateProxyMeasureRule(ModelTransformRule):
                         Metric(
                             name=measure.name,
                             type=MetricType.MEASURE_PROXY,
-                            type_params=MetricTypeParams(measures=[measure.name], expr=measure.name),
+                            type_params=MetricTypeParams(
+                                measures=[MetricInputMeasure(name=measure.name)],
+                                expr=measure.name,
+                            ),
                         )
                     )
 

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -19,29 +19,20 @@ class MetricMeasuresRule(ModelValidationRule):
     """Checks that the measures referenced in the metrics exist."""
 
     @staticmethod
-    @validate_safely(whats_being_done="checking measures referenced by the metric are exist")
+    @validate_safely(whats_being_done="checking all measures referenced by the metric exist")
     def _validate_metric_measure_references(
         metric: Metric, valid_measure_names: List[str]
     ) -> List[ValidationIssueType]:
         issues: List[ValidationIssueType] = []
-        measures_in_metric = []
 
-        if metric.type_params:
-            if metric.type_params.measures:
-                measures_in_metric.extend(metric.type_params.measures)
-            if metric.type_params.numerator:
-                measures_in_metric.append(metric.type_params.numerator)
-            if metric.type_params.denominator:
-                measures_in_metric.append(metric.type_params.denominator)
-
-        for measure_in_metric in measures_in_metric:
-            if measure_in_metric not in valid_measure_names:
+        for measure_reference in metric.measure_references:
+            if measure_reference.element_name not in valid_measure_names:
                 issues.append(
                     ValidationFatal(
                         model_object_reference=ValidationIssue.make_object_reference(
                             metric_name=metric.name,
                         ),
-                        message=f"Invalid measure {measure_in_metric} in metric {metric.name}",
+                        message=f"Invalid measure {measure_reference.element_name} in metric {metric.name}",
                     )
                 )
         return issues

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -34,6 +34,27 @@ def test_legacy_measure_metric_parsing() -> None:
     assert metric.type_params.measures is None
 
 
+def test_legacy_metric_input_measure_object_parsing() -> None:
+    """Test for parsing a simple metric specification with the `measure` parameter set with object notation"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: legacy_test
+          type: measure_proxy
+          type_params:
+            measure:
+              name: legacy_measure_from_object
+        """
+    )
+    file = YamlFile(file_path="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.type_params.measure == MetricInputMeasure(name="legacy_measure_from_object")
+
+
 def test_metric_metadata_parsing() -> None:
     """Test for asserting that internal metadata is parsed into the Metric object"""
     yaml_contents = textwrap.dedent(
@@ -82,6 +103,30 @@ def test_ratio_metric_parsing() -> None:
     assert metric.type_params.measures is None
 
 
+def test_ratio_metric_input_measure_object_parsing() -> None:
+    """Test for parsing a ratio metric specification with object inputs for numerator and denominator"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: ratio_test
+          type: ratio
+          type_params:
+            numerator:
+              name: numerator_measure_from_object
+            denominator:
+              name: denominator_measure_from_object
+        """
+    )
+    file = YamlFile(file_path="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.type_params.numerator == MetricInputMeasure(name="numerator_measure_from_object")
+    assert metric.type_params.denominator == MetricInputMeasure(name="denominator_measure_from_object")
+
+
 def test_expr_metric_parsing() -> None:
     """Test for parsing a metric specification with an expr and a list of measures"""
     yaml_contents = textwrap.dedent(
@@ -106,6 +151,33 @@ def test_expr_metric_parsing() -> None:
     assert metric.type_params.measures == [
         MetricInputMeasure(name="measure_one"),
         MetricInputMeasure(name="measure_two"),
+    ]
+
+
+def test_expr_metric_input_measure_object_parsing() -> None:
+    """Test for parsing a metric specification with object inputs for the list of measures"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: expr_test
+          type: expr
+          type_params:
+            measures:
+              - name: measure_one_from_object
+              - name: measure_two_from_object
+        """
+    )
+    file = YamlFile(file_path="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "expr_test"
+    assert metric.type is MetricType.EXPR
+    assert metric.type_params.measures == [
+        MetricInputMeasure(name="measure_one_from_object"),
+        MetricInputMeasure(name="measure_two_from_object"),
     ]
 
 

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -4,7 +4,7 @@ import pytest
 
 from metricflow.errors.errors import ParsingException
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
-from metricflow.model.objects.metric import CumulativeMetricWindow, MetricType
+from metricflow.model.objects.metric import CumulativeMetricWindow, MetricType, MetricInputMeasure
 from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_model
 from metricflow.model.parsing.yaml_file import YamlFile
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -30,7 +30,7 @@ def test_legacy_measure_metric_parsing() -> None:
     metric = model.metrics[0]
     assert metric.name == "legacy_test"
     assert metric.type is MetricType.MEASURE_PROXY
-    assert metric.type_params.measure == "legacy_measure"
+    assert metric.type_params.measure == MetricInputMeasure(name="legacy_measure")
     assert metric.type_params.measures is None
 
 
@@ -77,8 +77,8 @@ def test_ratio_metric_parsing() -> None:
     metric = model.metrics[0]
     assert metric.name == "ratio_test"
     assert metric.type is MetricType.RATIO
-    assert metric.type_params.numerator == "numerator_measure"
-    assert metric.type_params.denominator == "denominator_measure"
+    assert metric.type_params.numerator == MetricInputMeasure(name="numerator_measure")
+    assert metric.type_params.denominator == MetricInputMeasure(name="denominator_measure")
     assert metric.type_params.measures is None
 
 
@@ -103,7 +103,10 @@ def test_expr_metric_parsing() -> None:
     metric = model.metrics[0]
     assert metric.name == "expr_test"
     assert metric.type is MetricType.EXPR
-    assert metric.type_params.measures == ["measure_one", "measure_two"]
+    assert metric.type_params.measures == [
+        MetricInputMeasure(name="measure_one"),
+        MetricInputMeasure(name="measure_two"),
+    ]
 
 
 def test_cumulative_window_metric_parsing() -> None:
@@ -127,7 +130,7 @@ def test_cumulative_window_metric_parsing() -> None:
     metric = model.metrics[0]
     assert metric.name == "cumulative_test"
     assert metric.type is MetricType.CUMULATIVE
-    assert metric.type_params.measures == ["cumulative_measure"]
+    assert metric.type_params.measures == [MetricInputMeasure(name="cumulative_measure")]
     assert metric.type_params.window == CumulativeMetricWindow(count=7, granularity=TimeGranularity.DAY)
 
 
@@ -152,7 +155,7 @@ def test_grain_to_date_metric_parsing() -> None:
     metric = model.metrics[0]
     assert metric.name == "grain_to_date_test"
     assert metric.type is MetricType.CUMULATIVE
-    assert metric.type_params.measures == ["cumulative_measure"]
+    assert metric.type_params.measures == [MetricInputMeasure(name="cumulative_measure")]
     assert metric.type_params.window is None
     assert metric.type_params.grain_to_date is TimeGranularity.WEEK
 


### PR DESCRIPTION
Our Metric model object takes in MetricTypeParams that allows for various
input measure name references. These are all typed as strings or
lists of strings, since the current MetricFlow framework only requires
a pointer to the original measure model object.

Upcoming changes will add constraint expressions to the measure
pointers stored inside of the Metric model object, and as such we
will need to attach additional properties to each of the measures
referenced in the MetricTypeParams.

This PR converts the internal types of these measure representations
from strings to a new model object, the MetricInputMeasure, and updates
the parser to enable users to pass in either the existing string name
representation of the measure or a structured representation. This
paves the way for adding new properties, such as measure-specific
constraints, in metric definitions.