### PR TITLE
do not render an ALL TIME time constraint WHERE clause

### DIFF
--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -318,7 +318,12 @@ class MetricFlowQueryParser:
                 f"{time_constraint_start.isoformat()}"
             )
 
-        time_constraint = TimeRangeConstraint(start_time=time_constraint_start, end_time=time_constraint_end)
+        time_constraint: Optional[TimeRangeConstraint] = TimeRangeConstraint(
+            start_time=time_constraint_start, end_time=time_constraint_end
+        )
+        if time_constraint == TimeRangeConstraint.all_time():
+            # If the time constraint is all time, just ignore and not render
+            time_constraint = None
 
         requested_linkable_specs = self._parse_linkable_element_names(group_by_names, metric_specs)
         partial_time_dimension_spec_replacements = (


### PR DESCRIPTION
## Context
GIthub Issue: https://github.com/transform-data/metricflow/issues/10

Rendering the ALL TIME time range constraint is not important and clogs the output plans while providing not much input value.

## Changes
- Do not render a WHERE TimeConstraint if the time constraint ends up being the ALL TIME time range