### PR TITLE
Add basic inference rule functionality

### DIFF
--- a/metricflow/dataflow/sql_column.py
+++ b/metricflow/dataflow/sql_column.py
@@ -33,11 +33,11 @@ class SqlColumn(FrozenBaseModel):
         return self.table.db_name
 
     @property
-    def schema_name(self) -> Optional[str]:  # noqa: D
+    def schema_name(self) -> str:  # noqa: D
         return self.table.schema_name
 
     @property
-    def table_name(self) -> Optional[str]:  # noqa: D
+    def table_name(self) -> str:  # noqa: D
         return self.table.table_name
 
     @property

--- a/metricflow/inference/context/base.py
+++ b/metricflow/inference/context/base.py
@@ -1,11 +1,22 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Dict, Type
 
 
 class InferenceContext(ABC):
     """Encapsulates information that can be used by an inference signaling rule or inference policy."""
 
-    pass
+    # A registry for keeping track of all known InferenceContext types.
+    # This is useful for magicking them into existance from type annotation strings.
+    # It maps class names to class types.
+    known_subclasses: Dict[str, Type[InferenceContext]] = {}
+
+    def __init_subclass__(cls) -> None:
+        """Adds all `InferenceContext` subclasses to the `known_subclasses` registry."""
+        InferenceContext.known_subclasses[cls.__name__] = cls
+
+        super().__init_subclass__()
 
 
 TContext = TypeVar("TContext", bound=InferenceContext)

--- a/metricflow/inference/context/base.py
+++ b/metricflow/inference/context/base.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Dict, Type
+from typing import Generic, TypeVar
 
 
 class InferenceContext(ABC):
     """Encapsulates information that can be used by an inference signaling rule or inference policy."""
 
-    # A registry for keeping track of all known InferenceContext types.
-    # This is useful for magicking them into existance from type annotation strings.
-    # It maps class names to class types.
-    known_subclasses: Dict[str, Type[InferenceContext]] = {}
-
-    def __init_subclass__(cls) -> None:
-        """Adds all `InferenceContext` subclasses to the `known_subclasses` registry."""
-        InferenceContext.known_subclasses[cls.__name__] = cls
-
-        super().__init_subclass__()
+    pass
 
 
 TContext = TypeVar("TContext", bound=InferenceContext)

--- a/metricflow/inference/rule/base.py
+++ b/metricflow/inference/rule/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 import logging
-from typing import List, Tuple, Type
+from typing import List, Optional, Tuple, Type
 
 from metricflow.dataflow.sql_column import SqlColumn
 from metricflow.inference.context.base import InferenceContext
@@ -29,38 +29,69 @@ class InferenceSignalConfidence(Enum):
     LOW = 0
 
 
-class InferenceSignalType(str, Enum):
-    """The type of the inferred signal about a column. Effectively, this represents what a rule can think a column is."""
+class InferenceSignalNode(ABC):
+    """A node in the inference signal type hierarchy.
 
-    # identifiers
-    IDENTIFER = "identifier"
-    PRIMARY_IDENTIFIER = "identifier_primary"
-    FOREIGN_IDENTIFIER = "identifier_foreign"
+    This class can be used to assembly a type hierarchy tree. It can be used by heuristics
+    to check whether signals produced by rules are conflicting or complimentary, relying
+    on the property that sibling nodes are mutually exclusive in the hierarchy.
+    """
 
-    # dimension detection
-    DIMENSION = "dimension"
-    TIME_DIMENSION = "dimension_time"
-    CATEGORICAL_DIMENSION = "dimension_categorical"
+    def __init__(self, parent: Optional[InferenceSignalNode]) -> None:  # noqa: D
+        self.parent = parent
 
-    # measure fields, i.e, not an ID nor a dimension
-    MEASURE_FIELD = "measure_field"
+    @property
+    def ancestors(self) -> List[InferenceSignalNode]:
+        """The list of all ancestors for this node, from the root to the direct parent."""
+        if self.parent is None:
+            return []
 
-    @staticmethod
-    def conflict(a: InferenceSignalType, b: InferenceSignalType) -> bool:
-        """Helper function for determining whether two signal types conflict with each other.
+        return self.parent.ancestors + [self.parent]
 
-        This allows us to implement broad signal types with specializations. It makes it possible
-        for rules to produce results such as "I think this is an identifier, but I don't know
-        whether it is primary or foreign".
+    def is_descendant(self, other: InferenceSignalNode) -> bool:
+        """Whether self is a descendant of other."""
+        return other in self.ancestors
 
-        Example: A column cannot be both PRIMARY_IDENTIFIER and a FOREIGN_IDENTIFIER,
-        so there is a conflict in this case. However, a column that is a TIME_DIMENSION is still
-        a DIMENSION, so no conflict is found in that case.
 
-        NOTE: The implementation assumes that broader types are prefixes of more specific types,
-        e.g, "identifier" (generic) is a prefix of "identifier_primary" (specific).
-        """
-        return not a.value.startswith(b.value) and not b.value.startswith(a.value)
+# This is kinda horrible but there's no way of instancing the tree with type safety without
+# hardcoding it. Having some magic that dynamically assigns attributes could work, but then
+# we lose IDE autocompletion and static checking
+class _TreeNodes:  # noqa: D
+    root = InferenceSignalNode(None)
+    id = InferenceSignalNode(root)
+    foreign_id = InferenceSignalNode(id)
+    unique_id = InferenceSignalNode(id)
+    primary_id = InferenceSignalNode(unique_id)
+    dimension = InferenceSignalNode(root)
+    time_dimension = InferenceSignalNode(dimension)
+    categorical_dimension = InferenceSignalNode(dimension)
+    measure = InferenceSignalNode(root)
+
+
+class InferenceSignalType:
+    """All possible inference signal types."""
+
+    UNKNOWN = _TreeNodes.root
+
+    class ID:
+        """Indicates a column was inferred to be an ID."""
+
+        UNKNOWN = _TreeNodes.id
+        FOREIGN = _TreeNodes.foreign_id
+        UNIQUE = _TreeNodes.unique_id
+        PRIMARY = _TreeNodes.primary_id
+
+    class DIMENSION:
+        """Indicates a column was inferred to be a dimension."""
+
+        UNKNOWN = _TreeNodes.dimension
+        TIME = _TreeNodes.time_dimension
+        CATEGORICAL = _TreeNodes.categorical_dimension
+
+    class MEASURE:
+        """Indicates a column was inferred to be a measure."""
+
+        UNKNOWN = _TreeNodes.measure
 
 
 @dataclass(frozen=True)
@@ -68,14 +99,14 @@ class InferenceSignal:
     """Encapsulates a piece of evidence about a column produced by an inference rule.
 
     column: the target column for this signal
-    type: the type of the signal
+    type_node: the type node of the signal
     reason: a human-readable string that explains why this signal was produced. It may
         eventually reach the user's eyeballs.
     confidence: the confidence that this signal is correct.
     """
 
     column: SqlColumn
-    type: InferenceSignalType
+    type_node: InferenceSignalNode
     reason: str
     confidence: InferenceSignalConfidence
 

