### PR TITLE
Update source node generator for data warehouse validations to expect >= 1 nodes

### DIFF
--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -97,7 +97,7 @@ class DataWarehouseTaskBuilder:
             (render_tools.converter.create_sql_source_data_set(data_source_semantics),)
         )
 
-        assert len(source_nodes) == 1
+        assert len(source_nodes) >= 1
         return source_nodes[0]
 
     @staticmethod


### PR DESCRIPTION
The data warehouse model validator has a helper function '_data_source_node' to
generate the data source node for the validation query. To generate the source node
the function uses the 'create_from_data_sets' function and asserted that this only
returns one node. However the function actually generate multiple nodes per data
set supplied. This was breaking data warehouse validations for any data source
where more than one source node could be returned. This commit updates
'_data_source_node' to assume that more than one node can be returned from
'create_from_data_sets' and to return the first node.