### PR TITLE
BUG: ChangeMeasureAggregationState wasn't copying the MeasureInstance fully

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -545,13 +545,9 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         if len(output_nodes) == 1:
             return output_nodes[0]
         else:
-            # Remove the non-additive dimension params from measure_specs moving forward
             return FilterElementsNode(
                 parent_node=JoinAggregatedMeasuresByGroupByColumnsNode(parent_nodes=output_nodes),
-                include_specs=LinkableInstanceSpec.merge(
-                    queried_linkable_specs.as_tuple,
-                    tuple(MeasureSpec(element_name=x.element_name) for x in measure_specs),
-                ),
+                include_specs=LinkableInstanceSpec.merge(queried_linkable_specs.as_tuple, measure_specs),
             )
 
     @staticmethod

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -22,7 +22,6 @@ from metricflow.model.semantics.semantic_containers import DataSourceSemantics
 from metricflow.object_utils import assert_exactly_one_arg_set
 from metricflow.plan_conversion.select_column_gen import SelectColumnSet
 from metricflow.specs import (
-    MeasureSpec,
     InstanceSpec,
     IdentifierSpec,
     DimensionSpec,
@@ -413,9 +412,7 @@ class ChangeMeasureAggregationState(InstanceSetTransform[InstanceSet]):
                 associated_columns=x.associated_columns,
                 defined_from=x.defined_from,
                 aggregation_state=self._aggregation_state_changes[x.aggregation_state],
-                spec=MeasureSpec(
-                    element_name=x.spec.element_name,
-                ),
+                spec=x.spec,
             )
             for x in instance_set.measure_instances
         )

--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -54,3 +54,55 @@ integration_test:
       a.ds = b.ds
     GROUP BY
       a.ds
+---
+integration_test:
+  name: semi_additive_measure_query_with_join_linkable_specs
+  description: |
+    Tests semi-additive measure with a path hitting join linkable specs. 
+    There are cases (like this query where we have a non-local linkable spec "user__home_state_latest")
+    we are directly copying a MeasureSpec via constructing it. Previously, this led to a code path not passing all the attributes,
+    then somewhere along the path it would end up throwing a MeasureSpec not in [List of MeasureSpec] due to an attribute
+    being missing. This test case hits that path and ensures that we are copying the correct.  
+  model: SIMPLE_MODEL
+  metrics: ["current_account_balance_by_user"]
+  group_bys: ["user"]
+  where_constraint: "user__home_state_latest = 'CA'"
+  check_query: |
+    SELECT
+      e.user AS user
+      , SUM(e.current_account_balance_by_user) AS current_account_balance_by_user
+    FROM (
+      SELECT
+        c.user AS user
+        , d.home_state_latest AS user__home_state_latest
+        , c.current_account_balance_by_user AS current_account_balance_by_user
+      FROM (
+        SELECT
+          a.user AS user
+          , a.current_account_balance_by_user AS current_account_balance_by_user
+        FROM (
+          SELECT
+            ds
+            , user_id AS user
+            , account_balance AS current_account_balance_by_user
+          FROM {{ source_schema }}.fct_accounts
+        ) a
+        INNER JOIN (
+          SELECT
+            user_id AS user
+            , MAX(ds) AS ds
+          FROM {{ source_schema }}.fct_accounts
+          GROUP BY
+            user_id
+        ) b
+        ON
+          a.ds = b.ds AND a.user = b.user
+      ) c
+      LEFT OUTER JOIN
+        {{ source_schema }}.dim_users_latest d
+      ON
+        c.user = d.user_id
+    ) e
+    WHERE user__home_state_latest = 'CA'
+    GROUP BY
+      e.user

--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -59,10 +59,10 @@ integration_test:
   name: semi_additive_measure_query_with_join_linkable_specs
   description: |
     Tests semi-additive measure with a path hitting join linkable specs. 
-    There are cases (like this query where we have a non-local linkable spec "user__home_state_latest")
+    There are cases (like this query where we have a non-local linkable spec "user__home_state_latest") where
     we are directly copying a MeasureSpec via constructing it. Previously, this led to a code path not passing all the attributes,
     then somewhere along the path it would end up throwing a MeasureSpec not in [List of MeasureSpec] due to an attribute
-    being missing. This test case hits that path and ensures that we are copying the correct.  
+    being missing. This test case hits that path and ensures that we are copying attributes correctly.  
   model: SIMPLE_MODEL
   metrics: ["current_account_balance_by_user"]
   group_bys: ["user"]


### PR DESCRIPTION
When using the transform function `ChangeMeasureAggregationState` if a measure instance has a spec with a non-null `NonAdditiveDimensionParameters` it ends up not copying it over along with it. This caused errors when filtering elements such as 
```python
MeasureSpec(element_name=x, non_additive_dimension=<not None>) not in
   [...,MeasureSpec(element_name=x, non_additive_dimension=None),...]
```

Also removed the previous workaround which was removing the non_additive_dimension property from MeasureSpec during measure aggregation, but that was incorrect.