### PR TITLE
Followup: Reorder fields 

### DIFF
--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/BigQuerySqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/BigQuerySqlClient/test_build_metric_tasks__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(count_dogs) AS count_dogs
-  , metric_time
+  metric_time
+  , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/DuckDbSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/DuckDbSqlClient/test_build_metric_tasks__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(count_dogs) AS count_dogs
-  , metric_time
+  metric_time
+  , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/PostgresSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/PostgresSqlClient/test_build_metric_tasks__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(count_dogs) AS count_dogs
-  , metric_time
+  metric_time
+  , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/RedshiftSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/RedshiftSqlClient/test_build_metric_tasks__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(count_dogs) AS count_dogs
-  , metric_time
+  metric_time
+  , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/SnowflakeSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/SnowflakeSqlClient/test_build_metric_tasks__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(count_dogs) AS count_dogs
-  , metric_time
+  metric_time
+  , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,18 +5,18 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     subq_12.bookings AS bookings                                                          -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
         <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
         <!--     , subq_14.booking_value AS booking_value                                              -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                  -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(bookings) AS bookings                                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -39,9 +39,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(instant_bookings) AS instant_bookings                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -74,9 +74,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(booking_value) AS booking_value                                                 -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(booking_value) AS booking_value                                               -->
         <!--     FROM (                                                                                -->
         <!--       -- User Defined SQL Query                                                           -->
         <!--       SELECT * FROM ***************************.fct_bookings                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_joined_plan__ep_0.xml
@@ -9,9 +9,9 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     SUM(subq_2.bookings) AS bookings                                           -->
-        <!--     , subq_2.is_instant AS is_instant                                          -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10003.country AS listing__country_latest             -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
         <!--     -- Metric Time Dimension 'ds'                                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,8 +9,8 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     SUM(account_month_txns_src_10009.txn_count) AS txn_count                             -->
-        <!--     , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name        -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     , SUM(account_month_txns_src_10009.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10009       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
         <!--     -- Join Standard Outputs                                                             -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,52 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     subq_8.bookings AS bookings                                     -->
-        <!--     , subq_9.booking_value AS booking_value                         -->
-        <!--     , COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(bookings) AS bookings                                     -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10000                                   -->
-        <!--     ) subq_2                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_8                                                          -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(booking_value) AS booking_value                           -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10000                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_9                                                          -->
-        <!--   ON                                                                -->
-        <!--     subq_8.is_instant = subq_9.is_instant                           -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10000                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10000                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,18 +5,18 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     subq_12.bookings AS bookings                                                          -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
         <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
         <!--     , subq_14.booking_value AS booking_value                                              -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                  -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(bookings) AS bookings                                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -39,9 +39,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(instant_bookings) AS instant_bookings                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -74,9 +74,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(booking_value) AS booking_value                                                 -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(booking_value) AS booking_value                                               -->
         <!--     FROM (                                                                                -->
         <!--       -- User Defined SQL Query                                                           -->
         <!--       SELECT * FROM ***************************.fct_bookings                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_joined_plan__ep_0.xml
@@ -9,9 +9,9 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     SUM(subq_2.bookings) AS bookings                                           -->
-        <!--     , subq_2.is_instant AS is_instant                                          -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10003.country AS listing__country_latest             -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
         <!--     -- Metric Time Dimension 'ds'                                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,8 +9,8 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     SUM(account_month_txns_src_10009.txn_count) AS txn_count                             -->
-        <!--     , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name        -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     , SUM(account_month_txns_src_10009.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10009       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
         <!--     -- Join Standard Outputs                                                             -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,52 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     subq_8.bookings AS bookings                                     -->
-        <!--     , subq_9.booking_value AS booking_value                         -->
-        <!--     , COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(bookings) AS bookings                                     -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10000                                   -->
-        <!--     ) subq_2                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_8                                                          -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(booking_value) AS booking_value                           -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10000                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_9                                                          -->
-        <!--   ON                                                                -->
-        <!--     subq_8.is_instant = subq_9.is_instant                           -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10000                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10000                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,18 +5,18 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     subq_12.bookings AS bookings                                                          -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
         <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
         <!--     , subq_14.booking_value AS booking_value                                              -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                  -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(bookings) AS bookings                                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -39,9 +39,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(instant_bookings) AS instant_bookings                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -74,9 +74,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(booking_value) AS booking_value                                                 -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(booking_value) AS booking_value                                               -->
         <!--     FROM (                                                                                -->
         <!--       -- User Defined SQL Query                                                           -->
         <!--       SELECT * FROM ***************************.fct_bookings                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_joined_plan__ep_0.xml
@@ -9,9 +9,9 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     SUM(subq_2.bookings) AS bookings                                           -->
-        <!--     , subq_2.is_instant AS is_instant                                          -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10003.country AS listing__country_latest             -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
         <!--     -- Metric Time Dimension 'ds'                                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,8 +9,8 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     SUM(account_month_txns_src_10009.txn_count) AS txn_count                             -->
-        <!--     , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name        -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     , SUM(account_month_txns_src_10009.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10009       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
         <!--     -- Join Standard Outputs                                                             -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,52 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     subq_8.bookings AS bookings                                     -->
-        <!--     , subq_9.booking_value AS booking_value                         -->
-        <!--     , COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(bookings) AS bookings                                     -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10000                                   -->
-        <!--     ) subq_2                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_8                                                          -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(booking_value) AS booking_value                           -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10000                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_9                                                          -->
-        <!--   ON                                                                -->
-        <!--     subq_8.is_instant = subq_9.is_instant                           -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10000                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10000                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,18 +5,18 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     subq_12.bookings AS bookings                                                          -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
         <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
         <!--     , subq_14.booking_value AS booking_value                                              -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                  -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(bookings) AS bookings                                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -39,9 +39,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(instant_bookings) AS instant_bookings                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -74,9 +74,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(booking_value) AS booking_value                                                 -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(booking_value) AS booking_value                                               -->
         <!--     FROM (                                                                                -->
         <!--       -- User Defined SQL Query                                                           -->
         <!--       SELECT * FROM ***************************.fct_bookings                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_joined_plan__ep_0.xml
@@ -9,9 +9,9 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     SUM(subq_2.bookings) AS bookings                                           -->
-        <!--     , subq_2.is_instant AS is_instant                                          -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10003.country AS listing__country_latest             -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
         <!--     -- Metric Time Dimension 'ds'                                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,8 +9,8 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     SUM(account_month_txns_src_10009.txn_count) AS txn_count                             -->
-        <!--     , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name        -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     , SUM(account_month_txns_src_10009.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10009       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
         <!--     -- Join Standard Outputs                                                             -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,52 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     subq_8.bookings AS bookings                                     -->
-        <!--     , subq_9.booking_value AS booking_value                         -->
-        <!--     , COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(bookings) AS bookings                                     -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10000                                   -->
-        <!--     ) subq_2                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_8                                                          -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(booking_value) AS booking_value                           -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10000                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_9                                                          -->
-        <!--   ON                                                                -->
-        <!--     subq_8.is_instant = subq_9.is_instant                           -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10000                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10000                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,18 +5,18 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     subq_12.bookings AS bookings                                                          -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
         <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
         <!--     , subq_14.booking_value AS booking_value                                              -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                  -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(bookings) AS bookings                                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -39,9 +39,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(instant_bookings) AS instant_bookings                                           -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
@@ -74,9 +74,9 @@
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
         <!--     SELECT                                                                                -->
-        <!--       SUM(booking_value) AS booking_value                                                 -->
-        <!--       , ds                                                                                -->
+        <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
+        <!--       , SUM(booking_value) AS booking_value                                               -->
         <!--     FROM (                                                                                -->
         <!--       -- User Defined SQL Query                                                           -->
         <!--       SELECT * FROM ***************************.fct_bookings                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_joined_plan__ep_0.xml
@@ -9,9 +9,9 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     SUM(subq_2.bookings) AS bookings                                           -->
-        <!--     , subq_2.is_instant AS is_instant                                          -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10003.country AS listing__country_latest             -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
         <!--     -- Metric Time Dimension 'ds'                                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,8 +9,8 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     SUM(account_month_txns_src_10009.txn_count) AS txn_count                             -->
-        <!--     , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name        -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     , SUM(account_month_txns_src_10009.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10009       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
         <!--     -- Join Standard Outputs                                                             -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,52 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     subq_8.bookings AS bookings                                     -->
-        <!--     , subq_9.booking_value AS booking_value                         -->
-        <!--     , COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(bookings) AS bookings                                     -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10000                                   -->
-        <!--     ) subq_2                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_8                                                          -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       SUM(booking_value) AS booking_value                           -->
-        <!--       , is_instant                                                  -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10000                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_9                                                          -->
-        <!--   ON                                                                -->
-        <!--     subq_8.is_instant = subq_9.is_instant                           -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10000                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10000                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.messages
-  , subq_3.user_team___team_id
+  subq_3.user_team___team_id
   , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0_optimized.sql
@@ -1,9 +1,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(messages) AS messages
-  , user_team___team_id
+  user_team___team_id
   , user_team___user_id
+  , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,9 +1,9 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.messages
-  , subq_7.user_team___team_id
+  subq_7.user_team___team_id
   , subq_7.user_team___user_id
   , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,10 +4,10 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.messages) AS messages
-  , subq_10.user_team___team_id AS user_team___team_id
+  subq_10.user_team___team_id AS user_team___team_id
   , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10016.country AS user_team__country
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.messages
-    , subq_3.user_team___team_id
+    subq_3.user_team___team_id
     , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.bookings
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , subq_5.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node__plan0_optimized.sql
@@ -2,9 +2,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_7.bookings) AS bookings
-  , subq_7.listing AS listing
+  subq_7.listing AS listing
   , listings_latest_src_10003.country AS listing__country_latest
+  , SUM(subq_7.bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_19.bookings AS FLOAT64) / CAST(NULLIF(subq_19.views, 0) AS FLOAT64) AS bookings_per_view
-  , subq_19.ds
+  subq_19.ds
   , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS FLOAT64) / CAST(NULLIF(subq_19.views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,9 +3,9 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_28.bookings AS FLOAT64) / CAST(NULLIF(subq_37.views, 0) AS FLOAT64) AS bookings_per_view
-  , subq_28.ds AS ds
+  subq_28.ds AS ds
   , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS FLOAT64) / CAST(NULLIF(subq_37.views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_5.bookings AS FLOAT64) / CAST(NULLIF(subq_5.bookers, 0) AS FLOAT64) AS bookings_per_booker
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , CAST(subq_5.bookings AS FLOAT64) / CAST(NULLIF(subq_5.bookers, 0) AS FLOAT64) AS bookings_per_booker
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(bookings AS FLOAT64) / CAST(NULLIF(bookers, 0) AS FLOAT64) AS bookings_per_booker
-  , listing
+  listing
   , listing__country_latest
+  , CAST(bookings AS FLOAT64) / CAST(NULLIF(bookers, 0) AS FLOAT64) AS bookings_per_booker
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , listing
+  listing
   , listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS trailing_2_months_revenue
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC(created_at, month) AS ds__month
+  DATE_TRUNC(created_at, month) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_mtd
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_mtd
-  , DATE_TRUNC(created_at, month) AS ds__month
+  DATE_TRUNC(created_at, month) AS ds__month
+  , SUM(revenue) AS revenue_mtd
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_all_time
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC(created_at, month) AS ds__month
+  DATE_TRUNC(created_at, month) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS revenue_all_time
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC(created_at, month) AS ds__month
+  DATE_TRUNC(created_at, month) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC(created_at, month) AS ds__month
+  DATE_TRUNC(created_at, month) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_distinct_values__plan0.sql
@@ -9,8 +9,8 @@ FROM (
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.bookings
-      , subq_8.listing__country_latest
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.bookings
-  , subq_10.is_instant
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , is_instant
+  is_instant
+  , SUM(bookings) AS bookings
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.ds
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.listings
-  , subq_3.listing__country_latest
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(listings) AS listings
-  , listing__country_latest
+  listing__country_latest
+  , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.txn_count
-  , subq_10.account_id__customer_id__customer_name
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(account_month_txns_src_10009.txn_count) AS txn_count
-  , subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  , SUM(account_month_txns_src_10009.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10009
 LEFT OUTER JOIN (
   -- Join Standard Outputs

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_order_by_node__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_2.bookings
-    , subq_2.ds
+    subq_2.ds
     , subq_2.is_instant
+    , subq_2.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.identity_verifications
-  , subq_7.user__home_state
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.identity_verifications) AS identity_verifications
-  , users_ds_source_src_10006.home_state AS user__home_state
+  users_ds_source_src_10006.home_state AS user__home_state
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.messages
-  , subq_3.user_team___team_id
+  subq_3.user_team___team_id
   , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -1,9 +1,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(messages) AS messages
-  , user_team___team_id
+  user_team___team_id
   , user_team___user_id
+  , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,9 +1,9 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.messages
-  , subq_7.user_team___team_id
+  subq_7.user_team___team_id
   , subq_7.user_team___user_id
   , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,10 +4,10 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.messages) AS messages
-  , subq_10.user_team___team_id AS user_team___team_id
+  subq_10.user_team___team_id AS user_team___team_id
   , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10016.country AS user_team__country
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.messages
-    , subq_3.user_team___team_id
+    subq_3.user_team___team_id
     , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.bookings
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , subq_5.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node__plan0_optimized.sql
@@ -2,9 +2,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_7.bookings) AS bookings
-  , subq_7.listing AS listing
+  subq_7.listing AS listing
   , listings_latest_src_10003.country AS listing__country_latest
+  , SUM(subq_7.bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
-  , subq_19.ds
+  subq_19.ds
   , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,9 +3,9 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
-  , subq_28.ds AS ds
+  subq_28.ds AS ds
   , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_5.bookings AS DOUBLE) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE) AS bookings_per_booker
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , CAST(subq_5.bookings AS DOUBLE) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE) AS bookings_per_booker
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(bookings AS DOUBLE) / CAST(NULLIF(bookers, 0) AS DOUBLE) AS bookings_per_booker
-  , listing
+  listing
   , listing__country_latest
+  , CAST(bookings AS DOUBLE) / CAST(NULLIF(bookers, 0) AS DOUBLE) AS bookings_per_booker
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , listing
+  listing
   , listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS trailing_2_months_revenue
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_mtd
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_mtd
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_mtd
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_all_time
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS revenue_all_time
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0.sql
@@ -9,8 +9,8 @@ FROM (
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.bookings
-      , subq_8.listing__country_latest
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.bookings
-  , subq_10.is_instant
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , is_instant
+  is_instant
+  , SUM(bookings) AS bookings
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.ds
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.listings
-  , subq_3.listing__country_latest
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(listings) AS listings
-  , listing__country_latest
+  listing__country_latest
+  , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.txn_count
-  , subq_10.account_id__customer_id__customer_name
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(account_month_txns_src_10009.txn_count) AS txn_count
-  , subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  , SUM(account_month_txns_src_10009.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10009
 LEFT OUTER JOIN (
   -- Join Standard Outputs

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_order_by_node__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_2.bookings
-    , subq_2.ds
+    subq_2.ds
     , subq_2.is_instant
+    , subq_2.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.identity_verifications
-  , subq_7.user__home_state
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.identity_verifications) AS identity_verifications
-  , users_ds_source_src_10006.home_state AS user__home_state
+  users_ds_source_src_10006.home_state AS user__home_state
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.messages
-  , subq_3.user_team___team_id
+  subq_3.user_team___team_id
   , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -1,9 +1,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(messages) AS messages
-  , user_team___team_id
+  user_team___team_id
   , user_team___user_id
+  , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,9 +1,9 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.messages
-  , subq_7.user_team___team_id
+  subq_7.user_team___team_id
   , subq_7.user_team___user_id
   , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,10 +4,10 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.messages) AS messages
-  , subq_10.user_team___team_id AS user_team___team_id
+  subq_10.user_team___team_id AS user_team___team_id
   , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10016.country AS user_team__country
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.messages
-    , subq_3.user_team___team_id
+    subq_3.user_team___team_id
     , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.bookings
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , subq_5.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node__plan0_optimized.sql
@@ -2,9 +2,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_7.bookings) AS bookings
-  , subq_7.listing AS listing
+  subq_7.listing AS listing
   , listings_latest_src_10003.country AS listing__country_latest
+  , SUM(subq_7.bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
-  , subq_19.ds
+  subq_19.ds
   , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,9 +3,9 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
-  , subq_28.ds AS ds
+  subq_28.ds AS ds
   , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_5.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , CAST(subq_5.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(bookings AS DOUBLE PRECISION) / CAST(NULLIF(bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
-  , listing
+  listing
   , listing__country_latest
+  , CAST(bookings AS DOUBLE PRECISION) / CAST(NULLIF(bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , listing
+  listing
   , listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS trailing_2_months_revenue
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_mtd
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_mtd
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_mtd
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_all_time
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS revenue_all_time
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_distinct_values__plan0.sql
@@ -9,8 +9,8 @@ FROM (
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.bookings
-      , subq_8.listing__country_latest
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.bookings
-  , subq_10.is_instant
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , is_instant
+  is_instant
+  , SUM(bookings) AS bookings
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_limit_rows__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.ds
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.listings
-  , subq_3.listing__country_latest
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(listings) AS listings
-  , listing__country_latest
+  listing__country_latest
+  , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.txn_count
-  , subq_10.account_id__customer_id__customer_name
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(account_month_txns_src_10009.txn_count) AS txn_count
-  , subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  , SUM(account_month_txns_src_10009.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10009
 LEFT OUTER JOIN (
   -- Join Standard Outputs

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_order_by_node__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_2.bookings
-    , subq_2.ds
+    subq_2.ds
     , subq_2.is_instant
+    , subq_2.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.identity_verifications
-  , subq_7.user__home_state
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.identity_verifications) AS identity_verifications
-  , users_ds_source_src_10006.home_state AS user__home_state
+  users_ds_source_src_10006.home_state AS user__home_state
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.messages
-  , subq_3.user_team___team_id
+  subq_3.user_team___team_id
   , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -1,9 +1,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(messages) AS messages
-  , user_team___team_id
+  user_team___team_id
   , user_team___user_id
+  , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,9 +1,9 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.messages
-  , subq_7.user_team___team_id
+  subq_7.user_team___team_id
   , subq_7.user_team___user_id
   , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,10 +4,10 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.messages) AS messages
-  , subq_10.user_team___team_id AS user_team___team_id
+  subq_10.user_team___team_id AS user_team___team_id
   , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10016.country AS user_team__country
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.messages
-    , subq_3.user_team___team_id
+    subq_3.user_team___team_id
     , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.bookings
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , subq_5.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node__plan0_optimized.sql
@@ -2,9 +2,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_7.bookings) AS bookings
-  , subq_7.listing AS listing
+  subq_7.listing AS listing
   , listings_latest_src_10003.country AS listing__country_latest
+  , SUM(subq_7.bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
-  , subq_19.ds
+  subq_19.ds
   , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,9 +3,9 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
-  , subq_28.ds AS ds
+  subq_28.ds AS ds
   , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_5.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , CAST(subq_5.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(bookings AS DOUBLE PRECISION) / CAST(NULLIF(bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
-  , listing
+  listing
   , listing__country_latest
+  , CAST(bookings AS DOUBLE PRECISION) / CAST(NULLIF(bookers, 0) AS DOUBLE PRECISION) AS bookings_per_booker
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , listing
+  listing
   , listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS trailing_2_months_revenue
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_mtd
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_mtd
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_mtd
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_all_time
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS revenue_all_time
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_distinct_values__plan0.sql
@@ -9,8 +9,8 @@ FROM (
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.bookings
-      , subq_8.listing__country_latest
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.bookings
-  , subq_10.is_instant
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , is_instant
+  is_instant
+  , SUM(bookings) AS bookings
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_limit_rows__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.ds
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.listings
-  , subq_3.listing__country_latest
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(listings) AS listings
-  , listing__country_latest
+  listing__country_latest
+  , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.txn_count
-  , subq_10.account_id__customer_id__customer_name
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(account_month_txns_src_10009.txn_count) AS txn_count
-  , subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  , SUM(account_month_txns_src_10009.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10009
 LEFT OUTER JOIN (
   -- Join Standard Outputs

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_order_by_node__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_2.bookings
-    , subq_2.ds
+    subq_2.ds
     , subq_2.is_instant
+    , subq_2.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.identity_verifications
-  , subq_7.user__home_state
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.identity_verifications) AS identity_verifications
-  , users_ds_source_src_10006.home_state AS user__home_state
+  users_ds_source_src_10006.home_state AS user__home_state
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.messages
-  , subq_3.user_team___team_id
+  subq_3.user_team___team_id
   , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -1,9 +1,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(messages) AS messages
-  , user_team___team_id
+  user_team___team_id
   , user_team___user_id
+  , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,9 +1,9 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.messages
-  , subq_7.user_team___team_id
+  subq_7.user_team___team_id
   , subq_7.user_team___user_id
   , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,10 +4,10 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.messages) AS messages
-  , subq_10.user_team___team_id AS user_team___team_id
+  subq_10.user_team___team_id AS user_team___team_id
   , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10016.country AS user_team__country
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.messages
-    , subq_3.user_team___team_id
+    subq_3.user_team___team_id
     , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.bookings
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , subq_5.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node__plan0_optimized.sql
@@ -2,9 +2,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_7.bookings) AS bookings
-  , subq_7.listing AS listing
+  subq_7.listing AS listing
   , listings_latest_src_10003.country AS listing__country_latest
+  , SUM(subq_7.bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
-  , subq_19.ds
+  subq_19.ds
   , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,9 +3,9 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
-  , subq_28.ds AS ds
+  subq_28.ds AS ds
   , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(subq_5.bookings AS DOUBLE) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE) AS bookings_per_booker
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , CAST(subq_5.bookings AS DOUBLE) / CAST(NULLIF(subq_5.bookers, 0) AS DOUBLE) AS bookings_per_booker
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  CAST(bookings AS DOUBLE) / CAST(NULLIF(bookers, 0) AS DOUBLE) AS bookings_per_booker
-  , listing
+  listing
   , listing__country_latest
+  , CAST(bookings AS DOUBLE) / CAST(NULLIF(bookers, 0) AS DOUBLE) AS bookings_per_booker
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , subq_5.listing
+  subq_5.listing
   , subq_5.listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_simple_expr__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Compute Metrics via Expressions
 SELECT
-  booking_value * 0.05 AS booking_fees
-  , listing
+  listing
   , listing__country_latest
+  , booking_value * 0.05 AS booking_fees
 FROM (
   -- Join Standard Outputs
   -- Aggregate Measures

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS trailing_2_months_revenue
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_mtd
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_mtd
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_mtd
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.txn_revenue AS revenue_all_time
-  , subq_4.ds__month
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -5,8 +5,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS revenue_all_time
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS revenue_all_time
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS revenue_all_time
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
-  , subq_5.ds__month
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -6,8 +6,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(revenue) AS trailing_2_months_revenue
-  , DATE_TRUNC('month', created_at) AS ds__month
+  DATE_TRUNC('month', created_at) AS ds__month
+  , SUM(revenue) AS trailing_2_months_revenue
 FROM (
   -- User Defined SQL Query
   SELECT * FROM ***************************.fct_revenue

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_distinct_values__plan0.sql
@@ -9,8 +9,8 @@ FROM (
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_8.bookings
-      , subq_8.listing__country_latest
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.bookings
-  , subq_10.is_instant
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , is_instant
+  is_instant
+  , SUM(bookings) AS bookings
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_limit_rows__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.ds
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_3.listings
-  , subq_3.listing__country_latest
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(listings) AS listings
-  , listing__country_latest
+  listing__country_latest
+  , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.txn_count
-  , subq_10.account_id__customer_id__customer_name
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(account_month_txns_src_10009.txn_count) AS txn_count
-  , subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
+  , SUM(account_month_txns_src_10009.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10009
 LEFT OUTER JOIN (
   -- Join Standard Outputs

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_order_by_node__plan0.sql
@@ -6,9 +6,9 @@ SELECT
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_2.bookings
-    , subq_2.ds
+    subq_2.ds
     , subq_2.is_instant
+    , subq_2.bookings
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.identity_verifications
-  , subq_7.user__home_state
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -4,8 +4,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(subq_10.identity_verifications) AS identity_verifications
-  , users_ds_source_src_10006.home_state AS user__home_state
+  users_ds_source_src_10006.home_state AS user__home_state
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier__plan0.xml
@@ -4,16 +4,16 @@
         <!-- node_id = ss_4 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
-        <!--    'column_alias': 'messages'}                           -->
-        <!-- col1 =                                                   -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
         <!--    'column_alias': 'user_team___team_id'}                -->
-        <!-- col2 =                                                   -->
+        <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
         <!--    'column_alias': 'user_team___user_id'}                -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
+        <!--    'column_alias': 'messages'}                           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_join__plan0.xml
@@ -4,20 +4,20 @@
         <!-- node_id = ss_7 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
-        <!--    'column_alias': 'messages'}                           -->
-        <!-- col1 =                                                   -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
         <!--    'column_alias': 'user_team___team_id'}                -->
-        <!-- col2 =                                                   -->
+        <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
         <!--    'column_alias': 'user_team___user_id'}                -->
-        <!-- col3 =                                                   -->
+        <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_68),  -->
         <!--    'column_alias': 'user_team__country'}                 -->
+        <!-- col3 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+        <!--    'column_alias': 'messages'}                           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_order_by__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_order_by__plan0.xml
@@ -29,16 +29,16 @@
             <!-- node_id = ss_4 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
-            <!--    'column_alias': 'messages'}                           -->
-            <!-- col1 =                                                   -->
-            <!--   {'class': 'SqlSelectColumn',                           -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
             <!--    'column_alias': 'user_team___team_id'}                -->
-            <!-- col2 =                                                   -->
+            <!-- col1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
             <!--    'column_alias': 'user_team___user_id'}                -->
+            <!-- col2 =                                                   -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
+            <!--    'column_alias': 'messages'}                           -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = None -->
             <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -4,16 +4,16 @@
         <!-- node_id = ss_4 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
-        <!--    'column_alias': 'bookings'}                           -->
-        <!-- col1 =                                                   -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
         <!--    'column_alias': 'listing'}                            -->
-        <!-- col2 =                                                   -->
+        <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
         <!--    'column_alias': 'listing__country_latest'}            -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