--- a/metricflow/inference/rule/base.py
+++ b/metricflow/inference/rule/base.py
@@ -39,6 +39,10 @@ class InferenceSignalNode(ABC):
 
     def __init__(self, parent: Optional[InferenceSignalNode]) -> None:  # noqa: D
         self.parent = parent
+        self.children: List[InferenceSignalNode] = []
+
+        if parent is not None:
+            parent.children.append(self)
 
     @property
     def ancestors(self) -> List[InferenceSignalNode]:

--- a/metricflow/inference/rule/base.py
+++ b/metricflow/inference/rule/base.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+import logging
+import inspect
+from typing import List, Optional, Sequence, Tuple, Type
+
+from metricflow.dataflow.sql_column import SqlColumn
+from metricflow.inference.context.base import InferenceContext
+
+
+logger = logging.getLogger(__name__)
+
+
+class InferenceSignalConfidence(Enum):
+    """A discrete enumeration of possible confidence values for an inference signal.
+
+    We chose discrete confidence values instead of a continuous range (e.g a float between 0 and 1)
+    to standardize confidence outputs between heuristic rules. We want to avoid different rules
+    assuming different values for, say, "medium" or "high" confidence, since this could skew
+    results in favor/against certain rules.
+    """
+
+    FOR_SURE = 3
+    HIGH = 2
+    MEDIUM = 1
+    LOW = 0
+
+
+class InferenceSignalType(str, Enum):
+    """The type of the inferred signal about a column. Effectively, this represents what a rule can think a column is."""
+
+    # identifiers
+    IDENTIFER = "identifier"
+    PRIMARY_IDENTIFIER = "identifier_primary"
+    FOREIGN_IDENTIFIER = "identifier_foreign"
+
+    # dimension detection
+    DIMENSION = "dimension"
+    TIME_DIMENSION = "dimension_time"
+    CATEGORICAL_DIMENSION = "dimension_categorical"
+
+    # measure fields, i.e, not an ID nor a dimension
+    MEASURE_FIELD = "measure_field"
+
+    @staticmethod
+    def conflict(a: InferenceSignalType, b: InferenceSignalType) -> bool:
+        """Helper function for determining whether two signal types conflict with each other.
+
+        This allows us to implement broad signal types with specializations. It makes it possible
+        for rules to produce results such as "I think this is an identifier, but I don't know
+        whether it is primary or foreign".
+
+        Example: A column cannot be both PRIMARY_IDENTIFIER and a FOREIGN_IDENTIFIER,
+        so there is a conflict in this case. However, a column that is a TIME_DIMENSION is still
+        a DIMENSION, so no conflict is found in that case.
+
+        NOTE: The implementation assumes that broader types are prefixes of more specific types,
+        e.g, "identifier" (generic) is a prefix of "identifier_primary" (specific).
+        """
+        return not a.value.startswith(b.value) and not b.value.startswith(a.value)
+
+
+@dataclass(frozen=True)
+class InferenceSignal:
+    """Encapsulates a piece of evidence about a column produced by an inference rule.
+
+    column: the target column for this signal
+    type: the type of the signal
+    reason: a human-readable string that explains why this signal was produced. It may
+        eventually reach the user's eyeballs.
+    confidence: the confidence that this signal is correct.
+    """
+
+    column: SqlColumn
+    type: InferenceSignalType
+    reason: str
+    confidence: InferenceSignalConfidence
+
+
+RequiredContextsType = Tuple[Optional[Type[InferenceContext]], ...]
+
+
+class InferenceRule(ABC):
+    """Implements some sort of heuristic that produces signals about columns.
+
+    An inference rule produces zero or more `InferenceSignal` instances about whatever
+    columns it thinks it should, based on input `InferenceContext`s.
+
+    Concrete implementations should aim to be short and modularized. It is preferred to
+    compose multiple small rules that each produce a signal type than to make one large
+    rule with complex logic to produce a bunch of signals.
+    """
+
+    _required_contexts: RequiredContextsType
+
+    def __init_subclass__(cls) -> None:
+        """Initializes `cls._required_contexts` from `cls.process` type annotations."""
+        parameters = inspect.signature(cls.process).parameters
+        context_types: List[Optional[Type[InferenceContext]]] = []
+        for param in list(parameters.values())[1:]:  # exclude self
+            if param.annotation == inspect.Parameter.empty:
+                logger.warning(
+                    f"`{cls.__name__}.process`'s parameters must all be type annotated. "
+                    "Unanottated types will be provided None contexts, which might trigger further runtime errors."
+                )
+                context_types.append(None)
+            elif not issubclass(param.annotation, InferenceContext):
+                logger.warning(
+                    f"`{cls.__name__}.process` must only accept input contexts as arguments (except for `self`). "
+                    "Extra arguments will always be None."
+                )
+                context_types.append(None)
+            else:
+                context_types.append(param.annotation)
+
+        cls._required_contexts = tuple(context_types)
+
+        super().__init_subclass__()
+
+    @property
+    def required_contexts(self) -> RequiredContextsType:
+        """The context types this rule requires to run successfully."""
+        return self._required_contexts
+
+    @abstractmethod
+    def process(self, *contexts: Sequence[InferenceContext]) -> List[InferenceSignal]:
+        """The actual rule implementation that returns a list of signals based on the input contexts.
+
+        All input context instances will be provided in the same order as specified in REQUIRED_CONTEXTS.
+        """
+        raise NotImplementedError

--- a/metricflow/inference/rule/defaults.py
+++ b/metricflow/inference/rule/defaults.py
@@ -57,7 +57,7 @@ class RuleDefaults:
         """
         return ColumnMatcherRule(
             matcher=RuleDefaults._primary_identifier_matcher,
-            signal_type=InferenceSignalType.PRIMARY_IDENTIFIER,
+            type_node=InferenceSignalType.ID.PRIMARY,
             confidence=InferenceSignalConfidence.FOR_SURE,
         )
 
@@ -72,6 +72,6 @@ class RuleDefaults:
         """
         return ColumnMatcherRule(
             matcher=RuleDefaults._any_identifier_matcher,
-            signal_type=InferenceSignalType.IDENTIFER,
+            type_node=InferenceSignalType.ID.UNKNOWN,
             confidence=InferenceSignalConfidence.HIGH,
         )

--- a/metricflow/inference/rule/defaults.py
+++ b/metricflow/inference/rule/defaults.py
@@ -1,78 +1,77 @@
-import re
 from typing import List
+from metricflow.dataflow.sql_column import SqlColumn
 
 from metricflow.inference.rule.base import InferenceRule, InferenceSignalConfidence, InferenceSignalType
-from metricflow.inference.rule.rules import ColumnRegexMatcherRule
+from metricflow.inference.rule.rules import ColumnMatcherRule
 
 
 class RuleDefaults:
     """Static factory class for sensible default rules."""
 
