### PR TITLE
Separate `*Reference` classes out of specs.py

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -36,12 +36,12 @@ from metricflow.dataset.dataset import DataSet
 from metricflow.model.objects.metric import CumulativeMetricWindow
 from metricflow.model.objects.elements.measure import AggregationType
 from metricflow.object_utils import pformat_big_objects
+from metricflow.references import TimeDimensionReference
 from metricflow.specs import (
     OrderBySpec,
     InstanceSpec,
     MetricSpec,
     LinklessIdentifierSpec,
-    TimeDimensionReference,
     TimeDimensionSpec,
     SpecWhereClauseConstraint,
 )

--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -6,7 +6,8 @@ from metricflow.instances import (
     InstanceSet,
 )
 from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords
-from metricflow.specs import TimeDimensionReference, TimeDimensionSpec
+from metricflow.references import TimeDimensionReference
+from metricflow.specs import TimeDimensionSpec
 from metricflow.time.time_granularity import TimeGranularity
 
 

--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -9,7 +9,7 @@ from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.base import ModelWithMetadataParsing, HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
-from metricflow.specs import LinkableElementReference, MeasureReference
+from metricflow.references import LinkableElementReference, MeasureReference
 
 
 class DataSourceOrigin(ExtendedEnum):

--- a/metricflow/model/objects/elements/dimension.py
+++ b/metricflow/model/objects/elements/dimension.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from metricflow.model.objects.base import HashableBaseModel
-from metricflow.specs import DimensionReference, TimeDimensionReference
+from metricflow.references import DimensionReference, TimeDimensionReference
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.object_utils import ExtendedEnum
 

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Dict, Any
 
 from metricflow.model.objects.base import HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
-from metricflow.specs import IdentifierReference, CompositeSubIdentifierReference
+from metricflow.references import IdentifierReference, CompositeSubIdentifierReference
 
 
 class IdentifierType(ExtendedEnum):

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.base import ModelWithMetadataParsing, HashableBaseModel
 from metricflow.object_utils import ExtendedEnum, hash_strings
-from metricflow.specs import MeasureReference, TimeDimensionReference
+from metricflow.references import MeasureReference, TimeDimensionReference
 
 
 class AggregationType(ExtendedEnum):

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -12,7 +12,7 @@ from metricflow.model.objects.base import (
     PydanticParseableValueType,
 )
 from metricflow.object_utils import ExtendedEnum, hash_strings
-from metricflow.specs import MeasureReference
+from metricflow.references import MeasureReference
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.time.time_granularity import string_to_time_granularity
 

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -12,8 +12,8 @@ from metricflow.model.objects.elements.dimension import DimensionType, Dimension
 from metricflow.model.objects.elements.identifier import IdentifierType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.object_utils import pformat_big_objects, flatten_nested_sequence
