### PR TITLE
Make validation issue strings plain text by default

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -644,12 +644,12 @@ def _print_issues(
     issues: ModelValidationResults, show_non_blocking: bool = False, verbose: bool = False
 ) -> None:  # noqa: D
     for issue in issues.errors:
-        print(f"• {issue.as_readable_str(verbose=verbose)}")
+        print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
     if show_non_blocking:
         for issue in issues.future_errors:
-            print(f"• {issue.as_readable_str(verbose=verbose)}")
+            print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
         for issue in issues.warnings:
-            print(f"• {issue.as_readable_str(verbose=verbose)}")
+            print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
 
 
 def _run_dw_validations(

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -202,7 +202,7 @@ class ValidationFutureError(ValidationIssue, BaseModel):
     def as_readable_str(self, verbose: bool = False, prefix: Optional[str] = None) -> str:
         """Return a easily readable string that can be used to log the issue."""
         return (
-            f"{super().as_readable_str(verbose=verbose)}"
+            f"{super().as_readable_str(verbose=verbose, prefix=prefix)}"
             f"IMPORTANT: this error will break your model starting {self.error_date.strftime('%b %d, %Y')}. "
         )
 


### PR DESCRIPTION
The original implementation of ValidationIssue.as_readable_string
included a reference to click formatting that color-coded the
issue level. This looks great in the CLI, but in contexts where
that gets converted to plain text it inserts a bunch of unicode
sequences into the header of the error message, making the exception
traces harder to read.

This splits that behavior into a CLI-focused method and base method.
Local testing confirms the CLI output is unchanged, while error logs
no longer contain the unicode markers.
