### PR TITLE
Generate an explicit json schema from the parsing logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,8 @@ lint:
 .PHONY: postgresql postgres
 postgresql postgres:
 	make -C local-data-warehouses postgresql
+
+# Install metricflow for development work.
+.PHONY: json_schema
+json_schema:
+	python3 metricflow/model/parsing/explicit_schema.py

--- a/metricflow/model/parsing/explicit_schema.py
+++ b/metricflow/model/parsing/explicit_schema.py
@@ -1,0 +1,82 @@
+import json
+from copy import deepcopy
+
+from pathlib import Path
+from typing import Dict, List, Union
+
+from metricflow.model.parsing import schemas_internal
+
+TOP_LEVEL_SCHEMAS = {
+    "metric",
+    "data_source",
+    "derived_group_by_element_schema",
+    "materialization_schema",
+}
+
+BASE_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "MetricFlow file schema",
+}
+
+
+def generate_explict_schema(schema_store: Dict) -> Dict:
+    """Generates a single json schema object from the given schema store."""
+    ref_to_definition_mapping = {key: f"#/definitions/{key}" for key in schema_store.keys()}
+    definitions = {}
+    for schema_name, _schema in schema_store.items():
+        schema = deepcopy(_schema)
+
+        rewritten_schema = _rewrite_refs(schema, ref_to_definition_mapping)
+        assert isinstance(rewritten_schema, dict)
+
+        if "definitions" in rewritten_schema:
+            nested_definitions = rewritten_schema["definitions"]
+            for name in nested_definitions.keys():
+                definitions[name] = nested_definitions[name]
+            rewritten_schema.pop("definitions", None)
+
+        definitions[schema_name] = rewritten_schema
+
+    properties = {}
+    for schema_name in TOP_LEVEL_SCHEMAS:
+        properties[schema_name] = {"$ref": ref_to_definition_mapping[schema_name]}
+
+    full_schema: Dict = deepcopy(BASE_SCHEMA)
+    full_schema["properties"] = properties
+    full_schema["definitions"] = definitions
+
+    return full_schema
+
+
+def _rewrite_refs(obj: Union[Dict, List, bool, str], mapping: Dict) -> Union[Dict, List, bool, str]:
+    """Replaces the $refs from their names to their definition section identifiers."""
+    if isinstance(obj, dict):
+        _dict = {}
+        for k, v in obj.items():
+            if k == "$ref" and v in mapping:
+                _dict[k] = mapping[v]
+            else:
+                _dict[k] = _rewrite_refs(v, mapping)
+        return _dict
+    if isinstance(obj, list):
+        _list = []
+        for element in obj:
+            _list.append(_rewrite_refs(element, mapping))
+        return _list
+    return obj
+
+
+def write_schema(schema: Dict, output_dir: str, file_name: str) -> None:
+    """Writes the schema from the specified schema store to the given path"""
+
+    path = Path(output_dir).resolve()
+    path.mkdir(exist_ok=True)
+    with open(path / file_name, "w") as f:
+        json.dump(schema, f, indent=4, sort_keys=True)
+
+
+if __name__ == "__main__":
+    schema = generate_explict_schema(schemas_internal.schema_store)
+    output_dir = str(Path(__file__).parent / "schemas")
+    write_schema(schema, output_dir, "metricflow.json")

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -1,0 +1,728 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "composite_sub_identifier_schema": {
+            "$id": "composite_sub_identifier_schema",
+            "additionalProperties": false,
+            "properties": {
+                "expr": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ref": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "data_source": {
+            "$id": "data_source",
+            "additionalProperties": false,
+            "properties": {
+                "dbt_model": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dimensions": {
+                    "items": {
+                        "$ref": "#/definitions/dimension_schema"
+                    },
+                    "type": "array"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "identifiers": {
+                    "items": {
+                        "$ref": "#/definitions/identifier_schema"
+                    },
+                    "type": "array"
+                },
+                "measures": {
+                    "items": {
+                        "$ref": "#/definitions/measure_schema"
+                    },
+                    "type": "array"
+                },
+                "mutability": {
+                    "$ref": "#/definitions/mutability_schema"
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "sql_query": {
+                    "type": "string"
+                },
+                "sql_table": {
+                    "type": "string"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "derived_group_by_element_schema": {
+            "$id": "derived_group_by_element_schema",
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "expr": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "expr_elements": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "expr"
+            ],
+            "type": "object"
+        },
+        "dimension_schema": {
+            "$id": "dimension_schema",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "not": {
+                        "$ref": "#/definitions/is-time-dimension"
+                    }
+                },
+                {
+                    "required": [
+                        "type_params"
+                    ]
+                }
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "expr": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "is_partition": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "type": {
+                    "enum": [
+                        "CATEGORICAL",
+                        "TIME",
+                        "categorical",
+                        "time"
+                    ]
+                },
+                "type_params": {
+                    "$ref": "#/definitions/dimension_type_params_schema"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "dimension_type_params_schema": {
+            "$id": "dimension_type_params_schema",
+            "additionalProperties": false,
+            "properties": {
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "time_format": {
+                    "type": "string"
+                },
+                "time_granularity": {
+                    "enum": [
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                        "day",
+                        "week",
+                        "month",
+                        "quarter",
+                        "year"
+                    ]
+                }
+            },
+            "required": [
+                "time_granularity"
+            ],
+            "type": "object"
+        },
+        "identifier_schema": {
+            "$id": "identifier_schema",
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "entity": {
+                    "type": "string"
+                },
+                "expr": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "identifiers": {
+                    "items": {
+                        "$ref": "#/definitions/composite_sub_identifier_schema"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "type": {
+                    "enum": [
+                        "PRIMARY",
+                        "UNIQUE",
+                        "FOREIGN",
+                        "RENDER_ONLY",
+                        "primary",
+                        "unique",
+                        "foreign",
+                        "render_only"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "is-tableau": {
+            "properties": {
+                "location": {
+                    "enum": [
+                        "TABLEAU",
+                        "tableau"
+                    ]
+                }
+            }
+        },
+        "is-time-dimension": {
+            "properties": {
+                "type": {
+                    "enum": [
+                        "TIME",
+                        "time"
+                    ]
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "locked_metadata": {
+            "$id": "locked_metadata",
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "increase_is_good": {
+                    "type": "boolean"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "value_format": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "materialization_destination_schema": {
+            "$id": "materialization_destination_schema",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "not": {
+                        "$ref": "#/definitions/is-tableau"
+                    }
+                },
+                {
+                    "required": [
+                        "tableau_params"
+                    ]
+                }
+            ],
+            "properties": {
+                "format": {
+                    "enum": [
+                        "WIDE",
+                        "wide"
+                    ]
+                },
+                "location": {
+                    "enum": [
+                        "DW",
+                        "FAST_CACHE",
+                        "dw",
+                        "fast_cache",
+                        "TABLEAU",
+                        "tableau"
+                    ]
+                },
+                "rollups": {
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "type": "array"
+                },
+                "tableau_params": {
+                    "$id": "materialization_params_tableau",
+                    "properties": {
+                        "projects": {
+                            "projects": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "materialization_schema": {
+            "$id": "materialization_schema",
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "destination_table": {
+                    "type": "string"
+                },
+                "destinations": {
+                    "items": {
+                        "$ref": "#/definitions/materialization_destination_schema"
+                    },
+                    "type": "array"
+                },
+                "dimensions": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "metrics": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "dimensions",
+                "metrics"
+            ],
+            "type": "object"
+        },
+        "measure_schema": {
+            "$id": "measure_schema",
+            "additionalProperties": false,
+            "properties": {
+                "agg": {
+                    "enum": [
+                        "SUM",
+                        "MIN",
+                        "MAX",
+                        "AVERAGE",
+                        "COUNT_DISTINCT",
+                        "BOOLEAN",
+                        "SUM_BOOLEAN",
+                        "sum",
+                        "min",
+                        "max",
+                        "average",
+                        "count_distinct",
+                        "boolean",
+                        "sum_boolean"
+                    ]
+                },
+                "agg_time_dimension": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "create_metric": {
+                    "type": "boolean"
+                },
+                "create_metric_display_name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "expr": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "boolean"
+                    ]
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "non_additive_dimension": {
+                    "$ref": "#/definitions/non_additive_dimension_schema"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "agg"
+            ],
+            "type": "object"
+        },
+        "metric": {
+            "$id": "metric",
+            "additionalProperties": false,
+            "properties": {
+                "constraint": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "locked_metadata": {
+                    "$ref": "#/definitions/locked_metadata"
+                },
+                "name": {
+                    "pattern": "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$",
+                    "type": "string"
+                },
+                "owners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tier": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "type": {
+                    "enum": [
+                        "MEASURE_PROXY",
+                        "RATIO",
+                        "EXPR",
+                        "CUMULATIVE",
+                        "measure_proxy",
+                        "ratio",
+                        "expr",
+                        "cumulative"
+                    ]
+                },
+                "type_params": {
+                    "$ref": "#/definitions/metric_type_params"
+                },
+                "where_constraint": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "type_params"
+            ],
+            "type": "object"
+        },
+        "metric_input_measure_schema": {
+            "$id": "metric_input_measure_schema",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "metric_type_params": {
+            "$id": "metric_type_params",
+            "additionalProperties": false,
+            "properties": {
+                "denominator": {
+                    "$ref": "#/definitions/metric_input_measure_schema"
+                },
+                "expr": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "grain_to_date": {
+                    "type": "string"
+                },
+                "measure": {
+                    "$ref": "#/definitions/metric_input_measure_schema"
+                },
+                "measures": {
+                    "items": {
+                        "$ref": "#/definitions/metric_input_measure_schema"
+                    },
+                    "type": "array"
+                },
+                "numerator": {
+                    "$ref": "#/definitions/metric_input_measure_schema"
+                },
+                "window": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "mutability_schema": {
+            "$id": "mutability_schema",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "enum": [
+                        "IMMUTABLE",
+                        "APPEND_ONLY",
+                        "FULL_MUTATION",
+                        "DS_APPEND_ONLY",
+                        "immutable",
+                        "append_only",
+                        "full_mutation",
+                        "ds_append_only"
+                    ]
+                },
+                "type_params": {
+                    "$ref": "#/definitions/mutability_type_params_schema"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "mutability_type_params_schema": {
+            "$id": "mutability_type_params_schema",
+            "additionalProperties": false,
+            "properties": {
+                "along": {
+                    "type": "string"
+                },
+                "max": {
+                    "type": "string"
+                },
+                "min": {
+                    "type": "string"
+                },
+                "update_cron": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "non_additive_dimension_schema": {
+            "$id": "non_additive_dimension_schema",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "window_choice": {
+                    "enum": [
+                        "SUM",
+                        "MIN",
+                        "MAX",
+                        "AVERAGE",
+                        "COUNT_DISTINCT",
+                        "BOOLEAN",
+                        "SUM_BOOLEAN",
+                        "sum",
+                        "min",
+                        "max",
+                        "average",
+                        "count_distinct",
+                        "boolean",
+                        "sum_boolean"
+                    ]
+                },
+                "window_groupings": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "name",
+                "window_choice"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "data_source": {
+            "$ref": "#/definitions/data_source"
+        },
+        "derived_group_by_element_schema": {
+            "$ref": "#/definitions/derived_group_by_element_schema"
+        },
+        "materialization_schema": {
+            "$ref": "#/definitions/materialization_schema"
+        },
+        "metric": {
+            "$ref": "#/definitions/metric"
+        }
+    },
+    "title": "MetricFlow file schema",
+    "type": "object"
+}


### PR DESCRIPTION
Changes
- Adds functionality to generate an explicit json schema from the one defined throughout the metricflow parsing code.

- Adds a Makefile command to generate this explicit schema in `models/parsing/schemas`

The generated schema is similar to the one used for parsing but flattened into a single json file. Each subschema in the schema store becomes a definition, while each top level schema is a property that references it's corresponding definition. Some subschemas have their own definition sections, so for simplicity they are lifted into the single top level definitions section. 

With this change, we can easily reference schemas across tagged versions. e.g. `https://github.com/transform-data/metricflow/blob/v0.X.Y/metricflow/model/parsing/schemas/metricflow.json`. 

 The next step is a Github action that runs when the `models/parsing` folder is changed; this will make sure that the generated json schema matches the schema defined in the parsing code. 

Notes
-  I wasn't really sure where to put this code and made a choice fairly arbitarily so let me know if there's a better structure for it. 
- I decided to just use schemas-internal since that's what we use for parsing everywhere but it's an easy change to generate both.