### PR TITLE
Make mutability optional on configs

### DIFF
--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -61,7 +61,9 @@ class DataSource(HashableBaseModel, ModelWithMetadataParsing):
     measures: Sequence[Measure] = []
     dimensions: Sequence[Dimension] = []
 
-    mutability: Mutability
+    mutability: Mutability = Mutability(
+        type=MutabilityType.FULL_MUTATION, type_params=MutabilityTypeParams(update_cron="0 0,12 * * *")
+    )
 
     origin: DataSourceOrigin = DataSourceOrigin.SOURCE
     metadata: Optional[Metadata]

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -245,7 +245,7 @@ data_source_schema = {
         "constraint": {"$ref": "constraint_schema"},
     },
     "additionalProperties": False,
-    "required": ["name", "mutability"],
+    "required": ["name"],
 }
 
 derived_group_by_element_schema = {


### PR DESCRIPTION
## Context
We don't use mutability in the OSS, but we still require it in the model configs.

## Changes
- Make mutability a default to fully mutable unless stated otherwise