### PR TITLE
Use metric_time instead of ds in semi-additive test case

### DIFF
--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -34,10 +34,10 @@ integration_test:
   description: Tests selecting a measure with semi additive properties
   model: SIMPLE_MODEL
   metrics: ["total_account_balance_first_day"]
-  group_bys: ["ds"]
+  group_bys: ["metric_time"]
   check_query: |
     SELECT
-      a.ds AS ds
+      a.ds AS metric_time
       , SUM(a.total_account_balance_first_day) AS total_account_balance_first_day
     FROM (
       SELECT


### PR DESCRIPTION
Bringing this in line with the new query standard
