### PR TITLE
Improve error message for missing aggregation time dimension

### DIFF
--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -79,9 +79,11 @@ class Measure(HashableBaseModel, ModelWithMetadataParsing):
     @property
     def checked_agg_time_dimension(self) -> TimeDimensionReference:
         """Returns the aggregation time dimension, throwing an exception if it's not set."""
-        assert (
-            self.agg_time_dimension
-        ), f"Aggregation time dimension for {self.name} should have been set during model transformation"
+        assert self.agg_time_dimension, (
+            f"Aggregation time dimension for measure {self.name} is not set! This should either be set directly on "
+            f"the measure specification in the model, or else defaulted to the primary time dimension in the data "
+            f"source containing the measure."
+        )
         return TimeDimensionReference(element_name=self.agg_time_dimension)
 
     @property

--- a/metricflow/model/validations/agg_time_dimension.py
+++ b/metricflow/model/validations/agg_time_dimension.py
@@ -56,8 +56,8 @@ class AggregationTimeDimensionRule(ModelValidationRule):
                     ValidationError(
                         context=measure_context,
                         message=f"In data source '{data_source.name}', measure '{measure.name}' has the aggregation "
-                        f"time dimension is set to '{agg_time_dimension_reference.element_name}', "
-                        f"which not a valid time dimension in the data source",
+                        f"time dimension set to '{agg_time_dimension_reference.element_name}', "
+                        f"which is not a valid time dimension in the data source",
                     )
                 )
 

--- a/metricflow/test/model/validations/test_agg_time_dimension.py
+++ b/metricflow/test/model/validations/test_agg_time_dimension.py
@@ -19,9 +19,26 @@ def test_invalid_aggregation_time_dimension(simple_user_configured_model: UserCo
     with pytest.raises(
         ModelValidationException,
         match=(
-            "has the aggregation time dimension is set to 'invalid_time_dimension', which not a valid time dimension "
+            "has the aggregation time dimension set to 'invalid_time_dimension', which is not a valid time dimension "
             "in the data source"
         ),
+    ):
+        model_validator = ModelValidator()
+        model_validator.checked_validations(model)
+
+
+def test_unset_aggregation_time_dimension(data_warehouse_validation_model: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(data_warehouse_validation_model)
+    data_source_with_measures, _ = find_data_source_with(
+        model,
+        lambda data_source: len(data_source.measures) > 0,
+    )
+
+    data_source_with_measures.measures[0].agg_time_dimension = None
+
+    with pytest.raises(
+        ModelValidationException,
+        match=("Aggregation time dimension for measure \\w+ is not set!"),
     ):
         model_validator = ModelValidator()
         model_validator.checked_validations(model)


### PR DESCRIPTION
If the user fails to include either a primary time dimension or a
measure-specific aggregation time dimension for a measure in their
model they will encounter an assertion check either during validation
or querying. The original error message was really intended for
developers, but it is incidentally raised in validation. This quick fix
makes it a bit more user-friendly.
