### PR TITLE
Streamline YAML loading and parsing context construction

### DIFF
--- a/metricflow/model/objects/common.py
+++ b/metricflow/model/objects/common.py
@@ -50,7 +50,13 @@ class FileSlice(HashableBaseModel):  # noqa: D
     end_line_number: int
 
 
-class YamlConfigFile(HashableBaseModel):  # noqa: D
+class YamlConfigFile(HashableBaseModel):
+    """Serializable container for customer model YAML contents
+
+    The serialization support is included here for scenarios where persisting the contents in non-filesystem storage
+    services is necessary or desirable.
+    """
+
     filepath: str
     contents: str
     url: Optional[str]

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from string import Template
 from typing import Optional, Dict, List, Union, Type, Any
 
-import yaml
 from jsonschema import exceptions
 from yaml.scanner import ScannerError
 
@@ -26,7 +25,12 @@ from metricflow.model.parsing.validation import (
     MATERIALIZATION_TYPE,
     DOCUMENT_TYPES,
 )
-from metricflow.model.parsing.yaml_loader import ParsingContext, SafeLineLoader, PARSING_CONTEXT_KEY
+from metricflow.model.parsing.yaml_loader import (
+    ParsingContext,
+    SafeLineLoader,
+    YamlConfigLoader,
+    PARSING_CONTEXT_KEY,
+)
 from metricflow.model.validations.validator_helpers import ModelValidationResults
 
 logger = logging.getLogger(__name__)
