### PR TITLE
Disallow metric_time as an element name

### DIFF
--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -5,8 +5,10 @@ import logging
 from metricflow.instances import (
     InstanceSet,
 )
+from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords
 from metricflow.specs import TimeDimensionReference, TimeDimensionSpec
 from metricflow.time.time_granularity import TimeGranularity
+
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ class DataSet:
         Or to put in another way, if metrics for those measures were plotted together on a graph, this is the name of
         the time dimension for the x-axis.
         """
-        return TimeDimensionReference(element_name="metric_time")
+        return TimeDimensionReference(element_name=MetricFlowReservedKeywords.METRIC_TIME.value)
 
     @staticmethod
     def metric_time_dimension_name() -> str:

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -36,7 +36,7 @@ from metricflow.time.time_granularity import TimeGranularity
 class MetricFlowReservedKeywords(enum.Enum):
     """Enumeration of reserved keywords with helper for accessing the reason they are reserved"""
 
-    METRIC_TIME = "METRIC_TIME"
+    METRIC_TIME = "metric_time"
 
     @staticmethod
     def get_reserved_reason(keyword: MetricFlowReservedKeywords) -> str:
@@ -82,8 +82,8 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     f"({TimeGranularity.list_names()})",
                 )
             )
-        if name.upper() in {reserved_name.value for reserved_name in MetricFlowReservedKeywords}:
-            reason = MetricFlowReservedKeywords.get_reserved_reason(MetricFlowReservedKeywords(name.upper()))
+        if name.lower() in {reserved_name.value for reserved_name in MetricFlowReservedKeywords}:
+            reason = MetricFlowReservedKeywords.get_reserved_reason(MetricFlowReservedKeywords(name.lower()))
             issues.append(
                 ValidationError(
                     context=context,

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import enum
 import re
 from typing import Dict, Tuple, List, Optional
 from metricflow.instances import (
@@ -24,8 +27,27 @@ from metricflow.model.validations.validator_helpers import (
     ValidationIssueType,
     validate_safely,
 )
+from metricflow.object_utils import assert_values_exhausted
 from metricflow.specs import ElementReference
 from metricflow.time.time_granularity import TimeGranularity
+
+
+@enum.unique
+class MetricFlowReservedKeywords(enum.Enum):
+    """Enumeration of reserved keywords with helper for accessing the reason they are reserved"""
+
+    METRIC_TIME = "METRIC_TIME"
+
+    @staticmethod
+    def get_reserved_reason(keyword: MetricFlowReservedKeywords) -> str:
+        """Get the reason a given keyword is reserved. Guarantees an exhaustive switch"""
+        if keyword is MetricFlowReservedKeywords.METRIC_TIME:
+            return (
+                "Used as the query input for creating time series metrics from measures with "
+                "different time dimension names."
+            )
+        else:
+            assert_values_exhausted(keyword)
 
 
 class UniqueAndValidNameRule(ModelValidationRule):
@@ -58,6 +80,14 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     context=context,
                     message=f"Invalid name `{name}` - names cannot match reserved time granularity keywords "
                     f"({TimeGranularity.list_names()})",
+                )
+            )
+        if name.upper() in {reserved_name.value for reserved_name in MetricFlowReservedKeywords}:
+            reason = MetricFlowReservedKeywords.get_reserved_reason(MetricFlowReservedKeywords(name.upper()))
+            issues.append(
+                ValidationError(
+                    context=context,
+                    message=f"Invalid name `{name}` - this name is reserved by MetricFlow. Reason: {reason}",
                 )
             )
         return issues

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -7,7 +7,7 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
+from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords, UniqueAndValidNameRule
 from metricflow.object_utils import flatten_nested_sequence
 from metricflow.test.test_utils import find_data_source_with
 
@@ -246,3 +246,16 @@ def test_invalid_names() -> None:  # noqa:D
     assert UniqueAndValidNameRule.check_valid_name("month") != []
     assert UniqueAndValidNameRule.check_valid_name("quarter") != []
     assert UniqueAndValidNameRule.check_valid_name("year") != []
+
+
+def test_reserved_name() -> None:  # noqa: D
+    reserved_keyword = MetricFlowReservedKeywords.METRIC_TIME
+    reserved_reason = MetricFlowReservedKeywords.get_reserved_reason(reserved_keyword)
+    issues = UniqueAndValidNameRule.check_valid_name(reserved_keyword.value.lower())
+    match = False
+    for issue in issues:
+        if issue.message.find(reserved_reason) != -1:
+            match = True
+    assert (
+        match
+    ), f"Did not find reason: '{reserved_reason}' in issues: {issues} for name: '{reserved_keyword.value.lower()}'"


### PR DESCRIPTION
With the advent of the metric_time query construct it has effectively
become a reserved keyword for Metricflow, as we cannot resolve queries
that are requesting `metric_time` if there is some other time dimension
also named `metric_time` in the user model.

This commit adds a general MetricFlowReservedKeywords enumeration and
adds a validation check to assert that none of the checked names
match a value in the enum.
