### PR TITLE
Run the full test suite for engine-specific tests

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Snowflake configs
-        run: pytest metricflow/test/integration
+        run: pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_SNOWFLAKE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_SNOWFLAKE_PWD }}
@@ -71,7 +71,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Redshift configs
-        run: pytest metricflow/test/integration
+        run: pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_REDSHIFT_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_REDSHIFT_PWD }}
@@ -104,7 +104,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with BigQuery configs
-        run: pytest metricflow/test/integration
+        run: pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
@@ -137,7 +137,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with SQLite configs
-        run: pytest metricflow/test/integration
+        run: pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: "sqlite://"
 


### PR DESCRIPTION
Engine-specific tests currently only run for things under
metricflow/test/integration, but that does not cover all of the
engine-specific test cases. We need to run them on any test that
might generate engine-specific plan files, and also any test that
targets the SqlClient classes themselves.