-    # This is the default regex pattern that is used to determine if columns are identifiers.
-    # It simply matches column names ending with "id", case insensitive.
-    #
-    # We searched for words ending with "id" just to assess the chance of this resulting in a
-    # false positive. Our guess is most of those words would rarely, if ever, be used as column names.
-    # Therefore, not adding a mandatory "_" before "id" would benefit the product by matching names
-    # like "userid", despite the rare "squid", "mermaid" or "android" matches.
-    #
-    # See: https://www.thefreedictionary.com/words-that-end-in-id
-    ANY_IDENTIFIER_REGEX_PATTERN = re.compile(r"id$", flags=re.IGNORECASE)
+    @staticmethod
+    def _any_identifier_matcher(col: SqlColumn) -> bool:
+        """This is the default matcher that is used to determine if columns are identifiers.
 
-    # This is the default regex pattern that is used to determine if columns are primary identifiers.
-    #
-    # It is divided into two mutually exclusive parts "(A|B)":
-    # - "A" is "(\.id$)", which only matches strings ending with ".id". Since we're compiling with
-    #   re.IGNORECASE, it will also match "ID", "Id" and such. This will catch columns like
-    #   "db.schema.table.id", where we assume a column simply named "id" must mean it is the primary
-    #   identifier for its table.
-    # - "B" is "([a-z0-9_]+)s?\.(.*)\2_?id$". Here's how it works:
-    #    - Match the table name with "([a-z0-9_]+)", with the optional "s?" after the table name
-    #      (catches plural table names).
-    #    - The singular table name is saved onto the second capturing group.
-    #    - "(.*)\2_?id" then checks if the name is prefixed by the table name and ends with "id",
-    #      referencing the saved capturing group (table name) with "\2".
-    #   In short, we assume that column names prefixed by the table name and ending with ID are probably
-    #   primary identifiers for their tables. Examples:
-    #    - "db.schema.customer.customer_id"
-    #    - "db.schema.customers.customer_id"
-    #    - "db.schema.customers.customerid"
-    PRIMARY_IDENTIFIER_REGEX_PATTERN = re.compile(r"(\.id$)|([a-z0-9_]+)s?\.\2_?id$", flags=re.IGNORECASE)
+        It simply matches column names ending with "id", case insensitive.
+
+        We searched for words ending with "id" just to assess the chance of this resulting in a
+        false positive. Our guess is most of those words would rarely, if ever, be used as column names.
+        Therefore, not adding a mandatory "_" before "id" would benefit the product by matching names
+        like "userid", despite the rare "squid", "mermaid" or "android" matches.
+
+        See: https://www.thefreedictionary.com/words-that-end-in-id
+        """
+        return col.column_name.lower().endswith("id")
+
+    @staticmethod
+    def _primary_identifier_matcher(col: SqlColumn) -> bool:
+        """This is the default matcher that is used to determine if columns are primary identifiers.
+
+        It matches columns named "id" or columns named "<table>id" or "<table>_id", where "<table>"
+        is the name of the table this column belongs to.
+        """
+        col_lower = col.column_name.lower()
+        table_lower = col.table_name.lower()
+
+        if col_lower == "id":
+            return True
+
+        return col_lower == f"{table_lower}_id" or col_lower == f"{table_lower}id"
 
     @staticmethod
     def default_ruleset() -> List[InferenceRule]:
         """Returns a sensible default set of inference rules."""
         return [
-            RuleDefaults.primary_identifier_regex_rule(),
-            RuleDefaults.any_identifier_regex_rule(),
+            RuleDefaults.primary_identifier_rule(),
+            RuleDefaults.any_identifier_rule(),
         ]
 
     @staticmethod
-    def primary_identifier_regex_rule() -> ColumnRegexMatcherRule:
-        """A default for finding primary identifiers by their names based on regex matches.
+    def primary_identifier_rule() -> ColumnMatcherRule:
+        """A default for finding primary identifiers by their names based on column name matches.
 
         The returned rule will match columns such as `db.schema.mytable.mytable_id`,
         `db.schema.mytable.mytableid` and `db.schema.mytable.id`.
 
         It will always produce a PRIMARY_IDENTIFIER signal with FOR_SURE confidence.
         """
-        return ColumnRegexMatcherRule(
-            pattern=RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN,
+        return ColumnMatcherRule(
+            matcher=RuleDefaults._primary_identifier_matcher,
             signal_type=InferenceSignalType.PRIMARY_IDENTIFIER,
             confidence=InferenceSignalConfidence.FOR_SURE,
         )
 
     @staticmethod
-    def any_identifier_regex_rule() -> ColumnRegexMatcherRule:
-        """A default for finding identifiers of any type by their names based on regex matches.
+    def any_identifier_rule() -> ColumnMatcherRule:
+        """A default for finding identifiers of any type by their names based on column name matches.
 
         The returned rule will match columns such as `db.schema.mytable.id`,
         `db.schema.mytable.othertable_id` and `db.schema.mytable.othertableid`
 
         It will always produce an IDENTIFIER signal with HIGH confidence.
         """
