### PR TITLE
Change Pydantic Models to Serializable Dataclasses

### DIFF
--- a/metricflow/column_assoc.py
+++ b/metricflow/column_assoc.py
@@ -1,28 +1,31 @@
-from abc import ABC
-from typing import Union
+from dataclasses import dataclass
+from typing import Protocol, Optional
 
-from metricflow.model.objects.base import FrozenBaseModel
+from metricflow.object_utils import assert_exactly_one_arg_set
 
 
-class ColumnCorrelationKey(ABC, FrozenBaseModel):
+class ColumnCorrelationKey(Protocol):
     """Interface for a key object that is used to correlate columns between instance sets."""
 
     pass
 
 
+@dataclass(frozen=True)
 class SingleColumnCorrelationKey(ColumnCorrelationKey):
     """Key to use when there's only 1 column association in an instance."""
 
     pass
 
 
+@dataclass(frozen=True)
 class CompositeColumnCorrelationKey(ColumnCorrelationKey):
     """Key to use when there are multiple column associations in an instance"""
 
     sub_identifier: str
 
 
-class ColumnAssociation(FrozenBaseModel):
+@dataclass(frozen=True)
+class ColumnAssociation:
     """Used to describe how an instance is associated with columns in table / SQL query.
 
     Generally there will be a 1:1 mapping, but for composite identifiers, it can map to multiple columns. For that case,
@@ -33,4 +36,16 @@ class ColumnAssociation(FrozenBaseModel):
     # When an instance is passed from one dataflow node to another, we need to know how the columns from the input
     # corresponds to the columns from the output. Equality of this key is used to determine that relationship.
     # This could be made to be in a dictionary instead, but having it here means that it doesn't need to be hashable.
-    column_correlation_key: Union[CompositeColumnCorrelationKey, SingleColumnCorrelationKey]
+    single_column_correlation_key: Optional[SingleColumnCorrelationKey] = None
+    composite_column_correlation_key: Optional[ColumnCorrelationKey] = None
+
+    def __post_init__(self) -> None:  # noqa: D
+        assert_exactly_one_arg_set(
+            single_column_correlation_key=self.single_column_correlation_key,
+            composite_column_correlation_key=self.composite_column_correlation_key,
+        )
+
+    def column_correlation_key(self) -> ColumnCorrelationKey:  # noqa: D
+        result: ColumnCorrelationKey = self.single_column_correlation_key or self.composite_column_correlation_key
+        assert result
+        return result

--- a/metricflow/column_assoc.py
+++ b/metricflow/column_assoc.py
@@ -1,31 +1,40 @@
+from abc import ABC
 from dataclasses import dataclass
-from typing import Protocol, Optional
+from typing import Optional, Any
 
+from metricflow.dataclass_serialization import SerializableDataclass
 from metricflow.object_utils import assert_exactly_one_arg_set
 
 
-class ColumnCorrelationKey(Protocol):
+class ColumnCorrelationKey(ABC):
     """Interface for a key object that is used to correlate columns between instance sets."""
 
     pass
 
 
 @dataclass(frozen=True)
-class SingleColumnCorrelationKey(ColumnCorrelationKey):
+class SingleColumnCorrelationKey(ColumnCorrelationKey, SerializableDataclass):
     """Key to use when there's only 1 column association in an instance."""
 
-    pass
+    # Pydantic throws an error during serialization if a dataclass has no fields.
+    __PYDANTIC_BUG_WORKAROUND: bool = True
+
+    def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
+        return isinstance(other, SingleColumnCorrelationKey)
+
+    def __hash__(self) -> int:  # noqa: D
+        return hash(self.__class__.__name__)
 
 
 @dataclass(frozen=True)
-class CompositeColumnCorrelationKey(ColumnCorrelationKey):
+class CompositeColumnCorrelationKey(ColumnCorrelationKey, SerializableDataclass):
     """Key to use when there are multiple column associations in an instance"""
 
     sub_identifier: str
 
 
 @dataclass(frozen=True)
