### PR TITLE
Multi-Thread Semantic Validations

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -713,6 +713,13 @@ def _data_warehouse_validations_runner(
 @click.option(
     "--verbose-issues", is_flag=True, default=False, help="If specified, prints any extra details issues might have"
 )
+@click.option(
+    "--semantic-validation-workers",
+    required=False,
+    type=int,
+    default=1,
+    help="Optional. Uses the number of workers specified to run the semantic validations. Should only be used for exceptionally large configs",
+)
 @pass_config
 @exception_handler
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
@@ -722,6 +729,7 @@ def validate_configs(
     skip_dw: bool = False,
     show_all: bool = False,
     verbose_issues: bool = False,
+    semantic_validation_workers: int = 1,
 ) -> None:
     """Perform validations against the defined model configurations."""
     cfg.verbose = True
@@ -760,7 +768,7 @@ def validate_configs(
     # Semantic validation
     semantic_spinner = Halo(text="Validating semantics of built model", spinner="dots")
     semantic_spinner.start()
-    semantic_result = ModelValidator().validate_model(user_model)
+    semantic_result = ModelValidator(max_workers=semantic_validation_workers).validate_model(user_model)
 
     if not semantic_result.issues.has_blocking_issues:
         semantic_spinner.succeed(

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -52,7 +52,7 @@ class ModelValidator:
         ReservedKeywordsRule(),
     )
 
-    def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES, max_workers: int = 4) -> None:
+    def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES, max_workers: int = 1) -> None:
         """Constructor.
 
         Args:

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import copy
 import logging
 from typing import List, Sequence
@@ -51,11 +52,12 @@ class ModelValidator:
         ReservedKeywordsRule(),
     )
 
-    def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES) -> None:
+    def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES, max_workers: int = 4) -> None:
         """Constructor.
 
         Args:
             rules: List of validation rules to run. Defaults to DEFAULT_RULES
+            max_workers: sets the max number of rules to run against the model concurrently
         """
 
         # Raises an error if 'rules' is an empty sequence or None
@@ -63,14 +65,17 @@ class ModelValidator:
             raise ValueError("ModelValidator 'rules' must be a sequence with at least one ModelValidationRule.")
 
         self._rules = rules
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
 
     def validate_model(self, model: UserConfiguredModel) -> ModelBuildResult:
         """Validate a model according to configured rules."""
         model_copy = copy.deepcopy(model)
 
         issues: List[ValidationIssueType] = []
-        for validation_rule in self._rules:
-            issues.extend(validation_rule.validate_model(model_copy))
+
+        futures = [self._executor.submit(validation_rule.validate_model, model_copy) for validation_rule in self._rules]
+        for future in as_completed(futures):
+            issues.extend(future.result())
 
         return ModelBuildResult(model=model_copy, issues=ModelValidationResults.from_issues_sequence(issues))
 

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -1,4 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import copy
 import logging
 from typing import List, Sequence
@@ -65,7 +65,7 @@ class ModelValidator:
             raise ValueError("ModelValidator 'rules' must be a sequence with at least one ModelValidationRule.")
 
         self._rules = rules
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._executor = ProcessPoolExecutor(max_workers=max_workers)
 
     def validate_model(self, model: UserConfiguredModel) -> ModelBuildResult:
         """Validate a model according to configured rules."""

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -132,12 +132,15 @@ def test_validate_configs_data_warehouse_validations(cli_runner: MetricFlowCliRu
     ]
     with patch("metricflow.cli.main.model_build_result_from_config", return_value=mocked_parsing_result):
         with patch("metricflow.cli.main.path_to_models", return_value=""):
-            with patch.object(CLIContext, "sql_client", return_value=None):  # type: ignore
-                with patch(
-                    "metricflow.cli.main._run_dw_validations",
-                    return_value=ModelValidationResults(errors=dw_validation_issues),
-                ):
-                    resp = cli_runner.run(validate_configs)
+            with patch.object(
+                ModelValidator, "validate_model", return_value=MagicMock(issues=ModelValidationResults())
+            ):
+                with patch.object(CLIContext, "sql_client", return_value=None):  # type: ignore
+                    with patch(
+                        "metricflow.cli.main._run_dw_validations",
+                        return_value=ModelValidationResults(errors=dw_validation_issues),
+                    ):
+                        resp = cli_runner.run(validate_configs)
 
     assert "Data Warehouse Error" in resp.output
     assert resp.exit_code == 0


### PR DESCRIPTION
This might be a premature improvement, but it is a matter of time before it becomes absolutely necessary. Semantic validations are CPU bound. They don't depend on any external information. As we add more semantic validation rules and as configs grow larger, semantic validations become slower. Additionally, semantic validations don't depend on one another and they don't alter the underlying model. Thus the straight forward solution is to allow more CPU threads to be thrown at them. On a small config, there is virtually no difference in runtime currently. On exceedingly  large configs, time gains are seen (and to different degrees based on how many threads there are).