### PR TITLE
Add tests for metric config parsing

### DIFF
--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -57,7 +57,7 @@ def parse_directory_of_yaml_files_to_model(
         dirs[:] = [d for d in dirs if not d.startswith(".")]
 
         for file in files:
-            if not (file.endswith(".yaml") or file.endswith(".yml")):
+            if not SafeLineLoader.is_valid_yaml_file_ending(file):
                 continue
             # Skip hidden files
             if file.startswith("."):

--- a/metricflow/model/parsing/yaml_loader.py
+++ b/metricflow/model/parsing/yaml_loader.py
@@ -34,3 +34,8 @@ class SafeLineLoader(yaml.SafeLoader):
         )  # change to 1-indexed
 
         return mapping
+
+    @staticmethod
+    def is_valid_yaml_file_ending(filename: str) -> bool:
+        """Checks if YAML file name ends with one of the supported suffixes"""
+        return filename.endswith(".yaml") or filename.endswith(".yml")

--- a/metricflow/test/model/parsing/test_data_source_parsing.py
+++ b/metricflow/test/model/parsing/test_data_source_parsing.py
@@ -1,0 +1,443 @@
+import textwrap
+
+from metricflow.model.objects.common import YamlConfigFile
+from metricflow.model.objects.data_source import DataSourceOrigin, MutabilityType
+from metricflow.model.objects.elements.identifier import IdentifierType
+from metricflow.model.objects.elements.measure import AggregationType
+from metricflow.model.objects.elements.dimension import DimensionType
+from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_model
+from metricflow.time.time_granularity import TimeGranularity
+
+
+def test_base_data_source_attribute_parsing() -> None:
+    """Test for parsing a data source specification without regard for measures, identifiers, or dimensions"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: base_property_test
+          mutability:
+            type: append_only
+            type_params:
+              min: minimum_value
+              max: maximum_value
+              update_cron: "* * 1 * *"
+              along: dimension_column
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert data_source.name == "base_property_test"
+    assert data_source.origin == DataSourceOrigin.SOURCE  # auto-filled from default, not user-configurable
+    assert data_source.mutability.type == MutabilityType.APPEND_ONLY
+    assert data_source.mutability.type_params is not None
+    assert data_source.mutability.type_params.min == "minimum_value"
+    assert data_source.mutability.type_params.max == "maximum_value"
+    assert data_source.mutability.type_params.update_cron == "* * 1 * *"
+    assert data_source.mutability.type_params.along == "dimension_column"
+
+
+def test_data_source_metadata_parsing() -> None:
+    """Test for asserting that internal metadata is parsed into the DataSource object"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: metadata_test
+          mutability:
+            type: immutable
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert data_source.metadata is not None
+    assert data_source.metadata.repo_file_path == "test_dir/inline_for_test"
+    assert data_source.metadata.file_slice.filename == "inline_for_test"
+
+
+def test_data_source_sql_table_parsing() -> None:
+    """Test for parsing a data source specification with a sql_table provided"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: sql_table_test
+          mutability:
+            type: immutable
+          sql_table: "some_schema.source_table"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert data_source.sql_table == "some_schema.source_table"
+
+
+def test_data_source_sql_query_parsing() -> None:
+    """Test for parsing a data source specification with a sql_query provided"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: sql_query_test
+          mutability:
+            type: immutable
+          sql_query: "SELECT * FROM some_schema.source_table"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert data_source.sql_query == "SELECT * FROM some_schema.source_table"
+
+
+def test_data_source_dbt_model_parsing() -> None:
+    """Test for parsing a data source specification with a dbt model provided"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: dbt_model_test
+          mutability:
+            type: immutable
+          dbt_model: "dbt_source.some_model"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert data_source.dbt_model == "dbt_source.some_model"
+
+
+def test_data_source_identifier_parsing() -> None:
+    """Test for parsing a basic identifier out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: identifier_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          identifiers:
+            - name: example_identifier
+              type: primary
+              role: test_role
+              entity: other_identifier
+              expr: example_id
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.identifiers) == 1
+    identifier = data_source.identifiers[0]
+    assert identifier.name == "example_identifier"
+    assert identifier.type is IdentifierType.PRIMARY
+    assert identifier.role == "test_role"
+    assert identifier.entity == "other_identifier"
+    assert identifier.expr == "example_id"
+
+
+def test_data_source_identifier_default_entity_parsing() -> None:
+    """Test for parsing an identifier with no entity specified out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: entity_default_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          identifiers:
+            - name: example_default_entity_identifier
+              type: primary
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.identifiers) == 1
+    identifier = data_source.identifiers[0]
+    assert identifier.entity == "example_default_entity_identifier"
+
+
+def test_data_source_composite_sub_identifier_ref_parsing() -> None:
+    """Test for parsing a ref-based composite sub-identifier out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: composite_sub_identifier_ref_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          identifiers:
+            - name: example_identifier
+              type: primary
+              identifiers:
+                - name: composite_ref_identifier
+                  ref: other_identifier
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.identifiers) == 1
+    identifier = data_source.identifiers[0]
+    assert len(identifier.identifiers) == 1
+
+    ref_sub_identifier = identifier.identifiers[0]
+    assert ref_sub_identifier.name == "composite_ref_identifier"
+    assert ref_sub_identifier.ref == "other_identifier"
+    assert ref_sub_identifier.expr is None
+
+
+def test_data_source_composite_sub_identifier_expr_parsing() -> None:
+    """Test for parsing an expr-based composite sub-identifier out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: composite_sub_identifier_expr_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          identifiers:
+            - name: example_identifier
+              type: primary
+              identifiers:
+                - name: composite_expr_identifier
+                  expr: CAST(expr_identifier AS BIGINT)
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.identifiers) == 1
+    identifier = data_source.identifiers[0]
+    assert len(identifier.identifiers) == 1
+
+    expr_sub_identifier = identifier.identifiers[0]
+    assert expr_sub_identifier.name == "composite_expr_identifier"
+    assert expr_sub_identifier.expr == "CAST(expr_identifier AS BIGINT)"
+    assert expr_sub_identifier.ref is None
+
+
+def test_data_source_measure_parsing() -> None:
+    """Test for parsing a measure out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: measure_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          measures:
+            - name: example_measure
+              agg: count_distinct
+              expr: example_input
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.measures) == 1
+    measure = data_source.measures[0]
+    assert measure.name == "example_measure"
+    assert measure.agg is AggregationType.COUNT_DISTINCT
+    assert measure.create_metric is not True
+    assert measure.expr == "example_input"
+
+
+def test_data_source_measure_metadata_parsing() -> None:
+    """Test for parsing metadata for a measure object defined in a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: measure_metadata_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          measures:
+            - name: example_measure_with_metadata
+              agg: count_distinct
+              expr: example_input
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.measures) == 1
+    measure = data_source.measures[0]
+    assert measure.metadata is not None
+    assert measure.metadata.repo_file_path == "test_dir/inline_for_test"
+    assert measure.metadata.file_slice.filename == "inline_for_test"
+
+
+def test_data_source_create_metric_measure_parsing() -> None:
+    """Test for parsing a measure out of a data source specification when create metric is set"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: measure_parsing_create_metric_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          measures:
+            - name: example_measure
+              agg: count_distinct
+              create_metric: true
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.measures) == 1
+    measure = data_source.measures[0]
+    assert measure.create_metric is True
+
+
+def test_data_source_categorical_dimension_parsing() -> None:
+    """Test for parsing a categorical dimension out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: dimension_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          dimensions:
+            - name: example_categorical_dimension
+              type: categorical
+              expr: dimension_input
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.dimensions) == 1
+    dimension = data_source.dimensions[0]
+    assert dimension.name == "example_categorical_dimension"
+    assert dimension.type is DimensionType.CATEGORICAL
+    assert dimension.is_partition is not True
+
+
+def test_data_source_partition_dimension_parsing() -> None:
+    """Test for parsing a partition dimension out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: dimension_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          dimensions:
+            - name: example_categorical_dimension
+              type: categorical
+              is_partition: true
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.dimensions) == 1
+    dimension = data_source.dimensions[0]
+    assert dimension.is_partition is True
+
+
+def test_data_source_time_dimension_parsing() -> None:
+    """Test for parsing a time dimension out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: dimension_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          dimensions:
+            - name: example_time_dimension
+              type: time
+              type_params:
+                time_format: "%Y-%M-%D"
+                time_granularity: month
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.dimensions) == 1
+    dimension = data_source.dimensions[0]
+    assert dimension.type is DimensionType.TIME
+    assert dimension.type_params is not None
+    assert dimension.type_params.is_primary is not True
+    assert dimension.type_params.time_format == "%Y-%M-%D"
+    assert dimension.type_params.time_granularity is TimeGranularity.MONTH
+
+
+def test_data_source_primary_time_dimension_parsing() -> None:
+    """Test for parsing a primary time dimension out of a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: dimension_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          dimensions:
+            - name: example_time_dimension
+              type: time
+              type_params:
+                time_granularity: month
+                is_primary: true
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.data_sources) == 1
+    data_source = model.data_sources[0]
+    assert len(data_source.dimensions) == 1
+    dimension = data_source.dimensions[0]
+    assert dimension.type is DimensionType.TIME
+    assert dimension.type_params is not None
+    assert dimension.type_params.is_primary is True

