### PR TITLE
Add template for shopify metric model

### DIFF
--- a/config-templates/shopify/customer.yaml
+++ b/config-templates/shopify/customer.yaml
@@ -1,0 +1,55 @@
+data_source:
+  name: shopify_customer
+  owners:
+    - support@transformdata.io
+  sql_table: SHOPIFY.CUSTOMER ### Update to your customers schema.table
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: customer
+      type: primary
+      expr: id
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+      expr: created_at::date # Casting to date using Snowflake syntax. Update as needed based on your warehouse.
+  measures:
+    - name: total_customer_orders
+      agg: sum
+      expr: orders_count
+      create_metric: true
+    - name: total_spent
+      agg: sum
+      expr: total_spent
+      create_metric: true
+    - name: unique_customers
+      agg: count_distinct
+      expr: id
+      create_metric: true
+
+---
+metric:
+  name: weekly_customers
+  owners:
+    - hesham@transformdata.io
+  type: cumulative
+  type_params:
+    measures:
+      - unique_customers
+    window: 7 days
+
+---
+metric:
+  name: monthly_customers
+  owners:
+    - hesham@transformdata.io
+  type: cumulative
+  type_params:
+    measures:
+      - unique_customers
+    window: 1 month

--- a/config-templates/shopify/customer.yaml
+++ b/config-templates/shopify/customer.yaml
@@ -34,7 +34,7 @@ data_source:
 
 ---
 metric:
-  name: weekly_customers
+  name: rolling_7_customers
   owners:
     - hesham@transformdata.io
   type: cumulative

--- a/config-templates/shopify/customer.yaml
+++ b/config-templates/shopify/customer.yaml
@@ -1,12 +1,7 @@
 data_source:
   name: shopify_customer
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_table: SHOPIFY.CUSTOMER ### Update to your customers schema.table
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: customer
       type: primary

--- a/config-templates/shopify/customer.yaml
+++ b/config-templates/shopify/customer.yaml
@@ -30,8 +30,7 @@ data_source:
 ---
 metric:
   name: rolling_7_customers
-  owners:
-    - hesham@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   type: cumulative
   type_params:
     measures:
@@ -41,8 +40,7 @@ metric:
 ---
 metric:
   name: monthly_customers
-  owners:
-    - hesham@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   type: cumulative
   type_params:
     measures:

--- a/config-templates/shopify/customer_address.yaml
+++ b/config-templates/shopify/customer_address.yaml
@@ -8,8 +8,9 @@ data_source:
     type_params:
       update_cron: 0 2 * * *
   identifiers:
-    - name: id
+    - name: customer_address
       type: primary
+      expr: id
     - name: customer
       type: foreign
       expr: customer_id

--- a/config-templates/shopify/customer_address.yaml
+++ b/config-templates/shopify/customer_address.yaml
@@ -1,0 +1,22 @@
+data_source:
+  name: shopify_customers_addresses
+  owners:
+    - support@transformdata.io
+  sql_table: SHOPIFY.CUSTOMER_ADDRESS ### Update to your customer_address schema.table
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: id
+      type: primary
+    - name: customer
+      type: foreign
+      expr: customer_id
+  dimensions:
+    - name: country
+      type: categorical
+    - name: province
+      type: categorical
+    - name: zip
+      type: categorical

--- a/config-templates/shopify/customer_address.yaml
+++ b/config-templates/shopify/customer_address.yaml
@@ -1,12 +1,7 @@
 data_source:
   name: shopify_customers_addresses
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_table: SHOPIFY.CUSTOMER_ADDRESS ### Update to your customer_address schema.table
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: customer_address
       type: primary

--- a/config-templates/shopify/inventory_item.yaml
+++ b/config-templates/shopify/inventory_item.yaml
@@ -1,0 +1,44 @@
+data_source:
+  name: shopify_inventory_item
+  owners:
+    - support@transformdata.io
+  sql_table: SHOPIFY.INVENTORY_ITEM ### Update to your inventory_item schema.table
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: inventory_item
+      type: primary
+      expr: id
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+      expr: created_at::date # Casting to date using Snowflake syntax. Update as needed based on your warehouse.
+    - name: country_code_of_origin
+      type: categorical
+    - name: province_code_of_origin
+      type: categorical
+  measures:
+    - name: total_cost
+      agg: sum
+      expr: cost
+      create_metric: true
+    - name: total_unique_items
+      agg: sum
+      expr: 1
+      create_metric: true
+
+---
+metric:
+  name: mtd_total_cost
+  owners:
+    - hesham@transformdata.io
+  type: cumulative
+  type_params:
+    measures:
+      - total_cost
+    window: 1 month