-class ColumnAssociation:
+class ColumnAssociation(SerializableDataclass):
     """Used to describe how an instance is associated with columns in table / SQL query.
 
     Generally there will be a 1:1 mapping, but for composite identifiers, it can map to multiple columns. For that case,
@@ -37,7 +46,7 @@ class ColumnAssociation:
     # corresponds to the columns from the output. Equality of this key is used to determine that relationship.
     # This could be made to be in a dictionary instead, but having it here means that it doesn't need to be hashable.
     single_column_correlation_key: Optional[SingleColumnCorrelationKey] = None
-    composite_column_correlation_key: Optional[ColumnCorrelationKey] = None
+    composite_column_correlation_key: Optional[CompositeColumnCorrelationKey] = None
 
     def __post_init__(self) -> None:  # noqa: D
         assert_exactly_one_arg_set(
@@ -45,7 +54,11 @@ class ColumnAssociation:
             composite_column_correlation_key=self.composite_column_correlation_key,
         )
 
+    @property
     def column_correlation_key(self) -> ColumnCorrelationKey:  # noqa: D
-        result: ColumnCorrelationKey = self.single_column_correlation_key or self.composite_column_correlation_key
-        assert result
-        return result
+        if self.single_column_correlation_key:
+            return self.single_column_correlation_key
+        elif self.composite_column_correlation_key:
+            return self.composite_column_correlation_key
+
+        raise RuntimeError("single_column_correlation_key or composite_column_correlation_key should be set")

--- a/metricflow/constraints/time_constraint.py
+++ b/metricflow/constraints/time_constraint.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass
 from typing import Optional
 
 import pandas as pd
 
-from metricflow.model.objects.base import HashableBaseModel
+from metricflow.dataclass_serialization import SerializableDataclass
 from metricflow.time.time_granularity import TimeGranularity
 
 
-class TimeRangeConstraint(HashableBaseModel):
+@dataclass(frozen=True)
+class TimeRangeConstraint(SerializableDataclass):
     """Describes how the time dimension for metrics should be constrained."""
 
     start_time: datetime.datetime

--- a/metricflow/dataclass_serialization.py
+++ b/metricflow/dataclass_serialization.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import logging
+import typing
+from builtins import NameError
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Type, TypeVar, Dict, Tuple, Optional
+from typing import Union
+from typing import get_origin, get_args
+
+import pydantic
+from pydantic import BaseModel
+
+from metricflow.object_utils import pformat_big_objects
+
+logger = logging.getLogger(__name__)
+
+
+# Any Pydantic object
+PydanticT = TypeVar("PydanticT", bound=Type[BaseModel])
+
+
+class UnknownClassError(Exception):
+    """Raised when there's an issue getting type information for a SerializableDataclass"""
+
+    pass
+
+
+class DataclassDeserializationError(Exception):
+    """Raised when there is any error deserializing a dataclass."""
+
+    pass
+
+
+def _get_dataclass_field_types(dataclass_type: Type) -> Dict[str, Type]:
+    """Returns the types of fields in a dataclass. Returns a dict from the name of the field to the type."""
+    assert dataclasses.is_dataclass(dataclass_type)
+    try:
+        return typing.get_type_hints(dataclass_type, localns={})
+    except NameError as e:
+        raise UnknownClassError(
+            f"Error getting type hints for dataclass {dataclass_type}. Please see the nested exception as a required "
+            f"class may not be imported properly."
+        ) from e
+
+
+def _is_optional_type(type_to_check: Type) -> bool:
+    """Returns true if the given type is an optional type. Python represents optional as Union[SomeType, NoneType]."""
+    if get_origin(type_to_check) is typing.Union:
+        args = get_args(type_to_check)
+        if len(args) == 2 and type(None) in args:
+            return True
+    return False
+
+
+def _get_type_parameter_for_optional(type_to_check: Type) -> Type:
+    """Given Union[SomeType, NoneType], return SomeType."""
+    assert _is_optional_type(type_to_check)
+    return (
+        get_args(type_to_check)[0]
+        if not issubclass(get_args(type_to_check)[0], type(None))
+        else get_args(type_to_check)[0]
+    )
+
+
+def _is_supported_field_type_in_serializable_dataclass(field_type: Type) -> bool:
+    """Returns if a type of a given field in a SerializableDatclass is supported.
+
+    For container classes, this does not check the type of the type parameter for the container.
+    """
+    return (
+        (
+            _is_sequence_like_tuple_type(field_type)
+            and _is_supported_field_type_in_serializable_dataclass(
+                _get_type_parameter_for_sequence_like_tuple_type(field_type)
+            )
+        )
+        or (
+            _is_optional_type(field_type)
+            and _is_supported_field_type_in_serializable_dataclass(_get_type_parameter_for_optional(field_type))
+        )
+        or issubclass(field_type, Enum)
+        or issubclass(field_type, SerializableDataclass)
+        or issubclass(field_type, int)
+        or issubclass(field_type, float)
+        or issubclass(field_type, str)
+        or issubclass(field_type, datetime.datetime)
+        or issubclass(field_type, datetime.timedelta)
+        or issubclass(field_type, BaseModel)
+    )
+
+
+def _is_sequence_like_tuple_type(field_type: Type) -> bool:
+    """Returns true for tuple types that are like sequences.
+
+    In a dataclass definition:
+
+        foo: Tuple[SomeType, ...]
+
+    would return true, but
+
+       foo: Tuple[SomeType, SomeOtherType]
+
+    would not.
+    """
+    if get_origin(field_type) is tuple:
+        args = get_args(field_type)
+        return len(args) == 2 and args[1] is Ellipsis
+    return False
+
+
+def _get_type_parameter_for_sequence_like_tuple_type(field_type: Type) -> Type:
+    """Return the type parameter for a sequence like tuple type in a daclass definition.
+
+    e.g.
+
+        foo: Tuple[SomeType, ...]
+
+    should return SomeType.
+    """
+    assert _is_sequence_like_tuple_type(field_type)
+    args = get_args(field_type)
+    return args[0]
+
+
+class SerializableDataclass:
+    """Describes a dataclass that can be serialized using DataclassSerializer.
+
+    Previously, Pydnatic has been used for defining objects as it provides built in support for serialization and
+    deserialization. However, Pydantic object is slow compared to dataclass initialization, with tests showing 10x-100x
+    slower performance. This is an issue if many objects are created, which can happen in during plan generation. Using
+    the BaseModel.construct() is still not as fast as dataclass initiaization and it also makes for an awkward developer
+    interface. Because of this, MF implements a simple custom serializer / deserializer to work with the built-in
+    Python dataclass.
+
+    The dataclass must have concrete types for all fields and not all types are supported. Please see implementation
+    details in DataclassSerializer. Not adding post_init checks as there have been previous issues with slow object
+    initialization.
+
+    This is a concrete object as MyPy currently throws a type error if a Python dataclass is defined with an abstract
+    parent class.
+    """
+
+    pass
+
+
+SerializableDataclassT = TypeVar("SerializableDataclassT", bound=SerializableDataclass)
+
+
+class DataclassSerializer:
+    """Serializer that serializes SerializableDataclasses.
+
+    Pydantic is useful for serialization, but it has issues serializing dataclasses. We've seen issues with forward
+    references and recursion errors, but it's helpful for other data types. To serialize dataclasses, this class uses
+    the type annotation defined in the dataclass to create a Pydantic model, and then uses Pydantic to serialize to a
+    JSON string.
+    """
+
+    def __init__(self) -> None:  # noqa: D
+        self._to_pydantic_type_converter = DataClassTypeToPydanticTypeConverter()
+
+    def _convert_dataclass_instance_to_pydantic_model(  # type: ignore[misc]
+        self, object_type: Type, obj: Optional[Any] = None
+    ) -> Any:
+        if not _is_supported_field_type_in_serializable_dataclass(object_type):
+            raise RuntimeError(f"Unsupported field type: {object_type}")
+        elif _is_optional_type(object_type):
+            if obj is None:
+                return None
+            optional_field_type_parameter = _get_type_parameter_for_optional(object_type)
+            return self._convert_dataclass_instance_to_pydantic_model(
+                object_type=optional_field_type_parameter, obj=obj
+            )
+        elif _is_sequence_like_tuple_type(object_type):
+            if obj is None:
+                return None
+
+            tuple_field_type_parameter = _get_type_parameter_for_sequence_like_tuple_type(object_type)
+            return tuple(
+                self._convert_dataclass_instance_to_pydantic_model(
+                    object_type=tuple_field_type_parameter,
+                    obj=x,
+                )
+                for x in obj
+            )
+        elif issubclass(object_type, SerializableDataclass):
+            if not dataclasses.is_dataclass(object_type):
+                raise RuntimeError(f"{object_type} is not a dataclass")
+            if not isinstance(obj, SerializableDataclass):
+                raise RuntimeError(f"{obj} is not a SerializableDataclass")
+            PydanticModel = self._to_pydantic_type_converter.to_pydantic_type(object_type)
+
+            field_dict = _get_dataclass_field_types(object_type)
+            field_values: Dict[str, Any] = {}  # type: ignore
+            for field_name, field_type in field_dict.items():
+                field_values[field_name] = self._convert_dataclass_instance_to_pydantic_model(
+                    object_type=field_type, obj=getattr(obj, field_name)
+                )
+            return PydanticModel(**field_values)
+
+        return obj
+
+    def pydantic_serialize(self, obj: SerializableDataclassT) -> str:  # noqa: D
+        assert dataclasses.is_dataclass(obj)
+
+        return self._convert_dataclass_instance_to_pydantic_model(
+            # .__class__ seems to be the approach for new classes and there are differences with type(obj)
+            object_type=obj.__class__,
+            obj=obj,
+        ).json()
+
+
+class DataClassDeserializer:
+    """Corresponding deserializer for datclasses that were serialized by DataClassSerializer."""
+
+    def __init__(self) -> None:  # noqa: D
+        self._to_pydantic_type_converter = DataClassTypeToPydanticTypeConverter()
+
+    def _convert_field_in_pydantic_object_to_actual_object(  # type: ignore[misc]
+        self, field_type: Type, obj: Optional[Any] = None
+    ) -> Any:
+        if not _is_supported_field_type_in_serializable_dataclass(field_type):
+            raise RuntimeError(f"Unsupported type: {field_type}")
+        elif _is_optional_type(field_type):
+            optional_field_type_parameter = _get_type_parameter_for_optional(field_type)
+            if obj is None:
+                return None
+
+            return self._convert_field_in_pydantic_object_to_actual_object(
+                field_type=optional_field_type_parameter,
+                obj=obj,
+            )
+        elif _is_sequence_like_tuple_type(field_type):
+            assert isinstance(obj, tuple)
+            tuple_type_parameter = _get_type_parameter_for_sequence_like_tuple_type(field_type)
+            return tuple(
+                self._convert_field_in_pydantic_object_to_actual_object(
+                    field_type=tuple_type_parameter,
+                    obj=x,
+                )
+                for x in obj
+            )
+        elif issubclass(field_type, SerializableDataclass):
+            logger.debug(f"Handling field_type={field_type} object={repr(obj)}")
+            return self._construct_dataclass_from_pydantic_object(
+                dataclass_type=field_type,
+                obj=obj,
+            )
+        else:
+            return obj
+
+    def _construct_dataclass_from_pydantic_object(
+        self, dataclass_type: Type[SerializableDataclassT], obj: BaseModel
+    ) -> SerializableDataclassT:
+        logger.debug(f"Constructing dataclass of type {dataclass_type} from {repr(obj)}")
+        object_args = {}
+        field_dict = _get_dataclass_field_types(dataclass_type)
+        for field_name, field_type in field_dict.items():
+            object_args[field_name] = self._convert_field_in_pydantic_object_to_actual_object(
+                field_type=field_type,
+                obj=getattr(obj, field_name),
+            )
+
+        return dataclass_type(**object_args)
+
+    def pydantic_deserialize(  # noqa: D
+        self, dataclass_type: Type[SerializableDataclassT], serialized_obj: str
+    ) -> SerializableDataclassT:
+
+        try:
+            ClassAsPydantic = self._to_pydantic_type_converter.to_pydantic_type(dataclass_type)
+            logger.debug(f"Serialized object for creation of {ClassAsPydantic} is {serialized_obj}")
+            pydantic_object = ClassAsPydantic.parse_raw(serialized_obj)
+            return self._construct_dataclass_from_pydantic_object(
+                dataclass_type=dataclass_type,
+                obj=pydantic_object,
+            )
+
+        except Exception as e:
+            raise DataclassDeserializationError from e
+
+
+class DataClassTypeToPydanticTypeConverter:  # noqa: D
+    """Class that converts a SerializableDataclass into an equivalent Pydantic object.
+
+    Includes caching to make it efficient.
+    """
+
+    def __init__(self) -> None:  # noqa: D
+        self._dataclass_type_to_pydantic_type: Dict[Type, Type[BaseModel]] = {}
+
+    def to_pydantic_type(self, dataclass_type: Type[SerializableDataclass]) -> Type[BaseModel]:  # noqa: D
+        if dataclass_type not in self._dataclass_type_to_pydantic_type:
+            self._dataclass_type_to_pydantic_type[
+                dataclass_type
+            ] = DataClassTypeToPydanticTypeConverter._convert_dataclass_type_to_pydantic_type(dataclass_type)
+        return self._dataclass_type_to_pydantic_type[dataclass_type]
+
+    @staticmethod
+    def _convert_dataclass_type_to_pydantic_type(dataclass_type: Type) -> Type[BaseModel]:  # noqa: D
+        logger.debug(f"Converting {dataclass_type.__name__} to a pydantic class")
+        assert issubclass(dataclass_type, SerializableDataclass)
+        assert dataclasses.is_dataclass(dataclass_type)
+
+        field_dict = _get_dataclass_field_types(dataclass_type)
+
+        # Maps the name of the field to (type of field, default value)
+        fields_for_pydantic_model: Dict[str, Tuple[Type, Any]] = {}  # type: ignore
+        logger.debug(f"Need to add: {pformat_big_objects(field_dict.keys())}")
+        for field_name, field_type in field_dict.items():
+            field_definition = DataClassTypeToPydanticTypeConverter._convert_field_type_object(field_type)
+            fields_for_pydantic_model[field_name] = field_definition.as_tuple()
+            logger.debug(f"Adding {field_name} with type {field_type}")
+
+        class_name = dataclass_type.__name__ + "AsPydantic"
+        logger.debug(
+            f"Creating Pydantic model {class_name} with fields:\n{pformat_big_objects(fields_for_pydantic_model)}"
+        )
+        pydantic_model = pydantic.create_model(class_name, **fields_for_pydantic_model)
+        logger.debug(f"Finished creating Pydantic model {class_name}")
+        logger.debug(f"Finished converting {dataclass_type.__name__} to a pydantic class")
+        return pydantic_model
+
+    @staticmethod
+    def _convert_field_type_object(field_type: Type) -> DataclassFieldDefinition:
+        if not _is_supported_field_type_in_serializable_dataclass(field_type):
+            raise RuntimeError(f"Unsupported type: {field_type}")
+        elif _is_optional_type(field_type):
+            optional_field_type_parameter = _get_type_parameter_for_optional(field_type)
+            converted_field_definition = DataClassTypeToPydanticTypeConverter._convert_field_type_object(
+                optional_field_type_parameter
+            )
+            return DataclassFieldDefinition(  # type: ignore[arg-type]
+                Union[converted_field_definition.field_type, type(None)], converted_field_definition.default_value
+            )
+        elif _is_sequence_like_tuple_type(field_type):
+            tuple_field_type_parameter = _get_type_parameter_for_sequence_like_tuple_type(field_type)
+            converted_field_definition = DataClassTypeToPydanticTypeConverter._convert_field_type_object(
+                tuple_field_type_parameter
+            )
+            return DataclassFieldDefinition(
+                Tuple[converted_field_definition.field_type, ...], converted_field_definition.default_value
+            )
+        elif issubclass(field_type, SerializableDataclass):
+            return DataclassFieldDefinition(
+                DataClassTypeToPydanticTypeConverter._convert_dataclass_type_to_pydantic_type(field_type), ...
+            )
+        else:
+            return DataclassFieldDefinition(field_type, ...)
+
+
+@dataclass(frozen=True)
+class DataclassFieldDefinition:  # type: ignore[misc]
+    """Describes the field definition in a dataclass as describe by the annotation."""
+
+    field_type: Any  # type: ignore[misc]
+    default_value: Any  # type: ignore[misc]
+
+    def as_tuple(self) -> Tuple[Type, Any]:  # type: ignore[misc]  # noqa: D
+        return (self.annotated_field_type, self.default_value)
+
+    @property
+    def annotated_field_type(self) -> Type:  # noqa: D
+        return self.field_type

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -217,7 +217,9 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             computed_metrics_output=distinct_values_node,
             order_by_specs=(
                 OrderBySpec(
-                    item=linkable_spec,
+                    dimension_spec=dimension_spec,
+                    time_dimension_spec=time_dimension_spec,
+                    identifier_spec=identifier_spec,
                     descending=False,
                 ),
             ),

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -60,6 +60,7 @@ from metricflow.specs import (
     SpecWhereClauseConstraint,
     LinkableSpecSet,
     ColumnAssociationResolver,
+    LinklessIdentifierSpec,
 )
 from metricflow.time.time_granularity import TimeGranularity
 