--- a/metricflow/test/model/parsing/test_materialization_parsing.py
+++ b/metricflow/test/model/parsing/test_materialization_parsing.py
@@ -1,0 +1,236 @@
+import textwrap
+
+import pytest
+from metricflow.dataflow.sql_table import SqlTable
+
+from metricflow.errors.errors import ParsingException
+from metricflow.model.objects.common import YamlConfigFile
+from metricflow.model.objects.materialization import (
+    MaterializationFormat,
+    MaterializationLocation,
+    MaterializationTableauParams,
+)
+from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_model
+
+
+def test_simple_materialization_parsing() -> None:
+    """Test for parsing a simple maeterialization specification with no optional parameters"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: simple_materialization_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+            - time_dimension
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.name == "simple_materialization_test"
+    assert materialization.metrics == ["some_metric"]
+    assert materialization.dimensions == ["some_dimension", "time_dimension"]
+
+
+def test_materialization_metadata_parsing() -> None:
+    """Test for asserting that internal metadata is parsed into the Materialization object"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: simple_materialization_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+            - time_dimension
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.metadata is not None
+    assert materialization.metadata.repo_file_path == "test_dir/inline_for_test"
+    assert materialization.metadata.file_slice.filename == "inline_for_test"
+
+
+def test_materialization_with_simple_destinations_parsing() -> None:
+    """Test for parsing a materialization specification with destinations set"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: materialization_simple_destinations_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+          destinations:
+            - location: dw
+              format: wide
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.destinations is not None
+    assert len(materialization.destinations) == 1
+    destination = materialization.destinations[0]
+    assert destination.location is MaterializationLocation.DW
+    assert destination.format is MaterializationFormat.WIDE
+
+
+def test_materialization_with_rollup_destination_parsing() -> None:
+    """Test for parsing a materialization specification with a rollup set on a destination"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: materialization_simple_destinations_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+          destinations:
+            - location: dw
+              format: wide
+              rollups:
+               - []
+               - ["some_dimension", "*"]
+               - ["some_dimension"]
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.destinations is not None
+    assert len(materialization.destinations) == 1
+    destination = materialization.destinations[0]
+    assert destination.rollups is not None
+    assert destination.rollups == [[], ["some_dimension", "*"], ["some_dimension"]]
+
+
+def test_materialization_with_indented_rollup_destination_parsing() -> None:
+    """Test for parsing a materialization specification with a rollup set on a destination"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: materialization_simple_destinations_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+          destinations:
+            - location: dw
+              format: wide
+              rollups:
+               -
+                 - "some_dimension"
+                 - "*"
+               -
+                 - "some_dimension"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.destinations is not None
+    assert len(materialization.destinations) == 1
+    destination = materialization.destinations[0]
+    assert destination.rollups is not None
+    assert destination.rollups == [["some_dimension", "*"], ["some_dimension"]]
+
+
+def test_materialization_with_tableau_parameters_parsing() -> None:
+    """Test for parsing a materialization specification with Tableau parameters"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: materialization_simple_destinations_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+          destinations:
+            - location: dw
+              format: wide
+              tableau_params:
+                projects:
+                 - some_project
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.destinations is not None
+    assert len(materialization.destinations) == 1
+    destination = materialization.destinations[0]
+    assert destination.tableau_params == MaterializationTableauParams(projects=["some_project"])
+
+
+def test_materialization_with_destination_table_parsing() -> None:
+    """Test for parsing a materialization specification with a destination table set"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: materialization_simple_destinations_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+          destinations:
+            - location: dw
+              format: wide
+          destination_table: "bq_project.output_schema.materialization_table"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.materializations) == 1
+    materialization = model.materializations[0]
+    assert materialization.destinations is not None and len(materialization.destinations) == 1
+    assert materialization.destination_table is not None
+    assert materialization.destination_table == SqlTable(
+        db_name="bq_project", schema_name="output_schema", table_name="materialization_table"
+    )
+
+
+def test_materialization_with_invalid_destination_table_parsing_error() -> None:
+    """Test for parsing error thrown when the sql table name cannot be properly parsed"""
+    yaml_contents = textwrap.dedent(
+        """\
+        materialization:
+          name: materialization_simple_destinations_test
+          metrics:
+            - some_metric
+          dimensions:
+            - some_dimension
+          destinations:
+            - location: dw
+              format: wide
+          destination_table: "this is an invalid table name"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    with pytest.raises(ParsingException, match="Invalid input for a SQL table"):
+        parse_yaml_files_to_model(files=[file])

