### PR TITLE
Support metric_time in Where Constraints

### DIFF
--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -133,7 +133,9 @@ class MetricFlowQueryParser:
         }
 
         for spec_name in linkable_spec_names:
-            if spec_name.element_name in dimension_references:
+            if spec_name.element_name == DataSet.metric_time_dimension_name():
+                where_constraint_dimensions.append(TimeDimensionSpec.from_name(spec_name.qualified_name))
+            elif spec_name.element_name in dimension_references:
                 dimension = data_source_semantics.get_dimension(dimension_references[spec_name.element_name])
                 if dimension.type == DimensionType.CATEGORICAL:
                     where_constraint_dimensions.append(DimensionSpec.from_name(spec_name.qualified_name))

--- a/metricflow/test/integration/test_cases/itest_constraints.yaml
+++ b/metricflow/test/integration/test_cases/itest_constraints.yaml
@@ -124,3 +124,18 @@ integration_test:
     WHERE {{ render_time_constraint("created_at", "2020-01-01", "2021-01-01") }}
     GROUP BY  created_at
 
+---
+integration_test:
+  name: test_metric_time_in_where
+  description: Tests having metric_time in the where clause constraint.
+  model: SIMPLE_MODEL
+  metrics: ["bookings"]
+  group_bys: ["metric_time"]
+  where_constraint: "{{ render_time_constraint('metric_time', '2020-01-01', '2021-01-02') }}"
+  check_query: |
+    SELECT
+      SUM(1) AS bookings
+      , ds AS metric_time
+    FROM  {{ source_schema }}.fct_bookings
+    WHERE {{ render_time_constraint("ds", "2020-01-01", "2021-01-02") }}
+    GROUP BY ds


### PR DESCRIPTION
Although not recommended due to poor query optimization, this PR allows using `metric_time` in the where clause constraint.