-        return ColumnRegexMatcherRule(
-            pattern=RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN,
+        return ColumnMatcherRule(
+            matcher=RuleDefaults._any_identifier_matcher,
             signal_type=InferenceSignalType.IDENTIFER,
             confidence=InferenceSignalConfidence.HIGH,
         )

--- a/metricflow/inference/rule/defaults.py
+++ b/metricflow/inference/rule/defaults.py
@@ -1,0 +1,78 @@
+import re
+from typing import List
+
+from metricflow.inference.rule.base import InferenceRule, InferenceSignalConfidence, InferenceSignalType
+from metricflow.inference.rule.rules import ColumnRegexMatcherRule
+
+
+class RuleDefaults:
+    """Static factory class for sensible default rules."""
+
+    # This is the default regex pattern that is used to determine if columns are identifiers.
+    # It simply matches column names ending with "id", case insensitive.
+    #
+    # We searched for words ending with "id" just to assess the chance of this resulting in a
+    # false positive. Our guess is most of those words would rarely, if ever, be used as column names.
+    # Therefore, not adding a mandatory "_" before "id" would benefit the product by matching names
+    # like "userid", despite the rare "squid", "mermaid" or "android" matches.
+    #
+    # See: https://www.thefreedictionary.com/words-that-end-in-id
+    ANY_IDENTIFIER_REGEX_PATTERN = re.compile(r"id$", flags=re.IGNORECASE)
+
+    # This is the default regex pattern that is used to determine if columns are primary identifiers.
+    #
+    # It is divided into two mutually exclusive parts "(A|B)":
+    # - "A" is "(\.id$)", which only matches strings ending with ".id". Since we're compiling with
+    #   re.IGNORECASE, it will also match "ID", "Id" and such. This will catch columns like
+    #   "db.schema.table.id", where we assume a column simply named "id" must mean it is the primary
+    #   identifier for its table.
+    # - "B" is "([a-z0-9_]+)s?\.(.*)\2_?id$". Here's how it works:
+    #    - Match the table name with "([a-z0-9_]+)", with the optional "s?" after the table name
+    #      (catches plural table names).
+    #    - The singular table name is saved onto the second capturing group.
+    #    - "(.*)\2_?id" then checks if the name is prefixed by the table name and ends with "id",
+    #      referencing the saved capturing group (table name) with "\2".
+    #   In short, we assume that column names prefixed by the table name and ending with ID are probably
+    #   primary identifiers for their tables. Examples:
+    #    - "db.schema.customer.customer_id"
+    #    - "db.schema.customers.customer_id"
+    #    - "db.schema.customers.customerid"
+    PRIMARY_IDENTIFIER_REGEX_PATTERN = re.compile(r"(\.id$)|([a-z0-9_]+)s?\.\2_?id$", flags=re.IGNORECASE)
+
+    @staticmethod
+    def default_ruleset() -> List[InferenceRule]:
+        """Returns a sensible default set of inference rules."""
+        return [
+            RuleDefaults.primary_identifier_regex_rule(),
+            RuleDefaults.any_identifier_regex_rule(),
+        ]
+
+    @staticmethod
+    def primary_identifier_regex_rule() -> ColumnRegexMatcherRule:
+        """A default for finding primary identifiers by their names based on regex matches.
+
+        The returned rule will match columns such as `db.schema.mytable.mytable_id`,
+        `db.schema.mytable.mytableid` and `db.schema.mytable.id`.
+
+        It will always produce a PRIMARY_IDENTIFIER signal with FOR_SURE confidence.
+        """
+        return ColumnRegexMatcherRule(
+            pattern=RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN,
+            signal_type=InferenceSignalType.PRIMARY_IDENTIFIER,
+            confidence=InferenceSignalConfidence.FOR_SURE,
+        )
+
+    @staticmethod
+    def any_identifier_regex_rule() -> ColumnRegexMatcherRule:
+        """A default for finding identifiers of any type by their names based on regex matches.
+
+        The returned rule will match columns such as `db.schema.mytable.id`,
+        `db.schema.mytable.othertable_id` and `db.schema.mytable.othertableid`
+
+        It will always produce an IDENTIFIER signal with HIGH confidence.
+        """
+        return ColumnRegexMatcherRule(
+            pattern=RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN,
+            signal_type=InferenceSignalType.IDENTIFER,
+            confidence=InferenceSignalConfidence.HIGH,
+        )

--- a/metricflow/inference/rule/rules.py
+++ b/metricflow/inference/rule/rules.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+from typing import List
+
+from metricflow.inference.context.data_warehouse import DataWarehouseInferenceContext
+from metricflow.inference.rule.base import (
+    InferenceRule,
+    InferenceSignal,
+    InferenceSignalConfidence,
+    InferenceSignalType,
+)
+
+
+class ColumnRegexMatcherRule(InferenceRule):
+    """Inference rule that checks for matches across all column names."""
+
+    def __init__(
+        self, pattern: re.Pattern, signal_type: InferenceSignalType, confidence: InferenceSignalConfidence
+    ) -> None:
+        """Initialize the class.
+
+        pattern: regex Pattern to match against columns' full names, i.e `<db>.<schema>.<table>.<column>`
+        signal_type: the `InferenceSignalType` to produce whenever the pattern is matched
+        confidence: the `InferenceSignalConfidence` to produce whenever the pattern is matched
+        """
+        self.pattern = pattern
+        self.signal_type = signal_type
+        self.confidence = confidence
+
+    def process(self, warehouse: DataWarehouseInferenceContext) -> List[InferenceSignal]:  # type: ignore
+        """Try to match all columns' full names with the matching function or pattern.
+
+        If they do match, produce a signal with the configured type and confidence.
+        """
+        matching_columns = [column for column in warehouse.columns if self.pattern.match(column.sql)]
+        signals = [
+            InferenceSignal(
+                column=column,
+                type=self.signal_type,
+                reason=f"Column name matches regex pattern '{self.pattern.pattern}'",
+                confidence=self.confidence,
+            )
+            for column in matching_columns
+        ]
+        return signals

--- a/metricflow/inference/rule/rules.py
+++ b/metricflow/inference/rule/rules.py
@@ -33,7 +33,7 @@ class ColumnRegexMatcherRule(InferenceRule):
 
         If they do match, produce a signal with the configured type and confidence.
         """
-        matching_columns = [column for column in warehouse.columns if self.pattern.match(column.sql)]
+        matching_columns = [column for column in warehouse.columns if self.pattern.search(column.sql)]
         signals = [
             InferenceSignal(
                 column=column,

--- a/metricflow/inference/rule/rules.py
+++ b/metricflow/inference/rule/rules.py
@@ -8,7 +8,7 @@ from metricflow.inference.rule.base import (
     InferenceRule,
     InferenceSignal,
     InferenceSignalConfidence,
-    InferenceSignalType,
+    InferenceSignalNode,
 )
 
 
@@ -19,16 +19,16 @@ class ColumnMatcherRule(InferenceRule):
     """Inference rule that checks for matches across all columns."""
 
     def __init__(
-        self, matcher: ColumnMatcher, signal_type: InferenceSignalType, confidence: InferenceSignalConfidence
+        self, matcher: ColumnMatcher, type_node: InferenceSignalNode, confidence: InferenceSignalConfidence
     ) -> None:
         """Initialize the class.
 
         matcher: a function to determine whether a `SqlColumns` matches. If it does, produce the signal
-        signal_type: the `InferenceSignalType` to produce whenever the pattern is matched
+        type_node: the `InferenceSignalNode` to produce whenever the pattern is matched
         confidence: the `InferenceSignalConfidence` to produce whenever the pattern is matched
         """
         self.matcher = matcher
-        self.signal_type = signal_type
+        self.type_node = type_node
         self.confidence = confidence
 
     def process(self, warehouse: DataWarehouseInferenceContext) -> List[InferenceSignal]:  # type: ignore
@@ -40,7 +40,7 @@ class ColumnMatcherRule(InferenceRule):
         signals = [
             InferenceSignal(
                 column=column,
-                type=self.signal_type,
+                type_node=self.type_node,
                 reason=f"Column matched by rule {self.__class__.__name__}.",
                 confidence=self.confidence,
             )

--- a/metricflow/test/inference/rule/conftest.py
+++ b/metricflow/test/inference/rule/conftest.py
@@ -1,0 +1,64 @@
+import pytest
+
+from metricflow.dataflow.sql_column import SqlColumn
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.inference.context.data_warehouse import (
+    ColumnProperties,
+    DataWarehouseInferenceContext,
+    InferenceColumnType,
+    TableProperties,
+)
+
+
+@pytest.fixture
+def warehouse_ctx() -> DataWarehouseInferenceContext:
+    """A dummy DataWarehouseInferenceContext to be used as a fixture"""
+    return DataWarehouseInferenceContext(
+        table_props=[
+            TableProperties(
+                table=SqlTable.from_string("db.schema.table"),
+                column_props=[
+                    ColumnProperties(
+                        column=SqlColumn.from_string("db.schema.table.id"),
+                        type=InferenceColumnType.INTEGER,
+                        row_count=1,
+                        distinct_row_count=1,
+                        is_nullable=True,
+                        null_count=0,
+                        min_value=0,
+                        max_value=1,
+                    ),
+                    ColumnProperties(
+                        column=SqlColumn.from_string("db.schema.table.othertable_id"),
+                        type=InferenceColumnType.INTEGER,
+                        row_count=2,
+                        distinct_row_count=2,
+                        is_nullable=True,
+                        null_count=0,
+                        min_value=0,
+                        max_value=1,
+                    ),
+                    ColumnProperties(
+                        column=SqlColumn.from_string("db.schema.table.test_column"),
+                        type=InferenceColumnType.INTEGER,
+                        row_count=1,
+                        distinct_row_count=1,
+                        is_nullable=True,
+                        null_count=0,
+                        min_value=0,
+                        max_value=1,
+                    ),
+                    ColumnProperties(
+                        column=SqlColumn.from_string("db.schema.othertable.othertable_id"),
+                        type=InferenceColumnType.INTEGER,
+                        row_count=2,
+                        distinct_row_count=2,
+                        is_nullable=True,
+                        null_count=0,
+                        min_value=0,
+                        max_value=1,
+                    ),
+                ],
+            )
+        ]
+    )

--- a/metricflow/test/inference/rule/test_base.py
+++ b/metricflow/test/inference/rule/test_base.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch
+
+from metricflow.inference.context.base import InferenceContext
+from metricflow.inference.rule.base import InferenceRule, InferenceSignalType
+
+
+def test_inference_signal_type_conflict():
+    """Test `InferenceSignalType.conflict` by asserting it is commutative, i.e, conflict(a,b) == conflict(b,a) and it returns correct results."""
+
+    def conflict_commutative(a: InferenceSignalType, b: InferenceSignalType) -> bool:
+        """Assert the results of conflict(a, b) are the same as conflict(b, a). If passes assertion, returns the result"""
+        a_b = InferenceSignalType.conflict(a, b)
+        b_a = InferenceSignalType.conflict(b, a)
+        assert a_b == b_a
+        return a_b
+
+    # Make this test break if new entries are added to InferenceSignalType enum.
+    # Maybe this is not a very good solution, but we wanted to make sure all possible
+    # conflicts are covered, given that a policy thinking incompatible types are
+    # compatible or vice versa could be the reason for weird and untraceable bugs
+    # in inference (like IDs not being detected, or being wrongly detected).
+    assert len(InferenceSignalType) == 7
+
+    # IDENTIFIER
+    assert not conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.PRIMARY_IDENTIFIER)
+    assert not conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.FOREIGN_IDENTIFIER)
+    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.DIMENSION)
+    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.TIME_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.CATEGORICAL_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.MEASURE_FIELD)
+
+    # PRIMARY_IDENTIFIER
+    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.FOREIGN_IDENTIFIER)
+    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.DIMENSION)
+    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.TIME_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.CATEGORICAL_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.MEASURE_FIELD)
+
+    # FOREIGN_IDENTIFIER
+    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.DIMENSION)
+    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.TIME_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.CATEGORICAL_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.MEASURE_FIELD)
+
+    # DIMENSION
+    assert not conflict_commutative(InferenceSignalType.DIMENSION, InferenceSignalType.TIME_DIMENSION)
+    assert not conflict_commutative(InferenceSignalType.DIMENSION, InferenceSignalType.CATEGORICAL_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.DIMENSION, InferenceSignalType.MEASURE_FIELD)
+
+    # TIME_DIMENSION
+    assert conflict_commutative(InferenceSignalType.TIME_DIMENSION, InferenceSignalType.CATEGORICAL_DIMENSION)
+    assert conflict_commutative(InferenceSignalType.TIME_DIMENSION, InferenceSignalType.MEASURE_FIELD)
+
+    # CATEGORICAL_DIMENSION
+    assert conflict_commutative(InferenceSignalType.CATEGORICAL_DIMENSION, InferenceSignalType.MEASURE_FIELD)
+
+    # MEASURE_FIELD
+    # has already been tested in all previous cases since we're testing for commutability.
+
+
+def test_inference_rule_required_context_extraction():
+    """Assert that `InferenceRule.__init_subclass__()` properly initializes the subclass' required contexts from type annotations."""
+
+    class CtxType1(InferenceContext):
+        pass
+
+    class CtxType2(InferenceContext):
+        pass
+
+    class TestRule1(InferenceRule):
+        def process(self, ctx1: CtxType1):
+            pass
+
+    class TestRule2(InferenceRule):
+        def process(self, ctx2: CtxType2):
+            pass
+
+    class TestRule1And2(InferenceRule):
+        def process(self, ctx1: CtxType1, ctx2: CtxType2):
+            pass
+
+    assert TestRule1().required_contexts == (CtxType1,)
+    assert TestRule2().required_contexts == (CtxType2,)
+    assert TestRule1And2().required_contexts == (CtxType1, CtxType2)
+
+    # Assert it calls `logger.warning` whenever a context's type is not a subclass
+    # of `InferenceContext` or when it does not have annotations
+    with patch("metricflow.inference.rule.base.logger.warning") as warn_mock:
+
+        class ErrorRule(InferenceRule):
+            def process(self, ctx1: CtxType1, ctx2: int, ctx3):
+                pass
+
+        assert warn_mock.call_count == 2

--- a/metricflow/test/inference/rule/test_base.py
+++ b/metricflow/test/inference/rule/test_base.py
@@ -1,7 +1,4 @@
-from unittest.mock import patch
-
-from metricflow.inference.context.base import InferenceContext
-from metricflow.inference.rule.base import InferenceRule, InferenceSignalType
+from metricflow.inference.rule.base import InferenceSignalType
 
 
 def test_inference_signal_type_conflict():
@@ -56,41 +53,3 @@ def test_inference_signal_type_conflict():
 
     # MEASURE_FIELD
     # has already been tested in all previous cases since we're testing for commutability.
-
-
-def test_inference_rule_required_context_extraction():
-    """Assert that `InferenceRule.__init_subclass__()` properly initializes the subclass' required contexts from type annotations."""
-
-    class CtxType1(InferenceContext):
-        pass
-
-    class CtxType2(InferenceContext):
-        pass
-
-    class TestRule1(InferenceRule):
-        def process(self, contexts: CtxType1):  # type: ignore
-            pass
-
-    class TestRule2(InferenceRule):
-        def process(self, ctx2: CtxType2):  # type: ignore
-            pass
-
-    class TestRule1And2(InferenceRule):
-        def process(self, ctx1: CtxType1, ctx2: CtxType2):  # type: ignore
-            pass
-
-    assert TestRule1().required_contexts == (CtxType1,)
-    assert TestRule2().required_contexts == (CtxType2,)
-    assert TestRule1And2().required_contexts == (CtxType1, CtxType2)
-
-    # make sure we're emitting warnings when users try to use contexts that don't
-    # inherit from InferenceContext or if the process method is unannotated
-    with patch("metricflow.inference.rule.base.logger.warning") as warning_mock:
-
-        class TestError(InferenceRule):
-            def process(self, ctx: CtxType1, ctx2: int, ctx3):  # type: ignore
-                pass
-
-        print(TestError().required_contexts)
-        assert TestError().required_contexts == (CtxType1, None, None)
-        assert warning_mock.call_count == 2

--- a/metricflow/test/inference/rule/test_base.py
+++ b/metricflow/test/inference/rule/test_base.py
@@ -1,55 +1,27 @@
 from metricflow.inference.rule.base import InferenceSignalType
 
 
-def test_inference_signal_type_conflict():
-    """Test `InferenceSignalType.conflict` by asserting it is commutative, i.e, conflict(a,b) == conflict(b,a) and it returns correct results."""
-
-    def conflict_commutative(a: InferenceSignalType, b: InferenceSignalType) -> bool:
-        """Assert the results of conflict(a, b) are the same as conflict(b, a). If passes assertion, returns the result"""
-        a_b = InferenceSignalType.conflict(a, b)
-        b_a = InferenceSignalType.conflict(b, a)
-        assert a_b == b_a
-        return a_b
-
-    # Make this test break if new entries are added to InferenceSignalType enum.
-    # Maybe this is not a very good solution, but we wanted to make sure all possible
-    # conflicts are covered, given that a policy thinking incompatible types are
-    # compatible or vice versa could be the reason for weird and untraceable bugs
-    # in inference (like IDs not being detected, or being wrongly detected).
-    assert len(InferenceSignalType) == 7
+def test_inference_type_node_conflict():
+    """Make sure the inference signal type hierarchy is correctly configured."""
 
     # IDENTIFIER
-    assert not conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.PRIMARY_IDENTIFIER)
-    assert not conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.FOREIGN_IDENTIFIER)
-    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.DIMENSION)
-    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.TIME_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.CATEGORICAL_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.IDENTIFER, InferenceSignalType.MEASURE_FIELD)
+    assert InferenceSignalType.ID.UNKNOWN.is_descendant(InferenceSignalType.UNKNOWN)
+    assert not InferenceSignalType.ID.UNKNOWN.is_descendant(InferenceSignalType.DIMENSION.UNKNOWN)
+    assert not InferenceSignalType.ID.UNKNOWN.is_descendant(InferenceSignalType.MEASURE.UNKNOWN)
 