+        <!--    'column_alias': 'bookings'}                           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.xml
@@ -2,18 +2,18 @@
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
         <!-- node_id = ss_22 -->
-        <!-- col0 =                                                   -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
-        <!--    'column_alias': 'bookings_per_view'}                  -->
-        <!-- col1 =                                                    -->
+        <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
         <!--    'column_alias': 'ds'}                                  -->
-        <!-- col2 =                                                    -->
+        <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_409),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
+        <!--    'column_alias': 'bookings_per_view'}                  -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_data_source__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_data_source__plan0.xml
@@ -4,16 +4,16 @@
         <!-- node_id = ss_4 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
-        <!--    'column_alias': 'bookings_per_booker'}                -->
-        <!-- col1 =                                                   -->
-        <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_16),  -->
         <!--    'column_alias': 'listing'}                            -->
-        <!-- col2 =                                                   -->
+        <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
         <!--    'column_alias': 'listing__country_latest'}            -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
+        <!--    'column_alias': 'bookings_per_booker'}                -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -2,18 +2,18 @@
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
         <!-- node_id = ss_4 -->
-        <!-- col0 =                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                -->
-        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05),  -->
-        <!--    'column_alias': 'booking_fees'}                                            -->
-        <!-- col1 =                                                   -->
+        <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
         <!--    'column_alias': 'listing'}                            -->