@@ -672,7 +673,8 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
 
             # If we're joining something in, then we need the associated identifier and partitions.
             include_specs: List[LinkableInstanceSpec] = [
-                x.identifier_links[0] for x in join_recipe.satisfiable_linkable_specs
+                LinklessIdentifierSpec.from_reference(x.identifier_links[0])
+                for x in join_recipe.satisfiable_linkable_specs
             ]
             include_specs.extend([x.node_to_join_dimension_spec for x in join_recipe.join_on_partition_dimensions])
             include_specs.extend(

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -194,7 +194,8 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
                     # but since we're doing all left joins now, it's been left out.
 
                     required_identifier_matches_data_set_identifier = (
-                        needed_linkable_spec.identifier_links[0] == linkless_identifier_spec_in_node
+                        LinklessIdentifierSpec.from_reference(needed_linkable_spec.identifier_links[0])
+                        == linkless_identifier_spec_in_node
                     )
                     needed_linkable_spec_in_node = (
                         needed_linkable_spec.without_first_identifier_link() in linkable_specs_in_node
@@ -267,7 +268,7 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
     def evaluate_node(
         self,
         start_node: BaseOutput[SourceDataSetT],
-        required_linkable_specs: List[LinkableInstanceSpec],
+        required_linkable_specs: Sequence[LinkableInstanceSpec],
     ) -> LinkableInstanceSatisfiabilityEvaluation:
         """Evaluates if the "required_linkable_specs" can be realized by joining the "start_node" with other nodes.
 
@@ -296,7 +297,8 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
             is_local = required_linkable_spec in data_set_linkable_specs
             is_unjoinable = (
                 len(required_linkable_spec.identifier_links) == 0
-                or required_linkable_spec.identifier_links[0] not in data_set_linkable_specs
+                or LinklessIdentifierSpec.from_reference(required_linkable_spec.identifier_links[0])
+                not in data_set_linkable_specs
             )
             if is_local:
                 local_linkable_specs.append(required_linkable_spec)

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -14,13 +14,13 @@ from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.object_utils import pformat_big_objects, flatten_nested_sequence
 from metricflow.references import MeasureReference
 from metricflow.specs import (
-    LinklessIdentifierSpec,
     DEFAULT_TIME_GRANULARITY,
     LinkableSpecSet,
     DimensionSpec,
     TimeDimensionSpec,
     IdentifierSpec,
     MetricSpec,
+    IdentifierReference,
 )
 from metricflow.time.time_granularity import TimeGranularity
 
@@ -275,7 +275,7 @@ class LinkableElementSet:
             dimension_specs=tuple(
                 DimensionSpec(
                     element_name=x.element_name,
-                    identifier_links=tuple(LinklessIdentifierSpec.from_element_name(x) for x in x.identifier_links),
+                    identifier_links=tuple(IdentifierReference(element_name=x) for x in x.identifier_links),
                 )
                 for x in self.linkable_dimensions
                 if not x.time_granularity
@@ -283,7 +283,7 @@ class LinkableElementSet:
             time_dimension_specs=tuple(
                 TimeDimensionSpec(
                     element_name=x.element_name,
-                    identifier_links=tuple(LinklessIdentifierSpec.from_element_name(x) for x in x.identifier_links),
+                    identifier_links=tuple(IdentifierReference(element_name=x) for x in x.identifier_links),
                     time_granularity=x.time_granularity,
                 )
                 for x in self.linkable_dimensions
@@ -292,7 +292,7 @@ class LinkableElementSet:
             identifier_specs=tuple(
                 IdentifierSpec(
                     element_name=x.element_name,
-                    identifier_links=tuple(LinklessIdentifierSpec.from_element_name(x) for x in x.identifier_links),
+                    identifier_links=tuple(IdentifierReference(element_name=x) for x in x.identifier_links),
                 )
                 for x in self.linkable_identifiers
             ),

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -30,13 +30,13 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
     def resolve_metric_spec(self, metric_spec: MetricSpec) -> ColumnAssociation:  # noqa: D
         return ColumnAssociation(
             column_name=metric_spec.element_name,
-            column_correlation_key=SingleColumnCorrelationKey(),
+            single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
     def resolve_measure_spec(self, measure_spec: MeasureSpec) -> ColumnAssociation:  # noqa: D
         return ColumnAssociation(
             column_name=measure_spec.element_name,
-            column_correlation_key=SingleColumnCorrelationKey(),
+            single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
     def resolve_dimension_spec(self, dimension_spec: DimensionSpec) -> ColumnAssociation:  # noqa: D
@@ -45,7 +45,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
                 identifier_link_names=tuple(x.element_name for x in dimension_spec.identifier_links),
                 element_name=dimension_spec.element_name,
             ).qualified_name,
-            column_correlation_key=SingleColumnCorrelationKey(),
+            single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
     def resolve_time_dimension_spec(self, time_dimension_spec: TimeDimensionSpec) -> ColumnAssociation:  # noqa: D
@@ -63,7 +63,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
 
         return ColumnAssociation(
             column_name=column_name,
-            column_correlation_key=SingleColumnCorrelationKey(),
+            single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
     def resolve_identifier_spec(self, identifier_spec: IdentifierSpec) -> Tuple[ColumnAssociation, ...]:  # noqa: D
@@ -87,7 +87,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
                     column_associations += (
                         ColumnAssociation(
                             column_name=sub_identifier,
-                            column_correlation_key=CompositeColumnCorrelationKey(
+                            composite_column_correlation_key=CompositeColumnCorrelationKey(
                                 sub_identifier=StructuredLinkableSpecName(
                                     identifier_link_names=(),
                                     element_name=sub_id_name,
@@ -103,6 +103,6 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
                     identifier_link_names=tuple(x.element_name for x in identifier_spec.identifier_links),
                     element_name=identifier_spec.element_name,
                 ).qualified_name,
-                column_correlation_key=SingleColumnCorrelationKey(),
+                single_column_correlation_key=SingleColumnCorrelationKey(),
             ),
         )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -973,7 +973,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
             metric_instances.append(
                 MetricInstance(
                     associated_columns=(output_column_association,),
-                    defined_from=[MetricModelReference(metric_name=metric_spec.element_name)],
+                    defined_from=(MetricModelReference(metric_name=metric_spec.element_name),),
                     spec=metric_spec,
                 )
             )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -363,7 +363,7 @@ def _make_time_spine_data_set(
             associated_columns=(
                 ColumnAssociation(
                     column_name=metric_time_dimension_column_name,
-                    column_correlation_key=SingleColumnCorrelationKey(),
+                    single_column_correlation_key=SingleColumnCorrelationKey(),
                 ),
             ),
             spec=metric_time_dimension_instance.spec,

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -30,6 +30,7 @@ from metricflow.specs import (
     TimeDimensionSpec,
     LinklessIdentifierSpec,
     LinkableInstanceSpec,
+    IdentifierReference,
 )
 from metricflow.sql.sql_exprs import (
     SqlColumnReferenceExpression,
@@ -244,7 +245,10 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             # The new dimension spec should include the join on identifier.
             transformed_time_dimension_spec_from_right = TimeDimensionSpec(
                 element_name=time_dimension_instance.spec.element_name,
-                identifier_links=(self._join_on_identifier,) + time_dimension_instance.spec.identifier_links,
+                identifier_links=(
+                    (IdentifierReference(element_name=self._join_on_identifier.element_name),)
+                    + time_dimension_instance.spec.identifier_links
+                ),
                 time_granularity=time_dimension_instance.spec.time_granularity,
             )
             time_dimension_instances_with_additional_link.append(
@@ -303,7 +307,10 @@ class FilterLinkableInstancesWithLeadingLink(InstanceSetTransform[InstanceSet]):
         self._identifier_link = identifier_link
 
     def _should_pass(self, linkable_spec: LinkableInstanceSpec) -> bool:  # noqa: D
-        return len(linkable_spec.identifier_links) == 0 or linkable_spec.identifier_links[0] != self._identifier_link
+        return (
+            len(linkable_spec.identifier_links) == 0
+            or LinklessIdentifierSpec.from_reference(linkable_spec.identifier_links[0]) != self._identifier_link
+        )
 
     def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
 

--- a/metricflow/plan_conversion/spec_transforms.py
+++ b/metricflow/plan_conversion/spec_transforms.py
@@ -5,7 +5,6 @@ from metricflow.specs import (
     InstanceSpecSetTransform,
     InstanceSpecSet,
     ColumnAssociationResolver,
-    TransformOutputT,
 )
 from metricflow.sql.sql_exprs import (
     SqlExpressionNode,
@@ -198,7 +197,7 @@ class CreateSelectCoalescedColumnsForLinkableSpecs(InstanceSpecSetTransform[Sele
 class SelectOnlyLinkableSpecs(InstanceSpecSetTransform[InstanceSpecSet]):
     """Removes metrics and measures from the spec set."""
 
-    def transform(self, spec_set: InstanceSpecSet) -> TransformOutputT:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> InstanceSpecSet:  # noqa: D
         return InstanceSpecSet(
             metric_specs=(),
             measure_specs=(),

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -30,7 +30,6 @@ from metricflow.specs import (
     TimeDimensionSpec,
     IdentifierSpec,
     LinkableInstanceSpec,
-    LinklessIdentifierSpec,
     OrderBySpec,
     OutputColumnNameOverride,
     SpecWhereClauseConstraint,
@@ -132,7 +131,7 @@ class MetricFlowQueryParser:
 
         for spec_name in linkable_spec_names:
             if spec_name.element_name == DataSet.metric_time_dimension_name():
-                where_constraint_dimensions.append(TimeDimensionSpec.from_name(spec_name.qualified_name))
+                where_constraint_time_dimensions.append(TimeDimensionSpec.from_name(spec_name.qualified_name))
             elif spec_name.element_name in dimension_references:
                 dimension = data_source_semantics.get_dimension(dimension_references[spec_name.element_name])
                 if dimension.type == DimensionType.CATEGORICAL:
@@ -571,9 +570,7 @@ class MetricFlowQueryParser:
         for qualified_name in qualified_linkable_names:
             structured_name = StructuredLinkableSpecName.from_name(qualified_name)
             element_name = structured_name.element_name
-            identifier_links = tuple(
-                LinklessIdentifierSpec.from_element_name(x) for x in structured_name.identifier_link_names
-            )
+            identifier_links = tuple(IdentifierReference(element_name=x) for x in structured_name.identifier_link_names)
             # Create the spec based on the type of element referenced.
             if TimeDimensionReference(element_name=element_name) in self._known_time_dimension_element_references:
                 if structured_name.time_granularity:
@@ -693,7 +690,7 @@ class MetricFlowQueryParser:
                         dimension_spec=DimensionSpec(
                             element_name=parsed_name.element_name,
                             identifier_links=tuple(
-                                LinklessIdentifierSpec.from_element_name(x) for x in parsed_name.identifier_link_names
+                                IdentifierReference(element_name=x) for x in parsed_name.identifier_link_names
                             ),
                         ),
                         descending=descending,
@@ -703,9 +700,7 @@ class MetricFlowQueryParser:
                 TimeDimensionReference(element_name=parsed_name.element_name)
                 in self._known_time_dimension_element_references
             ):
-                identifier_links = tuple(
-                    LinklessIdentifierSpec.from_element_name(x) for x in parsed_name.identifier_link_names
-                )
+                identifier_links = tuple(IdentifierReference(element_name=x) for x in parsed_name.identifier_link_names)
                 if parsed_name.time_granularity:
                     order_by_specs.append(
                         OrderBySpec(
@@ -750,7 +745,7 @@ class MetricFlowQueryParser:
                         identifier_spec=IdentifierSpec(
                             element_name=parsed_name.element_name,
                             identifier_links=tuple(
-                                LinklessIdentifierSpec.from_element_name(x) for x in parsed_name.identifier_link_names
+                                IdentifierReference(element_name=x) for x in parsed_name.identifier_link_names
                             ),
                         ),
                         descending=descending,

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -678,7 +678,7 @@ class MetricFlowQueryParser:
                     )
                 order_by_specs.append(
                     OrderBySpec(
-                        item=MetricSpec(element_name=parsed_name.element_name),
+                        metric_spec=MetricSpec(element_name=parsed_name.element_name),
                         descending=descending,
                     )
                 )
@@ -690,7 +690,7 @@ class MetricFlowQueryParser:
                     )
                 order_by_specs.append(
                     OrderBySpec(
-                        item=DimensionSpec(
+                        dimension_spec=DimensionSpec(
                             element_name=parsed_name.element_name,
                             identifier_links=tuple(
                                 LinklessIdentifierSpec.from_element_name(x) for x in parsed_name.identifier_link_names
@@ -709,7 +709,7 @@ class MetricFlowQueryParser:
                 if parsed_name.time_granularity:
                     order_by_specs.append(
                         OrderBySpec(
-                            item=TimeDimensionSpec(
+                            time_dimension_spec=TimeDimensionSpec(
                                 element_name=parsed_name.element_name,
                                 identifier_links=identifier_links,
                                 time_granularity=parsed_name.time_granularity,
@@ -728,7 +728,7 @@ class MetricFlowQueryParser:
                     if partial_time_dimension_spec in time_dimension_spec_replacements:
                         order_by_specs.append(
                             OrderBySpec(
-                                item=time_dimension_spec_replacements[partial_time_dimension_spec],
+                                time_dimension_spec=time_dimension_spec_replacements[partial_time_dimension_spec],
                                 descending=descending,
                             )
                         )
@@ -747,7 +747,7 @@ class MetricFlowQueryParser:
                     )
                 order_by_specs.append(
                     OrderBySpec(
-                        item=IdentifierSpec(
+                        identifier_spec=IdentifierSpec(
                             element_name=parsed_name.element_name,
                             identifier_links=tuple(
                                 LinklessIdentifierSpec.from_element_name(x) for x in parsed_name.identifier_link_names

--- a/metricflow/references.py
+++ b/metricflow/references.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from metricflow.dataclass_serialization import SerializableDataclass
+
 
 @dataclass(frozen=True)
-class ElementReference:
+class ElementReference(SerializableDataclass):
     """Used when we need to refer to a dimension, measure, identifier, but other attributes are unknown."""
 
     element_name: str

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Sequence, Tuple, TypeVar, Generic
 
 from metricflow.column_assoc import ColumnAssociation
 from metricflow.constraints.time_constraint import TimeRangeConstraint
+from metricflow.object_utils import assert_exactly_one_arg_set
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.model.objects.base import FrozenBaseModel
 from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
@@ -303,8 +304,28 @@ class MetricSpec(InstanceSpec):  # noqa: D
 
 
 class OrderBySpec(FrozenBaseModel):  # noqa: D
-    item: InstanceSpec
+
+    metric_spec: Optional[MetricSpec] = None
+    dimension_spec: Optional[DimensionSpec] = None
+    time_dimension_spec: Optional[TimeDimensionSpec] = None
+    identifier_spec: Optional[IdentifierSpec] = None
     descending: bool
+
+    def __post_init__(self) -> None:  # noqa: D
+        assert_exactly_one_arg_set(
+            metric_spec=self.metric_spec,
+            dimension_spec=self.dimension_spec,
+            time_dimension_spec=self.time_dimension_spec,
+            identifier_spec=self.identifier_spec,
+        )
+
+    @property
+    def item(self) -> InstanceSpec:  # noqa: D
+        result: Optional[InstanceSpec] = (
+            self.metric_spec or self.dimension_spec or self.time_dimension_spec or self.identifier_spec
+        )
+        assert result
+        return result
 
 
 class FilterSpec(FrozenBaseModel):  # noqa: D

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -107,11 +107,11 @@ def test_order_by_plan(  # noqa: D
             time_dimension_specs=(MTD_SPEC_DAY,),
             order_by_specs=(
                 OrderBySpec(
-                    item=MTD_SPEC_DAY,
+                    time_dimension_spec=MTD_SPEC_DAY,
                     descending=False,
                 ),
                 OrderBySpec(
-                    item=MetricSpec(element_name="bookings"),
+                    metric_spec=MetricSpec(element_name="bookings"),
                     descending=True,
                 ),
             ),

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -11,9 +11,9 @@ from metricflow.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
     DimensionSpec,
-    LinklessIdentifierSpec,
     SpecWhereClauseConstraint,
     LinkableSpecSet,
+    IdentifierReference,
 )
 from metricflow.specs import (
     OrderBySpec,
@@ -75,7 +75,7 @@ def test_joined_plan(  # noqa: D
                 ),
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+                    identifier_links=(IdentifierReference(element_name="listing"),),
                 ),
             ),
         )
@@ -205,7 +205,7 @@ def test_expr_metrics_plan(
             dimension_specs=(
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing"),),
+                    identifier_links=(IdentifierReference(element_name="listing"),),
                 ),
             ),
             time_dimension_specs=(MTD_SPEC_DAY,),
@@ -238,7 +238,7 @@ def test_single_data_source_ratio_metrics_plan(
             dimension_specs=(
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing"),),
+                    identifier_links=(IdentifierReference(element_name="listing"),),
                 ),
             ),
             time_dimension_specs=(MTD_SPEC_DAY,),
@@ -271,7 +271,7 @@ def test_multi_data_source_ratio_metrics_plan(
             dimension_specs=(
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing"),),
+                    identifier_links=(IdentifierReference(element_name="listing"),),
                 ),
             ),
             time_dimension_specs=(MTD_SPEC_DAY,),
@@ -305,8 +305,8 @@ def test_multihop_join_plan(  # noqa: D
                 DimensionSpec(
                     element_name="customer_name",
                     identifier_links=(
-                        LinklessIdentifierSpec.from_element_name(element_name="account_id"),
-                        LinklessIdentifierSpec.from_element_name(element_name="customer_id"),
+                        IdentifierReference(element_name="account_id"),
+                        IdentifierReference(element_name="customer_id"),
                     ),
                 ),
             ),
@@ -349,7 +349,7 @@ def test_where_constrained_plan(  # noqa: D
                     dimension_specs=(
                         DimensionSpec(
                             element_name="country_latest",
-                            identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+                            identifier_links=(IdentifierReference(element_name="listing"),),
                         ),
                     )
                 ),
@@ -422,7 +422,7 @@ def test_where_constrained_with_common_linkable_plan(  # noqa: D
             dimension_specs=(
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+                    identifier_links=(IdentifierReference(element_name="listing"),),
                 ),
             ),
             where_constraint=SpecWhereClauseConstraint(
@@ -432,7 +432,7 @@ def test_where_constrained_with_common_linkable_plan(  # noqa: D
                     dimension_specs=(
                         DimensionSpec(
                             element_name="country_latest",
-                            identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+                            identifier_links=(IdentifierReference(element_name="listing"),),
                         ),
                     )
                 ),
@@ -468,8 +468,8 @@ def test_multihop_join_plan_ambiguous_dim(  # noqa: D
                     DimensionSpec(
                         element_name="home_country",
                         identifier_links=(
-                            LinklessIdentifierSpec.from_element_name(element_name="listing"),
-                            LinklessIdentifierSpec.from_element_name(element_name="user"),
+                            IdentifierReference(element_name="listing"),
+                            IdentifierReference(element_name="user"),
                         ),
                     ),
                 ),
@@ -515,7 +515,7 @@ def test_distinct_values_plan(  # noqa: D
         metric_specs=(MetricSpec(element_name="bookings"),),
         dimension_spec=DimensionSpec(
             element_name="country_latest",
-            identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+            identifier_links=(IdentifierReference(element_name="listing"),),
         ),
         limit=100,
     )

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -21,6 +21,7 @@ from metricflow.specs import (
     LinklessIdentifierSpec,
     DimensionSpec,
     InstanceSpecSet,
+    IdentifierReference,
 )
 from metricflow.sql.sql_exprs import SqlColumnReferenceExpression, SqlColumnReference
 from metricflow.sql.sql_plan import SqlSelectStatementNode, SqlSelectColumn, SqlTableFromClauseNode
@@ -125,7 +126,7 @@ def test_joined_node_data_set(
         dimension_specs=(
             DimensionSpec(
                 element_name="home_state_latest",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ),
         identifier_specs=(IdentifierSpec(element_name="user", identifier_links=()),),
@@ -137,27 +138,27 @@ def test_joined_node_data_set(
             TimeDimensionSpec(element_name="ds", identifier_links=(), time_granularity=TimeGranularity.YEAR),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.DAY,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.WEEK,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.MONTH,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.QUARTER,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.YEAR,
             ),
         ),

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -46,7 +46,9 @@ def test_no_parent_node_data_set(
             measure_instances=(
                 MeasureInstance(
                     associated_columns=(
-                        ColumnAssociation(column_name="bookings", column_correlation_key=SingleColumnCorrelationKey()),
+                        ColumnAssociation(
+                            column_name="bookings", single_column_correlation_key=SingleColumnCorrelationKey()
+                        ),
                     ),
                     defined_from=(
                         DataSourceElementReference(

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -23,6 +23,7 @@ from metricflow.specs import (
     LinklessIdentifierSpec,
     TimeDimensionSpec,
     LinkableInstanceSpec,
+    IdentifierReference,
 )
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
@@ -109,7 +110,7 @@ def test_node_evaluator_with_unjoinable_specs(  # noqa: D
         required_linkable_specs=[
             DimensionSpec(
                 element_name="verification_type",
-                identifier_links=(LinklessIdentifierSpec.from_element_name("verification"),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
             )
         ],
         start_node=bookings_source_node,
@@ -121,7 +122,7 @@ def test_node_evaluator_with_unjoinable_specs(  # noqa: D
         unjoinable_linkable_specs=(
             DimensionSpec(
                 element_name="verification_type",
-                identifier_links=(LinklessIdentifierSpec.from_element_name("verification"),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
             ),
         ),
     )
@@ -154,7 +155,7 @@ def test_node_evaluator_with_local_spec_using_primary_identifier(  # noqa: D
     evaluation = node_evaluator.evaluate_node(
         required_linkable_specs=[
             DimensionSpec(
-                element_name="home_state_latest", identifier_links=(LinklessIdentifierSpec.from_element_name("user"),)
+                element_name="home_state_latest", identifier_links=(IdentifierReference(element_name="user"),)
             )
         ],
         start_node=bookings_source_node,
@@ -165,7 +166,7 @@ def test_node_evaluator_with_local_spec_using_primary_identifier(  # noqa: D
             local_linkable_specs=(
                 DimensionSpec(
                     element_name="home_state_latest",
-                    identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                    identifier_links=(IdentifierReference(element_name="user"),),
                 ),
             ),
             joinable_linkable_specs=(),
@@ -183,9 +184,7 @@ def test_node_evaluator_with_local_spec_using_primary_composite_identifier(  # n
     bookings_source_node = consistent_id_object_repository.composite_model_read_nodes["users_source"]
     evaluation = node_evaluator.evaluate_node(
         required_linkable_specs=[
-            DimensionSpec(
-                element_name="country", identifier_links=(LinklessIdentifierSpec.from_element_name("user_team"),)
-            )
+            DimensionSpec(element_name="country", identifier_links=(IdentifierReference(element_name="user_team"),))
         ],
         start_node=bookings_source_node,
     )
@@ -195,7 +194,7 @@ def test_node_evaluator_with_local_spec_using_primary_composite_identifier(  # n
             local_linkable_specs=(
                 DimensionSpec(
                     element_name="country",
-                    identifier_links=(LinklessIdentifierSpec(element_name="user_team", identifier_links=()),),
+                    identifier_links=(IdentifierReference(element_name="user_team"),),
                 ),
             ),
             joinable_linkable_specs=(),
@@ -217,11 +216,11 @@ def test_node_evaluator_with_joined_spec(  # noqa: D
             DimensionSpec(element_name="is_instant", identifier_links=()),
             DimensionSpec(
                 element_name="country_latest",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing"),),
+                identifier_links=(IdentifierReference(element_name="listing"),),
             ),
             DimensionSpec(
                 element_name="capacity_latest",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing"),),
+                identifier_links=(IdentifierReference(element_name="listing"),),
             ),
         ],
         start_node=bookings_source_node,
@@ -232,25 +231,25 @@ def test_node_evaluator_with_joined_spec(  # noqa: D
         joinable_linkable_specs=(
             DimensionSpec(
                 element_name="country_latest",
-                identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="listing"),),
             ),
             DimensionSpec(
                 element_name="capacity_latest",
-                identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="listing"),),
             ),
         ),
         join_recipes=(
             JoinLinkableInstancesRecipe(
                 node_to_join=consistent_id_object_repository.simple_model_read_nodes["listings_latest"],
-                join_on_identifier=LinklessIdentifierSpec(element_name="listing", identifier_links=()),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name("listing"),
                 satisfiable_linkable_specs=[
                     DimensionSpec(
                         element_name="country_latest",
-                        identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                        identifier_links=(IdentifierReference(element_name="listing"),),
                     ),
                     DimensionSpec(
                         element_name="capacity_latest",
-                        identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                        identifier_links=(IdentifierReference(element_name="listing"),),
                     ),
                 ],
                 join_on_partition_dimensions=(),
@@ -271,7 +270,7 @@ def test_node_evaluator_with_joined_spec_on_unique_id(  # noqa: D
         required_linkable_specs=[
             DimensionSpec(
                 element_name="company_name",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="user"),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ],
         start_node=listings_node,
@@ -282,17 +281,17 @@ def test_node_evaluator_with_joined_spec_on_unique_id(  # noqa: D
         joinable_linkable_specs=(
             DimensionSpec(
                 element_name="company_name",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ),
         join_recipes=(
             JoinLinkableInstancesRecipe(
                 node_to_join=consistent_id_object_repository.simple_model_read_nodes["companies"],
-                join_on_identifier=LinklessIdentifierSpec(element_name="user", identifier_links=()),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name("user"),
                 satisfiable_linkable_specs=[
                     DimensionSpec(
                         element_name="company_name",
-                        identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                        identifier_links=(IdentifierReference(element_name="user"),),
                     ),
                 ],
                 join_on_partition_dimensions=(),
@@ -313,11 +312,11 @@ def test_node_evaluator_with_multiple_joined_specs(  # noqa: D
         required_linkable_specs=[
             DimensionSpec(
                 element_name="home_state_latest",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="user"),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
             IdentifierSpec(
                 element_name="user",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing"),),
+                identifier_links=(IdentifierReference(element_name="listing"),),
             ),
         ],
         start_node=views_source,
@@ -328,21 +327,21 @@ def test_node_evaluator_with_multiple_joined_specs(  # noqa: D
         joinable_linkable_specs=(
             IdentifierSpec(
                 element_name="user",
-                identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="listing"),),
             ),
             DimensionSpec(
                 element_name="home_state_latest",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ),
         join_recipes=(
             JoinLinkableInstancesRecipe(
                 node_to_join=consistent_id_object_repository.simple_model_read_nodes["listings_latest"],
-                join_on_identifier=LinklessIdentifierSpec(element_name="listing", identifier_links=()),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name("listing"),
                 satisfiable_linkable_specs=[
                     IdentifierSpec(
                         element_name="user",
-                        identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                        identifier_links=(IdentifierReference(element_name="listing"),),
                     )
                 ],
                 join_on_partition_dimensions=(),
@@ -350,11 +349,11 @@ def test_node_evaluator_with_multiple_joined_specs(  # noqa: D
             ),
             JoinLinkableInstancesRecipe(
                 node_to_join=consistent_id_object_repository.simple_model_read_nodes["users_latest"],
-                join_on_identifier=LinklessIdentifierSpec(element_name="user", identifier_links=()),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name("user"),
                 satisfiable_linkable_specs=[
                     DimensionSpec(
                         element_name="home_state_latest",
-                        identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                        identifier_links=(IdentifierReference(element_name="user"),),
                     )
                 ],
                 join_on_partition_dimensions=(),
@@ -377,8 +376,8 @@ def test_node_evaluator_with_multihop_joined_spec(  # noqa: D
         DimensionSpec(
             element_name="customer_name",
             identifier_links=(
-                LinklessIdentifierSpec.from_element_name(element_name="account_id"),
-                LinklessIdentifierSpec.from_element_name(element_name="customer_id"),
+                IdentifierReference(element_name="account_id"),
+                IdentifierReference(element_name="customer_id"),
             ),
         ),
     ]
@@ -401,21 +400,21 @@ def test_node_evaluator_with_multihop_joined_spec(  # noqa: D
             DimensionSpec(
                 element_name="customer_name",
                 identifier_links=(
-                    LinklessIdentifierSpec.from_element_name(element_name="account_id"),
-                    LinklessIdentifierSpec.from_element_name(element_name="customer_id"),
+                    IdentifierReference(element_name="account_id"),
+                    IdentifierReference(element_name="customer_id"),
                 ),
             ),
         ),
         join_recipes=(
             JoinLinkableInstancesRecipe(
                 node_to_join=evaluation.join_recipes[0].node_to_join,
-                join_on_identifier=LinklessIdentifierSpec(element_name="account_id", identifier_links=()),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name("account_id"),
                 satisfiable_linkable_specs=[
                     DimensionSpec(
                         element_name="customer_name",
                         identifier_links=(
-                            LinklessIdentifierSpec(element_name="account_id", identifier_links=()),
-                            LinklessIdentifierSpec(element_name="customer_id", identifier_links=()),
+                            IdentifierReference(element_name="account_id"),
+                            IdentifierReference(element_name="customer_id"),
                         ),
                     ),
                 ],
@@ -447,7 +446,7 @@ def test_node_evaluator_with_partition_joined_spec(  # noqa: D
         required_linkable_specs=[
             DimensionSpec(
                 element_name="home_state",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="user"),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ],
         start_node=consistent_id_object_repository.simple_model_read_nodes["id_verifications"],
@@ -458,17 +457,17 @@ def test_node_evaluator_with_partition_joined_spec(  # noqa: D
         joinable_linkable_specs=(
             DimensionSpec(
                 element_name="home_state",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ),
         join_recipes=(
             JoinLinkableInstancesRecipe(
                 node_to_join=consistent_id_object_repository.simple_model_read_nodes["users_ds_source"],
-                join_on_identifier=LinklessIdentifierSpec(element_name="user", identifier_links=()),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name("user"),
                 satisfiable_linkable_specs=[
                     DimensionSpec(
                         element_name="home_state",
-                        identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                        identifier_links=(IdentifierReference(element_name="user"),),
                     ),
                 ],
                 join_on_partition_dimensions=(),

--- a/metricflow/test/dataset/test_convert_data_source.py
+++ b/metricflow/test/dataset/test_convert_data_source.py
@@ -10,13 +10,13 @@ from metricflow.specs import (
     InstanceSpecSet,
     MeasureSpec,
     TimeDimensionSpec,
-    LinklessIdentifierSpec,
+    IdentifierReference,
 )
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
-from metricflow.time.time_granularity import TimeGranularity
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
+from metricflow.time.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def test_convert_table_data_source_without_measures(  # noqa: D
             DimensionSpec(element_name="home_state_latest", identifier_links=()),
             DimensionSpec(
                 element_name="home_state_latest",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
             ),
         ),
         identifier_specs=(IdentifierSpec(element_name="user", identifier_links=()),),
@@ -49,27 +49,27 @@ def test_convert_table_data_source_without_measures(  # noqa: D
             TimeDimensionSpec(element_name="ds", identifier_links=(), time_granularity=TimeGranularity.YEAR),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.DAY,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.WEEK,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.MONTH,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.QUARTER,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="user", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="user"),),
                 time_granularity=TimeGranularity.YEAR,
             ),
         ),
@@ -106,7 +106,7 @@ def test_convert_table_data_source_with_measures(  # noqa: D
             DimensionSpec(element_name="verification_type", identifier_links=()),
             DimensionSpec(
                 element_name="verification_type",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
             ),
         ),
         identifier_specs=(
@@ -114,7 +114,7 @@ def test_convert_table_data_source_with_measures(  # noqa: D
             IdentifierSpec(element_name="user", identifier_links=()),
             IdentifierSpec(
                 element_name="user",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
             ),
         ),
         time_dimension_specs=(
@@ -138,52 +138,52 @@ def test_convert_table_data_source_with_measures(  # noqa: D
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.DAY,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.WEEK,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.MONTH,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.QUARTER,
             ),
             TimeDimensionSpec(
                 element_name="ds",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.YEAR,
             ),
             TimeDimensionSpec(
                 element_name="ds_partitioned",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.DAY,
             ),
             TimeDimensionSpec(
                 element_name="ds_partitioned",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.WEEK,
             ),
             TimeDimensionSpec(
                 element_name="ds_partitioned",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.MONTH,
             ),
             TimeDimensionSpec(
                 element_name="ds_partitioned",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.QUARTER,
             ),
             TimeDimensionSpec(
                 element_name="ds_partitioned",
-                identifier_links=(LinklessIdentifierSpec(element_name="verification", identifier_links=()),),
+                identifier_links=(IdentifierReference(element_name="verification"),),
                 time_granularity=TimeGranularity.YEAR,
             ),
         ),

--- a/metricflow/test/plan_conversion/test_dataflow_to_execution.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_execution.py
@@ -1,6 +1,7 @@
 from _pytest.fixtures import FixtureRequest
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_execution import DataflowToExecutionPlanConverter
@@ -11,11 +12,10 @@ from metricflow.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
     DimensionSpec,
-    LinklessIdentifierSpec,
     TimeDimensionSpec,
+    IdentifierReference,
 )
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
-from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.plan_utils import assert_execution_plan_text_equal
 
@@ -54,7 +54,7 @@ def test_joined_plan(  # noqa: D
                 ),
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+                    identifier_links=(IdentifierReference("listing"),),
                 ),
             ),
         )
@@ -166,8 +166,8 @@ def test_multihop_joined_plan(  # noqa: D
                 DimensionSpec(
                     element_name="customer_name",
                     identifier_links=(
-                        LinklessIdentifierSpec.from_element_name(element_name="account_id"),
-                        LinklessIdentifierSpec.from_element_name(element_name="customer_id"),
+                        IdentifierReference(element_name="account_id"),
+                        IdentifierReference(element_name="customer_id"),
                     ),
                 ),
             ),

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -617,11 +617,11 @@ def test_order_by_node(
     order_by_node = OrderByLimitNode(
         order_by_specs=[
             OrderBySpec(
-                item=time_dimension_spec,
+                time_dimension_spec=time_dimension_spec,
                 descending=False,
             ),
             OrderBySpec(
-                item=metric_spec,
+                metric_spec=metric_spec,
                 descending=True,
             ),
         ],
@@ -1040,7 +1040,9 @@ def test_composite_identifier_with_order_by(  # noqa: D
             metric_specs=(MetricSpec(element_name="messages"),),
             identifier_specs=(IdentifierSpec(element_name="user_team", identifier_links=()),),
             order_by_specs=(
-                OrderBySpec(item=IdentifierSpec(element_name="user_team", identifier_links=()), descending=True),
+                OrderBySpec(
+                    identifier_spec=IdentifierSpec(element_name="user_team", identifier_links=()), descending=True
+                ),
             ),
         )
     )

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -27,7 +27,7 @@ from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationR
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.references import TimeDimensionReference
+from metricflow.references import TimeDimensionReference, IdentifierReference
 from metricflow.specs import (
     DimensionSpec,
     IdentifierSpec,
@@ -273,7 +273,7 @@ def test_single_join_node(  # noqa: D
     measure_spec = MeasureSpec(
         element_name="bookings",
     )
-    identifier_spec = LinklessIdentifierSpec(element_name="listing", identifier_links=())
+    identifier_spec = LinklessIdentifierSpec.from_element_name(element_name="listing")
     measure_source_node = consistent_id_object_repository.simple_model_read_nodes["bookings_source"]
     filtered_measure_node = FilterElementsNode[DataSourceDataSet](
         parent_node=measure_source_node, include_specs=[measure_spec, identifier_spec]
@@ -320,7 +320,7 @@ def test_multi_join_node(
     measure_spec = MeasureSpec(
         element_name="bookings",
     )
-    identifier_spec = LinklessIdentifierSpec(element_name="listing", identifier_links=())
+    identifier_spec = LinklessIdentifierSpec.from_element_name(element_name="listing")
     measure_source_node = consistent_id_object_repository.simple_model_read_nodes["bookings_source"]
     filtered_measure_node = FilterElementsNode[DataSourceDataSet](
         parent_node=measure_source_node, include_specs=[measure_spec, identifier_spec]
@@ -340,13 +340,13 @@ def test_multi_join_node(
         join_targets=[
             JoinDescription(
                 join_node=filtered_dimension_node,
-                join_on_identifier=LinklessIdentifierSpec.from_element_name("listing"),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name(element_name="listing"),
                 join_on_partition_dimensions=(),
                 join_on_partition_time_dimensions=(),
             ),
             JoinDescription(
                 join_node=filtered_dimension_node,
-                join_on_identifier=LinklessIdentifierSpec.from_element_name("listing"),
+                join_on_identifier=LinklessIdentifierSpec.from_element_name(element_name="listing"),
                 join_on_partition_dimensions=(),
                 join_on_partition_time_dimensions=(),
             ),
@@ -373,7 +373,7 @@ def test_compute_metrics_node(
     measure_spec = MeasureSpec(
         element_name="bookings",
     )
-    identifier_spec = LinklessIdentifierSpec(element_name="listing", identifier_links=())
+    identifier_spec = LinklessIdentifierSpec.from_element_name(element_name="listing")
     measure_source_node = consistent_id_object_repository.simple_model_read_nodes["bookings_source"]
     filtered_measure_node = FilterElementsNode[DataSourceDataSet](
         parent_node=measure_source_node, include_specs=[measure_spec, identifier_spec]
@@ -427,7 +427,7 @@ def test_compute_metrics_node_simple_expr(
     measure_spec = MeasureSpec(
         element_name="booking_value",
     )
-    identifier_spec = LinklessIdentifierSpec(element_name="listing", identifier_links=())
+    identifier_spec = LinklessIdentifierSpec.from_element_name(element_name="listing")
     measure_source_node = consistent_id_object_repository.simple_model_read_nodes["bookings_source"]
     filtered_measure_node = FilterElementsNode[DataSourceDataSet](
         parent_node=measure_source_node, include_specs=[measure_spec, identifier_spec]
@@ -499,7 +499,7 @@ def test_compute_metrics_node_ratio_from_single_data_source(
     denominator_spec = MeasureSpec(
         element_name="bookers",
     )
-    identifier_spec = LinklessIdentifierSpec(element_name="listing", identifier_links=())
+    identifier_spec = LinklessIdentifierSpec.from_element_name(element_name="listing")
     measure_source_node = consistent_id_object_repository.simple_model_read_nodes["bookings_source"]
     filtered_measures_node = FilterElementsNode[DataSourceDataSet](
         parent_node=measure_source_node, include_specs=[numerator_spec, denominator_spec, identifier_spec]
@@ -555,7 +555,7 @@ def test_compute_metrics_node_ratio_from_multiple_data_sources(
     """
     dimension_spec = DimensionSpec(
         element_name="country_latest",
-        identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+        identifier_links=(IdentifierReference(element_name="listing"),),
     )
     time_dimension_spec = TimeDimensionSpec(
         element_name="ds",
@@ -652,8 +652,8 @@ def test_multihop_node(
                 DimensionSpec(
                     element_name="customer_name",
                     identifier_links=(
-                        LinklessIdentifierSpec.from_element_name(element_name="account_id"),
-                        LinklessIdentifierSpec.from_element_name(element_name="customer_id"),
+                        IdentifierReference(element_name="account_id"),
+                        IdentifierReference(element_name="customer_id"),
                     ),
                 ),
             ),
@@ -694,7 +694,7 @@ def test_filter_with_where_constraint_on_join_dim(
                     dimension_specs=(
                         DimensionSpec(
                             element_name="country_latest",
-                            identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+                            identifier_links=(IdentifierReference(element_name="listing"),),
                         ),
                     )
                 ),
@@ -960,7 +960,7 @@ def test_partitioned_join(
             dimension_specs=(
                 DimensionSpec(
                     element_name="home_state",
-                    identifier_links=(LinklessIdentifierSpec.from_element_name("user"),),
+                    identifier_links=(IdentifierReference(element_name="user"),),
                 ),
             ),
         )
@@ -1069,7 +1069,7 @@ def test_composite_identifier_with_join(  # noqa: D
             dimension_specs=(
                 DimensionSpec(
                     element_name="country",
-                    identifier_links=(LinklessIdentifierSpec(element_name="user_team", identifier_links=()),),
+                    identifier_links=(IdentifierReference(element_name="user_team"),),
                 ),
             ),
             identifier_specs=(IdentifierSpec(element_name="user_team", identifier_links=()),),
@@ -1097,7 +1097,7 @@ def test_distinct_values(  # noqa: D
         metric_specs=(MetricSpec(element_name="bookings"),),
         dimension_spec=DimensionSpec(
             element_name="country_latest",
-            identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),),
+            identifier_links=(IdentifierReference(element_name="listing"),),
         ),
         limit=100,
     )
@@ -1124,7 +1124,7 @@ def test_local_dimension_using_local_identifier(  # noqa: D
             dimension_specs=(
                 DimensionSpec(
                     element_name="country_latest",
-                    identifier_links=(LinklessIdentifierSpec(element_name="listing", identifier_links=()),),
+                    identifier_links=(IdentifierReference(element_name="listing"),),
                 ),
             ),
         )

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -33,11 +33,13 @@ def test_query_parser(query_parser: MetricFlowQueryParser) -> None:  # noqa: D
     assert query_spec.identifier_specs == (IdentifierSpec(element_name="listing", identifier_links=()),)
     assert query_spec.order_by_specs == (
         OrderBySpec(
-            item=TimeDimensionSpec(element_name=MTD, identifier_links=(), time_granularity=TimeGranularity.DAY),
+            time_dimension_spec=TimeDimensionSpec(
+                element_name=MTD, identifier_links=(), time_granularity=TimeGranularity.DAY
+            ),
             descending=False,
         ),
         OrderBySpec(
-            item=MetricSpec(element_name="bookings"),
+            metric_spec=MetricSpec(element_name="bookings"),
             descending=True,
         ),
     )
@@ -58,7 +60,9 @@ def test_order_by_granularity_conversion(query_parser: MetricFlowQueryParser) ->
     # The lowest common granularity is MONTH, so we expect the PTD in the order by to have that granularity.
     assert (
         OrderBySpec(
-            item=TimeDimensionSpec(element_name=MTD, identifier_links=(), time_granularity=TimeGranularity.DAY),
+            time_dimension_spec=TimeDimensionSpec(
+                element_name=MTD, identifier_links=(), time_granularity=TimeGranularity.DAY
+            ),
             descending=True,
         ),
     ) == query_spec.order_by_specs
@@ -70,7 +74,9 @@ def test_order_by_granularity_no_conversion(query_parser: MetricFlowQueryParser)
     # The only granularity is DAY, so we expect the PTD in the order by to have that granularity.
     assert (
         OrderBySpec(
-            item=TimeDimensionSpec(element_name=MTD, identifier_links=(), time_granularity=TimeGranularity.DAY),
+            time_dimension_spec=TimeDimensionSpec(
+                element_name=MTD, identifier_links=(), time_granularity=TimeGranularity.DAY
+            ),
             descending=False,
         ),
     ) == query_spec.order_by_specs

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -5,12 +5,15 @@
         <OrderByLimitNode>
             <!-- description = Order By ['listing__country_latest'] Limit 100 -->
             <!-- node_id = obl_0 -->
-            <!-- order_by_spec =                                                -->
-            <!--   {'class': 'OrderBySpec',                                     -->
-            <!--    'item': {'element_name': 'country_latest',                  -->
-            <!--             'identifier_links': ({'element_name': 'listing',   -->
-            <!--                                   'identifier_links': ()},)},  -->
-            <!--    'descending': False}                                        -->
+            <!-- order_by_spec =                                                          -->
+            <!--   {'class': 'OrderBySpec',                                               -->
+            <!--    'metric_spec': None,                                                  -->
+            <!--    'dimension_spec': {'element_name': 'country_latest',                  -->
+            <!--                       'identifier_links': ({'element_name': 'listing',   -->
+            <!--                                             'identifier_links': ()},)},  -->
+            <!--    'time_dimension_spec': None,                                          -->
+            <!--    'identifier_spec': None,                                              -->
+            <!--    'descending': False}                                                  -->
             <!-- limit = 100 -->
             <FilterElementsNode>
                 <!-- description =                    -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -5,25 +5,27 @@
         <OrderByLimitNode>
             <!-- description = Order By ['listing__country_latest'] Limit 100 -->
             <!-- node_id = obl_0 -->
-            <!-- order_by_spec =                                                          -->
-            <!--   {'class': 'OrderBySpec',                                               -->
-            <!--    'metric_spec': None,                                                  -->
-            <!--    'dimension_spec': {'element_name': 'country_latest',                  -->
-            <!--                       'identifier_links': ({'element_name': 'listing',   -->
-            <!--                                             'identifier_links': ()},)},  -->
-            <!--    'time_dimension_spec': None,                                          -->
-            <!--    'identifier_spec': None,                                              -->
-            <!--    'descending': False}                                                  -->
+            <!-- order_by_spec =                                                              -->
+            <!--   {'class': 'OrderBySpec',                                                   -->
+            <!--    'descending': False,                                                      -->
+            <!--    'metric_spec': None,                                                      -->
+            <!--    'dimension_spec': {'class': 'DimensionSpec',                              -->
+            <!--                       'element_name': 'country_latest',                      -->
+            <!--                       'identifier_links': ({'class': 'IdentifierReference',  -->
+            <!--                                             'element_name': 'listing'},)},   -->
+            <!--    'time_dimension_spec': None,                                              -->
+            <!--    'identifier_spec': None}                                                  -->
             <!-- limit = 100 -->
             <FilterElementsNode>
                 <!-- description =                    -->
                 <!--   Pass Only Elements:            -->
                 <!--     ['listing__country_latest']  -->
                 <!-- node_id = pfe_3 -->
-                <!-- include_spec =                                                                  -->
-                <!--   {'class': 'DimensionSpec',                                                    -->
-                <!--    'element_name': 'country_latest',                                            -->
-                <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                <!-- include_spec =                                            -->
+                <!--   {'class': 'DimensionSpec',                              -->
+                <!--    'element_name': 'country_latest',                      -->
+                <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                <!--                          'element_name': 'listing'},)}    -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->
@@ -40,10 +42,11 @@
                             <!--   {'class': 'MeasureSpec',          -->
                             <!--    'element_name': 'bookings',      -->
                             <!--    'non_additive_dimension': None}  -->
-                            <!-- include_spec =                                                                  -->
-                            <!--   {'class': 'DimensionSpec',                                                    -->
-                            <!--    'element_name': 'country_latest',                                            -->
-                            <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                            <!-- include_spec =                                            -->
+                            <!--   {'class': 'DimensionSpec',                              -->
+                            <!--    'element_name': 'country_latest',                      -->
+                            <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                            <!--                          'element_name': 'listing'},)}    -->
                             <JoinToBaseOutputNode>
                                 <!-- description = Join Standard Outputs -->
                                 <!-- node_id = jso_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_expr_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_expr_metrics_plan__dfp_0.xml
