### PR TITLE
Add SQL Reserved Keyword Semantic Rule

### DIFF
--- a/metricflow/dataflow/sql_table.py
+++ b/metricflow/dataflow/sql_table.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Optional
+from typing import Any, Optional, Tuple, Union
 
 from metricflow.model.objects.base import FrozenBaseModel, PydanticCustomInputParser
 
@@ -49,3 +49,11 @@ class SqlTable(PydanticCustomInputParser, FrozenBaseModel):
         if self.db_name:
             return f"{self.db_name}.{self.schema_name}.{self.table_name}"
         return f"{self.schema_name}.{self.table_name}"
+
+    @property
+    def parts_tuple(self) -> Union[Tuple[str, str], Tuple[str, str, str]]:
+        """Return a tuple of the sql table parts"""
+        if self.db_name:
+            return (self.db_name, self.schema_name, self.table_name)
+        else:
+            return (self.schema_name, self.table_name)

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -19,6 +19,7 @@ from metricflow.model.validations.identifiers import (
 from metricflow.model.validations.materializations import ValidMaterializationRule
 from metricflow.model.validations.metrics import MetricMeasuresRule, CumulativeMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
+from metricflow.model.validations.reserved_keywords import ReservedKeywordsRule
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
 from metricflow.model.validations.validator_helpers import (
     ModelValidationResults,
@@ -48,6 +49,7 @@ class ModelValidator:
         UniqueAndValidNameRule(),
         ValidMaterializationRule(),
         AggregationTimeDimensionRule(),
+        ReservedKeywordsRule(),
     )
 
     def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES) -> None:

