### PR TITLE
Increase strictness of mypy typechecking

### DIFF
--- a/metricflow/dataflow/sql_table.py
+++ b/metricflow/dataflow/sql_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
-from metricflow.model.objects.base import FrozenBaseModel, PydanticCustomInputParser
+from metricflow.model.objects.base import FrozenBaseModel, PydanticCustomInputParser, PydanticParseableValueType
 
 
 class SqlTable(PydanticCustomInputParser, FrozenBaseModel):
@@ -12,7 +12,7 @@ class SqlTable(PydanticCustomInputParser, FrozenBaseModel):
     table_name: str
 
     @classmethod
-    def _from_yaml_value(cls, input: Any) -> SqlTable:
+    def _from_yaml_value(cls, input: PydanticParseableValueType) -> SqlTable:
         """Parses a SqlTable from string input found in a user-provided model specification
 
         Raises a ValueError on any non-string input, as all user-provided specifications of table identifiers

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -103,7 +103,7 @@ class DataWarehouseTaskBuilder:
     @staticmethod
     def renderize(
         sql_client: SqlClient, plan_converter: DataflowToSqlQueryPlanConverter, plan_id: str, nodes: FilterElementsNode
-    ):
+    ) -> Tuple[str, SqlBindParameters]:
         """Generates a sql query plan and returns the rendered sql and execution_parameters"""
         sql_plan = plan_converter.convert_to_sql_query_plan(
             sql_engine_attributes=sql_client.sql_engine_attributes,

--- a/metricflow/model/objects/base.py
+++ b/metricflow/model/objects/base.py
@@ -10,6 +10,9 @@ from pydantic import BaseModel, root_validator
 from metricflow.errors.errors import ParsingException
 from metricflow.model.parsing.yaml_loader import ParsingContext, PARSING_CONTEXT_KEY
 
+# Type alias for the implicit "Any" type used as input and output for Pydantic's parsing API
+PydanticParseableValueType = Any  # type: ignore[misc]
+
 
 class HashableBaseModel(BaseModel):
     """Extends BaseModel with a generic hash function"""
@@ -54,7 +57,7 @@ class ModelWithMetadataParsing(BaseModel):
 
     @root_validator(pre=True)
     @classmethod
-    def extract_metadata_from_parsing_context(cls, values: Any) -> Any:
+    def extract_metadata_from_parsing_context(cls, values: PydanticParseableValueType) -> PydanticParseableValueType:
         """Takes info from parsing context and converts it to a Metadata model object
 
         Per Pydantic's processing logic, this runs on the collection of input data for whatever model
@@ -104,7 +107,7 @@ class PydanticCustomInputParser(ABC, Generic[ModelObjectT_co]):
     """Implements required"""
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_validators__(cls):  # type: ignore[no-untyped-def]
         """Pydantic magic method for allowing parsing of arbitrary input on parse_obj invocation
 
         This allow for parsing and validation prior to object initialization. Most classes implementing this
@@ -115,6 +118,6 @@ class PydanticCustomInputParser(ABC, Generic[ModelObjectT_co]):
 
     @classmethod
     @abstractmethod
-    def _from_yaml_value(cls, input: Any) -> ModelObjectT_co:
+    def _from_yaml_value(cls, input: PydanticParseableValueType) -> ModelObjectT_co:
         """Abstract method for providing object-specific parsing logic"""
         raise NotImplementedError()

--- a/metricflow/model/objects/constraints/where.py
+++ b/metricflow/model/objects/constraints/where.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Dict, Any
 from moz_sql_parser import parse as moz_parse
 
 from metricflow.errors.errors import ConstraintParseException
-from metricflow.model.objects.base import HashableBaseModel, PydanticCustomInputParser
+from metricflow.model.objects.base import HashableBaseModel, PydanticCustomInputParser, PydanticParseableValueType
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class WhereClauseConstraint(PydanticCustomInputParser, HashableBaseModel):
         )
 
     @classmethod
-    def _from_yaml_value(cls, input: Any) -> WhereClauseConstraint:
+    def _from_yaml_value(cls, input: PydanticParseableValueType) -> WhereClauseConstraint:
         """Parses a WhereClauseConstraint from a constraint string found in a user-provided model specification
 
         User-provided constraint strings are SQL snippets conforming to the expectations of SQL WHERE clauses,

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from hashlib import sha1
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from metricflow.errors.errors import ParsingException
 from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
-from metricflow.model.objects.base import HashableBaseModel, ModelWithMetadataParsing, PydanticCustomInputParser
+from metricflow.model.objects.base import (
+    HashableBaseModel,
+    ModelWithMetadataParsing,
+    PydanticCustomInputParser,
+    PydanticParseableValueType,
+)
 from metricflow.object_utils import ExtendedEnum
 from metricflow.specs import MeasureReference
 from metricflow.time.time_granularity import TimeGranularity
