### PR TITLE
Remove fatal validation issues as a concept

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -643,8 +643,6 @@ def drop_materialization(cfg: CLIContext, materialization_name: str) -> None:
 def _print_issues(
     issues: ModelValidationResults, show_non_blocking: bool = False, verbose: bool = False
 ) -> None:  # noqa: D
-    for issue in issues.fatals:
-        print(f"• {issue.as_readable_str(verbose=verbose)}")
     for issue in issues.errors:
         print(f"• {issue.as_readable_str(verbose=verbose)}")
     if show_non_blocking:

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -25,7 +25,6 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationResults,
     ValidationIssueType,
     ModelValidationRule,
-    ValidationIssueLevel,
     ModelValidationException,
 )
 
@@ -72,9 +71,6 @@ class ModelValidator:
         issues: List[ValidationIssueType] = []
         for validation_rule in self._rules:
             issues.extend(validation_rule.validate_model(model_copy))
-            # If there are any fatal errors, stop the validation process.
-            if any([x.level == ValidationIssueLevel.FATAL for x in issues]):
-                break
 
         return ModelBuildResult(model=model_copy, issues=ModelValidationResults.from_issues_sequence(issues))
 

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -11,7 +11,6 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationIssueType,
     ValidationError,
-    ValidationFatal,
     validate_safely,
 )
 