--- a/metricflow/test/model/parsing/test_metadata_parsing.py
+++ b/metricflow/test/model/parsing/test_metadata_parsing.py
@@ -1,0 +1,104 @@
+import os
+from typing import Sequence
+
+from metricflow.model.objects.common import Metadata
+from metricflow.model.objects.elements.measure import Measure
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.parsing.yaml_loader import SafeLineLoader
+
+
+def test_data_source_metadata_parsing(simple_user_configured_model: UserConfiguredModel) -> None:
+    """Tests internal metadata object parsing from a file into the Data Source model object
+
+    This only tests some basic file name parsing for each data source since they are not guaranteed
+    to be collected in the same file in the simple model, and the output here has been transformed
+    so the contents might or might not match.
+    """
+    assert len(simple_user_configured_model.data_sources) > 0
+    for data_source in simple_user_configured_model.data_sources:
+        assert (
+            data_source.metadata is not None
+        ), f"Metadata should always be parsed out of the model, but None found for data source: {data_source}!"
+        _assert_metadata_filename_is_valid(data_source.metadata)
+
+
+def test_metric_metadata_parsing(simple_user_configured_model: UserConfiguredModel) -> None:
+    """Tests internal metadata object parsing from a file into the Metric model object
+
+    This only tests some basic file name parsing for each metric since they are not guaranteed
+    to be collected in the same file in the simple model, and the output here has been transformed
+    so the contents might or might not match.
+    """
+    assert len(simple_user_configured_model.metrics) > 0
+    for metric in simple_user_configured_model.metrics:
+        assert (
+            metric.metadata is not None
+        ), f"Metadata should always be parsed out of the model, but None found for metric: {metric}!"
+        _assert_metadata_filename_is_valid(metric.metadata)
+
+
+def test_materialization_metadata_parsing(simple_user_configured_model: UserConfiguredModel) -> None:
+    """Tests internal metadata object parsing from a file into the Materialization model object
+
+    This only tests some basic file name parsing for each materialization since they are not guaranteed
+    to be collected in the same file in the simple model, and the output here has been transformed
+    so the contents might or might not match.
+    """
+    assert len(simple_user_configured_model.materializations) > 0
+    for materialization in simple_user_configured_model.materializations:
+        assert (
+            materialization.metadata is not None
+        ), f"Metadata should always be parsed out of the model, but None found for materialization: {materialization}!"
+        _assert_metadata_filename_is_valid(materialization.metadata)
+
+
+def test_measure_metadata_parsing(simple_user_configured_model: UserConfiguredModel) -> None:
+    """Tests internal metadata object parsing from a file into the Measure model object"""
+    assert len(simple_user_configured_model.data_sources) > 0
+    for data_source in simple_user_configured_model.data_sources:
+        _assert_measure_metadata_is_valid(data_source.measures)
+
+
+def _assert_metadata_filename_is_valid(metadata: Metadata) -> None:
+    """Sequence of assertion steps to ensure the metadata object has consistent file name parsing"""
+    assert SafeLineLoader.is_valid_yaml_file_ending(metadata.repo_file_path), (
+        f"Expected repo file path in measure metadata to be a yaml file with an appropriate ending. "
+        f"Metadata: {metadata}"
+    )
+
+    assert (
+        os.path.basename(metadata.repo_file_path) == metadata.file_slice.filename
+    ), f"File name should be the final part of the repo file path. Metadata: {metadata}"
+    assert (
+        os.path.dirname(metadata.repo_file_path) != ""
+    ), f"Expected repo file path to be fully resolved, but it is filename only. Metadata: {metadata}"
+
+
+def _assert_measure_metadata_is_valid(measures: Sequence[Measure]) -> None:
+    """Sequence of assertion steps to show that we are parsing metadata consistently for measures
+
+    The assertions check that:
+    1. Metadata is always set by the parser
+    2. Metadata always contains a reasonable repo file path and file name
+    3. Start and end line numbers are always increasing for every measure in the data source
+
+    Since this test is operating on a transformed model, we do not make assertions about the raw YAML contents and how
+    they relate to the properties of the measures themselves.
+    """
+    last_end_number = 0
+    for measure in measures:
+        assert (
+            measure.metadata is not None
+        ), f"Metadata should always be parsed out of the model, but None found for measure {measure}!"
+
+        _assert_metadata_filename_is_valid(measure.metadata)
+
+        assert measure.metadata.file_slice.start_line_number > last_end_number, (
+            f"Start line numbers should always follow the end line number from the previous measure! "
+            f"Metadata: {measure.metadata}"
+        )
+        assert measure.metadata.file_slice.end_line_number > measure.metadata.file_slice.start_line_number, (
+            f"End line numbers should always be larger than start line numbers for a Measure definition entry! "
+            f"Metadata: {measure.metadata}"
+        )
+        last_end_number = measure.metadata.file_slice.end_line_number

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -1,0 +1,260 @@
+import textwrap
+
+import pytest
+
+from metricflow.errors.errors import ParsingException
+from metricflow.model.objects.common import YamlConfigFile
+from metricflow.model.objects.constraints.where import WhereClauseConstraint
+from metricflow.model.objects.metric import CumulativeMetricWindow, MetricType
+from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_model
+from metricflow.sql.sql_bind_parameters import SqlBindParameters
+from metricflow.time.time_granularity import TimeGranularity
+
+
+def test_legacy_measure_metric_parsing() -> None:
+    """Test for parsing a simple metric specification with the `measure` parameter instead of `measures`"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: legacy_test
+          type: measure_proxy
+          type_params:
+            measure: legacy_measure
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "legacy_test"
+    assert metric.type is MetricType.MEASURE_PROXY
+    assert metric.type_params.measure == "legacy_measure"
+    assert metric.type_params.measures is None
+
+
+def test_metric_metadata_parsing() -> None:
+    """Test for asserting that internal metadata is parsed into the Metric object"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: metadata_test
+          type: measure_proxy
+          type_params:
+            measures:
+              - metadata_test_measure
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.metadata is not None
+    assert metric.metadata.repo_file_path == "test_dir/inline_for_test"
+    assert metric.metadata.file_slice.filename == "inline_for_test"
+
+
+def test_ratio_metric_parsing() -> None:
+    """Test for parsing a ratio metric specification with numerator and denominator"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: ratio_test
+          type: ratio
+          type_params:
+            numerator: numerator_measure
+            denominator: denominator_measure
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "ratio_test"
+    assert metric.type is MetricType.RATIO
+    assert metric.type_params.numerator == "numerator_measure"
+    assert metric.type_params.denominator == "denominator_measure"
+    assert metric.type_params.measures is None
+
+
+def test_expr_metric_parsing() -> None:
+    """Test for parsing a metric specification with an expr and a list of measures"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: expr_test
+          type: expr
+          type_params:
+            measures:
+              - measure_one
+              - measure_two
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "expr_test"
+    assert metric.type is MetricType.EXPR
+    assert metric.type_params.measures == ["measure_one", "measure_two"]
+
+
+def test_cumulative_window_metric_parsing() -> None:
+    """Test for parsing a metric specification with a cumulative window"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: cumulative_test
+          type: cumulative
+          type_params:
+            measures:
+              - cumulative_measure
+            window: "7 days"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "cumulative_test"
+    assert metric.type is MetricType.CUMULATIVE
+    assert metric.type_params.measures == ["cumulative_measure"]
+    assert metric.type_params.window == CumulativeMetricWindow(count=7, granularity=TimeGranularity.DAY)
+
+
+def test_grain_to_date_metric_parsing() -> None:
+    """Test for parsing a metric specification with the grain to date cumulative setting"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: grain_to_date_test
+          type: cumulative
+          type_params:
+            measures:
+              - cumulative_measure
+            grain_to_date: "week"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "grain_to_date_test"
+    assert metric.type is MetricType.CUMULATIVE
+    assert metric.type_params.measures == ["cumulative_measure"]
+    assert metric.type_params.window is None
+    assert metric.type_params.grain_to_date is TimeGranularity.WEEK
+
+
+def test_constraint_metric_parsing() -> None:
+    """Test for parsing a metric specification with a constraint included"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: constraint_test
+          type: measure_proxy
+          type_params:
+            measures:
+              - input_measure
+          constraint: "some_dimension IN ('value1', 'value2')"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    model = parse_yaml_files_to_model(files=[file])
+
+    assert len(model.metrics) == 1
+    metric = model.metrics[0]
+    assert metric.name == "constraint_test"
+    assert metric.type is MetricType.MEASURE_PROXY
+    assert metric.constraint == WhereClauseConstraint(
+        where="some_dimension IN ('value1', 'value2')",
+        linkable_names=["some_dimension"],
+        sql_params=SqlBindParameters(),
+    )
+
+
+def test_invalid_metric_type_parsing_error() -> None:
+    """Test for error detection when parsing a metric specification with an invalid MetricType input value"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: invalid_type_test
+          type: this is not a valid type
+          type_params:
+            measures:
+              - input_measure
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    with pytest.raises(ParsingException, match="'this is not a valid type' is not one of"):
+        parse_yaml_files_to_model(files=[file])
+
+
+def test_invalid_cumulative_metric_window_format_parsing_error() -> None:
+    """Test for errror detection when parsing malformed cumulative metric window entries"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: invalid_cumulative_format_test
+          type: cumulative
+          type_params:
+            measures:
+              - cumulative_measure
+            window: "7 days long"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    with pytest.raises(ParsingException, match="Invalid window"):
+        parse_yaml_files_to_model(files=[file])
+
+
+def test_invalid_cumulative_metric_window_granularity_parsing_error() -> None:
+    """Test for errror detection when parsing malformed cumulative metric window entries"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: invalid_cumulative_granularity_test
+          type: cumulative
+          type_params:
+            measures:
+              - cumulative_measure
+            window: "7 moons"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    with pytest.raises(ParsingException, match="Invalid time granularity"):
+        parse_yaml_files_to_model(files=[file])
+
+
+def test_invalid_cumulative_metric_window_count_parsing_error() -> None:
+    """Test for errror detection when parsing malformed cumulative metric window entries"""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: invalid_cumulative_count_test
+          type: cumulative
+          type_params:
+            measures:
+              - cumulative_measure
+            window: "six days"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    with pytest.raises(ParsingException, match="Invalid count"):
+        parse_yaml_files_to_model(files=[file])


