### PR TITLE
Add readme and other metadata info to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # Welcome to MetricFlow
 
+See our latest updates in the [Metricflow Changelog](CHANGELOG.md)!
+
 MetricFlow translates a simple metric definition into reusable SQL, and executes it against the SQL engine of your choice. This makes it easy to get consistent metric output broken down by attributes (dimensions) of interest.
 
 MetricFlow is a computational framework for building and maintaining consistent metric logic. The name comes from the approach taken to generate metrics. Using the user-defined semantic model, a query is first compiled into a metric dataflow plan. The plan is then converted to an abstract SQL object model, optimized, and rendered to engine-specific SQL.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
 name = "metricflow"
 version = "0.100.2"
-description = ""
+description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 authors = ["Transform <hello@transformdata.io>"]
+license = "AGPLv3+"
+readme = "README.md"
+homepage = "https://transform.co/metricflow"
+repository = "https://github.com/transform-data/metricflow"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.10"


### PR DESCRIPTION
Our pypi page is essentially blank, and it appears this is because
we have not filled out the pyproject.toml fields poetry requires
to push any of our useful information to pypi.

With other package managers it's possible to customize the pypi
description to render, e.g., a brief header followed by the
changelog. Poetry does not allow this, and instead requires a pointer
to a README.md or some other specific readme location/format combo,
so as a comprise the changelog is now linked from the top of the
README.md as well.
