### PR TITLE
[Inference] Classify low cardinality strings as dimensions

### DIFF
--- a/metricflow/inference/rule/defaults.py
+++ b/metricflow/inference/rule/defaults.py
@@ -162,6 +162,25 @@ class CategoricalDimensionByBooleanTypeRule(ColumnMatcherRule):
         return props.type == InferenceColumnType.BOOLEAN
 
 
+class CategoricalDimensionByStringTypeAndLowCardinalityRule(LowCardinalityRatioRule):
+    """Inference rule that checks for string typed columns with cardinality below the specified threshold
+
+    It will always produce DIMENSION.CATEGORICAL with HIGH confidence
+    """
+
+    type_node = InferenceSignalType.DIMENSION.CATEGORICAL
+    confidence = InferenceSignalConfidence.HIGH
+    only_applies_to_parent_signal = False
+    match_reason = "Column type is STRING and cardinality ratio is below 0.4"
+
+    def match_column(self, props: ColumnProperties) -> bool:
+        """This is a bit of a hack for composing rules by invoking one directly here"""
+
+        if props.type != InferenceColumnType.STRING:
+            return False
+        return super().match_column(props=props)
+
+
 class CategoricalDimensionByStringTypeRule(ColumnMatcherRule):
     """Inference rule that checks for string columns.
 
@@ -242,12 +261,13 @@ DEFAULT_RULESET = [
     AnyIdentifierByNameRule(),
     PrimaryIdentifierByNameRule(),
     UniqueIdentifierByDistinctCountRule(),
-    ForeignIdentifierByCardinalityRatioRule(0.4),
+    ForeignIdentifierByCardinalityRatioRule(0.6),
     TimeDimensionByTimeTypeRule(),
     PrimaryTimeDimensionByNameRule(),
     PrimaryTimeDimensionIfOnlyTimeRule(),
     CategoricalDimensionByBooleanTypeRule(),
     CategoricalDimensionByStringTypeRule(),
+    CategoricalDimensionByStringTypeAndLowCardinalityRule(0.4),
     CategoricalDimensionByIntegerTypeRule(),
     CategoricalDimensionByCardinalityRatioRule(0.2),
     MeasureByRealTypeRule(),

--- a/metricflow/inference/solver/weighted_tree.py
+++ b/metricflow/inference/solver/weighted_tree.py
@@ -120,7 +120,7 @@ class WeightedTypeTreeInferenceSolver(InferenceSolver):
                 reasons=[],
                 problems=[
                     "No signals were extracted for this column",
-                    "Inference solver could not determine a type for this column",
+                    "Inference solver could not determine if column was an identifier, a dimension, or a measure",
                 ],
             )
 
@@ -160,6 +160,8 @@ class WeightedTypeTreeInferenceSolver(InferenceSolver):
             node = next_node
 
         if node == InferenceSignalType.UNKNOWN:
-            problems.append("Inference solver could not determine a type for this column")
+            problems.append(
+                "Inference solver could not determine if column was an identifier, a dimension, or a measure"
+            )
 
         return InferenceResult(column=column, type_node=node, reasons=reasons, problems=problems)

--- a/metricflow/test/inference/context/test_snowflake.py
+++ b/metricflow/test/inference/context/test_snowflake.py
@@ -19,13 +19,28 @@ def test_column_type_conversion() -> None:  # noqa: D
 
     # known snowflake types
     assert ctx_provider._column_type_from_show_columns_data_type("FIXED") == InferenceColumnType.INTEGER
-    assert ctx_provider._column_type_from_show_columns_data_type("TEXT") == InferenceColumnType.STRING
     assert ctx_provider._column_type_from_show_columns_data_type("REAL") == InferenceColumnType.FLOAT
     assert ctx_provider._column_type_from_show_columns_data_type("BOOLEAN") == InferenceColumnType.BOOLEAN
     assert ctx_provider._column_type_from_show_columns_data_type("DATE") == InferenceColumnType.DATETIME
     assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_TZ") == InferenceColumnType.DATETIME
     assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_LTZ") == InferenceColumnType.DATETIME
     assert ctx_provider._column_type_from_show_columns_data_type("TIMESTAMP_NTZ") == InferenceColumnType.DATETIME
+
+    # String types
+    assert ctx_provider._column_type_from_show_columns_data_type("VARCHAR") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("VARCHAR(256)") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("CHAR") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("CHAR(8)") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("CHARACTER(8)") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("NCHAR(8)") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("STRING") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("TEXT") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("NVARCHAR(16777216)") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("NVARCHAR2(16777216)") == InferenceColumnType.STRING
+    assert ctx_provider._column_type_from_show_columns_data_type("CHAR VARYING(16777216)") == InferenceColumnType.STRING
+    assert (
+        ctx_provider._column_type_from_show_columns_data_type("NCHAR VARYING(16777216)") == InferenceColumnType.STRING
+    )
 
     # unknowns
     assert ctx_provider._column_type_from_show_columns_data_type("BINARY") == InferenceColumnType.UNKNOWN

--- a/metricflow/test/inference/rule/test_defaults.py
+++ b/metricflow/test/inference/rule/test_defaults.py
@@ -166,6 +166,26 @@ def test_categorical_dimension_by_string_type_matcher() -> None:  # noqa: D
     )
 
 
+def test_categorical_dimension_by_string__and_cardinality_type_matcher() -> None:  # noqa: D
+    """Tests the composite of string type and cardinality below supplied threshold
+
+    Since the helper cardinality ratio is always either 1 or 0.9, the cardinality thresholds are set to either above
+    0.9 (for checks which should match) or below 0.9 (for checks which should not match, or where the match does
+    not matter)
+    """
+
+    assert defaults.CategoricalDimensionByStringTypeAndLowCardinalityRule(0.99).match_column(
+        get_column_properties("db.schema.table.low_cardinality_string_col", InferenceColumnType.STRING, unique=False)
+    )
+    # INTEGER type columns never match this rule
+    assert not defaults.CategoricalDimensionByStringTypeAndLowCardinalityRule(0.99).match_column(
+        get_column_properties("db.schema.table.int_col", InferenceColumnType.INTEGER, unique=False)
+    )
+    assert not defaults.CategoricalDimensionByCardinalityRatioRule(0.40).match_column(
+        get_column_properties("db.schema.table.high_cardinality_string_col", InferenceColumnType.STRING, unique=False)
+    )
+
+
 def test_categorical_dimension_by_integer_type_matcher() -> None:  # noqa: D
     assert defaults.CategoricalDimensionByIntegerTypeRule().match_column(
         get_column_properties("db.schema.table.dim", InferenceColumnType.INTEGER, True)


### PR DESCRIPTION
#204 highlighted an issue where string type columns were not being classified as dimensions.

This PR is an attempt at improving our detection there. The core of it is a new rule, which classifies a column in the warehouse as a dimension if it is both a STRING type AND relatively low cardinality (below 40% unique).

It's not clear if this is a huge improvement. It should reduce the false negative rate, which appears to be burdensome on early users, but it could result in a higher than expected false positive rate where string foreign key fields, or string fields which should be omitted (like the "name" field for a customer_organization table, where you might have a lot of duplicate entries for franchise customers or whatever). However, this rule appears to be useful, even if we need to tweak the thresholds somewhat.

As a matter of future work, we might consider making these cardinality thresholds adjustable on the CLI, although figuring out how to do so cleanly is a bit of a challenge.