@@ -18,10 +18,11 @@
                     <!--   {'class': 'MeasureSpec',           -->
                     <!--    'element_name': 'booking_value',  -->
                     <!--    'non_additive_dimension': None}   -->
-                    <!-- include_spec =                                                                  -->
-                    <!--   {'class': 'DimensionSpec',                                                    -->
-                    <!--    'element_name': 'country_latest',                                            -->
-                    <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                    <!-- include_spec =                                            -->
+                    <!--   {'class': 'DimensionSpec',                              -->
+                    <!--    'element_name': 'country_latest',                      -->
+                    <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                    <!--                          'element_name': 'listing'},)}    -->
                     <!-- include_spec =                               -->
                     <!--   {'class': 'TimeDimensionSpec',             -->
                     <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
@@ -20,10 +20,11 @@
                     <!--    'non_additive_dimension': None}  -->
                     <!-- include_spec =                                                                      -->
                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
-                    <!-- include_spec =                                                                  -->
-                    <!--   {'class': 'DimensionSpec',                                                    -->
-                    <!--    'element_name': 'country_latest',                                            -->
-                    <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                    <!-- include_spec =                                            -->
+                    <!--   {'class': 'DimensionSpec',                              -->
+                    <!--    'element_name': 'country_latest',                      -->
+                    <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                    <!--                          'element_name': 'listing'},)}    -->
                     <JoinToBaseOutputNode>
                         <!-- description = Join Standard Outputs -->
                         <!-- node_id = jso_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_data_source_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_data_source_ratio_metrics_plan__dfp_0.xml