-        <!-- col2 =                                                   -->
+        <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
         <!--    'column_alias': 'listing__country_latest'}            -->
+        <!-- col2 =                                                                        -->
+        <!--   {'class': 'SqlSelectColumn',                                                -->
+        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05),  -->
+        <!--    'column_alias': 'booking_fees'}                                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_9 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
-        <!--    'column_alias': 'trailing_2_months_revenue'}           -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
         <!--    'column_alias': 'ds__month'}                           -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+        <!--    'column_alias': 'trailing_2_months_revenue'}           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_9 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
-        <!--    'column_alias': 'revenue_mtd'}                         -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
         <!--    'column_alias': 'ds__month'}                           -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+        <!--    'column_alias': 'revenue_mtd'}                         -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_9 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
-        <!--    'column_alias': 'revenue_all_time'}                    -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
         <!--    'column_alias': 'ds__month'}                           -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
+        <!--    'column_alias': 'revenue_all_time'}                    -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_12 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
-        <!--    'column_alias': 'revenue_all_time'}                    -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
         <!--    'column_alias': 'ds__month'}                           -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
+        <!--    'column_alias': 'revenue_all_time'}                    -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_12 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
-        <!--    'column_alias': 'trailing_2_months_revenue'}           -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
         <!--    'column_alias': 'ds__month'}                           -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
