### PR TITLE
Add protocols for read-only semantic containers

### DIFF
--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -36,7 +36,7 @@ from metricflow.specs import (
     LinklessIdentifierSpec,
     InstanceSpecSet,
 )
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ class NodeEvaluatorForLinkableInstances(Generic[SourceDataSetT]):
 
     def __init__(
         self,
-        data_source_semantics: DataSourceSemantics,
+        data_source_semantics: DataSourceSemanticsAccessor,
         nodes_available_for_joins: Sequence[BaseOutput[SourceDataSetT]],
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver[SourceDataSetT],
     ) -> None:

--- a/metricflow/dataflow/builder/partitions.py
+++ b/metricflow/dataflow/builder/partitions.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Tuple, Sequence, List
 
 from metricflow.dataset.dataset import DataSet
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 from metricflow.specs import (
     DimensionSpec,
     TimeDimensionSpec,
@@ -33,7 +33,7 @@ class PartitionTimeDimensionJoinDescription:
 class PartitionJoinResolver:
     """When joining data sets, this class helps to figure out the necessary partition specs to join on."""
 
-    def __init__(self, data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
+    def __init__(self, data_source_semantics: DataSourceSemanticsAccessor) -> None:  # noqa: D
         self._data_source_semantics = data_source_semantics
 
     def _get_partitions(self, spec_set: InstanceSpecSet) -> PartitionSpecSet:

--- a/metricflow/model/semantic_model.py
+++ b/metricflow/model/semantic_model.py
@@ -1,7 +1,7 @@
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MetricSemantics
-from metricflow.protocols.semantics import DataSourceSemanticsAccessor
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor, MetricSemanticsAccessor
 
 
 class SemanticModel:
@@ -23,5 +23,5 @@ class SemanticModel:
         return self._data_source_semantics
 
     @property
-    def metric_semantics(self) -> MetricSemantics:  # noqa: D
+    def metric_semantics(self) -> MetricSemanticsAccessor:  # noqa: D
         return self._metric_semantics

--- a/metricflow/model/semantic_model.py
+++ b/metricflow/model/semantic_model.py
@@ -1,6 +1,7 @@
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MetricSemantics
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 
 
 class SemanticModel:
@@ -18,7 +19,7 @@ class SemanticModel:
         return self._user_configured_model
 
     @property
-    def data_source_semantics(self) -> DataSourceSemantics:  # noqa: D
+    def data_source_semantics(self) -> DataSourceSemanticsAccessor:  # noqa: D
         return self._data_source_semantics
 
     @property

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -134,7 +134,11 @@ class MetricSemantics:  # noqa: D
 
 
 class DataSourceSemantics:
-    """Tracks semantic information for data source held in a set of DataSourceContainers"""
+    """Tracks semantic information for data source held in a set of DataSourceContainers
+
+    This implements both the DataSourceSemanticsAccessors protocol, the interface type we use throughout the codebase.
+    That interface prevents unwanted calls to methods for adding data sources to the container.
+    """
 
     def __init__(  # noqa: D
         self,

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -18,7 +18,7 @@ from metricflow.instances import (
     InstanceSetTransform,
     TimeDimensionInstance,
 )
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 from metricflow.object_utils import assert_exactly_one_arg_set
 from metricflow.plan_conversion.select_column_gen import SelectColumnSet
 from metricflow.specs import (
@@ -149,7 +149,10 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
     """
 
     def __init__(  # noqa: D
-        self, table_alias: str, column_resolver: ColumnAssociationResolver, data_source_semantics: DataSourceSemantics
+        self,
+        table_alias: str,
+        column_resolver: ColumnAssociationResolver,
+        data_source_semantics: DataSourceSemanticsAccessor,
     ) -> None:
         self._data_source_semantics = data_source_semantics
         super().__init__(table_alias=table_alias, column_resolver=column_resolver)

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -12,8 +12,9 @@ from metricflow.dataflow.dataflow_plan import (
     FilterElementsNode,
     JoinDescription,
 )
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MAX_JOIN_HOPS
+from metricflow.model.semantics.semantic_containers import MAX_JOIN_HOPS
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 from metricflow.spec_set_transforms import ToElementNameSet
 from metricflow.references import TimeDimensionReference
 from metricflow.specs import IdentifierSpec, InstanceSpec, LinkableInstanceSpec
@@ -45,7 +46,7 @@ class PreDimensionJoinNodeProcessor(Generic[SqlDataSetT]):
 
     def __init__(  # noqa: D
         self,
-        data_source_semantics: DataSourceSemantics,
+        data_source_semantics: DataSourceSemanticsAccessor,
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver[SqlDataSetT],
     ):
         self._node_data_set_resolver = node_data_set_resolver

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -1,0 +1,106 @@
+"""Protocols for classes meant to manage semantic information of useful object types.
+
+These are useful as more generic descriptors of interfaces around classes like semantic containers and such, which
+might be best used in a read-only mode. These containers could also pull in extra dependencies in their internal
+implementations, dependencies which are best isolated inside the packages containing the concrete objects rather
+than the interface specifications.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Dict, List, Optional, Protocol, Sequence
+
+from metricflow.instances import DataSourceElementReference, DataSourceReference
+from metricflow.model.objects.data_source import DataSource, DataSourceOrigin
+from metricflow.model.objects.elements.dimension import Dimension
+from metricflow.model.objects.elements.identifier import Identifier
+from metricflow.model.objects.elements.measure import Measure, NonAdditiveDimensionParameters
+from metricflow.model.semantics.element_group import ElementGrouper
+from metricflow.references import DimensionReference, IdentifierReference, MeasureReference, TimeDimensionReference
+from metricflow.specs import MeasureSpec
+
+
+class DataSourceSemanticsAccessor(Protocol):
+    """Protocol defining core interface for accessing semantic information about a set of data source objects
+
+    This is primarily useful for restricting caller access to the subset of container methods and imports we want
+    them to use. For example, the DataSourceSemantics class might implement this protocol but also include some
+    public methods for adding or removing data sources from the container, while this protocol only allows the
+    caller to invoke the accessor methods which retrieve semantic information about the collected data sources.
+    """
+
+    @abstractmethod
+    def get_dimension_references(self) -> List[DimensionReference]:
+        """Retrieve all dimension references from the collection of data sources"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_dimension(
+        self, dimension_reference: DimensionReference, origin: Optional[DataSourceOrigin] = None
+    ) -> Dimension:
+        """Retrieve the dimension model object associated with the time dimension reference"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_time_dimension(self, time_dimension_reference: TimeDimensionReference) -> Dimension:
+        """Retrieve the dimension model object associated with the time dimension reference"""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def measure_references(self) -> List[MeasureReference]:
+        """Return all measure references from the collection of data sources"""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def non_additive_dimension_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionParameters]:
+        """Return a mapping from all semi-additive measures to their corresponding non additive dimension parameters
+
+        This includes all measures with non-additive dimension parameters, if any, from the collection of data sources.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_measure(self, measure_reference: MeasureReference) -> Measure:
+        """Retrieve the measure model object associated with the measure reference"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_identifier_references(self) -> List[IdentifierReference]:
+        """Retrieve all identifier references from the collection of data sources"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_data_sources_for_measure(self, measure_reference: MeasureReference) -> List[DataSource]:
+        """Retrieve a list of all data source model objects associated with the measure reference"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_identifier_in_data_source(self, ref: DataSourceElementReference) -> Optional[Identifier]:
+        """Retrieve the identifier matching the element -> data source mapping, if any"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self, data_source_name: str) -> Optional[DataSource]:
+        """Retrieve the data source model object matching the given name, if any"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_by_reference(self, data_source_reference: DataSourceReference) -> Optional[DataSource]:
+        """Retrieve the data source model object matching the input data source reference, if any"""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def data_source_references(self) -> Sequence[DataSourceReference]:
+        """Return all DataSourceReference objects associated with the data sources in the collection"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_aggregation_time_dimensions_with_measures(
+        self, data_source_reference: DataSourceReference
+    ) -> ElementGrouper[TimeDimensionReference, MeasureSpec]:
+        """Return all aggregation time dimensions in the given data source with their associated measures"""
+        raise NotImplementedError

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -18,9 +18,9 @@ from metricflow.errors.errors import UnableToSatisfyQueryError
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
 from metricflow.model.objects.elements.dimension import DimensionType
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.object_utils import pformat_big_objects
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.references import DimensionReference, IdentifierReference, TimeDimensionReference
 from metricflow.specs import (
@@ -105,12 +105,12 @@ class MetricFlowQueryParser:
 
     @staticmethod
     def convert_to_linkable_specs(
-        data_source_semantics: DataSourceSemantics, where_constraint_names: List[str]
+        data_source_semantics: DataSourceSemanticsAccessor, where_constraint_names: List[str]
     ) -> LinkableSpecSet:
         """Processes where_clause_constraint.linkable_names into associated LinkableInstanceSpecs (dims, times, ids)
 
         where_constraint_names: WhereConstraintClause.linkable_names
-        data_source_semantics: DataSourceSemantics from the instantiated class
+        data_source_semantics: DataSourceSemanticsAccessor from the instantiated class
 
         output: InstanceSpecSet of Tuple(DimensionSpec), Tuple(TimeDimensionSpec), Tuple(IdentifierSpec)
         """
@@ -153,14 +153,15 @@ class MetricFlowQueryParser:
 
     @staticmethod
     def convert_to_spec_where_constraint(
-        data_source_semantics: DataSourceSemantics, where_constraint: WhereClauseConstraint
+        data_source_semantics: DataSourceSemanticsAccessor, where_constraint: WhereClauseConstraint
     ) -> SpecWhereClauseConstraint:
         """Converts a where constraint to one using specs."""
         return SpecWhereClauseConstraint(
             where_condition=where_constraint.where,
             linkable_names=tuple(where_constraint.linkable_names),
             linkable_spec_set=MetricFlowQueryParser.convert_to_linkable_specs(
-                data_source_semantics=data_source_semantics, where_constraint_names=where_constraint.linkable_names
+                data_source_semantics=data_source_semantics,
+                where_constraint_names=where_constraint.linkable_names,
             ),
             execution_parameters=where_constraint.sql_params,
         )


### PR DESCRIPTION
Many of our internal operations for building and converting dataflow
plans rely on our semantic containers (DataSourceSemantics and
MetricSemantics). These containers pull in a lot of dependencies and
also allow callers to modify them on the fly by adding data sources
or metrics to them.

This PR adds more limited scope accessor-only Protocols for
DataSourceSemantics and MetricSemantics, and converts all
relevant references to use it instead of the concrete implementations
found in semantic_containers.py

This gives us more protection against inadvertent use of methods
like `DataSourceSemantics.add_data_source` and limits the scope of
transitive imports running through our semantic_containers module.