--- a/config-templates/shopify/inventory_item.yaml
+++ b/config-templates/shopify/inventory_item.yaml
@@ -1,12 +1,7 @@
 data_source:
   name: shopify_inventory_item
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_table: SHOPIFY.INVENTORY_ITEM ### Update to your inventory_item schema.table
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: inventory_item
       type: primary

--- a/config-templates/shopify/inventory_item.yaml
+++ b/config-templates/shopify/inventory_item.yaml
@@ -30,8 +30,7 @@ data_source:
 ---
 metric:
   name: mtd_total_cost
-  owners:
-    - hesham@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   type: cumulative
   type_params:
     measures:

--- a/config-templates/shopify/inventory_level.yaml
+++ b/config-templates/shopify/inventory_level.yaml
@@ -1,0 +1,29 @@
+data_source:
+  name: shopify_inventory_level
+  owners:
+    - support@transformdata.io
+  sql_table: SHOPIFY.INVENTORY_LEVEL ### Update to your inventory_level schema.table
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: inventory_item
+      type: primary
+      expr: inventory_item_id
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+      expr: updated_at::date # Casting to date using Snowflake syntax. Update as needed based on your warehouse.
+  measures:
+    - name: total_inventory_quantity
+      agg: sum
+      expr: available
+      create_metric: true
+    - name: avg_inventory_quantity
+      agg: average
+      expr: available
+      create_metric: true

--- a/config-templates/shopify/inventory_level.yaml
+++ b/config-templates/shopify/inventory_level.yaml
@@ -1,12 +1,7 @@
 data_source:
   name: shopify_inventory_level
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_table: SHOPIFY.INVENTORY_LEVEL ### Update to your inventory_level schema.table
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: inventory_item
       type: primary

--- a/config-templates/shopify/order.yaml
+++ b/config-templates/shopify/order.yaml
@@ -1,0 +1,50 @@
+data_source:
+  name: shopify_order
+  owners:
+    - support@transformdata.io
+  sql_table: SHOPIFY."ORDER" ### Update to your order schema.table
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: order
+      type: primary
+      expr: id
+    - name: customer
+      type: foreign
+      expr: customer_id
+  
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+      expr: created_at::date # Casting to date using Snowflake syntax. Update as needed based on your warehouse.
+    - name: currency
+      type: categorical
+    - name: shipping_address_country
+      type: categorical
+    - name: shipping_address_province
+      type: categorical
+    - name: shipping_address_zip
+      type: categorical
+      
+  measures:
+    - name: total_orders
+      agg: count_distinct
+      expr: id
+      create_metric: true
+    - name: total_sales_amount_usd
+      agg: sum
+      expr: total_price
+      create_metric: true
+    - name: avg_order_value_usd
+      agg: average
+      expr: total_price
+      create_metric: true
+    - name: total_cancellations
+      agg: sum_boolean
+      expr: case when cancelled_at is not null then 1 else 0 end
+      create_metric: true

--- a/config-templates/shopify/order.yaml
+++ b/config-templates/shopify/order.yaml
@@ -1,12 +1,7 @@
 data_source:
   name: shopify_order
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_table: SHOPIFY."ORDER" ### Update to your order schema.table
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: order
       type: primary

--- a/config-templates/shopify/order_line.yaml
+++ b/config-templates/shopify/order_line.yaml
@@ -1,14 +1,9 @@
 # ORDER_LINE CONFIG
 data_source:
   name: shopify_order_line
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_query: |
     select * from SHOPIFY.ORDER_LINE a left join SHOPIFY."ORDER" b on a.order = b.order # We're joining because any data source with measures needs a primary time dimension. 
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: order_line
       type: primary