@@ -11,10 +11,11 @@
                 <!--   Pass Only Elements:                                                -->
                 <!--     ['listing__country_latest', 'metric_time', 'bookings', 'views']  -->
                 <!-- node_id = pfe_6 -->
-                <!-- include_spec =                                                                  -->
-                <!--   {'class': 'DimensionSpec',                                                    -->
-                <!--    'element_name': 'country_latest',                                            -->
-                <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                <!-- include_spec =                                            -->
+                <!--   {'class': 'DimensionSpec',                              -->
+                <!--    'element_name': 'country_latest',                      -->
+                <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                <!--                          'element_name': 'listing'},)}    -->
                 <!-- include_spec =                               -->
                 <!--   {'class': 'TimeDimensionSpec',             -->
                 <!--    'element_name': 'metric_time',            -->
@@ -44,10 +45,11 @@
                             <!--   {'class': 'MeasureSpec',          -->
                             <!--    'element_name': 'bookings',      -->
                             <!--    'non_additive_dimension': None}  -->
-                            <!-- include_spec =                                                                  -->
-                            <!--   {'class': 'DimensionSpec',                                                    -->
-                            <!--    'element_name': 'country_latest',                                            -->
-                            <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                            <!-- include_spec =                                            -->
+                            <!--   {'class': 'DimensionSpec',                              -->
+                            <!--    'element_name': 'country_latest',                      -->
+                            <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                            <!--                          'element_name': 'listing'},)}    -->
                             <!-- include_spec =                               -->
                             <!--   {'class': 'TimeDimensionSpec',             -->
                             <!--    'element_name': 'metric_time',            -->
@@ -144,10 +146,11 @@
                             <!--   {'class': 'MeasureSpec',          -->
                             <!--    'element_name': 'views',         -->
                             <!--    'non_additive_dimension': None}  -->
-                            <!-- include_spec =                                                                  -->
-                            <!--   {'class': 'DimensionSpec',                                                    -->
-                            <!--    'element_name': 'country_latest',                                            -->
-                            <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                            <!-- include_spec =                                            -->
+                            <!--   {'class': 'DimensionSpec',                              -->
+                            <!--    'element_name': 'country_latest',                      -->
+                            <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                            <!--                          'element_name': 'listing'},)}    -->
                             <!-- include_spec =                               -->
                             <!--   {'class': 'TimeDimensionSpec',             -->
                             <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
@@ -18,11 +18,13 @@
                     <!--   {'class': 'MeasureSpec',          -->
                     <!--    'element_name': 'txn_count',     -->
                     <!--    'non_additive_dimension': None}  -->
-                    <!-- include_spec =                                                                     -->
-                    <!--   {'class': 'DimensionSpec',                                                       -->
-                    <!--    'element_name': 'customer_name',                                                -->
-                    <!--    'identifier_links': ({'element_name': 'account_id', 'identifier_links': ()},    -->
-                    <!--                         {'element_name': 'customer_id', 'identifier_links': ()})}  -->
+                    <!-- include_spec =                                             -->
+                    <!--   {'class': 'DimensionSpec',                               -->
+                    <!--    'element_name': 'customer_name',                        -->
+                    <!--    'identifier_links': ({'class': 'IdentifierReference',   -->
+                    <!--                          'element_name': 'account_id'},    -->
+                    <!--                         {'class': 'IdentifierReference',   -->
+                    <!--                          'element_name': 'customer_id'})}  -->
                     <JoinToBaseOutputNode>
                         <!-- description = Join Standard Outputs -->
                         <!-- node_id = jso_2 -->
@@ -91,10 +93,11 @@
                             <!--    'element_name': 'ds_partitioned',         -->
                             <!--    'identifier_links': (),                   -->
                             <!--    'time_granularity': TimeGranularity.DAY}  -->
