### PR TITLE
Github Action to check JSON schema consistency

### DIFF
--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
 
   pull_request:
-    # run these jobs when a PR is opened, edited, reopened, or updated (synchronize)
-    # edited = title, body, or the base branch of the PR is modified
+    # run these jobs when a PR is opened, reopened, or updated (synchronize)
     # synchronize = commit(s) pushed to the pull request
     types:
       - opened
@@ -47,7 +46,7 @@ jobs:
           if [[ $(git diff) ]]
           then
             git diff
-            echo 'Failure: JSON schema and generated schema do not match.'
+            echo 'Failure: JSON schema and generated schema do not match. Run make json_schema and commit the updated schema changes before merge.'
             exit 1
           else
             echo 'Success: JSON schema and generated schema match.'

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -1,0 +1,55 @@
+name: JSON Schema Consistency Check
+on:
+  workflow_dispatch:
+
+  pull_request:
+    # run these jobs when a PR is opened, edited, reopened, or updated (synchronize)
+    # edited = title, body, or the base branch of the PR is modified
+    # synchronize = commit(s) pushed to the pull request
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - 'metricflow/model/parsing/**'
+
+jobs:
+   json-schema-consistency-check:
+    name: Schema Consistency Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.pythonLocation }}
+            ~/.cache/pypoetry
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install Poetry
+        run: pip install poetry && poetry config virtualenvs.create false
+
+      - name: Install Metricflow
+        run: poetry install
+      
+      - name: Generate JSON Schema
+        run: python3 metricflow/model/parsing/explicit_schema.py
+
+      - name: Schema Consistency Check
+        run: |
+          if [[ $(git diff) ]]
+          then
+            git diff
+            echo 'Failure: JSON schema and generated schema do not match.'
+            exit 1
+          else
+            echo 'Success: JSON schema and generated schema match.'
+          fi
+


### PR DESCRIPTION
Adds a Github action that is triggered when models/parsing is edited. 

The action regenerates the JSON schema using the latest changes in `models/parsing`. If the generated schema doesn't match the existing json schema in `/models/parsing/schemas/metricflow.json`, the action fails. 

This is a follow up to the work in https://github.com/transform-data/metricflow/pull/211

I'm not sure a great way to test Github actions so I tested against a forked repo to avoid spamming metricflow's Github Action log; a failure looks like this: https://github.com/jack-transform/metricflow-jckelly-test/runs/7968193985?check_suite_focus=true