@@ -29,7 +28,7 @@ class MetricMeasuresRule(ModelValidationRule):
         for measure_reference in metric.measure_references:
             if measure_reference.element_name not in valid_measure_names:
                 issues.append(
-                    ValidationFatal(
+                    ValidationError(
                         context=MetricContext(
                             file_context=FileContext.from_metadata(metadata=metric.metadata),
                             metric=MetricModelReference(metric_name=metric.name),

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -22,8 +22,6 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationContext,
     ValidationError,
-    ValidationFatal,
-    ValidationIssueLevel,
     ValidationIssueType,
     validate_safely,
 )
@@ -148,7 +146,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
         for name, _type, context in element_info_tuples:
             if name in name_to_type:
                 issues.append(
-                    ValidationFatal(
+                    ValidationError(
                         context=context,
                         message=f"In data source `{data_source.name}`, can't use name `{name.element_name}` for a "
                         f"{_type} when it was already used for a {name_to_type[name]}",
@@ -199,7 +197,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
         for name, type_, context in object_info_tuples:
             if name in name_to_type:
                 issues.append(
-                    ValidationFatal(
+                    ValidationError(
                         context=context,
                         message=f"Can't use name `{name}` for a {type_} when it was already used for a "
                         f"{name_to_type[name]}",
@@ -213,7 +211,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
             for metric in model.metrics:
                 if metric.name in metric_names:
                     issues.append(
-                        ValidationFatal(
+                        ValidationError(
                             context=MetricContext(
                                 file_context=FileContext.from_metadata(metadata=metric.metadata),
                                 metric=MetricModelReference(metric_name=metric.name),
@@ -223,9 +221,6 @@ class UniqueAndValidNameRule(ModelValidationRule):
                     )
                 else:
                     metric_names.add(metric.name)
-
-        if any([x.level == ValidationIssueLevel.FATAL for x in issues]):
-            return issues
 
         for name, _, context in object_info_tuples:
             issues += UniqueAndValidNameRule.check_valid_name(name=name, context=context)

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -19,7 +19,6 @@ from metricflow.model.parsing.config_linter import ConfigLinter
 from metricflow.model.validations.validator_helpers import (
     ModelValidationResults,
     ValidationError,
-    ValidationFatal,
     ValidationFutureError,
     ValidationWarning,
 )
@@ -85,7 +84,6 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
         ValidationWarning(context=None, message="warning_message"),  # type: ignore
         ValidationFutureError(context=None, message="future_error_message", error_date=datetime.now()),  # type: ignore
         ValidationError(context=None, message="error_message"),  # type: ignore
-        ValidationFatal(context=None, message="fatal_message"),  # type: ignore
     )
     mocked_build_result = MagicMock(issues=ModelValidationResults.from_issues_sequence(issues))
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):
@@ -93,7 +91,6 @@ def test_validate_configs(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
             with patch.object(ModelValidator, "validate_model", return_value=mocked_build_result):
                 resp = cli_runner.run(validate_configs)
 
-    assert "fatal_message" in resp.output
     assert "error_message" in resp.output
     assert resp.exit_code == 0
 
@@ -106,7 +103,6 @@ def test_future_errors_and_warnings_conditionally_show_up(cli_runner: MetricFlow
         ValidationWarning(context=None, message="warning_message"),  # type: ignore
         ValidationFutureError(context=None, message="future_error_message", error_date=datetime.now()),  # type: ignore
         ValidationError(context=None, message="error_message"),  # type: ignore
-        ValidationFatal(context=None, message="fatal_message"),  # type: ignore
     )
     mocked_build_result = MagicMock(issues=ModelValidationResults.from_issues_sequence(issues))
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):

--- a/metricflow/test/model/validations/test_validator_helpers.py
+++ b/metricflow/test/model/validations/test_validator_helpers.py
@@ -18,7 +18,6 @@ from metricflow.model.validations.validator_helpers import (
     MetricContext,
     ModelValidationResults,
     ValidationError,
-    ValidationFatal,
     ValidationFutureError,
     ValidationIssueLevel,
     ValidationIssueType,
@@ -89,15 +88,15 @@ def list_of_issues() -> List[ValidationIssueType]:  # noqa: D
         )
     )
     issues.append(
-        ValidationFatal(
+        ValidationError(
             context=MetricContext(
                 file_context=file_context,
                 metric=MetricModelReference(metric_name="My metric"),
             ),
-            message="Something caused a fatal, problem #6",
+            message="Something caused a error, problem #6",
         )
     )
-    issues.append(ValidationFatal(context=file_context, message="Something caused a fatal, probelm #7"))
+    issues.append(ValidationError(context=file_context, message="Something caused a error, probelm #7"))
     return issues
 
 
@@ -107,13 +106,11 @@ def test_creating_model_validation_results_from_issue_list(  # noqa: D
     warnings = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.WARNING]
     future_errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.FUTURE_ERROR]
     errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.ERROR]
-    fatals = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.FATAL]
 
     model_validation_issues = ModelValidationResults.from_issues_sequence(list_of_issues)
     assert len(model_validation_issues.warnings) == len(warnings)
     assert len(model_validation_issues.future_errors) == len(future_errors)
     assert len(model_validation_issues.errors) == len(errors)
-    assert len(model_validation_issues.fatals) == len(fatals)
     assert model_validation_issues.has_blocking_issues
 
     model_validation_issues = ModelValidationResults(warnings=warnings, future_errors=future_errors)
@@ -136,7 +133,6 @@ def test_jsonifying_and_reloading_model_validation_results_is_equal(  # noqa: D
     new_context_types = [issue.context.__class__ for issue in model_validation_issues_new.warnings]
     new_context_types += [issue.context.__class__ for issue in model_validation_issues_new.future_errors]
     new_context_types += [issue.context.__class__ for issue in model_validation_issues_new.errors]
-    new_context_types += [issue.context.__class__ for issue in model_validation_issues_new.fatals]
     assert set_context_types == set(new_context_types)
 
 
@@ -148,4 +144,3 @@ def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssue
     assert merged.warnings == validation_results.warnings + validation_results_dup.warnings
     assert merged.future_errors == validation_results.future_errors + validation_results_dup.future_errors
     assert merged.errors == validation_results.errors + validation_results_dup.errors
-    assert merged.fatals == validation_results.fatals + validation_results_dup.fatals


### PR DESCRIPTION
Fatal validation issues comes from a time when our validators weren't resilient enough, wherein one thing being bad meant other validations couldn't be run properly. This is no longer the case, it hasn't been for awhile. Fatal issues are actually problematic because they can slow down the cycle of writing configs. This is because fatals mean that instead of getting all the semantic validation issues, you only get issues up until a fatal issue is reached. In our current process, parts of validation are run in their entirety in order: linting -> parsing -> semantic -> data warehouse. If there is an error in a given stage, the next stage cannot be entered. But, in this system errors are the gate keepers. Fatals are no more.