### PR TITLE
Refactor data warehouse validations to use 'sql_query_plan_renderer'

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -743,7 +743,7 @@ def validate_configs(
 
     dw_results = ModelValidationResults()
     if not skip_dw:
-        dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client, mf_engine=cfg.mf)
+        dw_validator = DataWarehouseModelValidator(sql_client=cfg.sql_client, system_schema=cfg.mf_system_schema)
         dw_results = _data_warehouse_validations_runner(dw_validator=dw_validator, model=user_model, timeout=dw_timeout)
 
     merged_results = ModelValidationResults.merge([lint_results, build_result.issues, dw_results])

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
+from copy import deepcopy
 
 from dataclasses import dataclass, field
 from functools import partial
 from math import floor
 from time import perf_counter
 from typing import Callable, List, Optional, Tuple
+from metricflow.dataflow.builder.source_node import SourceNodeBuilder
+from metricflow.dataflow.dataflow_plan import BaseOutput, FilterElementsNode
+from metricflow.dataset.convert_data_source import DataSourceToDataSetConverter
+from metricflow.dataset.data_source_adapter import DataSourceDataSet
 
 from metricflow.dataset.dataset import DataSet
 from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowExplainResult, MetricFlowQueryRequest
 from metricflow.instances import DataSourceElementReference, DataSourceReference, MetricModelReference
 from metricflow.model.objects.data_source import DataSource
