### PR TITLE
Add CLI for data source inference

### DIFF
--- a/metricflow/cli/custom_click_types.py
+++ b/metricflow/cli/custom_click_types.py
@@ -1,0 +1,68 @@
+from typing import Callable, Generic, List, Optional, TypeVar
+import click
+
+T = TypeVar("T")
+
+
+class ListParamType(click.ParamType, Generic[T]):
+    """A click parameter that is a list of elements.
+
+    It can be used to parse strings like "1,2,4,8" into a List[int], for example.
+    """
+
+    name = "list"
+
+    def __init__(
+        self,
+        value_converter: Callable[[str], T] = lambda x: x,  # type: ignore
+        min_length: int = 0,
+        max_length: Optional[int] = None,
+        separator: str = ",",
+        *args,
+        **kwargs,
+    ) -> None:
+        """Initialize the list param type.
+
+        converter: a function to convert each list value.
+            Defaults to not converting and keeping them as strings.
+        min_length: minimum length for the list, inclusive.
+            Defaults to 0.
+        max_length: maximum length for the list, inclusive.
+            If None, there is no maximum length.
+            Defaults to None.
+        separator: the list separator.
+            Defaults to `,`.
+        """
+        self.value_converter = value_converter
+        self.min_length = min_length
+        self.max_length = max_length
+        self.separator = separator
+
+        super().__init__(*args, **kwargs)
+
+    def convert(self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> List[T]:  # noqa: D
+        str_values = value.split(self.separator)
+
+        if len(str_values) < self.min_length:
+            self.fail(
+                f"list has length {len(str_values)}, which is less than the minimum allowed length of {self.min_length}",
+                param,
+                ctx,
+            )
+
+        if self.max_length is not None and len(str_values) > self.max_length:
+            self.fail(
+                f"list has length {len(str_values)}, which is more than the maximum allowed length of {self.max_length}",
+                param,
+                ctx,
+            )
+
+        converted_values: List[T] = []
+        for str_val in str_values:
+            try:
+                converted_val = self.value_converter(str_val)
+            except Exception:
+                self.fail(f"{str_val} could not be converted by value converter", param, ctx)
+            converted_values.append(converted_val)
+
+        return converted_values

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -732,7 +732,7 @@ def validate_configs(cfg: CLIContext, dw_timeout: Optional[int] = None, skip_dw:
         _data_warehouse_validations_runner(dw_validator=dw_validator, model=user_model, timeout=dw_timeout)
 
 
-def _get_spin_context_manager(text: str) -> Callable[[], ContextManager[None]]:
+def _get_spin_context_manager_factory(text: str) -> Callable[[], ContextManager[None]]:
     @contextlib.contextmanager
     def _context_manager() -> Iterator[None]:
         start_ms = int(time.time_ns() / 10e6)
@@ -757,23 +757,33 @@ class CLIInferenceProgressReporter(InferenceProgressReporter):
     @staticmethod
     @contextlib.contextmanager
     def table(table: SqlTable, index: int, total: int) -> Iterator[None]:  # noqa: D
-        with _get_spin_context_manager(f"🔍 Querying `{table.sql}` ({index + 1} out of {total})")():
+        with _get_spin_context_manager_factory(f"🔍 Querying `{table.sql}` ({index + 1} out of {total})")():
             yield
 
-    rules = staticmethod(_get_spin_context_manager("🤔 Processing inference rules"))  # type: ignore
-    solver = staticmethod(_get_spin_context_manager("🧠 Solving column types"))  # type: ignore
-    renderers = staticmethod(_get_spin_context_manager("📝 Writing output"))  # type: ignore
+    rules = staticmethod(_get_spin_context_manager_factory("🤔 Processing inference rules"))  # type: ignore
+    solver = staticmethod(_get_spin_context_manager_factory("🧠 Solving column types"))  # type: ignore
+    renderers = staticmethod(_get_spin_context_manager_factory("📝 Writing output"))  # type: ignore
 
 
 @cli.command()
 @click.option(
     "--tables",
+    cls=click_custom.MutuallyExclusiveOption,
+    mutually_exclusive=["schema"],
     type=click_custom.ListParamType(
         value_converter=lambda table_str: SqlTable.from_string(table_str),
         min_length=1,
     ),
-    required=True,
+    required=False,
     help="Comma-separated list of table names to be queried for inference.",
+)
+@click.option(
+    "--schema",
+    cls=click_custom.MutuallyExclusiveOption,
+    mutually_exclusive=["tables"],
+    type=str,
+    required=False,
+    help="Name of a schema to be queried for inference. Will list all tables in this schema.",
 )
 @click.option(
     "--max-sample-size",
@@ -824,7 +834,8 @@ class CLIInferenceProgressReporter(InferenceProgressReporter):
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
 def infer(
     cfg: CLIContext,
-    tables: List[SqlTable],
+    tables: Optional[List[SqlTable]],
+    schema: Optional[str],
     max_sample_size: int,
     solver_threshold: float,
     solver_weights: List[int],
@@ -832,6 +843,7 @@ def infer(
     overwrite: bool,
 ) -> None:
     """Infer data source configurations from warehouse information."""
+
     if cfg.sql_client.sql_engine_attributes.sql_engine_type is not SupportedSqlEngine.SNOWFLAKE:
         click.echo(
             "Data Source Inference is currently only supported for Snowflake. "
@@ -839,6 +851,19 @@ def infer(
             "stable feature. Stay tuned!"
         )
         return
+
+    if tables is None and schema is None:
+        raise click.UsageError("Either `--tables` or `--schema` have to be provided.")
+
+    if schema is not None and tables is None:
+        with _get_spin_context_manager_factory(f"🔍 Fetching available tables for schema `{schema}`")():
+            # we know it's a Snowflake client, but `list_tables` is not in the `SqlClient` interface.
+            tables_strs: List[str] = cfg.sql_client.list_tables(schema)  # type: ignore
+            tables = [SqlTable(schema_name=schema, table_name=table_name.upper()) for table_name in tables_strs]
+
+        if len(tables) == 0:
+            click.echo("Schema has no tables.")
+            return
 
     provider = SnowflakeInferenceContextProvider(client=cfg.sql_client, tables=tables, max_sample_size=max_sample_size)
 

--- a/metricflow/decorators.py
+++ b/metricflow/decorators.py
@@ -19,10 +19,9 @@ def beta_feature_warning(
         @functools.wraps(func)
         def _decorated(*args, **kwargs):
             click.echo(
-                click.style(f"{feature_name} is still in Beta 🧪. ", bold=True)
+                click.style(f"‼️ Warning: {feature_name} is still in Beta 🧪. ", fg="red", bold=True)
                 + "As such, you should not expect it to be 100% stable or be free of bugs. Any public CLI or Python interfaces may change without prior notice."
-                + "\n\n"
-                "If you find any bugs or feel like something is not behaving as it should, feel free to open an issue on the Metricflow Github repo."
+                " If you find any bugs or feel like something is not behaving as it should, feel free to open an issue on the Metricflow Github repo.\n"
             )
             return func(*args, **kwargs)
 

--- a/metricflow/decorators.py
+++ b/metricflow/decorators.py
@@ -1,0 +1,31 @@
+import functools
+from typing import Callable, TypeVar
+
+import click
+
+T = TypeVar("T")
+
+
+# unfortunately we can't use `typing.ParamSpec` to properly type the decorated function
+# because it is only available for Python 3.10+.
+def beta_feature_warning(
+    feature_name: str,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Marks a function as Beta, meaning its interface should not be expected to be stable and remain unchanged."""
+
+    def _decorator(
+        func: Callable[..., T],
+    ) -> Callable[..., T]:
+        @functools.wraps(func)
+        def _decorated(*args, **kwargs):
+            click.echo(
+                click.style(f"{feature_name} is still in Beta 🧪. ", bold=True)
+                + "As such, you should not expect it to be 100% stable or be free of bugs. Any public CLI or Python interfaces may change without prior notice."
+                + "\n\n"
+                "If you find any bugs or feel like something is not behaving as it should, feel free to open an issue on the Metricflow Github repo."
+            )
+            return func(*args, **kwargs)
+
+        return _decorated
+
+    return _decorator

--- a/metricflow/inference/runner.py
+++ b/metricflow/inference/runner.py
@@ -5,6 +5,7 @@ from typing import List
 
 import more_itertools
 
+from metricflow.decorators import beta_feature_warning
 from metricflow.inference.context.base import InferenceContextProvider
 from metricflow.inference.context.data_warehouse import DataWarehouseInferenceContextProvider
 from metricflow.inference.rule.base import InferenceRule
@@ -20,6 +21,7 @@ from metricflow.inference.renderer.base import InferenceRenderer
 class InferenceRunner:
     """Glues together all other inference classes in a sequence that actually runs inference."""
 
+    @beta_feature_warning(feature_name="Data Source Inference")
     def __init__(
         self,
         context_providers: List[InferenceContextProvider],

--- a/metricflow/inference/runner.py
+++ b/metricflow/inference/runner.py
@@ -1,16 +1,88 @@
 from __future__ import annotations
+from abc import ABC, abstractmethod
 from collections import defaultdict
+import contextlib
 
-from typing import List
+from typing import Iterator, List
 
 import more_itertools
 
+from metricflow.dataflow.sql_table import SqlTable
 from metricflow.decorators import beta_feature_warning
 from metricflow.inference.context.base import InferenceContextProvider
 from metricflow.inference.context.data_warehouse import DataWarehouseInferenceContextProvider
 from metricflow.inference.rule.base import InferenceRule
 from metricflow.inference.solver.base import InferenceSolver
 from metricflow.inference.renderer.base import InferenceRenderer
+
+
+class InferenceProgressReporter(ABC):
+    """Base class for reporting progress while running inference."""
+
+    @staticmethod
+    @abstractmethod
+    @contextlib.contextmanager
+    def warehouse() -> Iterator[None]:
+        """Context manager that wraps the warehouse context fetching step."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    @contextlib.contextmanager
+    def table(table: SqlTable, index: int, total: int) -> Iterator[None]:
+        """Context manager that wraps context fetching for a single table."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    @contextlib.contextmanager
+    def rules() -> Iterator[None]:
+        """Context manager that wraps all rule-processing."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    @contextlib.contextmanager
+    def solver() -> Iterator[None]:
+        """Context manager that wraps the solving step."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    @contextlib.contextmanager
+    def renderers() -> Iterator[None]:
+        """Context manager that wraps the rendering step."""
+        raise NotImplementedError
+
+
+class NoOpInferenceProgressReporter(InferenceProgressReporter):
+    """Pass-through implementation if `InferenceProgressReporter`."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def warehouse() -> Iterator[None]:  # noqa: D
+        yield
+
+    @staticmethod
+    @contextlib.contextmanager
+    def table(table: SqlTable, index: int, total: int) -> Iterator[None]:  # noqa: D
+        yield
+
+    @staticmethod
+    @contextlib.contextmanager
+    def rules() -> Iterator[None]:  # noqa: D
+        yield
+
+    @staticmethod
+    @contextlib.contextmanager
+    def solver() -> Iterator[None]:  # noqa: D
+        yield
+
+    @staticmethod
+    @contextlib.contextmanager
+    def renderers() -> Iterator[None]:  # noqa: D
+        yield
+
 
 # TODO: we still need to add input/output context validations and optimizations.
 # Case 1: Rule 1 requires Context of type A, but no provider privides it. Should fail before running
@@ -28,6 +100,7 @@ class InferenceRunner:
         ruleset: List[InferenceRule],
         solver: InferenceSolver,
         renderers: List[InferenceRenderer],
+        progress_reporter: InferenceProgressReporter = NoOpInferenceProgressReporter(),
     ) -> None:
         """Initialize the inference runner.
 
@@ -35,6 +108,7 @@ class InferenceRunner:
         ruleset: the set of rules that will produce signals
         solver: the inference solver to be used
         renderers: the renderers that will write inference results as meaningful output
+        progress_reporter: `InferenceProgressReporter` to report progress
         """
         if len(context_providers) != 1 or not isinstance(context_providers[0], DataWarehouseInferenceContextProvider):
             raise ValueError("Currently, InferenceRunner requires exactly one DataWarehouseInferenceContextProvider.")
@@ -49,16 +123,25 @@ class InferenceRunner:
         self.ruleset = ruleset
         self.solver = solver
         self.renderers = renderers
+        self._progress = progress_reporter
 
     def run(self) -> None:
         """Runs inference with the given configs."""
-        warehouse = self.context_providers[0].get_context()
-        signals_by_column = defaultdict(list)
-        signals = [rule.process(warehouse) for rule in self.ruleset]
-        for rule_signal in more_itertools.flatten(signals):
-            signals_by_column[rule_signal.column].append(rule_signal)
 
-        results = [self.solver.solve_column(column, signals) for column, signals in signals_by_column.items()]
+        with self._progress.warehouse():
+            warehouse = self.context_providers[0].get_context(
+                table_progress=self._progress.table,
+            )
 
-        for renderer in self.renderers:
-            renderer.render(results)
+        with self._progress.rules():
+            signals_by_column = defaultdict(list)
+            signals = [rule.process(warehouse) for rule in self.ruleset]
+            for rule_signal in more_itertools.flatten(signals):
+                signals_by_column[rule_signal.column].append(rule_signal)
+
+        with self._progress.solver():
+            results = [self.solver.solve_column(column, signals) for column, signals in signals_by_column.items()]
+
+        with self._progress.renderers():
+            for renderer in self.renderers:
+                renderer.render(results)

--- a/metricflow/test/cli/test_custom_click_types.py
+++ b/metricflow/test/cli/test_custom_click_types.py
@@ -1,0 +1,46 @@
+import pytest
+import click
+
+from metricflow.cli.custom_click_types import ListParamType
+
+
+def test_check_min_length():
+    """Make sure `ListParamType` checks for `min_length` param."""
+    ltype = ListParamType(min_length=2)
+    ltype.convert("1,2", None, None)
+    with pytest.raises(click.BadParameter):
+        ltype.convert("1", None, None)
+
+
+def test_check_max_length():
+    """Make sure `ListParamType` checks for `max_length` param."""
+    ltype = ListParamType(max_length=2)
+    ltype.convert("1,2", None, None)
+    with pytest.raises(click.BadParameter):
+        ltype.convert("1,2,3", None, None)
+
+
+def test_use_value_converter():
+    """Make sure `ListParamType` uses `value_converter`."""
+    ltype = ListParamType(value_converter=lambda x_str: int(x_str))
+    values = ltype.convert("1,2,3,4,5", None, None)
+
+    assert values == [1, 2, 3, 4, 5]
+
+
+def test_value_converter_fail():
+    """Make sure `ListParamType` fails gracefully when a value cannot be converted."""
+    ltype = ListParamType(value_converter=lambda x_str: int(x_str))
+    with pytest.raises(click.BadParameter):
+        ltype.convert("1,abc", None, None)
+
+
+def test_use_separator():
+    """Make sure `ListParamType` uses `separator`."""
+    ltype = ListParamType(separator=":")
+
+    sep_values = ltype.convert("1:2:3:4:5", None, None)
+    assert sep_values == ["1", "2", "3", "4", "5"]
+
+    no_sep_values = ltype.convert("1,2,3,4,5", None, None)
+    assert no_sep_values == ["1,2,3,4,5"]


### PR DESCRIPTION
This PR adds a CLI interface for data source inference.

Main functionalities are:
- Main function in `metricflow/cli/main.py` for using all parameters to construct an inference pipeline.
- New `InferenceProgressReporter` class for reporting begin/end of inference pipeline steps. This can be useful for custom reporting in scripts but is also used to peek into the inference pipeline in a generic and non-intrusive way.
- New `custom_click_types` module with a couple of CLI helper functions to make our lives easier:
  - `MutuallyExclusiveOption`: class for making click options mutually exclusive
  - `ListParamType`: class for making list parameters like `1,2,3,4` that are automatically coerced to useful lists like `[1,2,3,4]`. See docs and implementation for more details.

## Examples

### Help guide
<img width="576" alt="image" src="https://user-images.githubusercontent.com/18057473/182253745-caf1e214-ae00-47d0-832c-3ea71ce73f53.png">

### Usage

<img width="938" alt="inference-cli" src="https://user-images.githubusercontent.com/18057473/182253588-77b4549e-1949-4bb5-95ef-a70a4a5ce779.png">

NOTE: Table and schema names were censored for obvious reasons.