-                            <!-- include_spec =                                                                      -->
-                            <!--   {'class': 'DimensionSpec',                                                        -->
-                            <!--    'element_name': 'customer_name',                                                 -->
-                            <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},)}  -->
+                            <!-- include_spec =                                              -->
+                            <!--   {'class': 'DimensionSpec',                                -->
+                            <!--    'element_name': 'customer_name',                         -->
+                            <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                            <!--                          'element_name': 'customer_id'},)}  -->
                             <JoinToBaseOutputNode>
                                 <!-- description = Join Standard Outputs -->
                                 <!-- node_id = jso_0 -->
@@ -148,14 +151,16 @@
                                     <!--   {'class': 'DimensionSpec',                  -->
                                     <!--    'element_name': 'customer_atomic_weight',  -->
                                     <!--    'identifier_links': ()}                    -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'DimensionSpec',                                                        -->
-                                    <!--    'element_name': 'customer_name',                                                 -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},)}  -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'DimensionSpec',                                                        -->
-                                    <!--    'element_name': 'customer_atomic_weight',                                        -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},)}  -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'DimensionSpec',                                -->
+                                    <!--    'element_name': 'customer_name',                         -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},)}  -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'DimensionSpec',                                -->
+                                    <!--    'element_name': 'customer_atomic_weight',                -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},)}  -->
                                     <!-- include_spec =                     -->
                                     <!--   {'class': 'IdentifierSpec',      -->
                                     <!--    'element_name': 'customer_id',  -->
@@ -185,31 +190,36 @@
                                     <!--    'element_name': 'ds_partitioned',          -->
                                     <!--    'identifier_links': (),                    -->
                                     <!--    'time_granularity': TimeGranularity.YEAR}  -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'TimeDimensionSpec',                                                    -->
