### PR TITLE
Refine triggers for SQL Engine Test actions

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -1,13 +1,11 @@
 name: MetricFlow SQL Engine Tests
 
 on:
-  schedule:
-    - cron: '0 12 * * *' # run once per day
+  push:
+    branches:
+      - main
   pull_request:
     types: [ labeled ]
-  pull_request_target:
-      types: [opened, synchronize, reopened]
-
 
 jobs:
   snowflake-tests:


### PR DESCRIPTION
Previously, the SQL Engine tests were triggered under three conditions,
only one of which has proved useful:

1. PR label: this worked correctly and behaved exactly as we would hope
2. Schedule: this worked correctly in the main repo, but had other problems
3. PR submission/update: this never worked correctly

This commit replaces the schedule and PR submission triggers with a
dispatch on push to the main branch. We do this for the following reasons:

1. The schedule causes problems with forked repos since they would not
have the appropriate configuration for running these tests by default.
Furthermore, the scheduled runs were never approved internally, so they
were simply sitting there waiting for eternity and providing no value.
2. The PR submission runs were quite noisy - we generally don't need
to pre-validate every PR against the full suite of engine tests. As such,
we prefer to allow reviewers and committers to attach a label when appropriate,
instead of ignoring unfinished workflow events.
3. Triggering on push to main allows us to then make selective choices about
when to run the workflow on each PR without troubling the contributor,
and will hopefully avoid most issues for community members contributing
via repo forks, as they're most likely not pushing to their main branch.