+from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.metric import Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.validations.validator_helpers import (
     DataSourceContext,
     DataSourceElementContext,
@@ -24,8 +31,40 @@ from metricflow.model.validations.validator_helpers import (
     ValidationIssue,
     ValidationWarning,
 )
+from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
+from metricflow.specs import DimensionSpec
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
+
+
+@dataclass
+class QueryRenderingTools:
+    """General tools that data warehosue validations use for rendering the validation queries
+
+    This is necessary for the validation steps that generate raw partial queries against the individual data sources
+    (e.g., selecting a single dimension column).
+    """
+
+    semantic_model: SemanticModel
+    source_node_builder: SourceNodeBuilder
+    converter: DataSourceToDataSetConverter
+    time_spine_source: TimeSpineSource
+    plan_converter: DataflowToSqlQueryPlanConverter
+
+    def __init__(self, model: UserConfiguredModel, system_schema: str) -> None:  # noqa: D
+        self.semantic_model = SemanticModel(user_configured_model=model)
+        self.source_node_builder = SourceNodeBuilder(semantic_model=self.semantic_model)
+        self.time_spine_source = TimeSpineSource(schema_name=system_schema)
+        self.converter = DataSourceToDataSetConverter(
+            column_association_resolver=DefaultColumnAssociationResolver(semantic_model=self.semantic_model)
+        )
+        self.plan_converter = DataflowToSqlQueryPlanConverter(
+            column_association_resolver=DefaultColumnAssociationResolver(self.semantic_model),
+            semantic_model=self.semantic_model,
+            time_spine_source=self.time_spine_source,
+        )
 
 
 @dataclass
@@ -41,75 +80,68 @@ class DataWarehouseValidationTask:
 class DataWarehouseTaskBuilder:
     """Task builder for standard data warehouse validation tasks"""
 
-    QUERY_TEMPLATE = "SELECT {columns_select} FROM {data_source} AS source{unique_id}"
-    WHERE_TEMPLATE = " WHERE {where_filters}"
-    PARTITION_COL_TEMPLATE = "{partition} IS NOT NULL"
-    WRAPPED_COL_TEMPLATE = "({column}) AS col{unique_id}"
-
     @staticmethod
-    def _wrap_col(col: str, id: int) -> str:  # noqa: D
-        return DataWarehouseTaskBuilder.WRAPPED_COL_TEMPLATE.format(column=col, unique_id=id)
-
-    @staticmethod
-    def _where_clause_from_partitions(data_source: DataSource) -> str:
-        """Takes the partitions for a data source and genrates a WHERE clause based on their definintions"""
-        if not data_source.partitions:
-            return ""
-
-        where_stmts: List[str] = []
-        for partition in data_source.partitions:
-            element = f"({partition.expr})" if partition.expr else partition.name
-            where_stmts.append(DataWarehouseTaskBuilder.PARTITION_COL_TEMPLATE.format(partition=element))
-        return DataWarehouseTaskBuilder.WHERE_TEMPLATE.format(where_filters=" AND ".join(where_stmts))
-
-    @staticmethod
-    def _gen_query(data_source: DataSource, id: int, columns: List[str] = ["true"]) -> str:
-        """Generates a basic sql query to select parts of them model definition
-
-        Generates a basic sql query for verifying the model's definition with
-        the data warehouse. For example if a data source with an sql_table
-        value of 'table1' and no partition was passed in no columns list the
-        query generated would be "SELECT (true) as col1 FROM table1 AS source0". If a the
-        data source had a partition, say on the dimension 'dim1' then the query
-        would be "SELECT (true) as col1 FROM table1 AS source0 WHERE dim1 IS NOT NULL".
-        And if in addition columns ["dim2", "dim3"] were passed in then the
-        query would be "SELECT (dim2) as col1, (dim3) as col2 FROM table1 AS source0 WHERE
-        dim1 IS NOT NULL".
-
-        Args:
-            data_source: The data source to generate the query for
-            id: A unique id used to alias the table reference
-            columns: Column strings to select
-        Returns:
-            A string representing the query for the passed in arguments.
-        """
-        data_source_str = data_source.sql_table if data_source.sql_table else f"({data_source.sql_query})"
-
-        wrapped_cols = [DataWarehouseTaskBuilder._wrap_col(col, index) for index, col in enumerate(columns)]
-        columns_select = ", ".join(wrapped_cols)
-
-        query = DataWarehouseTaskBuilder.QUERY_TEMPLATE.format(
-            data_source=data_source_str, columns_select=columns_select, unique_id=id
+    def _data_source_node(render_tools: QueryRenderingTools, data_source: DataSource) -> BaseOutput[DataSourceDataSet]:
+        """Builds and returns the DataSourceDataSet node for the given data source"""
+        data_source_semantics = render_tools.semantic_model.data_source_semantics.get_by_reference(
+            DataSourceReference(data_source_name=data_source.name)
         )
-        query += DataWarehouseTaskBuilder._where_clause_from_partitions(data_source=data_source)
-        return query
+        assert data_source_semantics
+
+        source_nodes = render_tools.source_node_builder.create_from_data_sets(
+            (render_tools.converter.create_sql_source_data_set(data_source_semantics),)
+        )
+
+        assert len(source_nodes) == 1
+        return source_nodes[0]
+
+    @staticmethod
+    def renderize(
+        sql_client: SqlClient, plan_converter: DataflowToSqlQueryPlanConverter, plan_id: str, nodes: FilterElementsNode
+    ):
+        """Generates a sql query plan and returns the rendered sql and execution_parameters"""
+        sql_plan = plan_converter.convert_to_sql_query_plan(
+            sql_engine_attributes=sql_client.sql_engine_attributes,
+            sql_query_plan_id=plan_id,
+            dataflow_plan_node=nodes,
+        )
+
+        rendered_plan = sql_client.sql_engine_attributes.sql_query_plan_renderer.render_sql_query_plan(sql_plan)
+        return (rendered_plan.sql, rendered_plan.execution_parameters)
 
     @classmethod
-    def _gen_query_and_params(
-        cls, data_source: DataSource, id: int, columns: List[str] = ["true"]
-    ) -> Tuple[str, SqlBindParameters]:
-        """A wrapping function for _gen_query which also returns an empty set of SqlBindParameters"""
-        query = cls._gen_query(data_source=data_source, id=id, columns=columns)
-        return (query, SqlBindParameters())
-
-    @classmethod
-    def gen_data_source_tasks(cls, model: UserConfiguredModel) -> List[DataWarehouseValidationTask]:
+    def gen_data_source_tasks(
+        cls, model: UserConfiguredModel, sql_client: SqlClient, system_schema: str
+    ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the data sources of the model"""
+
+        # we need a dimension to query that we know exists (i.e. the dimension
+        # is guaranteed to not cause a problem) on each data source.
+        # Additionally, we don't want to modify the original model, so we
+        # first make a deep copy of it
+        model = deepcopy(model)
+        for data_source in model.data_sources:
+            data_source.dimensions = list(data_source.dimensions) + [
+                Dimension(name=f"validation_dim_for_{data_source.name}", type=DimensionType.CATEGORICAL, expr="1")
+            ]
+
+        render_tools = QueryRenderingTools(model=model, system_schema=system_schema)
+
         tasks: List[DataWarehouseValidationTask] = []
-        for index, data_source in enumerate(model.data_sources):
+        for data_source in model.data_sources:
+            source_node = cls._data_source_node(render_tools=render_tools, data_source=data_source)
+            spec = DimensionSpec.from_name(name=f"validation_dim_for_{data_source.name}")
+            filter_elements_node = FilterElementsNode(parent_node=source_node, include_specs=[spec])
+
             tasks.append(
                 DataWarehouseValidationTask(
-                    query_and_params_callable=partial(cls._gen_query_and_params, data_source=data_source, id=index),
+                    query_and_params_callable=partial(
+                        cls.renderize,
+                        sql_client=sql_client,
+                        plan_converter=render_tools.plan_converter,
+                        plan_id=f"{data_source.name}_validation",
+                        nodes=filter_elements_node,
+                    ),
                     context=DataSourceContext(
                         file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source=DataSourceReference(data_source_name=data_source.name),
@@ -117,10 +149,13 @@ class DataWarehouseTaskBuilder:
                     error_message=f"Unable to access data source `{data_source.name}` in data warehouse",
                 )
             )
+
         return tasks
 
     @classmethod
-    def gen_dimension_tasks(cls, model: UserConfiguredModel) -> List[DataWarehouseValidationTask]:
+    def gen_dimension_tasks(
+        cls, model: UserConfiguredModel, sql_client: SqlClient, system_schema: str
+    ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the dimensions of the model
 
         The high level tasks returned are "short cut" queries which try to
@@ -130,44 +165,58 @@ class DataWarehouseTaskBuilder:
         on the data source to identify which have issues.
         """
 
-        tasks: List[DataWarehouseValidationTask] = []
-        for index, data_source in enumerate(model.data_sources):
-            # generate the subtasks
-            data_source_tasks: List[DataWarehouseValidationTask] = []
-            data_source_columns: List[str] = []
-            for dimension in data_source.dimensions:
-                dim_to_query = dimension.expr if dimension.expr is not None else dimension.name
-                data_source_columns.append(dim_to_query)
+        render_tools = QueryRenderingTools(model=model, system_schema=system_schema)
 
-                data_source_tasks.append(
+        tasks: List[DataWarehouseValidationTask] = []
+        for data_source in model.data_sources:
+            if not data_source.dimensions:
+                continue
+
+            source_node = cls._data_source_node(render_tools=render_tools, data_source=data_source)
+
+            data_source_sub_tasks: List[DataWarehouseValidationTask] = []
+            dataset = render_tools.converter.create_sql_source_data_set(data_source)
+            data_source_specs = (
+                dataset.instance_set.spec_set.dimension_specs + dataset.instance_set.spec_set.time_dimension_specs
+            )
+            for spec in data_source_specs:
+                filter_elements_node = FilterElementsNode(parent_node=source_node, include_specs=[spec])
+                data_source_sub_tasks.append(
                     DataWarehouseValidationTask(
                         query_and_params_callable=partial(
-                            cls._gen_query_and_params, data_source=data_source, id=index, columns=[dim_to_query]
+                            cls.renderize,
+                            sql_client=sql_client,
+                            plan_converter=render_tools.plan_converter,
+                            plan_id=f"{data_source.name}_dim_{spec.element_name}_validation",
+                            nodes=filter_elements_node,
                         ),
                         context=DataSourceElementContext(
                             file_context=FileContext.from_metadata(metadata=data_source.metadata),
                             data_source_element=DataSourceElementReference(
-                                data_source_name=data_source.name, element_name=dimension.name
+                                data_source_name=data_source.name, element_name=spec.element_name
                             ),
                             element_type=DataSourceElementType.DIMENSION,
                         ),
-                        error_message=f"Unable to query `{dim_to_query}` in data warehouse for dimension "
-                        f"`{dimension.name}` on data source `{data_source.name}`.",
+                        error_message=f"Unable to query dimension `{spec.element_name}` on data source `{data_source.name}` in data warehouse",
                     )
                 )
 
-            # generate the shortcut tasks with sub tasks
+            filter_elements_node = FilterElementsNode(parent_node=source_node, include_specs=data_source_specs)
             tasks.append(
                 DataWarehouseValidationTask(
                     query_and_params_callable=partial(
-                        cls._gen_query_and_params, data_source=data_source, id=index, columns=data_source_columns
+                        cls.renderize,
+                        sql_client=sql_client,
+                        plan_converter=render_tools.plan_converter,
+                        plan_id=f"{data_source.name}_all_dimensions_validation",
+                        nodes=filter_elements_node,
                     ),
                     context=DataSourceContext(
                         file_context=FileContext.from_metadata(metadata=data_source.metadata),
                         data_source=DataSourceReference(data_source_name=data_source.name),
                     ),
                     error_message=f"Failed to query dimensions in data warehouse for data source `{data_source.name}`",
-                    on_fail_subtasks=data_source_tasks,
+                    on_fail_subtasks=data_source_sub_tasks,
                 )
             )
         return tasks
@@ -184,9 +233,14 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_metric_tasks(
-        cls, model: UserConfiguredModel, mf_engine: MetricFlowEngine
+        cls, model: UserConfiguredModel, sql_client: SqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the metrics of the model"""
+        mf_engine = MetricFlowEngine(
+            semantic_model=SemanticModel(user_configured_model=model),
+            sql_client=sql_client,
+            system_schema=system_schema,
+        )
         tasks: List[DataWarehouseValidationTask] = []
         for metric in model.metrics:
             tasks.append(
@@ -215,9 +269,9 @@ class DataWarehouseModelValidator:
     them (assuming the model has passed these validations before use).
     """
 
-    def __init__(self, sql_client: SqlClient, mf_engine: MetricFlowEngine) -> None:  # noqa: D
+    def __init__(self, sql_client: SqlClient, system_schema: str) -> None:  # noqa: D
         self._sql_client = sql_client
-        self._mf_engine = mf_engine
+        self._sql_schema = system_schema
 
     def run_tasks(
         self, tasks: List[DataWarehouseValidationTask], timeout: Optional[int] = None
@@ -274,7 +328,9 @@ class DataWarehouseModelValidator:
         Returns:
             A list of validation issues discovered when running the passed in tasks against the data warehosue
         """
-        tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(model=model)
+        tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(
+            model=model, sql_client=self._sql_client, system_schema=self._sql_schema
+        )
         return self.run_tasks(tasks=tasks, timeout=timeout)
 
     def validate_dimensions(self, model: UserConfiguredModel, timeout: Optional[int] = None) -> ModelValidationResults:
@@ -287,7 +343,9 @@ class DataWarehouseModelValidator:
         Returns:
             A list of validation issues. If there are no validation issues, an empty list is returned.
         """
-        tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(model=model)
+        tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
+            model=model, sql_client=self._sql_client, system_schema=self._sql_schema
+        )
         return self.run_tasks(tasks=tasks, timeout=timeout)
 
     def validate_metrics(self, model: UserConfiguredModel, timeout: Optional[int] = None) -> ModelValidationResults:
@@ -301,5 +359,7 @@ class DataWarehouseModelValidator:
             A list of validation issues. If there are no validation issues, an empty list is returned.
         """
 
-        tasks = DataWarehouseTaskBuilder.gen_metric_tasks(model=model, mf_engine=self._mf_engine)
+        tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
+            model=model, sql_client=self._sql_client, system_schema=self._sql_schema
+        )
         return self.run_tasks(tasks=tasks, timeout=timeout)

--- a/metricflow/test/model/validations/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/validations/test_data_warehouse_tasks.py
@@ -1,10 +1,8 @@
 from copy import deepcopy
 from typing import Tuple
 
-import pytest
 from _pytest.fixtures import FixtureRequest
 
-from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.model.data_warehouse_model_validator import (
     DataWarehouseModelValidator,
     DataWarehouseTaskBuilder,
@@ -15,51 +13,30 @@ from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.elements.measure import AggregationType, Measure
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.model.semantic_model import SemanticModel
-from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
-from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta
 from metricflow.test.plan_utils import assert_snapshot_text_equal, make_schema_replacement_function
-from metricflow.test.test_utils import as_datetime
-from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
-
-
-@pytest.fixture(scope="module")
-def mf_engine(  # noqa: D
-    data_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
-    time_spine_source: TimeSpineSource,
-    mf_test_session_state: MetricFlowTestSessionState,
-) -> MetricFlowEngine:
-    semantic_model = SemanticModel(data_warehouse_validation_model)
-    return MetricFlowEngine(
-        semantic_model=semantic_model,
-        sql_client=sql_client,
-        column_association_resolver=DefaultColumnAssociationResolver(semantic_model=semantic_model),
-        time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
-        time_spine_source=time_spine_source,
-        system_schema=mf_test_session_state.mf_system_schema,
-    )
 
 
 def test_build_data_source_tasks(
-    mf_test_session_state: MetricFlowTestSessionState, data_warehouse_validation_model: UserConfiguredModel
+    mf_test_session_state: MetricFlowTestSessionState,
+    data_warehouse_validation_model: UserConfiguredModel,
+    sql_client: SqlClient,
 ) -> None:  # noqa:D
-    tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(model=data_warehouse_validation_model)
-    assert len(tasks) == len(data_warehouse_validation_model.data_sources)
-    (query_string, _params) = tasks[0].query_and_params_callable()
-    assert (
-        query_string
-        == f"SELECT (true) AS col0 FROM (SELECT * FROM {mf_test_session_state.mf_source_schema}.fct_animals) AS source0 "
-        f"WHERE is_dog IS NOT NULL"
+    tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(
+        model=data_warehouse_validation_model,
+        sql_client=sql_client,
+        system_schema=mf_test_session_state.mf_system_schema,
     )
+    assert len(tasks) == len(data_warehouse_validation_model.data_sources)
 
 
-def test_task_runner(sql_client: SqlClient, mf_engine: MetricFlowEngine) -> None:  # noqa: D
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=mf_engine)
+def test_task_runner(sql_client: SqlClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
+    dw_validator = DataWarehouseModelValidator(
+        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+    )
 
     def good_query() -> Tuple[str, SqlBindParameters]:
         return ("SELECT 'foo' AS foo", SqlBindParameters())
@@ -88,11 +65,13 @@ def test_validate_data_sources(  # noqa: D
     data_warehouse_validation_model: UserConfiguredModel,
     create_data_warehouse_validation_model_tables: bool,
     sql_client: SqlClient,
-    mf_engine: MetricFlowEngine,
+    mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(data_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=mf_engine)
+    dw_validator = DataWarehouseModelValidator(
+        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+    )
 
     issues = dw_validator.validate_data_sources(model)
     assert len(issues.all_issues) == 0
@@ -100,7 +79,7 @@ def test_validate_data_sources(  # noqa: D
     model.data_sources.append(
         data_source_with_guaranteed_meta(
             name="test_data_source2",
-            sql_table="doesnt_exist",
+            sql_table="doesnt.exist",
             dimensions=[],
             mutability=Mutability(type=MutabilityType.IMMUTABLE),
         )
@@ -113,34 +92,31 @@ def test_validate_data_sources(  # noqa: D
 
 
 def test_build_dimension_tasks(  # noqa: D
-    data_warehouse_validation_model: UserConfiguredModel, mf_test_session_state: MetricFlowTestSessionState
+    data_warehouse_validation_model: UserConfiguredModel,
+    sql_client: SqlClient,
+    mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
-    tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(model=data_warehouse_validation_model)
-    assert len(tasks) == 1  # on data source query with all dimensions
-    assert len(tasks[0].on_fail_subtasks) == 2  # a sub task for each dimension on the data source
-    (query_string, _params) = tasks[0].query_and_params_callable()
-    assert (
-        f"SELECT (ds) AS col0, (is_dog) AS col1 FROM (SELECT * FROM {mf_test_session_state.mf_source_schema}.fct_animals) AS source0 WHERE is_dog IS NOT NULL"
-        == query_string
+    tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
+        model=data_warehouse_validation_model,
+        sql_client=sql_client,
+        system_schema=mf_test_session_state.mf_system_schema,
     )
-    (query_string, _params) = tasks[0].on_fail_subtasks[0].query_and_params_callable()
-    assert (
-        f"SELECT (ds) AS col0 FROM (SELECT * FROM {mf_test_session_state.mf_source_schema}.fct_animals) AS source0 WHERE is_dog IS NOT NULL"
-        == query_string
-    )
-    (query_string, _params) = tasks[0].on_fail_subtasks[1].query_and_params_callable()
-    assert (
-        f"SELECT (is_dog) AS col0 FROM (SELECT * FROM {mf_test_session_state.mf_source_schema}.fct_animals) AS source0 WHERE is_dog IS NOT NULL"
-        == query_string
-    )
+    # on data source query with all dimensions
+    assert len(tasks) == 1
+    # 1 categorical dimension task, 1 time dimension task, 4 granularity based time dimension tasks
+    assert len(tasks[0].on_fail_subtasks) == 6
 
 
 def test_validate_dimensions(  # noqa: D
-    data_warehouse_validation_model: UserConfiguredModel, sql_client: SqlClient, mf_engine: MetricFlowEngine
+    data_warehouse_validation_model: UserConfiguredModel,
+    sql_client: SqlClient,
+    mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(data_warehouse_validation_model)
 
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=mf_engine)
+    dw_validator = DataWarehouseModelValidator(
+        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+    )
 
     issues = dw_validator.validate_dimensions(model)
     assert len(issues.all_issues) == 0
@@ -152,26 +128,20 @@ def test_validate_dimensions(  # noqa: D
     issues = dw_validator.validate_dimensions(model)
     # One isssue is created for the short circuit query failure, and another is
     # created for the sub task checking the specific dimension
-    print("\nModelValidationResults", issues)
     assert len(issues.all_issues) == 2
-    assert (
-        f"Failed to query dimensions in data warehouse for data source `{model.data_sources[0].name}`"
-        in issues.all_issues[0].message
-    )
-    assert (
-        f"Unable to query `doesnt_exist` in data warehouse for dimension `doesnt_exist` on data source `{model.data_sources[0].name}`"
-        in issues.all_issues[1].message
-    )
 
 
 def test_build_metric_tasks(  # noqa: D
     request: FixtureRequest,
     data_warehouse_validation_model: UserConfiguredModel,
     sql_client: SqlClient,
-    mf_engine: MetricFlowEngine,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
-    tasks = DataWarehouseTaskBuilder.gen_metric_tasks(model=data_warehouse_validation_model, mf_engine=mf_engine)
+    tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
+        model=data_warehouse_validation_model,
+        system_schema=mf_test_session_state.mf_system_schema,
+        sql_client=sql_client,
+    )
     assert len(tasks) == 1
     (query_string, _params) = tasks[0].query_and_params_callable()
     assert_snapshot_text_equal(
@@ -191,12 +161,12 @@ def test_build_metric_tasks(  # noqa: D
 def test_validate_metrics(  # noqa: D
     data_warehouse_validation_model: UserConfiguredModel,
     sql_client: SqlClient,
-    mf_engine: MetricFlowEngine,
-    time_spine_source: TimeSpineSource,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(data_warehouse_validation_model)
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=mf_engine)
+    dw_validator = DataWarehouseModelValidator(
+        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+    )
 
     issues = dw_validator.validate_metrics(model)
     assert len(issues.all_issues) == 0
@@ -216,19 +186,10 @@ def test_validate_metrics(  # noqa: D
     model = ModelTransformer.pre_validation_transform_model(model)
     model = ModelTransformer.post_validation_transform_model(model)
 
-    # Get new metric flow engine which has the context of the updated model
-    semantic_model = SemanticModel(model)
-    new_engine = MetricFlowEngine(
-        semantic_model=semantic_model,
-        sql_client=sql_client,
-        column_association_resolver=DefaultColumnAssociationResolver(semantic_model=semantic_model),
-        time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
-        time_spine_source=time_spine_source,
-        system_schema=mf_test_session_state.mf_system_schema,
-    )
-
     # Validate new metric created by proxy causes an issue (because the column used doesn't exist)
-    dw_validator = DataWarehouseModelValidator(sql_client=sql_client, mf_engine=new_engine)
+    dw_validator = DataWarehouseModelValidator(
+        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+    )
     issues = dw_validator.validate_metrics(model)
     assert len(issues.all_issues) == 1
     assert len(issues.errors) == 1


### PR DESCRIPTION
This change is two fold. First generating queries for measures and identifiers is fair bit harder than the queries we'd been generating for data_sources and dimensions, which was going to increase the complexity of the task builder greatly. So we wanted to begin using the tools the rest of MetricFlow uses for generating queries, no need to reinvent the wheel. Additionally, by using the `sql_query_plan_renderer` we ensure validation queries are similar to what MetricFlow would render using the same elements.

**TLDR**: This makes future work on data warehouse validations easier and makes validations consistent with the rest of MetricFlow.