@@ -29,7 +34,7 @@ class MetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
     # TODO add constraint handling property
 
     @classmethod
-    def _from_yaml_value(cls, input: Any):
+    def _from_yaml_value(cls, input: PydanticParseableValueType) -> MetricInputMeasure:
         """Parses a MetricInputMeasure from a string (name only) or object (struct spec) input
 
         Internally, we will pass fully formed instance of a MetricInputMeasure through in any case where
@@ -70,7 +75,7 @@ class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
         return f"{self.count} {self.granularity.value}"
 
     @classmethod
-    def _from_yaml_value(cls, input: Any) -> CumulativeMetricWindow:
+    def _from_yaml_value(cls, input: PydanticParseableValueType) -> CumulativeMetricWindow:
         """Parses a CumulativeMetricWindow from a string input found in a user provided model specification
 
         The CumulativeMetricWindow is always expected to be provided as a string in user-defined YAML configs.

--- a/metricflow/model/parsing/schema_validator.py
+++ b/metricflow/model/parsing/schema_validator.py
@@ -4,7 +4,7 @@ from jsonschema._utils import extras_msg
 from jsonschema.validators import extend
 
 
-def custom_find_additional_properties(instance, schema):
+def custom_find_additional_properties(instance, schema):  # type: ignore[no-untyped-def]
     """Return the set of additional properties for the given ``instance``.
 
     NOTE: This is a modified copy of the ``find_additional_properties`` method
@@ -30,7 +30,7 @@ def custom_find_additional_properties(instance, schema):
             yield property
 
 
-def customAdditionalProperties(validator, aP, instance, schema):
+def customAdditionalProperties(validator, aP, instance, schema):  # type: ignore[no-untyped-def]
     """Validator for checking if a schema has additionalProperties when it shouldn't
 
     NOTE: This is a modified copy of the ``additionalProperties`` method

--- a/metricflow/test/model/validations/test_reserved_keywords.py
+++ b/metricflow/test/model/validations/test_reserved_keywords.py
@@ -20,7 +20,7 @@ def test_no_reserved_keywords(simple_model__pre_transforms: UserConfiguredModel)
     assert len(issues) == 0
 
 
-def test_reserved_keywords_in_sql_table(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+def test_reserved_keywords_in_sql_table(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
     model = copied_model(simple_model__pre_transforms)
     (data_source_with_sql_table, _index) = find_data_source_with(
         model=model, function=lambda data_source: data_source.sql_table is not None
@@ -32,7 +32,7 @@ def test_reserved_keywords_in_sql_table(simple_model__pre_transforms: UserConfig
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_dimensions(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+def test_reserved_keywords_in_dimensions(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
     model = copied_model(simple_model__pre_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.dimensions) > 0
@@ -45,7 +45,7 @@ def test_reserved_keywords_in_dimensions(simple_model__pre_transforms: UserConfi
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_measures(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+def test_reserved_keywords_in_measures(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
     model = copied_model(simple_model__pre_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.measures) > 0
@@ -58,7 +58,7 @@ def test_reserved_keywords_in_measures(simple_model__pre_transforms: UserConfigu
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_identifiers(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+def test_reserved_keywords_in_identifiers(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
     model = copied_model(simple_model__pre_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.identifiers) > 0
@@ -72,7 +72,9 @@ def test_reserved_keywords_in_identifiers(simple_model__pre_transforms: UserConf
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_composite_identifiers(simple_model__pre_transforms: UserConfiguredModel):  # noqa: D
+def test_reserved_keywords_in_composite_identifiers(  # noqa: D
+    simple_model__pre_transforms: UserConfiguredModel,
+) -> None:
     model = copied_model(simple_model__pre_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.identifiers) > 0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+# https://mypy.readthedocs.io/en/stable/config_file.html
+warn_unused_configs = True
+disallow_any_explicit = True
+disallow_untyped_defs = True
+warn_redundant_casts = True
+namespace_packages = True
+plugins = sqlalchemy.ext.mypy.plugin


### PR DESCRIPTION
Metricflow originally used the stock mypy options for typechecking,
but recent PRs involving more direct worth with Pydantic and
jsonschema objects and methods (which tend to be Any or incompletely
typed due to the nature of JSON values) has resulted in a
proliferation of incompletely typed methods.

This commit adds a mypy.ini with a few initial options in place to
rein in potential accidental spread of Any types and incompletely typed
methods, and fixes the relevant mypy errors. We do this in one
fell swoop just because the total number of errors was fairly small.