### PR TITLE
Add MaterializationModelReference

### DIFF
--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -58,6 +58,12 @@ class MetricModelReference(ModelReference):
     metric_name: str
 
 
+class MaterializationModelReference(ModelReference):
+    """A reference to a materialization definition in the model."""
+
+    materialization_name: str
+
+
 # Type for the specification used in the instance.
 SpecT = TypeVar("SpecT", bound=InstanceSpec)
 


### PR DESCRIPTION
It came up in another PR, #128 that we should be using *Reference classes for referencing things like data source, metrics,
materializations, and etc. Those all existed, except for materializations. This PR simply adds that class and nothing extra. I'm doing it as a separate PR simply because it's unrelated to #128 except for the fact that #128 requires its existence.