### PR TITLE
Fix where clause parsing for empty functions

### DIFF
--- a/metricflow/model/objects/constraints/where.py
+++ b/metricflow/model/objects/constraints/where.py
@@ -63,6 +63,8 @@ class WhereClauseConstraint(HashableBaseModel, ParseableField):
 
         where = parsed["where"]
         if isinstance(where, dict):
+            if not len(where.keys()) == 1:
+                raise ConstraintParseException(f"expected parsed constraint to contain exactly one key; got {where}")
             return WhereClauseConstraint(
                 where=s,
                 linkable_names=constraint_dimension_names_from_dict(where),
@@ -88,9 +90,6 @@ def strip_where(s: str) -> str:
 
 
 def constraint_dimension_names_from_dict(where: Dict[str, Any]) -> List[str]:  # type: ignore[misc] # noqa: D
-    if not len(where.keys()) == 1:
-        raise ConstraintParseException(f"expected parsed constraint to contain exactly one key; got {where}")
-
     dims = []
     for key, clause in where.items():
         if key == LITERAL_STR or key == INTERVAL_LITERAL:

--- a/metricflow/test/constraints/test_where.py
+++ b/metricflow/test/constraints/test_where.py
@@ -1,13 +1,19 @@
-import pytest
-
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
 
 
-@pytest.mark.skip(reason="Does not currently parse correctly.")
-def test_where_constraint_parsing() -> None:  # noqa: D
-    """Currently throws an exception:
-
-    ConstraintParseException: expected parsed constraint to contain exactly one key; got {}
-    """
-    parsed_where = WhereClauseConstraint.parse("ds = CAST('2020-01-01' AS TIMESTAMP) AND is_instant")
+def test_where_constraint_parsing() -> None:
+    """Simple test of a parsed where with a function and some boolean and equality checks"""
+    parsed_where = WhereClauseConstraint.parse("ds >= CAST('2020-01-01' AS TIMESTAMP) AND is_instant")
     assert set(parsed_where.linkable_names) == {"ds", "is_instant"}
+
+
+def test_where_constraint_parsing_empty_function() -> None:
+    """Test involving an empty function, which produces an empty object"""
+    parsed_where = WhereClauseConstraint.parse("is_internal IS FALSE AND is_instant = false AND ds = CURRENT_DATE()")
+    assert set(parsed_where.linkable_names) == {"is_internal", "is_instant", "ds"}
+
+
+def test_where_constraint_with_between() -> None:
+    """Testing a where constraint with a BETWEEN expression"""
+    parsed_where = WhereClauseConstraint.parse("WHERE ds < CURRENT_DATE() AND price BETWEEN min_price AND 1.50")
+    assert set(parsed_where.linkable_names) == {"ds", "price", "min_price"}


### PR DESCRIPTION
The parser we use for the WHERE clause returns a JSON-like structure
with dict types representing key/value pairs for things like literals
and function definitions. For a function taking arguments, the key
would be the name of the function and the value would be a list of
arguments, which themselves could be strings, lists, or dicts.

For any function taking no arguments, such as CURRENT_DATE(), or one
taking keywords, such as CAST(x AS DOUBLE), the parsed output would
represent the keywords (or empty set of arguments) as an empty dict.

Since we recursively call a helper that asserts that the dict contains
exactly one key, our parsing logic throws an error on such input.

This commit simply moves that assertion where it belongs - into the
first call into the recursive processing function, the one for the
top-level where clause, because at that level we expect exactly one
key: the index into the comparison, or else the function name.
The test suite for this function has also been expanded.