+        <!--    'column_alias': 'trailing_2_months_revenue'}           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
@@ -28,12 +28,12 @@
                 <!-- node_id = ss_13 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
-                <!--    'column_alias': 'bookings'}                            -->
-                <!-- col1 =                                                    -->
-                <!--   {'class': 'SqlSelectColumn',                            -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_15 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
-        <!--    'column_alias': 'bookings'}                            -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
         <!--    'column_alias': 'is_instant'}                          -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+        <!--    'column_alias': 'bookings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
@@ -17,12 +17,12 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
             <!--    'column_alias': 'ds'}                                  -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
+            <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- where = None -->
             <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_identifier__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_identifier__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_9 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
-        <!--    'column_alias': 'listings'}                            -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+        <!--    'column_alias': 'listings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
@@ -2,14 +2,14 @@
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
         <!-- node_id = ss_13 -->
-        <!-- col0 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
-        <!--    'column_alias': 'txn_count'}                           -->
-        <!-- col1 =                                                        -->
+        <!-- col0 =                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),      -->
         <!--    'column_alias': 'account_id__customer_id__customer_name'}  -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
+        <!--    'column_alias': 'txn_count'}                           -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
@@ -29,16 +29,16 @@
             <!-- node_id = ss_2 -->
             <!-- col0 =                                                  -->
             <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