-    # PRIMARY_IDENTIFIER
-    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.FOREIGN_IDENTIFIER)
-    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.DIMENSION)
-    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.TIME_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.CATEGORICAL_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.PRIMARY_IDENTIFIER, InferenceSignalType.MEASURE_FIELD)
-
-    # FOREIGN_IDENTIFIER
-    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.DIMENSION)
-    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.TIME_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.CATEGORICAL_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.FOREIGN_IDENTIFIER, InferenceSignalType.MEASURE_FIELD)
+    assert InferenceSignalType.ID.UNIQUE.is_descendant(InferenceSignalType.ID.UNKNOWN)
+    assert InferenceSignalType.ID.FOREIGN.is_descendant(InferenceSignalType.ID.UNKNOWN)
+    assert InferenceSignalType.ID.PRIMARY.is_descendant(InferenceSignalType.ID.UNIQUE)
 
     # DIMENSION
-    assert not conflict_commutative(InferenceSignalType.DIMENSION, InferenceSignalType.TIME_DIMENSION)
-    assert not conflict_commutative(InferenceSignalType.DIMENSION, InferenceSignalType.CATEGORICAL_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.DIMENSION, InferenceSignalType.MEASURE_FIELD)
+    assert InferenceSignalType.DIMENSION.UNKNOWN.is_descendant(InferenceSignalType.UNKNOWN)
+    assert not InferenceSignalType.DIMENSION.UNKNOWN.is_descendant(InferenceSignalType.ID.UNKNOWN)
+    assert not InferenceSignalType.DIMENSION.UNKNOWN.is_descendant(InferenceSignalType.MEASURE.UNKNOWN)
 
