### PR TITLE
Simplify 'validate_model' return flow logic

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -69,11 +69,7 @@ class ModelValidator:
             issues.extend(validation_rule.validate_model(model_copy))
             # If there are any fatal errors, stop the validation process.
             if any([x.level == ValidationIssueLevel.FATAL for x in issues]):
-                return ModelBuildResult(model=model_copy, issues=tuple(issues))
-
-        # If there are any errors, don't run any transforms and return the issues found.
-        if any([x.level == ValidationIssueLevel.ERROR for x in issues]):
-            return ModelBuildResult(model=model_copy, issues=tuple(issues))
+                break
 
         return ModelBuildResult(model=model_copy, issues=tuple(issues))
 


### PR DESCRIPTION
I noticed while working on a separate branch that the `validate_model` return logic had three statements which all did the same thing. This refactor just simplifies that logic so it only has one return and is less confusing.