@@ -140,7 +144,9 @@ def parse_config_yaml(
         # Validates that config yaml conforms to json schema
         validate_config_structure(config_yaml)
 
-        for config_document in yaml.load_all(config_yaml.contents, Loader=SafeLineLoader):
+        for config_document in YamlConfigLoader.load_all_with_context(
+            name=config_yaml.filepath, contents=config_yaml.contents
+        ):
             # The config document can be None if there is nothing but white space between two `---`
             # this isn't really an issue, so lets just swallow it
             if config_document is None:

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -198,14 +198,13 @@ def parse_config_yaml(
             # retrieve last top-level key as type
             document_type = next(iter(config_document.keys()))
             object_cfg = config_document[document_type]
-            yaml_contents_by_line = config_yaml.contents.splitlines()
 
             if document_type == METRIC_TYPE:
-                results.append(parse(metric_class, object_cfg, yaml_contents_by_line))
+                results.append(parse(metric_class, object_cfg))
             elif document_type == DATA_SOURCE_TYPE:
-                results.append(parse(data_source_class, object_cfg, yaml_contents_by_line))
+                results.append(parse(data_source_class, object_cfg))
             elif document_type == MATERIALIZATION_TYPE:
-                results.append(parse(materialization_class, object_cfg, yaml_contents_by_line))
+                results.append(parse(materialization_class, object_cfg))
             else:
                 errors.append(
                     str(
@@ -250,7 +249,6 @@ def parse_config_yaml(
 def parse(  # type: ignore[misc]
     _type: Type[Union[DataSource, Metric, Materialization]],
     yaml_dict: Dict[str, Any],
-    contents_by_line: List[str],
 ) -> Any:
     """Parses a model object from (jsonschema-validated) yaml into python object"""
 
@@ -261,7 +259,7 @@ def parse(  # type: ignore[misc]
         "repo_file_path": ctx.filename,
         "file_slice": {
             "filename": os.path.split(ctx.filename)[-1],
-            "content": "\n".join(contents_by_line[max(0, ctx.start_line - 1) : ctx.end_line]),
+            "content": ctx.content,
             "start_line_number": ctx.start_line,
             "end_line_number": ctx.end_line,
         },
@@ -275,10 +273,10 @@ def parse(  # type: ignore[misc]
                 if isinstance(yaml_dict[field_name], list):
                     objects = []
                     for obj in yaml_dict[field_name]:
-                        objects.append(parse(field_value.type_, obj, contents_by_line))  # type: ignore
+                        objects.append(parse(field_value.type_, obj))  # type: ignore
                     yaml_dict[field_name] = objects
                 else:
-                    yaml_dict[field_name] = parse(field_value.type_, yaml_dict[field_name], contents_by_line)  # type: ignore
+                    yaml_dict[field_name] = parse(field_value.type_, yaml_dict[field_name])  # type: ignore
             elif issubclass(field_value.type_, ParseableField):
                 if isinstance(yaml_dict[field_name], list):
                     objects = []

--- a/metricflow/model/parsing/validation.py
+++ b/metricflow/model/parsing/validation.py
@@ -1,10 +1,10 @@
 import logging
 
-import yaml
 from jsonschema import exceptions
 
 from metricflow.errors.errors import ParsingException
 from metricflow.model.objects.common import YamlConfigFile
+from metricflow.model.parsing.yaml_loader import YamlConfigLoader
 from metricflow.model.parsing.schemas_internal import (
     metric_validator,
     data_source_validator,
@@ -27,7 +27,7 @@ def validate_config_structure(config_yaml: YamlConfigFile) -> None:  # noqa: D
     we can get all the validation errors rather than just the first
     """
     errors = []
-    for config_document in yaml.load_all(config_yaml.contents, Loader=yaml.SafeLoader):
+    for config_document in YamlConfigLoader.load_all_without_context(config_yaml.contents):
         # The config document can be None if there is nothing but white space between two `---`
         # this isn't really an issue, so lets just swallow it
         if config_document is None:

--- a/metricflow/model/parsing/yaml_loader.py
+++ b/metricflow/model/parsing/yaml_loader.py
@@ -10,11 +10,27 @@ import yaml
 PARSING_CONTEXT_KEY = "__parsing_context__"
 
 
-class ParsingContext:  # noqa: D
-    def __init__(self, start_line: int, end_line: int, filename: str) -> None:  # noqa: D
+class ParsingContext:
+    """Container class for file slice information used to populate model metadata for certain objects"""
+
+    def __init__(self, start_line: int, end_line: int, filename: str, content_node: yaml.Node) -> None:
+        """Initializer for the ParsingContext class.
+
+        The contents are represented internally as a yaml.Node in order to allow for lazy serialization to
+        string representations.
+        """
         self.start_line = start_line
         self.end_line = end_line
         self.filename = filename
+        self._content_node = content_node
+
+    @property
+    def content(self) -> str:
+        """Serialized contents associated with the file slice represented by this ParsingContext object
+
+        This should only be called when a string representation of the contents are needed.
+        """
+        return yaml.serialize(node=self._content_node)
 
     def __str__(self) -> str:  # noqa: D
         return f"line: {self.start_line}, filename: {self.filename}"
@@ -56,10 +72,25 @@ class SafeLineLoader(yaml.SafeLoader):
     # which supports yaml1.2 and maintains round-trip parsing, for now we use
     # the more established road
     # https://stackoverflow.com/questions/55441300/how-can-i-get-the-parent-node-within-yaml-loader-add-contructor
-    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> Dict:  # noqa: D
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> Dict:
+        """Override of the construct_mapping method in the PyYAML SafeLoader class
+
+        This override exists in order to populate the parsing context object with file location
+        and raw YAML content information, which will be used to populate the Metadata model construct
+        for nodes which request it. The file identifier (node.start_mark.name) is derived from the
+        name property on the file-like object passed in as the stream parameter of the load_all call.
+        The line numbers are part of the start and end mark properties.
+
+        The content_node is a PyYAML node. We do not serialize it inside the loader because it's a full
+        serialization pass on whatever contents this particular mapping node might contain, which could
+        be the entire model collection. Rather, we store the node and serialize it on-demand later.
+
+        Note: PyYAML uses metaclasses quite heavily so construct_mapping is in fact defined in the
+        SafeConstructor class.
+        """
         mapping = super(SafeLineLoader, self).construct_mapping(node, deep=deep)
         mapping[PARSING_CONTEXT_KEY] = ParsingContext(
-            node.start_mark.line + 1, node.end_mark.line, node.start_mark.name
+            node.start_mark.line + 1, node.end_mark.line, node.start_mark.name, node
         )  # change to 1-indexed
 
         return mapping

--- a/metricflow/test/integration/configured_test_case.py
+++ b/metricflow/test/integration/configured_test_case.py
@@ -6,10 +6,8 @@ from collections import OrderedDict
 from enum import Enum
 from typing import Sequence, Tuple, Optional
 
-import yaml
-
 from metricflow.model.objects.utils import FrozenBaseModel
-from metricflow.model.parsing.yaml_loader import SafeLineLoader
+from metricflow.model.parsing.yaml_loader import YamlConfigLoader
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +99,7 @@ class ConfiguredIntegrationTestCaseRepository:
 
         with open(file_path) as f:
             file_contents = f.read()
-            for config_document in yaml.load_all(file_contents, Loader=SafeLineLoader):
+            for config_document in YamlConfigLoader.load_all_without_context(file_contents):
                 # The config document can be None if there is nothing but white space between two `---`
                 # this isn't really an issue, so lets just swallow it
                 if config_document is None:
@@ -111,7 +109,7 @@ class ConfiguredIntegrationTestCaseRepository:
                         f"Test query object YAML must be a dict. Got `{type(config_document)}`: {config_document}"
                     )
 
-                keys = tuple(x for x in config_document.keys() if x != "__parsing_context__")
+                keys = tuple(x for x in config_document.keys())
                 if len(keys) != 1:
                     raise TestCaseParseException(
                         f"Test case document should have one type of key, but this has {len(keys)}. "
@@ -123,7 +121,6 @@ class ConfiguredIntegrationTestCaseRepository:
                 object_cfg = config_document[document_type]
                 if document_type == DOCUMENT_KEY:
                     try:
-                        del object_cfg["__parsing_context__"]
                         results.append(ConfiguredIntegrationTestCase(**object_cfg, file_path=file_path))
                     except Exception as e:
                         raise TestCaseParseException(f"Error while parsing: {file_path}") from e

--- a/metricflow/test/model/parsing/test_data_source_parsing.py
+++ b/metricflow/test/model/parsing/test_data_source_parsing.py
@@ -59,6 +59,14 @@ def test_data_source_metadata_parsing() -> None:
     assert data_source.metadata is not None
     assert data_source.metadata.repo_file_path == "test_dir/inline_for_test"
     assert data_source.metadata.file_slice.filename == "inline_for_test"
+    expected_metadata_content = textwrap.dedent(
+        """\
+        name: metadata_test
+        mutability:
+          type: immutable
+        """
+    )
+    assert data_source.metadata.file_slice.content == expected_metadata_content
 
 
 def test_data_source_sql_table_parsing() -> None:
@@ -299,6 +307,14 @@ def test_data_source_measure_metadata_parsing() -> None:
     assert measure.metadata is not None
     assert measure.metadata.repo_file_path == "test_dir/inline_for_test"
     assert measure.metadata.file_slice.filename == "inline_for_test"
+    expected_metadata_content = textwrap.dedent(
+        """\
+      name: example_measure_with_metadata
+      agg: count_distinct
+      expr: example_input
+      """
+    )
+    assert measure.metadata.file_slice.content == expected_metadata_content
 
 
 def test_data_source_create_metric_measure_parsing() -> None:

--- a/metricflow/test/model/parsing/test_materialization_parsing.py
+++ b/metricflow/test/model/parsing/test_materialization_parsing.py
@@ -59,6 +59,17 @@ def test_materialization_metadata_parsing() -> None:
     assert materialization.metadata is not None
     assert materialization.metadata.repo_file_path == "test_dir/inline_for_test"
     assert materialization.metadata.file_slice.filename == "inline_for_test"
+    expected_metadata_content = textwrap.dedent(
+        """\
+        name: simple_materialization_test
+        metrics:
+        - some_metric
+        dimensions:
+        - some_dimension
+        - time_dimension
+        """
+    )
+    assert materialization.metadata.file_slice.content == expected_metadata_content
 
 
 def test_materialization_with_simple_destinations_parsing() -> None:

--- a/metricflow/test/model/parsing/test_metadata_parsing.py
+++ b/metricflow/test/model/parsing/test_metadata_parsing.py
@@ -110,3 +110,5 @@ def _assert_measure_metadata_is_valid(measures: Sequence[Measure]) -> None:
             f"Metadata: {measure.metadata}"
         )
         last_end_number = measure.metadata.file_slice.end_line_number
+        # if measure.name == "bookers":
+        #     raise ValueError(measure)

--- a/metricflow/test/model/parsing/test_metadata_parsing.py
+++ b/metricflow/test/model/parsing/test_metadata_parsing.py
@@ -110,5 +110,3 @@ def _assert_measure_metadata_is_valid(measures: Sequence[Measure]) -> None:
             f"Metadata: {measure.metadata}"
         )
         last_end_number = measure.metadata.file_slice.end_line_number
-        # if measure.name == "bookers":
-        #     raise ValueError(measure)

--- a/metricflow/test/model/parsing/test_metadata_parsing.py
+++ b/metricflow/test/model/parsing/test_metadata_parsing.py
@@ -1,3 +1,5 @@
+"""Tests for end to end object metadata parsing from the simple model YAML files"""
+
 import os
 from typing import Sequence
 
@@ -12,7 +14,7 @@ def test_data_source_metadata_parsing(simple_user_configured_model: UserConfigur
 
     This only tests some basic file name parsing for each data source since they are not guaranteed
     to be collected in the same file in the simple model, and the output here has been transformed
-    so the contents might or might not match.
+    so the YAML contents might or might not match.
     """
     assert len(simple_user_configured_model.data_sources) > 0
     for data_source in simple_user_configured_model.data_sources:
@@ -27,7 +29,7 @@ def test_metric_metadata_parsing(simple_user_configured_model: UserConfiguredMod
 
     This only tests some basic file name parsing for each metric since they are not guaranteed
     to be collected in the same file in the simple model, and the output here has been transformed
-    so the contents might or might not match.
+    so the YAML contents might or might not match.
     """
     assert len(simple_user_configured_model.metrics) > 0
     for metric in simple_user_configured_model.metrics:
@@ -42,7 +44,7 @@ def test_materialization_metadata_parsing(simple_user_configured_model: UserConf
 
     This only tests some basic file name parsing for each materialization since they are not guaranteed
     to be collected in the same file in the simple model, and the output here has been transformed
-    so the contents might or might not match.
+    so the YAML contents might or might not match.
     """
     assert len(simple_user_configured_model.materializations) > 0
     for materialization in simple_user_configured_model.materializations:
@@ -53,7 +55,13 @@ def test_materialization_metadata_parsing(simple_user_configured_model: UserConf
 
 
 def test_measure_metadata_parsing(simple_user_configured_model: UserConfiguredModel) -> None:
-    """Tests internal metadata object parsing from a file into the Measure model object"""
+    """Tests internal metadata object parsing from a file into the Measure model object
+
+    This tests the complete parsing process for Measure object metadata, including some baseline testing of things
+    like file line number extraction and propagation. As with other cases, no assertions are made on the
+    YAML contents themselves since they may change from the raw files into the UserConfiguredModel object we access
+    here.
+    """
     assert len(simple_user_configured_model.data_sources) > 0
     for data_source in simple_user_configured_model.data_sources:
         _assert_measure_metadata_is_valid(data_source.measures)

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -55,6 +55,16 @@ def test_metric_metadata_parsing() -> None:
     assert metric.metadata is not None
     assert metric.metadata.repo_file_path == "test_dir/inline_for_test"
     assert metric.metadata.file_slice.filename == "inline_for_test"
+    expected_metadata_content = textwrap.dedent(
+        """\
+        name: metadata_test
+        type: measure_proxy
+        type_params:
+          measures:
+          - metadata_test_measure
+        """
+    )
+    assert metric.metadata.file_slice.content == expected_metadata_content
 
 
 def test_ratio_metric_parsing() -> None:


### PR DESCRIPTION
Metricflow's YAML file loading uses two different loader types,
depending on whether we want file parsing context metadata included
in the payload or not. These were invoked via the one-line
yaml.load_all calls with the relevant parser (although sometimes we'd
use the wrong one and load context data in only to remove it later).

This causes problems with our context-aware parsing, because PyYAML
will only correctly populate the `name` field on its output nodes if
the input stream is a file-like object with the `name` property set
correctly. See the [relevant PyYAML source](https://github.com/yaml/pyyaml/blob/8cdff2c80573b8be8e8ad28929264a913a63aa33/lib/yaml/reader.py#L72-L85
) for details.

This PR streamlines the parser by centralizing our logic for converting 
an input string into a file-like object, and requesting the context-aware
loader when needed. 

We take advantage of this to streamline our context processing, making
both file name and input contents available through the ParsingContext
object instead of wiring them through custom callbacks.

This enables us to move onto Pydantic's parsing abstractions for 
things like populating the metadata field in a more re-usable manner.