-            <!--    'column_alias': 'bookings'}                          -->
-            <!-- col1 =                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
             <!--    'column_alias': 'ds'}                                -->
-            <!-- col2 =                                                  -->
+            <!-- col1 =                                                  -->
             <!--   {'class': 'SqlSelectColumn',                          -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
             <!--    'column_alias': 'is_instant'}                        -->
+            <!-- col2 =                                                  -->
+            <!--   {'class': 'SqlSelectColumn',                          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
+            <!--    'column_alias': 'bookings'}                          -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = None -->
             <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
@@ -4,12 +4,12 @@
         <!-- node_id = ss_12 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
-        <!--    'column_alias': 'identity_verifications'}              -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
         <!--    'column_alias': 'user__home_state'}                    -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
+        <!--    'column_alias': 'identity_verifications'}              -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,13 +1,13 @@
 -- Combine Metrics
 SELECT
-  subq_8.bookings AS bookings
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
   , subq_9.booking_payments AS booking_payments
-  , COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.metric_time
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
@@ -137,8 +137,8 @@ FROM (
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.booking_payments
-    , subq_7.metric_time
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,14 +1,14 @@
 -- Combine Metrics
 SELECT
-  subq_18.bookings AS bookings
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
   , subq_19.booking_payments AS booking_payments
-  , COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , metric_time
+    metric_time
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -33,8 +33,8 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(booking_value) AS booking_payments
-    , booking_paid_at AS metric_time
+    booking_paid_at AS metric_time
+    , SUM(booking_value) AS booking_payments
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,13 +1,13 @@
 -- Combine Metrics
 SELECT
-  subq_8.bookings AS bookings
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
   , subq_9.booking_payments AS booking_payments
-  , COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.metric_time
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
@@ -137,8 +137,8 @@ FROM (
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.booking_payments
-    , subq_7.metric_time
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,14 +1,14 @@
 -- Combine Metrics
 SELECT
-  subq_18.bookings AS bookings
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
   , subq_19.booking_payments AS booking_payments
-  , COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , metric_time
+    metric_time
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -33,8 +33,8 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(booking_value) AS booking_payments
-    , booking_paid_at AS metric_time
+    booking_paid_at AS metric_time
+    , SUM(booking_value) AS booking_payments
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,13 +1,13 @@
 -- Combine Metrics
 SELECT
-  subq_8.bookings AS bookings
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
   , subq_9.booking_payments AS booking_payments
-  , COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.metric_time
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
@@ -137,8 +137,8 @@ FROM (
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.booking_payments
-    , subq_7.metric_time
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,14 +1,14 @@
 -- Combine Metrics
 SELECT
-  subq_18.bookings AS bookings
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
   , subq_19.booking_payments AS booking_payments
-  , COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , metric_time
+    metric_time
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -33,8 +33,8 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(booking_value) AS booking_payments
-    , booking_paid_at AS metric_time
+    booking_paid_at AS metric_time
+    , SUM(booking_value) AS booking_payments
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,13 +1,13 @@
 -- Combine Metrics
 SELECT
-  subq_8.bookings AS bookings
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
   , subq_9.booking_payments AS booking_payments
-  , COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.metric_time
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
@@ -137,8 +137,8 @@ FROM (
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.booking_payments
-    , subq_7.metric_time
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,14 +1,14 @@
 -- Combine Metrics
 SELECT
-  subq_18.bookings AS bookings
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
   , subq_19.booking_payments AS booking_payments
-  , COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , metric_time
+    metric_time
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -33,8 +33,8 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(booking_value) AS booking_payments
-    , booking_paid_at AS metric_time
+    booking_paid_at AS metric_time
+    , SUM(booking_value) AS booking_payments
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,13 +1,13 @@
 -- Combine Metrics
 SELECT
-  subq_8.bookings AS bookings
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
   , subq_9.booking_payments AS booking_payments
-  , COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_3.bookings
-    , subq_3.metric_time
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
@@ -137,8 +137,8 @@ FROM (
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.booking_payments
-    , subq_7.metric_time
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,14 +1,14 @@
 -- Combine Metrics
 SELECT
-  subq_18.bookings AS bookings
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
   , subq_19.booking_payments AS booking_payments
-  , COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , metric_time
+    metric_time
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -33,8 +33,8 @@ FULL OUTER JOIN (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(booking_value) AS booking_payments
-    , booking_paid_at AS metric_time
+    booking_paid_at AS metric_time
+    , SUM(booking_value) AS booking_payments
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -2,18 +2,18 @@
     <SqlSelectStatementNode>
         <!-- description = Combine Metrics -->
         <!-- node_id = ss_14 -->
-        <!-- col0 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
-        <!--    'column_alias': 'bookings'}                            -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
-        <!--    'column_alias': 'booking_payments'}                    -->
-        <!-- col2 =                                                                   -->
+        <!-- col0 =                                                                   -->
         <!--   {'class': 'SqlSelectColumn',                                           -->
         <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
         <!--    'column_alias': 'metric_time'}                                        -->
+        <!-- col1 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+        <!--    'column_alias': 'bookings'}                            -->
+        <!-- col2 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+        <!--    'column_alias': 'booking_payments'}                    -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- join_0 =                                                    -->
         <!--   {'class': 'SqlJoinDescription',                           -->
@@ -27,12 +27,12 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
-            <!--    'column_alias': 'bookings'}                            -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
             <!--    'column_alias': 'metric_time'}                         -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
+            <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -483,12 +483,12 @@
             <!-- node_id = ss_13 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
-            <!--    'column_alias': 'booking_payments'}                    -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
             <!--    'column_alias': 'metric_time'}                         -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+            <!--    'column_alias': 'booking_payments'}                    -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
             <!-- where = None -->
             <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_query__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , ds