-                                    <!--    'element_name': 'ds_partitioned',                                                -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},),  -->
-                                    <!--    'time_granularity': TimeGranularity.DAY}                                         -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'TimeDimensionSpec',                                                    -->
-                                    <!--    'element_name': 'ds_partitioned',                                                -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},),  -->
-                                    <!--    'time_granularity': TimeGranularity.WEEK}                                        -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'TimeDimensionSpec',                                                    -->
-                                    <!--    'element_name': 'ds_partitioned',                                                -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},),  -->
-                                    <!--    'time_granularity': TimeGranularity.MONTH}                                       -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'TimeDimensionSpec',                                                    -->
-                                    <!--    'element_name': 'ds_partitioned',                                                -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},),  -->
-                                    <!--    'time_granularity': TimeGranularity.QUARTER}                                     -->
-                                    <!-- include_spec =                                                                      -->
-                                    <!--   {'class': 'TimeDimensionSpec',                                                    -->
-                                    <!--    'element_name': 'ds_partitioned',                                                -->
-                                    <!--    'identifier_links': ({'element_name': 'customer_id', 'identifier_links': ()},),  -->
-                                    <!--    'time_granularity': TimeGranularity.YEAR}                                        -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'TimeDimensionSpec',                            -->
+                                    <!--    'element_name': 'ds_partitioned',                        -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},),  -->
+                                    <!--    'time_granularity': TimeGranularity.DAY}                 -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'TimeDimensionSpec',                            -->
+                                    <!--    'element_name': 'ds_partitioned',                        -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},),  -->
+                                    <!--    'time_granularity': TimeGranularity.WEEK}                -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'TimeDimensionSpec',                            -->
+                                    <!--    'element_name': 'ds_partitioned',                        -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},),  -->
+                                    <!--    'time_granularity': TimeGranularity.MONTH}               -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'TimeDimensionSpec',                            -->
+                                    <!--    'element_name': 'ds_partitioned',                        -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},),  -->
+                                    <!--    'time_granularity': TimeGranularity.QUARTER}             -->
+                                    <!-- include_spec =                                              -->
+                                    <!--   {'class': 'TimeDimensionSpec',                            -->
+                                    <!--    'element_name': 'ds_partitioned',                        -->
+                                    <!--    'identifier_links': ({'class': 'IdentifierReference',    -->
+                                    <!--                          'element_name': 'customer_id'},),  -->
+                                    <!--    'time_granularity': TimeGranularity.YEAR}                -->
                                     <ReadSqlSourceNode>
                                         <!-- description =                                                                          -->
                                         <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='customer_table'))  -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -5,16 +5,22 @@
         <OrderByLimitNode>
             <!-- description = Order By ['metric_time', 'bookings'] -->
             <!-- node_id = obl_0 -->
-            <!-- order_by_spec =                                        -->
-            <!--   {'class': 'OrderBySpec',                             -->
-            <!--    'item': {'element_name': 'metric_time',             -->
-            <!--             'identifier_links': (),                    -->
-            <!--             'time_granularity': TimeGranularity.DAY},  -->
-            <!--    'descending': False}                                -->
-            <!-- order_by_spec =                           -->
-            <!--   {'class': 'OrderBySpec',                -->
-            <!--    'item': {'element_name': 'bookings'},  -->
-            <!--    'descending': True}                    -->
+            <!-- order_by_spec =                                                       -->
+            <!--   {'class': 'OrderBySpec',                                            -->
+            <!--    'metric_spec': None,                                               -->
+            <!--    'dimension_spec': None,                                            -->
+            <!--    'time_dimension_spec': {'element_name': 'metric_time',             -->
+            <!--                            'identifier_links': (),                    -->
+            <!--                            'time_granularity': TimeGranularity.DAY},  -->
+            <!--    'identifier_spec': None,                                           -->
+            <!--    'descending': False}                                               -->
+            <!-- order_by_spec =                                  -->
+            <!--   {'class': 'OrderBySpec',                       -->
+            <!--    'metric_spec': {'element_name': 'bookings'},  -->
+            <!--    'dimension_spec': None,                       -->
+            <!--    'time_dimension_spec': None,                  -->
+            <!--    'identifier_spec': None,                      -->
+            <!--    'descending': True}                           -->
             <!-- limit = None -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -7,20 +7,21 @@
             <!-- node_id = obl_0 -->
             <!-- order_by_spec =                                                       -->
             <!--   {'class': 'OrderBySpec',                                            -->
+            <!--    'descending': False,                                               -->
             <!--    'metric_spec': None,                                               -->
             <!--    'dimension_spec': None,                                            -->
-            <!--    'time_dimension_spec': {'element_name': 'metric_time',             -->
+            <!--    'time_dimension_spec': {'class': 'TimeDimensionSpec',              -->
+            <!--                            'element_name': 'metric_time',             -->
             <!--                            'identifier_links': (),                    -->
             <!--                            'time_granularity': TimeGranularity.DAY},  -->
-            <!--    'identifier_spec': None,                                           -->
-            <!--    'descending': False}                                               -->
-            <!-- order_by_spec =                                  -->
-            <!--   {'class': 'OrderBySpec',                       -->
-            <!--    'metric_spec': {'element_name': 'bookings'},  -->
-            <!--    'dimension_spec': None,                       -->
-            <!--    'time_dimension_spec': None,                  -->
-            <!--    'identifier_spec': None,                      -->
-            <!--    'descending': True}                           -->
+            <!--    'identifier_spec': None}                                           -->
+            <!-- order_by_spec =                                                         -->
+            <!--   {'class': 'OrderBySpec',                                              -->
+            <!--    'descending': True,                                                  -->
+            <!--    'metric_spec': {'class': 'MetricSpec', 'element_name': 'bookings'},  -->
+            <!--    'dimension_spec': None,                                              -->
+            <!--    'time_dimension_spec': None,                                         -->
+            <!--    'identifier_spec': None}                                             -->
             <!-- limit = None -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_data_source_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_data_source_ratio_metrics_plan__dfp_0.xml
@@ -22,10 +22,11 @@
                     <!--   {'class': 'MeasureSpec',          -->
                     <!--    'element_name': 'bookers',       -->
                     <!--    'non_additive_dimension': None}  -->
-                    <!-- include_spec =                                                                  -->
-                    <!--   {'class': 'DimensionSpec',                                                    -->
-                    <!--    'element_name': 'country_latest',                                            -->
-                    <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                    <!-- include_spec =                                            -->
+                    <!--   {'class': 'DimensionSpec',                              -->
+                    <!--    'element_name': 'country_latest',                      -->
+                    <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                    <!--                          'element_name': 'listing'},)}    -->
                     <!-- include_spec =                               -->
                     <!--   {'class': 'TimeDimensionSpec',             -->
                     <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -23,16 +23,18 @@
                     <WhereConstraintNode>
                         <!-- description = Constrain Output with WHERE -->
                         <!-- node_id = wcc_0 -->
-                        <!-- where_condition =                                                                                  -->
-                        <!--   {'class': 'SpecWhereClauseConstraint',                                                           -->
-                        <!--    'where_condition': "listing__country_latest = 'us'",                                            -->
-                        <!--    'linkable_names': ('listing__country_latest',),                                                 -->
-                        <!--    'linkable_spec_set': {'dimension_specs': ({'element_name': 'country_latest',                    -->
-                        <!--                                               'identifier_links': ({'element_name': 'listing',     -->
-                        <!--                                                                     'identifier_links': ()},)},),  -->
-                        <!--                          'time_dimension_specs': (),                                               -->
-                        <!--                          'identifier_specs': ()},                                                  -->
-                        <!--    'execution_parameters': {'param_dict': {}}}                                                     -->
+                        <!-- where_condition =                                                                                     -->
+                        <!--   {'class': 'SpecWhereClauseConstraint',                                                              -->
+                        <!--    'where_condition': "listing__country_latest = 'us'",                                               -->
+                        <!--    'linkable_names': ('listing__country_latest',),                                                    -->
+                        <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                                                  -->
+                        <!--                          'dimension_specs': ({'class': 'DimensionSpec',                               -->
+                        <!--                                               'element_name': 'country_latest',                       -->
+                        <!--                                               'identifier_links': ({'class': 'IdentifierReference',   -->
+                        <!--                                                                     'element_name': 'listing'},)},),  -->
+                        <!--                          'time_dimension_specs': (),                                                  -->
+                        <!--                          'identifier_specs': ()},                                                     -->
+                        <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                          -->
                         <FilterElementsNode>
                             <!-- description =                                              -->
                             <!--   Pass Only Elements:                                      -->
@@ -44,10 +46,11 @@
                             <!--    'non_additive_dimension': None}  -->
                             <!-- include_spec =                                                                      -->
                             <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
