### PR TITLE
Enable custom Pydantic model deserialization

### DIFF
--- a/metricflow/dataflow/sql_table.py
+++ b/metricflow/dataflow/sql_table.py
@@ -16,15 +16,10 @@ class SqlTable(PydanticCustomInputParser, FrozenBaseModel):
         """Parses a SqlTable from string input found in a user-provided model specification
 
         Raises a ValueError on any non-string input, as all user-provided specifications of table identifiers
-        should be strings conforming to the expectations defined in the from_string method. The lone exception
-        is for SqlTable instance inputs, which could arise if we are initializing Materialization objects internally
-        without direct access to user input.
+        should be strings conforming to the expectations defined in the from_string method.
         """
         if isinstance(input, str):
             return SqlTable.from_string(input)
-        elif isinstance(input, SqlTable):
-            # This is internally constructed, pass it through and ignore it in error messaging
-            return input
         else:
             raise ValueError(
                 f"SqlTable inputs from model configs are expected to always be of type string, but got type "

--- a/metricflow/model/objects/constraints/where.py
+++ b/metricflow/model/objects/constraints/where.py
@@ -48,16 +48,9 @@ class WhereClauseConstraint(PydanticCustomInputParser, HashableBaseModel):
 
         User-provided constraint strings are SQL snippets conforming to the expectations of SQL WHERE clauses,
         and as such we parse them using our standard parse method below.
-
-        Note in some cases we might wish to initialize a WhereClauseConstraint inside of a model object. In such
-        cases we simply pass the instance along, since it should have been pre-validated on initialization and
-        therefore we expect it to be internally consistent.
         """
         if isinstance(input, str):
             return WhereClauseConstraint.parse(input)
-        elif isinstance(input, WhereClauseConstraint):
-            # This is internally constructed, pass it through and ignore it in error messaging
-            return input
         else:
             raise ValueError(f"Expected input to be of type string, but got type {type(input)} with value: {input}")
 

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -37,22 +37,12 @@ class MetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
     def _from_yaml_value(cls, input: PydanticParseableValueType) -> MetricInputMeasure:
         """Parses a MetricInputMeasure from a string (name only) or object (struct spec) input
 
-        Internally, we will pass fully formed instance of a MetricInputMeasure through in any case where
-        the Measure object defined in the DataSource has `create_metric` set to True. For these cases, we
-        do not need to do further parsing.
-
         For user input cases, the original YAML spec for a Metric included measure(s) specified as string names
         or lists of string names. As such, configs pre-dating the addition of this model type will only provide the
-        base name for this object. The addition of new properties requires a key/value input for each
-        entry, which would need to be handled by object (dict) type parsing logic.
+        base name for this object.
         """
-        if isinstance(input, MetricInputMeasure):
-            # Internally constructed, pass it through and ignore this case in error messaging
-            return input
-        elif isinstance(input, str):
+        if isinstance(input, str):
             return MetricInputMeasure(name=input)
-        elif isinstance(input, dict):
-            return MetricInputMeasure(**input)
         else:
             raise ValueError(
                 f"MetricInputMeasure inputs from model configs are expected to be of either type string or "
@@ -79,13 +69,9 @@ class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
         """Parses a CumulativeMetricWindow from a string input found in a user provided model specification
 
         The CumulativeMetricWindow is always expected to be provided as a string in user-defined YAML configs.
-        It may also be a CumulativeMetricWindow in cases where we are internally constructing Metric objects.
         """
         if isinstance(input, str):
             return CumulativeMetricWindow.parse(input)
-        elif isinstance(input, CumulativeMetricWindow):
-            # This is internally constructed, pass it through and ignore it in error messaging
-            return input
         else:
             raise ValueError(
                 f"CumulativeMetricWindow inputs from model configs are expected to always be of type string, but got "

--- a/metricflow/test/model/parsing/test_model_deserialization.py
+++ b/metricflow/test/model/parsing/test_model_deserialization.py
@@ -1,0 +1,12 @@
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+
+
+def test_model_serialization_deserialization(simple_user_configured_model: UserConfiguredModel) -> None:
+    """Tests Pydantic serialization and deserialization of a UserConfiguredModel
+
+    This ensures any custom parsing operations internal to our Pydantic models are properly applied to not only
+    user-provided YAML input, but also to internal parsing operations based on serialized model objects.
+    """
+    serialized_model = simple_user_configured_model.json()
+    deserialized_model = simple_user_configured_model.parse_raw(serialized_model)
+    assert deserialized_model == simple_user_configured_model


### PR DESCRIPTION
The initial cutover to using Pydantic-native parsing via input
validator overrides only allowed for dict-type or class instance inputs
on a per-model object basis. For example, the SqlTable class would
only accept strings or SqlTable objects, and every individual
class implementing our PydanticCustomInputParser base was responsible
for handling dict or calling class type inputs.

The issue with this object-by-object approach is any time someone
either uses direct initialization or, more importantly, uses Pydantic
to serialize and deserialize a model, they will encounter failures
whenever a value needs to be parsed by pydantic through one of these
custom override classes unless every single one of them implements
the relevant instance conditions.

This change centralizes that logic by moving it into the
PydanticCustomInputParser and passing the values along as appropriate.