--- a/config-templates/shopify/order_line.yaml
+++ b/config-templates/shopify/order_line.yaml
@@ -10,13 +10,15 @@ data_source:
     type_params:
       update_cron: 0 2 * * *
   identifiers:
-    - name: id
+    - name: order_line
       type: primary
+      expr: id
     - name: order
       type: foreign
       expr: order_id
-    - name: product_id
+    - name: product
       type: foreign
+      expr: product_id
   dimensions:
     - name: ds
       type: time

--- a/config-templates/shopify/order_line.yaml
+++ b/config-templates/shopify/order_line.yaml
@@ -1,0 +1,43 @@
+# ORDER_LINE CONFIG
+data_source:
+  name: shopify_order_line
+  owners:
+    - support@transformdata.io
+  sql_query: |
+    select * from SHOPIFY.ORDER_LINE a left join SHOPIFY."ORDER" b on a.order = b.order # We're joining because any data source with measures needs a primary time dimension. 
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: id
+      type: primary
+    - name: order
+      type: foreign
+      expr: order_id
+    - name: product_id
+      type: foreign
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+      expr: created_at::date # Casting to date using Snowflake syntax. Update as needed based on your warehouse.
+    - name: vendor
+      type: categorical
+    - name: title
+      type: categorical
+  measures:
+    - name: total_quantity
+      agg: sum
+      expr: quantity
+      create_metric: true
+    - name: avg_value
+      agg: average
+      expr: price
+      create_metric: true
+    - name: total_weight_grams
+      agg: sum
+      expr: grams
+      create_metric: true

--- a/config-templates/shopify/order_line.yaml
+++ b/config-templates/shopify/order_line.yaml
@@ -2,8 +2,9 @@
 data_source:
   name: shopify_order_line
   owners:  # This will throw an error unless you add a list of owners or remove this entry.
+  # We're joining because any data source with measures needs a primary time dimension.
   sql_query: |
-    select * from SHOPIFY.ORDER_LINE a left join SHOPIFY."ORDER" b on a.order = b.order # We're joining because any data source with measures needs a primary time dimension. 
+    select * from SHOPIFY.ORDER_LINE a left join SHOPIFY."ORDER" b on a.order = b.order
   identifiers:
     - name: order_line
       type: primary

--- a/config-templates/shopify/product_variant.yaml
+++ b/config-templates/shopify/product_variant.yaml
@@ -1,0 +1,36 @@
+data_source:
+  name: shopify_product_variant
+  owners:
+    - support@transformdata.io
+  sql_table: SHOPIFY.PRODUCT_VARIANT ### Update to your product_variant schema.table
+  mutability:
+    type: full_mutation
+    type_params:
+      update_cron: 0 2 * * *
+  identifiers:
+    - name: product
+      type: primary
+      expr: product_id
+    - name: inventory_item
+      type: foreign
+      expr: inventory_item_id
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        is_primary: True
+        time_granularity: day
+      expr: created_at::date # Casting to date using Snowflake syntax. Update as needed based on your warehouse.
+  measures:
+    - name: average_product_price
+      agg: average
+      expr: price
+      create_metric: true
+    - name: total_inventory_product_quantity
+      agg: sum
+      expr: inventory_quantity
+      create_metric: true
+    - name: total_inventory_value
+      agg: sum
+      expr: inventory_quantity * price
+      create_metric: true 

--- a/config-templates/shopify/product_variant.yaml
+++ b/config-templates/shopify/product_variant.yaml
@@ -1,12 +1,7 @@
 data_source:
   name: shopify_product_variant
-  owners:
-    - support@transformdata.io
+  owners:  # This will throw an error unless you add a list of owners or remove this entry.
   sql_table: SHOPIFY.PRODUCT_VARIANT ### Update to your product_variant schema.table
-  mutability:
-    type: full_mutation
-    type_params:
-      update_cron: 0 2 * * *
   identifiers:
     - name: product
       type: primary


### PR DESCRIPTION
Shopify customers often get a bunch of useful sales and inventory data in their warehouse. Some MetricFlow users might find it convenient to include that Shopify data in their overall metric model. This commit adds a baseline set of data source files to set up an initial MetricFlow-friendly model of the underlying Shopify data.