-                            <!-- include_spec =                                                                  -->
-                            <!--   {'class': 'DimensionSpec',                                                    -->
-                            <!--    'element_name': 'country_latest',                                            -->
-                            <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                            <!-- include_spec =                                            -->
+                            <!--   {'class': 'DimensionSpec',                              -->
+                            <!--    'element_name': 'country_latest',                      -->
+                            <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                            <!--                          'element_name': 'listing'},)}    -->
                             <JoinToBaseOutputNode>
                                 <!-- description = Join Standard Outputs -->
                                 <!-- node_id = jso_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -27,12 +27,14 @@
                         <!--   {'class': 'SpecWhereClauseConstraint',                                                        -->
                         <!--    'where_condition': "metric_time >= '2020-01-01'",                                            -->
                         <!--    'linkable_names': ('metric_time',),                                                          -->
-                        <!--    'linkable_spec_set': {'dimension_specs': (),                                                 -->
-                        <!--                          'time_dimension_specs': ({'element_name': 'metric_time',               -->
+                        <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                                            -->
+                        <!--                          'dimension_specs': (),                                                 -->
+                        <!--                          'time_dimension_specs': ({'class': 'TimeDimensionSpec',                -->
+                        <!--                                                    'element_name': 'metric_time',               -->
                         <!--                                                    'identifier_links': (),                      -->
                         <!--                                                    'time_granularity': TimeGranularity.DAY},),  -->
                         <!--                          'identifier_specs': ()},                                               -->
-                        <!--    'execution_parameters': {'param_dict': {}}}                                                  -->
+                        <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                    -->
                         <FilterElementsNode>
                             <!-- description =                                  -->
                             <!--   Pass Only Elements:                          -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -12,16 +12,18 @@
                 <WhereConstraintNode>
                     <!-- description = Constrain Output with WHERE -->
                     <!-- node_id = wcc_0 -->
-                    <!-- where_condition =                                                                                  -->
-                    <!--   {'class': 'SpecWhereClauseConstraint',                                                           -->
-                    <!--    'where_condition': "listing__country_latest = 'us'",                                            -->
-                    <!--    'linkable_names': ('listing__country_latest',),                                                 -->
-                    <!--    'linkable_spec_set': {'dimension_specs': ({'element_name': 'country_latest',                    -->
-                    <!--                                               'identifier_links': ({'element_name': 'listing',     -->
-                    <!--                                                                     'identifier_links': ()},)},),  -->
-                    <!--                          'time_dimension_specs': (),                                               -->
-                    <!--                          'identifier_specs': ()},                                                  -->
-                    <!--    'execution_parameters': {'param_dict': {}}}                                                     -->
+                    <!-- where_condition =                                                                                     -->
+                    <!--   {'class': 'SpecWhereClauseConstraint',                                                              -->
+                    <!--    'where_condition': "listing__country_latest = 'us'",                                               -->
+                    <!--    'linkable_names': ('listing__country_latest',),                                                    -->
+                    <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                                                  -->
+                    <!--                          'dimension_specs': ({'class': 'DimensionSpec',                               -->
+                    <!--                                               'element_name': 'country_latest',                       -->
+                    <!--                                               'identifier_links': ({'class': 'IdentifierReference',   -->
+                    <!--                                                                     'element_name': 'listing'},)},),  -->
+                    <!--                          'time_dimension_specs': (),                                                  -->
+                    <!--                          'identifier_specs': ()},                                                     -->
+                    <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                          -->
                     <FilterElementsNode>
                         <!-- description =                                -->
                         <!--   Pass Only Elements:                        -->
@@ -31,10 +33,11 @@
                         <!--   {'class': 'MeasureSpec',          -->
                         <!--    'element_name': 'bookings',      -->
                         <!--    'non_additive_dimension': None}  -->
-                        <!-- include_spec =                                                                  -->
-                        <!--   {'class': 'DimensionSpec',                                                    -->
-                        <!--    'element_name': 'country_latest',                                            -->
-                        <!--    'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}  -->
+                        <!-- include_spec =                                            -->
+                        <!--   {'class': 'DimensionSpec',                              -->
+                        <!--    'element_name': 'country_latest',                      -->
+                        <!--    'identifier_links': ({'class': 'IdentifierReference',  -->
+                        <!--                          'element_name': 'listing'},)}    -->
                         <JoinToBaseOutputNode>
                             <!-- description = Join Standard Outputs -->
                             <!-- node_id = jso_0 -->

--- a/metricflow/test/test_dataclass_serialization.py
+++ b/metricflow/test/test_dataclass_serialization.py
@@ -1,0 +1,139 @@
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple, Protocol
+
+import pytest
+
+from metricflow.dataclass_serialization import SerializableDataclass, DataClassDeserializer, DataclassSerializer
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def dataclass_serializer() -> DataclassSerializer:  # noqa: D
+    return DataclassSerializer()
+
+
+@pytest.fixture
+def dataclass_deserializer() -> DataClassDeserializer:  # noqa: D
+    return DataClassDeserializer()
+
+
+@dataclass(frozen=True)
+class SimpleDataclass(SerializableDataclass):  # noqa: D
+    field0: int
+
+
+@dataclass(frozen=True)
+class NestedDataclass(SerializableDataclass):  # noqa: D
+    field1: SimpleDataclass
+
+
+@dataclass(frozen=True)
+class DeeplyNestedDataclass(SerializableDataclass):  # noqa: D
+    field2: NestedDataclass
+
+
+@dataclass(frozen=True)
+class DataclassWithOptional(SerializableDataclass):  # noqa: D
+    field3: Optional[SimpleDataclass] = None
+    field4: Optional[SimpleDataclass] = None
+
+
+@dataclass(frozen=True)
+class DataclassWithTuple(SerializableDataclass):  # noqa: D
+    field5: Tuple[SimpleDataclass, ...]
+
+
+class SimpleProtocol(Protocol):  # noqa: D
+    field6: int
+
+
+@dataclass(frozen=True)
+class SimpleClassWithProtocol(SimpleProtocol, SerializableDataclass):  # noqa: D
+    field6: int
+
+
+@dataclass(frozen=True)
+class NestedDataclassWithProtocol(SerializableDataclass):  # noqa: D
+    field7: SimpleClassWithProtocol
+
+
+def test_simple_dataclass(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    obj = SimpleDataclass(field0=1)
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(SimpleDataclass, serialized_obj=serialized_object)
+    assert obj == deserialized_object
+
+
+def test_nested_dataclass(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    obj = NestedDataclass(field1=SimpleDataclass(field0=1))
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(NestedDataclass, serialized_obj=serialized_object)
+    assert obj == deserialized_object
+
+
+def test_deeply_nested_dataclass(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    obj = DeeplyNestedDataclass(field2=NestedDataclass(field1=SimpleDataclass(field0=1)))
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(
+        DeeplyNestedDataclass, serialized_obj=serialized_object
+    )
+    assert obj == deserialized_object
+
+
+def test_dataclass_with_optional(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    # DataclassWithOptional has 2 optional fields, so this tests the None and not-None cases.
+    obj = DataclassWithOptional(field4=SimpleDataclass(field0=1))
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(
+        DataclassWithOptional, serialized_obj=serialized_object
+    )
+    assert obj == deserialized_object
+
+
+def test_dataclass_with_tuple(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    obj = DataclassWithTuple(field5=(SimpleDataclass(field0=1),))
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(
+        DataclassWithTuple, serialized_obj=serialized_object
+    )
+    assert obj == deserialized_object
+
+
+def test_dataclass_with_protocol(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    obj = SimpleClassWithProtocol(field6=1)
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(
+        SimpleClassWithProtocol, serialized_obj=serialized_object
+    )
+    assert obj == deserialized_object
+
+
+def test_nested_dataclass_with_protocol(  # noqa: D
+    dataclass_serializer: DataclassSerializer, dataclass_deserializer: DataClassDeserializer
+) -> None:
+    obj = NestedDataclassWithProtocol(field7=SimpleClassWithProtocol(field6=1))
+    serialized_object = dataclass_serializer.pydantic_serialize(obj)
+
+    deserialized_object = dataclass_deserializer.pydantic_deserialize(
+        NestedDataclassWithProtocol, serialized_obj=serialized_object
+    )
+    assert obj == deserialized_object

--- a/metricflow/test/test_instance_serialization.py
+++ b/metricflow/test/test_instance_serialization.py
@@ -1,0 +1,26 @@
+import pytest
+
+from metricflow.dataclass_serialization import DataclassSerializer, DataClassDeserializer
+from metricflow.instances import InstanceSet
+from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
+
+
+@pytest.fixture
+def serializer() -> DataclassSerializer:  # noqa: D
+    return DataclassSerializer()
+
+
+@pytest.fixture
+def deserializer() -> DataClassDeserializer:  # noqa: D
+    return DataClassDeserializer()
+
+
+def test_serialization(  # noqa: D
+    consistent_id_object_repository: ConsistentIdObjectRepository,
+    serializer: DataclassSerializer,
+    deserializer: DataClassDeserializer,
+) -> None:
+    for _, data_set in consistent_id_object_repository.simple_model_data_sets.items():
+        serialized_obj = serializer.pydantic_serialize(data_set.instance_set)
+        deserialized_obj = deserializer.pydantic_deserialize(dataclass_type=InstanceSet, serialized_obj=serialized_obj)
+        assert data_set.instance_set == deserialized_obj

--- a/metricflow/test/test_object_utils.py
+++ b/metricflow/test/test_object_utils.py
@@ -2,7 +2,7 @@ import logging
 import textwrap
 
 from metricflow.object_utils import pretty_format, pformat_big_objects
-from metricflow.specs import DimensionSpec, LinklessIdentifierSpec
+from metricflow.specs import DimensionSpec, IdentifierReference
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ def test_pretty_print() -> None:  # noqa: D
 
 def test_pformat_big_objects() -> None:  # noqa: D
     dimension_spec = DimensionSpec(
-        element_name="country_latest", identifier_links=(LinklessIdentifierSpec.from_element_name("listing"),)
+        element_name="country_latest", identifier_links=(IdentifierReference(element_name="listing"),)
     )
 
     assert pformat_big_objects(dimension_spec) == (
@@ -26,18 +26,20 @@ def test_pformat_big_objects() -> None:  # noqa: D
             """\
             {'class': 'DimensionSpec',
              'element_name': 'country_latest',
-             'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}
+             'identifier_links': ({'class': 'IdentifierReference',
+                                   'element_name': 'listing'},)}
             """
         ).rstrip()
     )
-
+    logger.error(f"Output:\n{pformat_big_objects(dimension_spec=dimension_spec)}")
     assert pformat_big_objects(dimension_spec=dimension_spec) == (
         textwrap.dedent(
             """\
             dimension_spec:
                 {'class': 'DimensionSpec',
                  'element_name': 'country_latest',
-                 'identifier_links': ({'element_name': 'listing', 'identifier_links': ()},)}
+                 'identifier_links': ({'class': 'IdentifierReference',
+                                       'element_name': 'listing'},)}
             """
         ).rstrip()
     )

--- a/metricflow/test/test_specs.py
+++ b/metricflow/test/test_specs.py
@@ -12,6 +12,7 @@ from metricflow.specs import (
     MetricSpec,
     MeasureSpec,
     LinklessIdentifierSpec,
+    IdentifierReference,
 )
 from metricflow.time.time_granularity import TimeGranularity
 
@@ -21,8 +22,8 @@ def dimension_spec() -> DimensionSpec:  # noqa: D
     return DimensionSpec(
         element_name="platform",
         identifier_links=(
-            LinklessIdentifierSpec.from_element_name(element_name="user_id"),
-            LinklessIdentifierSpec.from_element_name(element_name="device_id"),
+            IdentifierReference(element_name="user_id"),
+            IdentifierReference(element_name="device_id"),
         ),
     )
 
@@ -31,7 +32,7 @@ def dimension_spec() -> DimensionSpec:  # noqa: D
 def time_dimension_spec() -> TimeDimensionSpec:  # noqa: D
     return TimeDimensionSpec(
         element_name="signup_ts",
-        identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="user_id"),),
+        identifier_links=(IdentifierReference(element_name="user_id"),),
         time_granularity=TimeGranularity.DAY,
     )
 
@@ -40,7 +41,7 @@ def time_dimension_spec() -> TimeDimensionSpec:  # noqa: D
 def identifier_spec() -> IdentifierSpec:  # noqa: D
     return IdentifierSpec(
         element_name="user_id",
-        identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing_id"),),
+        identifier_links=(IdentifierReference(element_name="listing_id"),),
     )
 
 
@@ -51,7 +52,7 @@ def test_merge_specs(dimension_spec: DimensionSpec, identifier_spec: IdentifierS
 
 def test_dimension_without_first_identifier_link(dimension_spec: DimensionSpec) -> None:  # noqa: D
     assert dimension_spec.without_first_identifier_link() == DimensionSpec(
-        element_name="platform", identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="device_id"),)
+        element_name="platform", identifier_links=(IdentifierReference(element_name="device_id"),)
     )
 
 
@@ -96,9 +97,7 @@ def test_merge_linkable_specs(dimension_spec: DimensionSpec, identifier_spec: Id
 
 def test_qualified_name() -> None:  # noqa: D
     assert (
-        DimensionSpec(
-            element_name="country", identifier_links=(LinklessIdentifierSpec.from_element_name("listing_id"),)
-        ).qualified_name
+        DimensionSpec(element_name="country", identifier_links=(IdentifierReference("listing_id"),)).qualified_name
         == "listing_id__country"
     )
 
@@ -133,7 +132,7 @@ def spec_set() -> InstanceSpecSet:  # noqa: D
         identifier_specs=(
             IdentifierSpec(
                 element_name="user_id",
-                identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing_id"),),
+                identifier_links=(IdentifierReference(element_name="listing_id"),),
             ),
         ),
     )
@@ -149,7 +148,7 @@ def test_spec_set_linkable_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D
         ),
         IdentifierSpec(
             element_name="user_id",
-            identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing_id"),),
+            identifier_links=(IdentifierReference(element_name="listing_id"),),
         ),
     }
 
@@ -168,7 +167,7 @@ def test_spec_set_all_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D
         ),
         IdentifierSpec(
             element_name="user_id",
-            identifier_links=(LinklessIdentifierSpec.from_element_name(element_name="listing_id"),),
+            identifier_links=(IdentifierReference(element_name="listing_id"),),
         ),
     }
 

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -1,27 +1,27 @@
 from __future__ import annotations
 
 import logging
-import pandas as pd
 from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
 from typing import Tuple, List, Dict, Sequence, Set, Optional
+
+import pandas as pd
 
 from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.dataflow_plan import BaseOutput
 from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.instances import MetricModelReference
+from metricflow.model.objects.metric import MetricType
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.query.query_exceptions import InvalidQueryException
-from metricflow.references import TimeDimensionReference, MeasureReference
+from metricflow.references import TimeDimensionReference, MeasureReference, IdentifierReference
 from metricflow.specs import (
     MetricSpec,
     TimeDimensionSpec,
-    LinklessIdentifierSpec,
     DEFAULT_TIME_GRANULARITY,
 )
-from metricflow.model.objects.metric import MetricType
-from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.time.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class PartialTimeDimensionSpec:
     """
 
     element_name: str
-    identifier_links: Tuple[LinklessIdentifierSpec, ...]
+    identifier_links: Tuple[IdentifierReference, ...]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Many frequently used objects in Metricflow are Pydantic models to support serialization. However, we have seen performance issues as Pydantic objects are slow to construct. This PR introduces a `SerializableDataclass` and a corresponding serializer / deserializer so that we can migrate those objects (mainly the `*Spec` and `*Instance` classes) to be regular Python dataclasses. This produces a significant performance improvement in more complex queries - gains up to a 10x reduction in compilation times have been seen in testing.

Because the serializer has restrictions on the fields in the dataclasses, some model changes were necessary.