-    # TIME_DIMENSION
-    assert conflict_commutative(InferenceSignalType.TIME_DIMENSION, InferenceSignalType.CATEGORICAL_DIMENSION)
-    assert conflict_commutative(InferenceSignalType.TIME_DIMENSION, InferenceSignalType.MEASURE_FIELD)
+    assert InferenceSignalType.DIMENSION.CATEGORICAL.is_descendant(InferenceSignalType.DIMENSION.UNKNOWN)
+    assert InferenceSignalType.DIMENSION.TIME.is_descendant(InferenceSignalType.DIMENSION.UNKNOWN)
 
-    # CATEGORICAL_DIMENSION
-    assert conflict_commutative(InferenceSignalType.CATEGORICAL_DIMENSION, InferenceSignalType.MEASURE_FIELD)
-
-    # MEASURE_FIELD
-    # has already been tested in all previous cases since we're testing for commutability.
+    # MEASURE
+    assert InferenceSignalType.MEASURE.UNKNOWN.is_descendant(InferenceSignalType.UNKNOWN)
+    assert not InferenceSignalType.MEASURE.UNKNOWN.is_descendant(InferenceSignalType.ID.UNKNOWN)
+    assert not InferenceSignalType.MEASURE.UNKNOWN.is_descendant(InferenceSignalType.DIMENSION.UNKNOWN)

--- a/metricflow/test/inference/rule/test_base.py
+++ b/metricflow/test/inference/rule/test_base.py
@@ -68,27 +68,29 @@ def test_inference_rule_required_context_extraction():
         pass
 
     class TestRule1(InferenceRule):
-        def process(self, ctx1: CtxType1):
+        def process(self, contexts: CtxType1):  # type: ignore
             pass
 
     class TestRule2(InferenceRule):
-        def process(self, ctx2: CtxType2):
+        def process(self, ctx2: CtxType2):  # type: ignore
             pass
 
     class TestRule1And2(InferenceRule):
-        def process(self, ctx1: CtxType1, ctx2: CtxType2):
+        def process(self, ctx1: CtxType1, ctx2: CtxType2):  # type: ignore
             pass
 
     assert TestRule1().required_contexts == (CtxType1,)
     assert TestRule2().required_contexts == (CtxType2,)
     assert TestRule1And2().required_contexts == (CtxType1, CtxType2)
 
-    # Assert it calls `logger.warning` whenever a context's type is not a subclass
-    # of `InferenceContext` or when it does not have annotations
-    with patch("metricflow.inference.rule.base.logger.warning") as warn_mock:
+    # make sure we're emitting warnings when users try to use contexts that don't
+    # inherit from InferenceContext or if the process method is unannotated
+    with patch("metricflow.inference.rule.base.logger.warning") as warning_mock:
 
-        class ErrorRule(InferenceRule):
-            def process(self, ctx1: CtxType1, ctx2: int, ctx3):
+        class TestError(InferenceRule):
+            def process(self, ctx: CtxType1, ctx2: int, ctx3):  # type: ignore
                 pass
 
-        assert warn_mock.call_count == 2
+        print(TestError().required_contexts)
+        assert TestError().required_contexts == (CtxType1, None, None)
+        assert warning_mock.call_count == 2

