### PR TITLE
Remove unused 'constraint' attribute of 'data_source_schema'

### DIFF
--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -262,7 +262,6 @@ data_source_schema = {
         "measures": {"type": "array", "items": {"$ref": "measure_schema"}},
         "dimensions": {"type": "array", "items": {"$ref": "dimension_schema"}},
         "mutability": {"$ref": "mutability_schema"},
-        "constraint": {"$ref": "constraint_schema"},
     },
     "additionalProperties": False,
     "required": ["name"],


### PR DESCRIPTION
It seems like 9 months ago we added a 'constraint' attribute to the
'data_source_schema' in anticipation of adding a 'constraint' property to the
'DataSource' object. However, we never added this 'constraint' functionally.
Additionally, we never defined the corresponding 'constraint_schema' that would
be needed to resolve/parse this 'constraint' property.

The good news is, removing this attribute won't break anyone's configs. This is
because if someone is currently including this attribute for a data source,
parsing of the configs failed. More good news is that if we ever do want to add
a constraint attribute to data sources, we can always re-implent it.