+from metricflow.references import MeasureReference
 from metricflow.specs import (
-    MeasureReference,
     LinklessIdentifierSpec,
     DEFAULT_TIME_GRANULARITY,
     LinkableSpecSet,

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -24,15 +24,17 @@ from metricflow.model.semantics.linkable_spec_resolver import (
     ValidLinkableSpecResolver,
     LinkableElementProperties,
 )
-from metricflow.specs import (
-    LinkableInstanceSpec,
-    LinkableElementReference,
-    MeasureSpec,
-    MeasureReference,
+from metricflow.references import (
     DimensionReference,
     IdentifierReference,
-    MetricSpec,
+    LinkableElementReference,
+    MeasureReference,
     TimeDimensionReference,
+)
+from metricflow.specs import (
+    LinkableInstanceSpec,
+    MeasureSpec,
+    MetricSpec,
 )
 
 logger = logging.getLogger(__name__)

--- a/metricflow/model/transformations/agg_time_dimension.py
+++ b/metricflow/model/transformations/agg_time_dimension.py
@@ -5,7 +5,7 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import DimensionType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.transformations.transform_rule import ModelTransformRule
-from metricflow.specs import TimeDimensionReference
+from metricflow.references import TimeDimensionReference
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/model/validations/agg_time_dimension.py
+++ b/metricflow/model/validations/agg_time_dimension.py
@@ -13,7 +13,7 @@ from metricflow.model.validations.validator_helpers import (
     validate_safely,
     ValidationError,
 )
-from metricflow.specs import TimeDimensionReference
+from metricflow.references import TimeDimensionReference
 
 
 class AggregationTimeDimensionRule(ModelValidationRule):

--- a/metricflow/model/validations/common_identifiers.py
+++ b/metricflow/model/validations/common_identifiers.py
@@ -13,7 +13,7 @@ from metricflow.model.validations.validator_helpers import (
     validate_safely,
     ValidationIssueType,
 )
-from metricflow.specs import IdentifierReference
+from metricflow.references import IdentifierReference
 
 
 class CommonIdentifiersRule(ModelValidationRule):

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -16,7 +16,7 @@ from metricflow.model.validations.validator_helpers import (
     ValidationError,
     validate_safely,
 )
-from metricflow.specs import MeasureReference
+from metricflow.references import MeasureReference
 from metricflow.time.time_constants import SUPPORTED_GRANULARITIES
 
 logger = logging.getLogger(__name__)

--- a/metricflow/model/validations/dimension_const.py
+++ b/metricflow/model/validations/dimension_const.py
@@ -14,7 +14,7 @@ from metricflow.model.validations.validator_helpers import (
     validate_safely,
 )
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.specs import DimensionReference
+from metricflow.references import DimensionReference
 from metricflow.time.time_granularity import TimeGranularity
 
 

--- a/metricflow/model/validations/identifiers.py
+++ b/metricflow/model/validations/identifiers.py
@@ -23,7 +23,7 @@ from metricflow.model.validations.validator_helpers import (
     ValidationWarning,
 )
 from metricflow.model.validations.validator_helpers import ValidationFutureError
-from metricflow.specs import IdentifierReference
+from metricflow.references import IdentifierReference
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/model/validations/unique_valid_name.py
+++ b/metricflow/model/validations/unique_valid_name.py
@@ -26,7 +26,7 @@ from metricflow.model.validations.validator_helpers import (
     validate_safely,
 )
 from metricflow.object_utils import assert_values_exhausted
-from metricflow.specs import ElementReference
+from metricflow.references import ElementReference
 from metricflow.time.time_granularity import TimeGranularity
 
 

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -15,7 +15,8 @@ from metricflow.dataflow.dataflow_plan import (
 from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MAX_JOIN_HOPS
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.spec_set_transforms import ToElementNameSet
-from metricflow.specs import IdentifierSpec, InstanceSpec, LinkableInstanceSpec, TimeDimensionReference
+from metricflow.references import TimeDimensionReference
+from metricflow.specs import IdentifierSpec, InstanceSpec, LinkableInstanceSpec
 
 SqlDataSetT = TypeVar("SqlDataSetT", bound=SqlDataSet)
 

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -22,6 +22,7 @@ from metricflow.model.semantics.semantic_containers import DataSourceSemantics
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.object_utils import pformat_big_objects
 from metricflow.query.query_exceptions import InvalidQueryException
+from metricflow.references import DimensionReference, IdentifierReference, TimeDimensionReference
 from metricflow.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
@@ -31,12 +32,9 @@ from metricflow.specs import (
     LinkableInstanceSpec,
     LinklessIdentifierSpec,
     OrderBySpec,
-    DimensionReference,
-    IdentifierReference,
     OutputColumnNameOverride,
     SpecWhereClauseConstraint,
     LinkableSpecSet,
-    TimeDimensionReference,
 )
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.time.time_granularity_solver import (

--- a/metricflow/references.py
+++ b/metricflow/references.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ElementReference:
+    """Used when we need to refer to a dimension, measure, identifier, but other attributes are unknown."""
+
+    element_name: str
+
+
+@dataclass(frozen=True)
+class LinkableElementReference(ElementReference):
+    """Used when we need to refer to a dimension or identifier, but other attributes are unknown."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class MeasureReference(ElementReference):
+    """Used when we need to refer to a measure (separate from LinkableElementReference because measures aren't linkable"""
+
+    pass
+
+
+@dataclass(frozen=True)
+class DimensionReference(LinkableElementReference):  # noqa: D
+    pass
+
+    @property
+    def time_dimension_reference(self) -> TimeDimensionReference:  # noqa: D
+        return TimeDimensionReference(element_name=self.element_name)
+
+
+@dataclass(frozen=True)
+class IdentifierReference(LinkableElementReference):  # noqa: D
+    pass
+
+
+@dataclass(frozen=True)
+class CompositeSubIdentifierReference(ElementReference):  # noqa: D
+    pass
+
+
+@dataclass(frozen=True)
+class TimeDimensionReference(DimensionReference):  # noqa: D
+    pass
+
+    def dimension_reference(self) -> DimensionReference:  # noqa: D
+        return DimensionReference(element_name=self.element_name)

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import itertools
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple, TypeVar, Generic
 
 from metricflow.column_assoc import ColumnAssociation
@@ -20,6 +19,7 @@ from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.model.objects.base import FrozenBaseModel
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
+from metricflow.references import DimensionReference, MeasureReference, TimeDimensionReference
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 
 
@@ -265,54 +265,6 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
             element_name=self.element_name,
             time_granularity=self.time_granularity,
         ).qualified_name
-
-
-@dataclass(frozen=True)
-class ElementReference:
-    """Used when we need to refer to a dimension, measure, identifier, but other attributes are unknown."""
-
-    element_name: str
-
-
-@dataclass(frozen=True)
-class LinkableElementReference(ElementReference):
-    """Used when we need to refer to a dimension or identifier, but other attributes are unknown."""
-
-    pass
-
-
-@dataclass(frozen=True)
-class MeasureReference(ElementReference):
-    """Used when we need to refer to a measure (separate from LinkableElementReference because measures aren't linkable"""
-
-    pass
-
-
-@dataclass(frozen=True)
-class DimensionReference(LinkableElementReference):  # noqa: D
-    pass
-
-    @property
-    def time_dimension_reference(self) -> TimeDimensionReference:  # noqa: D
-        return TimeDimensionReference(element_name=self.element_name)
-
-
-@dataclass(frozen=True)
-class IdentifierReference(LinkableElementReference):  # noqa: D
-    pass
-
-
-@dataclass(frozen=True)
-class CompositeSubIdentifierReference(ElementReference):  # noqa: D
-    pass
-
-
-@dataclass(frozen=True)
-class TimeDimensionReference(DimensionReference):  # noqa: D
-    pass
-
-    def dimension_reference(self) -> DimensionReference:  # noqa: D
-        return DimensionReference(element_name=self.element_name)
 
 
 # How to avoid circular import here

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -18,6 +18,7 @@ from metricflow.column_assoc import ColumnAssociation
 from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.model.objects.base import FrozenBaseModel
+from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.references import DimensionReference, MeasureReference, TimeDimensionReference
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -265,10 +266,6 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
             element_name=self.element_name,
             time_granularity=self.time_granularity,
         ).qualified_name
-
-
-# How to avoid circular import here
-from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters  # noqa: E402
 
 
 class MeasureSpec(InstanceSpec):  # noqa: D

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -6,7 +6,8 @@ from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
 from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MetricSemantics
-from metricflow.specs import MetricSpec, MeasureReference
+from metricflow.references import MeasureReference
+from metricflow.specs import MetricSpec
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -7,7 +7,7 @@ from metricflow.model.objects.elements.measure import Measure, AggregationType
 from metricflow.model.objects.metric import MetricType, MetricTypeParams, Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException
-from metricflow.specs import DimensionReference, MeasureReference, TimeDimensionReference
+from metricflow.references import DimensionReference, MeasureReference, TimeDimensionReference
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity
 

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -8,8 +8,7 @@ from metricflow.model.objects.elements.measure import Measure, AggregationType
 from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException
-from metricflow.specs import DimensionReference, IdentifierReference
-from metricflow.specs import TimeDimensionReference
+from metricflow.references import DimensionReference, IdentifierReference, TimeDimensionReference
 from metricflow.test.fixtures.table_fixtures import DEFAULT_DS
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
 from metricflow.time.time_granularity import TimeGranularity

--- a/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
+++ b/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
@@ -5,7 +5,8 @@ from metricflow.dataflow.dataflow_plan import MetricTimeDimensionTransformNode
 from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.specs import TimeDimensionReference, MetricFlowQuerySpec, MetricSpec
+from metricflow.references import TimeDimensionReference
+from metricflow.specs import MetricFlowQuerySpec, MetricSpec
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.plan_conversion.test_dataflow_to_sql_plan import convert_and_check

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -27,6 +27,7 @@ from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationR
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
+from metricflow.references import TimeDimensionReference
 from metricflow.specs import (
     DimensionSpec,
     IdentifierSpec,
@@ -39,7 +40,6 @@ from metricflow.specs import (
     TimeDimensionSpec,
     SpecWhereClauseConstraint,
     LinkableSpecSet,
-    TimeDimensionReference,
 )
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql.sql_bind_parameters import SqlBindParameters

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -13,13 +13,12 @@ from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.instances import MetricModelReference
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.query.query_exceptions import InvalidQueryException
+from metricflow.references import TimeDimensionReference, MeasureReference
 from metricflow.specs import (
     MetricSpec,
     TimeDimensionSpec,
     LinklessIdentifierSpec,
     DEFAULT_TIME_GRANULARITY,
-    TimeDimensionReference,
-    MeasureReference,
 )
 from metricflow.model.objects.metric import MetricType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel


### PR DESCRIPTION
## Context
Currently, all the `*Reference` and `*Spec` all lives together in the `specs.py` file. We should split these out as they have different functionality. This helps with code organization by not cluttering a file with unrelated code.

## Changes
- Removed all `*Reference` classes out of `specs.py` -> `references.py`
- Moved an import in the middle of the file in `specs.py` back to the top of the file. Wasn't possible due to circular import prior to the move.