--- a/metricflow/test/inference/rule/test_defaults.py
+++ b/metricflow/test/inference/rule/test_defaults.py
@@ -1,0 +1,36 @@
+from metricflow.inference.rule.base import InferenceSignalConfidence, InferenceSignalType
+from metricflow.inference.rule.defaults import RuleDefaults
+
+from metricflow.inference.rule.rules import ColumnRegexMatcherRule
+
+
+def test_any_identifier_regex():  # noqa: D
+    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.id")
+    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.tableid")
+    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.table_id")
+    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.othertable_id")
+    assert not RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.whatever")
+
+
+def test_any_identifier_regex_rule_factory():  # noqa: D
+    rule = RuleDefaults.any_identifier_regex_rule()
+    assert isinstance(rule, ColumnRegexMatcherRule)
+    assert rule.pattern == RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN
+    assert rule.confidence == InferenceSignalConfidence.HIGH
+    assert rule.signal_type == InferenceSignalType.IDENTIFER
+
+
+def test_primary_identifier_regex():  # noqa: D
+    assert RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.id")
+    assert RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.tableid")
+    assert RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.table_id")
+    assert not RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.othertable_id")
+    assert not RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.whatever")
+
+
+def test_primary_identifier_regex_rule_factory():  # noqa: D
+    rule = RuleDefaults.primary_identifier_regex_rule()
+    assert isinstance(rule, ColumnRegexMatcherRule)
+    assert rule.pattern == RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN
+    assert rule.confidence == InferenceSignalConfidence.FOR_SURE
+    assert rule.signal_type == InferenceSignalType.PRIMARY_IDENTIFIER

--- a/metricflow/test/inference/rule/test_defaults.py
+++ b/metricflow/test/inference/rule/test_defaults.py
@@ -18,7 +18,7 @@ def test_any_identifier_rule_factory():  # noqa: D
     assert isinstance(rule, ColumnMatcherRule)
     assert rule.matcher == RuleDefaults._any_identifier_matcher
     assert rule.confidence == InferenceSignalConfidence.HIGH
-    assert rule.signal_type == InferenceSignalType.IDENTIFER
+    assert rule.type_node == InferenceSignalType.ID.UNKNOWN
 
 
 def test_primary_identifier_matcher():  # noqa: D
@@ -35,4 +35,4 @@ def test_primary_identifier_rule_factory():  # noqa: D
     assert isinstance(rule, ColumnMatcherRule)
     assert rule.matcher == RuleDefaults._primary_identifier_matcher
     assert rule.confidence == InferenceSignalConfidence.FOR_SURE
-    assert rule.signal_type == InferenceSignalType.PRIMARY_IDENTIFIER
+    assert rule.type_node == InferenceSignalType.ID.PRIMARY

--- a/metricflow/test/inference/rule/test_defaults.py
+++ b/metricflow/test/inference/rule/test_defaults.py
@@ -1,36 +1,38 @@
+from metricflow.dataflow.sql_column import SqlColumn
 from metricflow.inference.rule.base import InferenceSignalConfidence, InferenceSignalType
 from metricflow.inference.rule.defaults import RuleDefaults
 
-from metricflow.inference.rule.rules import ColumnRegexMatcherRule
+from metricflow.inference.rule.rules import ColumnMatcherRule
 
 
-def test_any_identifier_regex():  # noqa: D
-    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.id")
-    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.tableid")
-    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.table_id")
-    assert RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.othertable_id")
-    assert not RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.whatever")
+def test_any_identifier_matcher():  # noqa: D
+    assert RuleDefaults._any_identifier_matcher(SqlColumn.from_string("db.schema.table.id"))
+    assert RuleDefaults._any_identifier_matcher(SqlColumn.from_string("db.schema.table.tableid"))
+    assert RuleDefaults._any_identifier_matcher(SqlColumn.from_string("db.schema.table.table_id"))
+    assert RuleDefaults._any_identifier_matcher(SqlColumn.from_string("db.schema.table.othertable_id"))
+    assert not RuleDefaults._any_identifier_matcher(SqlColumn.from_string("db.schema.table.whatever"))
 
 
-def test_any_identifier_regex_rule_factory():  # noqa: D
-    rule = RuleDefaults.any_identifier_regex_rule()
-    assert isinstance(rule, ColumnRegexMatcherRule)
-    assert rule.pattern == RuleDefaults.ANY_IDENTIFIER_REGEX_PATTERN
+def test_any_identifier_rule_factory():  # noqa: D
+    rule = RuleDefaults.any_identifier_rule()
+    assert isinstance(rule, ColumnMatcherRule)
+    assert rule.matcher == RuleDefaults._any_identifier_matcher
     assert rule.confidence == InferenceSignalConfidence.HIGH
     assert rule.signal_type == InferenceSignalType.IDENTIFER
 
 
-def test_primary_identifier_regex():  # noqa: D
-    assert RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.id")
-    assert RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.tableid")
-    assert RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.table_id")
-    assert not RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.othertable_id")
-    assert not RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN.search("db.schema.table.whatever")
+def test_primary_identifier_matcher():  # noqa: D
+    assert RuleDefaults._primary_identifier_matcher(SqlColumn.from_string("db.schema.table.id"))
+    assert RuleDefaults._primary_identifier_matcher(SqlColumn.from_string("db.schema.table.tableid"))
+    assert RuleDefaults._primary_identifier_matcher(SqlColumn.from_string("db.schema.table.table_id"))
+    assert not RuleDefaults._primary_identifier_matcher(SqlColumn.from_string("db.schema.table.othertable_id"))
+    assert not RuleDefaults._primary_identifier_matcher(SqlColumn.from_string("db.schema.table.othertableid"))
+    assert not RuleDefaults._primary_identifier_matcher(SqlColumn.from_string("db.schema.table.whatever"))
 
 
-def test_primary_identifier_regex_rule_factory():  # noqa: D
-    rule = RuleDefaults.primary_identifier_regex_rule()
-    assert isinstance(rule, ColumnRegexMatcherRule)
-    assert rule.pattern == RuleDefaults.PRIMARY_IDENTIFIER_REGEX_PATTERN
+def test_primary_identifier_rule_factory():  # noqa: D
+    rule = RuleDefaults.primary_identifier_rule()
+    assert isinstance(rule, ColumnMatcherRule)
+    assert rule.matcher == RuleDefaults._primary_identifier_matcher
     assert rule.confidence == InferenceSignalConfidence.FOR_SURE
     assert rule.signal_type == InferenceSignalType.PRIMARY_IDENTIFIER

--- a/metricflow/test/inference/rule/test_rules.py
+++ b/metricflow/test/inference/rule/test_rules.py
@@ -1,0 +1,57 @@
+import re
+from metricflow.dataflow.sql_column import SqlColumn
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.inference.context.data_warehouse import (
+    ColumnProperties,
+    DataWarehouseInferenceContext,
+    InferenceColumnType,
+    TableProperties,
+)
+
+from metricflow.inference.rule.base import InferenceSignalConfidence, InferenceSignalType
+from metricflow.inference.rule.rules import ColumnRegexMatcherRule
+
+warehouse = DataWarehouseInferenceContext(
+    table_props=[
+        TableProperties(
+            table=SqlTable.from_string("db.schema.table"),
+            column_props=[
+                ColumnProperties(
+                    column=SqlColumn.from_string("db.schema.table.asd"),
+                    type=InferenceColumnType.INTEGER,
+                    row_count=1,
+                    distinct_row_count=1,
+                    is_nullable=True,
+                    null_count=0,
+                    min_value=0,
+                    max_value=1,
+                ),
+                ColumnProperties(
+                    column=SqlColumn.from_string("db.schema.table.bla"),
+                    type=InferenceColumnType.INTEGER,
+                    row_count=1,
+                    distinct_row_count=1,
+                    is_nullable=True,
+                    null_count=0,
+                    min_value=0,
+                    max_value=1,
+                ),
+            ],
+        )
+    ]
+)
+
+
+def test_column_regex_matcher():  # noqa: D
+    rule = ColumnRegexMatcherRule(
+        pattern=re.compile(r".*bla$"),  # have to pass in
+        signal_type=InferenceSignalType.DIMENSION,
+        confidence=InferenceSignalConfidence.MEDIUM,
+    )
+
+    signals = rule.process(warehouse)
+
+    assert len(signals) == 1
+    assert signals[0].confidence == InferenceSignalConfidence.MEDIUM
+    assert signals[0].type == InferenceSignalType.DIMENSION
+    assert signals[0].column == SqlColumn.from_string("db.schema.table.bla")