--- a/metricflow/model/validations/reserved_keywords.py
+++ b/metricflow/model/validations/reserved_keywords.py
@@ -1,0 +1,157 @@
+from typing import List
+from metricflow.instances import DataSourceElementReference
+
+
+from metricflow.model.objects.data_source import DataSource
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.validator_helpers import (
+    DataSourceContext,
+    DataSourceElementContext,
+    DataSourceElementType,
+    FileContext,
+    ModelValidationRule,
+    ValidationError,
+    ValidationIssueType,
+    validate_safely,
+)
+
+# A non-exaustive tuple of reserved keywords
+# This list was created by running an intersection of keywords for redshift,
+# postgres, bigquery, and snowflake
+RESERVED_KEYWORDS = (
+    "AND",
+    "AS",
+    "CREATE",
+    "DISTINCT",
+    "FOR",
+    "FROM",
+    "FULL",
+    "HAVING",
+    "IN",
+    "INNER",
+    "INTO",
+    "IS",
+    "JOIN",
+    "LEFT",
+    "LIKE",
+    "NATURAL",
+    "NOT",
+    "NULL",
+    "ON",
+    "OR",
+    "RIGHT",
+    "SELECT",
+    "UNION",
+    "USING",
+    "WHERE",
+    "WITH",
+)
+
+
+class ReservedKeywordsRule(ModelValidationRule):
+    """Check that any element that ends up being selected by name (instead of expr) isn't a commonly reserved keyword.
+
+    Note: This rule DOES NOT catch all keywords. That is because keywords are
+    engine specific, and semantic validations are not engine specific. I.e. if
+    you change your underlying data warehouse engine, semantic validations
+    should still pass, but your data warehouse validations might fail. However,
+    data warehouse validations are slow in comparison to semantic validation
+    rules. Thus this rule is intended to catch words that are reserved keywords
+    in all supported engines and to fail fast. E.g., `USER` is a reserved keyword
+    in Redshift but not in all other supported engines. Therefore if one is
+    using Redshift and sets a dimension name to `user`, the config would pass
+    this rule, but would then fail Data Warehouse Validations.
+    """
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking that data source sub element names aren't reserved sql keywords")
+    def _validate_data_source_sub_elements(data_source: DataSource) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+
+        for dimension in data_source.dimensions:
+            if dimension.name.upper() in RESERVED_KEYWORDS:
+                issues.append(
+                    ValidationError(
+                        context=DataSourceElementContext(
+                            file_context=FileContext.from_metadata(data_source.metadata),
+                            data_source_element=DataSourceElementReference(
+                                data_source_name=data_source.name, element_name=dimension.name
+                            ),
+                            element_type=DataSourceElementType.DIMENSION,
+                        ),
+                        message=f"'{dimension.name}' is an SQL reserved keyword, and thus cannot be used as a dimension 'name'.",
+                    )
+                )
+
+        for identifier in data_source.identifiers:
+            if identifier.is_composite:
+                msg = "'{name}' is an SQL reserved keyword, and thus cannot be used as a sub-identifier 'name'"
+                names = [sub_ident.name for sub_ident in identifier.identifiers if sub_ident.name is not None]
+            else:
+                msg = "'{name}' is an SQL reserved keyword, and thus cannot be used as an identifier 'name'"
+                names = [identifier.name]
+
+            for name in names:
+                if name.upper() in RESERVED_KEYWORDS:
+                    issues.append(
+                        ValidationError(
+                            context=DataSourceElementContext(
+                                file_context=FileContext.from_metadata(data_source.metadata),
+                                data_source_element=DataSourceElementReference(
+                                    data_source_name=data_source.name, element_name=identifier.name
+                                ),
+                                element_type=DataSourceElementType.IDENTIFIER,
+                            ),
+                            message=msg.format(name=name),
+                        )
+                    )
+
+        for measure in data_source.measures:
+            if measure.name.upper() in RESERVED_KEYWORDS:
+                issues.append(
+                    ValidationError(
+                        context=DataSourceElementContext(
+                            file_context=FileContext.from_metadata(data_source.metadata),
+                            data_source_element=DataSourceElementReference(
+                                data_source_name=data_source.name, element_name=measure.name
+                            ),
+                            element_type=DataSourceElementType.MEASURE,
+                        ),
+                        message=f"'{measure.name}' is an SQL reserved keyword, and thus cannot be used as an measure 'name'.",
+                    )
+                )
+
+        return issues
+
+    @classmethod
+    @validate_safely(whats_being_done="checking that data_source sql_tables are not sql reserved keywords")
+    def _validate_data_sources(cls, model: UserConfiguredModel) -> List[ValidationIssueType]:
+        """Checks names of objects that are not nested."""
+        issues: List[ValidationIssueType] = []
+        set_keywords = set(RESERVED_KEYWORDS)
+
+        for data_source in model.data_sources:
+            if data_source.sql_table is not None:
+                set_sql_table_path_parts = set([part.upper() for part in data_source.sql_table.split(".")])
+                keyword_intersection = set_keywords.intersection(set_sql_table_path_parts)
+
+                if len(keyword_intersection) > 0:
+                    issues.append(
+                        ValidationError(
+                            context=DataSourceContext(
+                                file_context=FileContext.from_metadata(data_source.metadata),
+                                data_source=data_source.reference,
+                            ),
+                            message=f"'{data_source.sql_table}' contains the SQL reserved keyword(s) {keyword_intersection}, and thus cannot be used for 'sql_table'.",
+                        )
+                    )
+            issues += cls._validate_data_source_sub_elements(data_source=data_source)
+
+        return issues
+
+    @classmethod
+    @validate_safely(
+        whats_being_done="running model validation ensuring elements that aren't selected via a defined expr don't contain reserved keywords"
+    )
+    def validate_model(cls, model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+        return cls._validate_data_sources(model=model)

--- a/metricflow/model/validations/reserved_keywords.py
+++ b/metricflow/model/validations/reserved_keywords.py
@@ -1,4 +1,5 @@
 from typing import List
+from metricflow.dataflow.sql_table import SqlTable
 from metricflow.instances import DataSourceElementReference
 
 
@@ -132,7 +133,9 @@ class ReservedKeywordsRule(ModelValidationRule):
 
         for data_source in model.data_sources:
             if data_source.sql_table is not None:
-                set_sql_table_path_parts = set([part.upper() for part in data_source.sql_table.split(".")])
+                set_sql_table_path_parts = set(
+                    [part.upper() for part in SqlTable.from_string(data_source.sql_table).parts_tuple]
+                )
                 keyword_intersection = set_keywords.intersection(set_sql_table_path_parts)
 
                 if len(keyword_intersection) > 0:

--- a/metricflow/test/model/validations/test_reserved_keywords.py
+++ b/metricflow/test/model/validations/test_reserved_keywords.py
@@ -1,0 +1,90 @@
+import copy
+import random
+from metricflow.model.objects.elements.identifier import CompositeSubIdentifier
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.reserved_keywords import RESERVED_KEYWORDS, ReservedKeywordsRule
+from metricflow.model.validations.validator_helpers import ValidationIssueLevel
+from metricflow.test.test_utils import find_data_source_with
+
+
+def random_keyword() -> str:  # noqa: D
+    return random.choice(RESERVED_KEYWORDS)
+
+
+def copied_model(simple_model__pre_transforms: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
+    return copy.deepcopy(simple_model__pre_transforms)
+
+
+def test_no_reserved_keywords(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+    issues = ReservedKeywordsRule.validate_model(simple_model__pre_transforms)
+    assert len(issues) == 0
+
+
+def test_reserved_keywords_in_sql_table(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+    model = copied_model(simple_model__pre_transforms)
+    (data_source_with_sql_table, _index) = find_data_source_with(
+        model=model, function=lambda data_source: data_source.sql_table is not None
+    )
+    data_source_with_sql_table.sql_table = f"{random_keyword()}.{random_keyword()}"
+
+    issues = ReservedKeywordsRule.validate_model(model)
+    assert len(issues) == 1
+    assert issues[0].level == ValidationIssueLevel.ERROR
+
+
+def test_reserved_keywords_in_dimensions(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+    model = copied_model(simple_model__pre_transforms)
+    (data_source, _index) = find_data_source_with(
+        model=model, function=lambda data_source: len(data_source.dimensions) > 0
+    )
+    dimension = data_source.dimensions[0]
+    dimension.name = random_keyword()
+
+    issues = ReservedKeywordsRule.validate_model(model)
+    assert len(issues) == 1
+    assert issues[0].level == ValidationIssueLevel.ERROR
+
+
+def test_reserved_keywords_in_measures(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+    model = copied_model(simple_model__pre_transforms)
+    (data_source, _index) = find_data_source_with(
+        model=model, function=lambda data_source: len(data_source.measures) > 0
+    )
+    measure = data_source.measures[0]
+    measure.name = random_keyword()
+
+    issues = ReservedKeywordsRule.validate_model(model)
+    assert len(issues) == 1
+    assert issues[0].level == ValidationIssueLevel.ERROR
+
+
+def test_reserved_keywords_in_identifiers(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+    model = copied_model(simple_model__pre_transforms)
+    (data_source, _index) = find_data_source_with(
+        model=model, function=lambda data_source: len(data_source.identifiers) > 0
+    )
+    identifier = data_source.identifiers[0]
+    identifier.name = random_keyword()
+    identifier.identifiers = []
+
+    issues = ReservedKeywordsRule.validate_model(model)
+    assert len(issues) == 1
+    assert issues[0].level == ValidationIssueLevel.ERROR
+
+
+def test_reserved_keywords_in_composite_identifiers(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+    model = copied_model(simple_model__pre_transforms)
+    (data_source, _index) = find_data_source_with(
+        model=model, function=lambda data_source: len(data_source.identifiers) > 0
+    )
+    identifier = data_source.identifiers[0]
+    identifier.identifiers = [
+        CompositeSubIdentifier(name=random_keyword()),  # should error
+        CompositeSubIdentifier(name=random_keyword()),  # should error
+        CompositeSubIdentifier(expr="SELECT TRUE AS col1"),  # shouldn't error
+    ]
+
+    issues = ReservedKeywordsRule.validate_model(model)
+    assert len(issues) == 2
+    assert issues[0].level == ValidationIssueLevel.ERROR
+    assert issues[1].level == ValidationIssueLevel.ERROR


### PR DESCRIPTION
This PR adds a rule which ensures when element `names` are used for sql generation (i.e. the element `expr` or `ref` aren't used) that they aren't SQL reserved keywords.

It should be known that this rule should not be a catch all. Data warehouse validations should catch these issues, but we currently don't have identifier and measure data warehouse validations (coming soon), and data warehouse validations are slow in comparison to semantic validation rules. Thus this rule is intended to catch words that are likely reserved keywords in all engines and to fail fast.