+  ds
+  , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_write_to_table_query__query0.sql
@@ -2,8 +2,8 @@ CREATE TABLE ***************************.test_table AS (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , ds
+    ds
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_query__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , ds
+  ds
+  , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_write_to_table_query__query0.sql
@@ -2,8 +2,8 @@ CREATE TABLE ***************************.test_table AS (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , ds
+    ds
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_query__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , ds
+  ds
+  , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_write_to_table_query__query0.sql
@@ -2,8 +2,8 @@ CREATE TABLE ***************************.test_table AS (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , ds
+    ds
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_query__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , ds
+  ds
+  , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_write_to_table_query__query0.sql
@@ -2,8 +2,8 @@ CREATE TABLE ***************************.test_table AS (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , ds
+    ds
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_query__query0.sql
@@ -1,8 +1,8 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  SUM(bookings) AS bookings
-  , ds
+  ds
+  , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_write_to_table_query__query0.sql
@@ -2,8 +2,8 @@ CREATE TABLE ***************************.test_table AS (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    SUM(bookings) AS bookings
-    , ds
+    ds
+    , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
     -- Metric Time Dimension 'ds'


### PR DESCRIPTION
## Context
This is an amendment PR that fixes a few stragglers that were missed during this PR https://github.com/transform-data/metricflow/pull/156

There were cases in the visitor like this
```python3
select_columns=tuple(metric_select_columns) + non_metric_select_column_set.as_tuple()
```
which just adds the `metric_select_columns`  and the `non_metric_select_column_set.as_tuple()`. This leads to the ordering being this (metric, others…). Since the ordering is sorted in the `as_tuple()` method. So in order to make the ordering the way we wanted it to be, we have to combine the columns sets and use `as_tuple()` on the entire thing.

## Changes
- Ensure that we are correctly ordering the select_columns using `SelectColumnSet.as_tuple` method rather than appending the `SqlSelectColumn` in the visitor which doesn't respect the ordering.