### PR DESCRIPTION
## Add tests for metric config parsing

The core MetricFlow model parser converts user-defined YAML files
into MetricFlow model objects via a combination of standard,
jsonschema-backed YAML parsing and Pydantic BaseModel object
parsing. This is managed by a set of custom parsers.

Although all of these paths are probably tested indirectly via
test model parsing in various other test cases, the concrete attribute
parsing is not directly tested anywhere. This makes the expected output
of the core parsing logic a bit harder to reason through.

This is the first of three commits to add direct tests for the core parser
logic, which will make updates and changes safer and easier to reason about.
This commit adds test coverage for metric parsing. All tests have YAML
inline instead of saved in a file, as the file and directory reading logic
is outside the scope of the metric parser itself and the metric config spec
is simple enough to comfortably fit inside of each test function.

## Add tests for materialization config parsing

Second of three commits adding test coverage on core parsing logic.
This one covers all of the materialization object types, especially
the one object implementing custom string input parsing.

Also of note for materializations is the nested list construct for
the `rollups` attribute, which presents something of an edge case.

Please see the recent commit titled "Add tests for metric config parsing"
for more background on the reasoning behind this set of changes.

## Add tests for data source config parsing

Third of three, this adds test coverage for bare data source parsing
with various options enabled. There are no error states to check at
the moment because data source properties are all fairly simple.
Note this includes a base test for the metadata parsing for the measure
objects as well, since those are defined in the datasource and have
metadata propagated into them as part of that parsing process.

See commit titled "Add tests for metric config parsing" for more context
on this change.

## Add test for Metadata parsing from simple model files

A recent commit enabled Metadata parsing for model objects (see
PR #75), but the particulars of how the metadata was parsed into
the object were not tested. Since the metadata parsing itself is
currently handled by a custom extraction in the dir_to_model.py
module, we add some tests to ensure upcoming adjustments to the
parser keep the metadata parsing consistent with current behavior.

Note these tests provided detailed and limited scope coverage for
the specific case of parsing YAML files into the UserDefinedModel.
This is by design, as upcoming changes will be focused mainly
on internal parsing logic rather than expanding inputs. We can
broaden out the behavior of these tests if we ever allow for things
like YAML bytestream inputs in place of file paths for YAML file
locations.