--- a/metricflow/test/inference/rule/test_rules.py
+++ b/metricflow/test/inference/rule/test_rules.py
@@ -8,7 +8,7 @@ def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext):  # noqa: 
     matcher: ColumnMatcher = lambda col: col.column_name.endswith("test_column")
     rule = ColumnMatcherRule(
         matcher=matcher,  # have to pass in
-        signal_type=InferenceSignalType.DIMENSION,
+        type_node=InferenceSignalType.DIMENSION.UNKNOWN,
         confidence=InferenceSignalConfidence.MEDIUM,
     )
 
@@ -16,5 +16,5 @@ def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext):  # noqa: 
 
     assert len(signals) == 1
     assert signals[0].confidence == InferenceSignalConfidence.MEDIUM
-    assert signals[0].type == InferenceSignalType.DIMENSION
+    assert signals[0].type_node == InferenceSignalType.DIMENSION.UNKNOWN
     assert signals[0].column == SqlColumn.from_string("db.schema.table.test_column")

--- a/metricflow/test/inference/rule/test_rules.py
+++ b/metricflow/test/inference/rule/test_rules.py
@@ -1,13 +1,13 @@
-import re
 from metricflow.dataflow.sql_column import SqlColumn
 from metricflow.inference.context.data_warehouse import DataWarehouseInferenceContext
 from metricflow.inference.rule.base import InferenceSignalConfidence, InferenceSignalType
-from metricflow.inference.rule.rules import ColumnRegexMatcherRule
+from metricflow.inference.rule.rules import ColumnMatcher, ColumnMatcherRule
 
 
-def test_column_regex_matcher(warehouse_ctx: DataWarehouseInferenceContext):  # noqa: D
-    rule = ColumnRegexMatcherRule(
-        pattern=re.compile(r"test_column$"),  # have to pass in
+def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext):  # noqa: D
+    matcher: ColumnMatcher = lambda col: col.column_name.endswith("test_column")
+    rule = ColumnMatcherRule(
+        matcher=matcher,  # have to pass in
         signal_type=InferenceSignalType.DIMENSION,
         confidence=InferenceSignalConfidence.MEDIUM,
     )

--- a/metricflow/test/inference/rule/test_rules.py
+++ b/metricflow/test/inference/rule/test_rules.py
@@ -1,57 +1,20 @@
 import re
 from metricflow.dataflow.sql_column import SqlColumn
-from metricflow.dataflow.sql_table import SqlTable
-from metricflow.inference.context.data_warehouse import (
-    ColumnProperties,
-    DataWarehouseInferenceContext,
-    InferenceColumnType,
-    TableProperties,
-)
-
+from metricflow.inference.context.data_warehouse import DataWarehouseInferenceContext
 from metricflow.inference.rule.base import InferenceSignalConfidence, InferenceSignalType
 from metricflow.inference.rule.rules import ColumnRegexMatcherRule
 
-warehouse = DataWarehouseInferenceContext(
-    table_props=[
-        TableProperties(
-            table=SqlTable.from_string("db.schema.table"),
-            column_props=[
-                ColumnProperties(
-                    column=SqlColumn.from_string("db.schema.table.asd"),
-                    type=InferenceColumnType.INTEGER,
-                    row_count=1,
-                    distinct_row_count=1,
-                    is_nullable=True,
-                    null_count=0,
-                    min_value=0,
-                    max_value=1,
-                ),
-                ColumnProperties(
-                    column=SqlColumn.from_string("db.schema.table.bla"),
-                    type=InferenceColumnType.INTEGER,
-                    row_count=1,
-                    distinct_row_count=1,
-                    is_nullable=True,
-                    null_count=0,
-                    min_value=0,
-                    max_value=1,
-                ),
-            ],
-        )
-    ]
-)
 
-
-def test_column_regex_matcher():  # noqa: D
+def test_column_regex_matcher(warehouse_ctx: DataWarehouseInferenceContext):  # noqa: D
     rule = ColumnRegexMatcherRule(
-        pattern=re.compile(r".*bla$"),  # have to pass in
+        pattern=re.compile(r"test_column$"),  # have to pass in
         signal_type=InferenceSignalType.DIMENSION,
         confidence=InferenceSignalConfidence.MEDIUM,
     )
 
-    signals = rule.process(warehouse)
+    signals = rule.process(warehouse_ctx)
 
     assert len(signals) == 1
     assert signals[0].confidence == InferenceSignalConfidence.MEDIUM
     assert signals[0].type == InferenceSignalType.DIMENSION
-    assert signals[0].column == SqlColumn.from_string("db.schema.table.bla")
+    assert signals[0].column == SqlColumn.from_string("db.schema.table.test_column")


### PR DESCRIPTION
# What does this PR do?

It adds the base classes required for implementing inference rules with minimal effort. Those classes make it easy for custom rules to return signals about columns, associated with confidence scores and reasons. For example, a custom rule could return a signal as follows:
```python
InferenceSignal(
    column=SqlColumn.from_names(db="db", schema="schema", table="table", column="id")
    type=InferenceSignalType.PRIMARY_IDENTIFIER,
    confidence=InferenceSignalConfidence.FOR_SURE,
    reason="The column is named `id`"
)
```

A heuristic that reasons about a collection of signals could then use confidence values to make conclusions about a column, giving well-described reasons to the end user. It could also prevent false positives by detecting conflicting signals (see `InferenceSignal.conflict`).

Apart from that, it also makes it very easy for an `InferenceRunner` to determine which contexts are required by a rule to run without failure by using introspection from type annotations in the `process` method.

Example:
```python
class CtxType1(InferenceContext):
    pass

class CtxType2(InferenceContext):
    pass

class TestRule1(InferenceRule):
    def process(self, ctx1: CtxType1):
        pass

class TestRule2(InferenceRule):
    def process(self, ctx2: CtxType2):
        pass

class TestRule1And2(InferenceRule):
    def process(self, ctx1: CtxType1, ctx2: CtxType2):
        pass

print(TestRule1().required_contexts)  # (CtxType1,)
print(TestRule2().required_contexts)  # (CtxType2,)
print(TestRule1And2().required_contexts)  # (CtxType1, CtxType2)
```

Finally, added a basic rule that produces signals based on a Regex matches to column names.