### PR TITLE
Clean up object and module organization

### DIFF
--- a/metricflow/aggregation_properties.py
+++ b/metricflow/aggregation_properties.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from metricflow.object_utils import ExtendedEnum
+
+
+class AggregationType(ExtendedEnum):
+    """Aggregation methods for measures"""
+
+    SUM = "sum"
+    MIN = "min"
+    MAX = "max"
+    COUNT_DISTINCT = "count_distinct"
+    # BOOLEAN is deprecated. Remove when customers have migrated.
+    BOOLEAN = "boolean"
+    SUM_BOOLEAN = "sum_boolean"
+    AVERAGE = "average"
+
+    # COUNT = "count" not yet implemented ... non-expansive as COUNT(COUNT(X), COUNT(Y)) != COUNT(COUNT(X ∪ Y))
+    # AVERAGE = "average"  not yet implemented ...requires us to keep track of two quantities, count and sum
+
+    @property
+    def is_expansive(self) -> bool:
+        """Expansive ≝ Op( X ∪ Y ∪ ...) = Op( Op(X) ∪ Op(Y) ∪ ...)"""
+        return self in (AggregationType.SUM, AggregationType.MIN, AggregationType.MAX, AggregationType.BOOLEAN)
+
+    @property
+    def fill_nulls_with_0(self) -> bool:
+        """Indicates if charts should show 0 instead of null where there are gaps in data."""
+        return self in (AggregationType.SUM, AggregationType.COUNT_DISTINCT, AggregationType.SUM_BOOLEAN)
+
+    @property
+    def can_limit_dimension_values(self) -> bool:
+        """Indicates if we can limit dimension values in charts.
+
+        Currently, this means:
+        1. The dimensions we care about most are the ones with the highest numeric values
+        2. We can calculate the "other" column in the postprocessor (meaning the metric is expansive)
+        """
+        return self in (AggregationType.SUM, AggregationType.SUM_BOOLEAN)

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -39,6 +39,7 @@ from metricflow.dataflow.dataflow_plan_to_text import dataflow_dag_as_text
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.dataset import DataSet
 from metricflow.errors.errors import UnableToSatisfyQueryError
+from metricflow.model.spec_converters import WhereConstraintConverter
 from metricflow.model.objects.metric import MetricType, CumulativeMetricWindow
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.object_utils import pformat_big_objects, assert_exactly_one_arg_set
@@ -46,7 +47,6 @@ from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationR
 from metricflow.plan_conversion.node_processor import PreDimensionJoinNodeProcessor
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs import (
     MetricSpec,
     LinkableInstanceSpec,
@@ -147,7 +147,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
 
             combined_where = query_spec.where_constraint
             if metric.constraint:
-                metric_constraint = MetricFlowQueryParser.convert_to_spec_where_constraint(
+                metric_constraint = WhereConstraintConverter.convert_to_spec_where_constraint(
                     self._data_source_semantics, metric.constraint
                 )
                 if combined_where:

--- a/metricflow/dataflow/builder/measure_additiveness.py
+++ b/metricflow/dataflow/builder/measure_additiveness.py
@@ -23,9 +23,9 @@ def group_measure_specs_by_additiveness(measure_specs: Sequence[MeasureSpec]) ->
     bucket = collections.defaultdict(list)
     additive_bucket = []
     for spec in measure_specs:
-        non_additive_dimension = spec.non_additive_dimension
-        if non_additive_dimension:
-            bucket[non_additive_dimension.bucket_hash].append(spec)
+        non_additive_dimension_spec = spec.non_additive_dimension_spec
+        if non_additive_dimension_spec:
+            bucket[non_additive_dimension_spec.bucket_hash].append(spec)
         else:
             additive_bucket.append(spec)
     return GroupedMeasureSpecsByAdditiveness(

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -9,9 +9,8 @@ from metricflow.dataflow.dataflow_plan import (
 )
 from metricflow.dataflow.builder.measure_additiveness import group_measure_specs_by_additiveness
 from metricflow.dataset.data_source_adapter import DataSourceDataSet
-from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.specs import LinklessIdentifierSpec, TimeDimensionSpec, InstanceSpec
+from metricflow.specs import LinklessIdentifierSpec, NonAdditiveDimensionSpec, TimeDimensionSpec, InstanceSpec
 from metricflow.plan_conversion.instance_converters import RemoveMeasures
 
 
@@ -29,7 +28,7 @@ class SourceNodeBuilder:
     def _build_semi_additive_source_node(
         self,
         parent_node: BaseOutput[DataSourceDataSet],
-        non_additive_dimension: NonAdditiveDimensionParameters,
+        non_additive_dimension: NonAdditiveDimensionSpec,
         filter_specs: Sequence[InstanceSpec],
     ) -> SemiAdditiveJoinNode[DataSourceDataSet]:
         """Builds a SemiAdditiveJoinNode given measures and non-additive dimension attributes."""
@@ -95,11 +94,11 @@ class SourceNodeBuilder:
                     # Build a SemiAdditiveJoinNode for each semi-additive measure grouping.
                     grouped_semi_additive_measures = grouped_measures_by_additiveness.grouped_semi_additive_measures
                     for measure_group in grouped_semi_additive_measures:
-                        non_additive_dimension_params = measure_group[0].non_additive_dimension
-                        assert non_additive_dimension_params
+                        non_additive_dimension = measure_group[0].non_additive_dimension
+                        assert non_additive_dimension
                         semi_additive_join_node = self._build_semi_additive_source_node(
                             parent_node=read_node,
-                            non_additive_dimension=non_additive_dimension_params,
+                            non_additive_dimension=non_additive_dimension,
                             filter_specs=tuple(instance_set_with_no_measures.spec_set.all_specs) + measure_group,
                         )
                         source_nodes.append(

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -28,7 +28,7 @@ class SourceNodeBuilder:
     def _build_semi_additive_source_node(
         self,
         parent_node: BaseOutput[DataSourceDataSet],
-        non_additive_dimension: NonAdditiveDimensionSpec,
+        non_additive_dimension_spec: NonAdditiveDimensionSpec,
         filter_specs: Sequence[InstanceSpec],
     ) -> SemiAdditiveJoinNode[DataSourceDataSet]:
         """Builds a SemiAdditiveJoinNode given measures and non-additive dimension attributes."""
@@ -38,15 +38,15 @@ class SourceNodeBuilder:
             replace_description="Pass Only Semi-additive Measures",
         )
 
-        time_dimension_spec = TimeDimensionSpec.from_name(non_additive_dimension.name)
+        time_dimension_spec = TimeDimensionSpec.from_name(non_additive_dimension_spec.name)
         window_groupings = tuple(
-            LinklessIdentifierSpec.from_element_name(name) for name in non_additive_dimension.window_groupings
+            LinklessIdentifierSpec.from_element_name(name) for name in non_additive_dimension_spec.window_groupings
         )
         return SemiAdditiveJoinNode[DataSourceDataSet](
             parent_node=filter_semi_additive_measure_node,
             identifier_specs=window_groupings,
             time_dimension_spec=time_dimension_spec,
-            agg_by_function=non_additive_dimension.window_choice,
+            agg_by_function=non_additive_dimension_spec.window_choice,
         )
 
     def create_from_data_sets(self, data_sets: Sequence[DataSourceDataSet]) -> Sequence[BaseOutput[DataSourceDataSet]]:
@@ -94,11 +94,11 @@ class SourceNodeBuilder:
                     # Build a SemiAdditiveJoinNode for each semi-additive measure grouping.
                     grouped_semi_additive_measures = grouped_measures_by_additiveness.grouped_semi_additive_measures
                     for measure_group in grouped_semi_additive_measures:
-                        non_additive_dimension = measure_group[0].non_additive_dimension
-                        assert non_additive_dimension
+                        non_additive_dimension_spec = measure_group[0].non_additive_dimension_spec
+                        assert non_additive_dimension_spec
                         semi_additive_join_node = self._build_semi_additive_source_node(
                             parent_node=read_node,
-                            non_additive_dimension=non_additive_dimension,
+                            non_additive_dimension_spec=non_additive_dimension_spec,
                             filter_specs=tuple(instance_set_with_no_measures.spec_set.all_specs) + measure_group,
                         )
                         source_nodes.append(

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -34,7 +34,7 @@ from metricflow.dataflow.builder.partitions import (
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.dataset import DataSet
 from metricflow.model.objects.metric import CumulativeMetricWindow
-from metricflow.model.objects.elements.measure import AggregationType
+from metricflow.aggregation_properties import AggregationType
 from metricflow.object_utils import pformat_big_objects
 from metricflow.references import TimeDimensionReference
 from metricflow.specs import (

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -20,9 +20,9 @@ from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.elements.identifier import Identifier, IdentifierType
 from metricflow.model.objects.elements.measure import Measure
+from metricflow.model.spec_converters import MeasureConverter
 from metricflow.specs import (
     TimeDimensionSpec,
-    MeasureSpec,
     DimensionSpec,
     IdentifierSpec,
     ColumnAssociationResolver,
@@ -184,10 +184,7 @@ class DataSourceToDataSetConverter:
         measure_instances = []
         select_columns = []
         for measure in measures or []:
-            measure_spec = MeasureSpec(
-                element_name=measure.reference.element_name,
-                non_additive_dimension=measure.non_additive_dimension,
-            )
+            measure_spec = MeasureConverter.convert_to_measure_spec(measure=measure)
             measure_instance = MeasureInstance(
                 associated_columns=measure_spec.column_associations(self._column_association_resolver),
                 spec=measure_spec,

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -1,46 +1,11 @@
 from __future__ import annotations
 
 from typing import Optional, List
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.base import ModelWithMetadataParsing, HashableBaseModel
-from metricflow.object_utils import ExtendedEnum, hash_strings
+from metricflow.object_utils import hash_strings
 from metricflow.references import MeasureReference, TimeDimensionReference
-
-
-class AggregationType(ExtendedEnum):
-    """Aggregation methods for measures"""
-
-    SUM = "sum"
-    MIN = "min"
-    MAX = "max"
-    COUNT_DISTINCT = "count_distinct"
-    # BOOLEAN is deprecated. Remove when customers have migrated.
-    BOOLEAN = "boolean"
-    SUM_BOOLEAN = "sum_boolean"
-    AVERAGE = "average"
-
-    # COUNT = "count" not yet implemented ... non-expansive as COUNT(COUNT(X), COUNT(Y)) != COUNT(COUNT(X ∪ Y))
-    # AVERAGE = "average"  not yet implemented ...requires us to keep track of two quantities, count and sum
-
-    @property
-    def is_expansive(self) -> bool:
-        """Expansive ≝ Op( X ∪ Y ∪ ...) = Op( Op(X) ∪ Op(Y) ∪ ...)"""
-        return self in (AggregationType.SUM, AggregationType.MIN, AggregationType.MAX, AggregationType.BOOLEAN)
-
-    @property
-    def fill_nulls_with_0(self) -> bool:
-        """Indicates if charts should show 0 instead of null where there are gaps in data."""
-        return self in (AggregationType.SUM, AggregationType.COUNT_DISTINCT, AggregationType.SUM_BOOLEAN)
-
-    @property
-    def can_limit_dimension_values(self) -> bool:
-        """Indicates if we can limit dimension values in charts.
-
-        Currently, this means:
-        1. The dimensions we care about most are the ones with the highest numeric values
-        2. We can calculate the "other" column in the postprocessor (meaning the metric is expansive)
-        """
-        return self in (AggregationType.SUM, AggregationType.SUM_BOOLEAN)
 
 
 class NonAdditiveDimensionParameters(HashableBaseModel):

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -4,7 +4,6 @@ from typing import Optional, List
 from metricflow.aggregation_properties import AggregationType
 from metricflow.model.objects.common import Metadata
 from metricflow.model.objects.base import ModelWithMetadataParsing, HashableBaseModel
-from metricflow.object_utils import hash_strings
 from metricflow.references import MeasureReference, TimeDimensionReference
 
 
@@ -17,13 +16,6 @@ class NonAdditiveDimensionParameters(HashableBaseModel):
     name: str
     window_choice: AggregationType
     window_groupings: List[str] = []
-
-    @property
-    def bucket_hash(self) -> str:
-        """Returns the hash value used for grouping equivalent params."""
-        values = [self.window_choice.name, self.name]
-        values.extend(sorted(self.window_groupings))
-        return hash_strings(values)
 
 
 class Measure(HashableBaseModel, ModelWithMetadataParsing):

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -12,10 +12,11 @@ from metricflow.errors.errors import (
     InvalidDataSourceError,
 )
 from metricflow.instances import DataSourceReference, DataSourceElementReference
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.objects.data_source import DataSource, DataSourceOrigin
 from metricflow.model.objects.elements.dimension import Dimension
 from metricflow.model.objects.elements.identifier import Identifier
-from metricflow.model.objects.elements.measure import Measure, AggregationType, NonAdditiveDimensionParameters
+from metricflow.model.objects.elements.measure import Measure, NonAdditiveDimensionParameters
 from metricflow.model.objects.metric import Metric, MetricType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -123,7 +123,7 @@ class MetricSemantics:  # noqa: D
         return tuple(
             MeasureSpec(
                 element_name=x.element_name,
-                non_additive_dimension=self._data_source_semantics.non_additive_dimensions_by_measure.get(x),
+                non_additive_dimension_spec=self._data_source_semantics.non_additive_dimension_specs_by_measure.get(x),
             )
             for x in metric.measure_references
         )
@@ -153,7 +153,7 @@ class DataSourceSemantics:
         self._measure_aggs: Dict[
             MeasureReference, AggregationType
         ] = {}  # maps measures to their one consistent aggregation
-        self._measure_non_additive_dimensions: Dict[MeasureReference, NonAdditiveDimensionSpec] = {}
+        self._measure_non_additive_dimension_specs: Dict[MeasureReference, NonAdditiveDimensionSpec] = {}
         self._dimension_index: Dict[DimensionReference, List[DataSource]] = defaultdict(list)
         self._linkable_reference_index: Dict[LinkableElementReference, List[DataSource]] = defaultdict(list)
         self._entity_index: Dict[Optional[str], List[DataSource]] = defaultdict(list)
@@ -215,8 +215,8 @@ class DataSourceSemantics:
         return list(self._measure_index.keys())
 
     @property
-    def non_additive_dimensions_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:  # noqa: D
-        return self._measure_non_additive_dimensions
+    def non_additive_dimension_specs_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:  # noqa: D
+        return self._measure_non_additive_dimension_specs
 
     def get_measure(self, measure_reference: MeasureReference) -> Measure:  # noqa: D
         if measure_reference not in self._measure_index:
@@ -301,12 +301,12 @@ class DataSourceSemantics:
                 value=MeasureConverter.convert_to_measure_spec(measure=measure),
             )
             if measure.non_additive_dimension:
-                non_additive_dimension = NonAdditiveDimensionSpec(
+                non_additive_dimension_spec = NonAdditiveDimensionSpec(
                     name=measure.non_additive_dimension.name,
                     window_choice=measure.non_additive_dimension.window_choice,
                     window_groupings=tuple(measure.non_additive_dimension.window_groupings),
                 )
-                self._measure_non_additive_dimensions[measure.reference] = non_additive_dimension
+                self._measure_non_additive_dimension_specs[measure.reference] = non_additive_dimension_spec
         for dim in data_source.dimensions:
             self._linkable_reference_index[dim.reference].append(data_source)
             self._dimension_index[dim.reference].append(data_source)

--- a/metricflow/model/spec_converters.py
+++ b/metricflow/model/spec_converters.py
@@ -14,16 +14,41 @@ from typing import List
 from metricflow.dataset.dataset import DataSet
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
 from metricflow.model.objects.elements.dimension import DimensionType
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.protocols.semantics import DataSourceSemanticsAccessor
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.specs import (
     DimensionSpec,
     IdentifierSpec,
     LinkableSpecSet,
+    MeasureSpec,
+    NonAdditiveDimensionSpec,
     SpecWhereClauseConstraint,
     StructuredLinkableSpecName,
     TimeDimensionSpec,
 )
+
+
+class MeasureConverter:
+    """Static class for converting Measure model objects to MeasureSpec instances"""
+
+    @staticmethod
+    def convert_to_measure_spec(measure: Measure) -> MeasureSpec:
+        """Converts a Measure to a MeasureSpec, and properly handles non-additive dimension properties"""
+        non_additive_dimension = (
+            NonAdditiveDimensionSpec(
+                name=measure.non_additive_dimension.name,
+                window_choice=measure.non_additive_dimension.window_choice,
+                window_groupings=tuple(measure.non_additive_dimension.window_groupings),
+            )
+            if measure.non_additive_dimension is not None
+            else None
+        )
+
+        return MeasureSpec(
+            element_name=measure.name,
+            non_additive_dimension=non_additive_dimension,
+        )
 
 
 class WhereConstraintConverter:

--- a/metricflow/model/spec_converters.py
+++ b/metricflow/model/spec_converters.py
@@ -35,7 +35,7 @@ class MeasureConverter:
     @staticmethod
     def convert_to_measure_spec(measure: Measure) -> MeasureSpec:
         """Converts a Measure to a MeasureSpec, and properly handles non-additive dimension properties"""
-        non_additive_dimension = (
+        non_additive_dimension_spec = (
             NonAdditiveDimensionSpec(
                 name=measure.non_additive_dimension.name,
                 window_choice=measure.non_additive_dimension.window_choice,
@@ -47,7 +47,7 @@ class MeasureConverter:
 
         return MeasureSpec(
             element_name=measure.name,
-            non_additive_dimension=non_additive_dimension,
+            non_additive_dimension_spec=non_additive_dimension_spec,
         )
 
 

--- a/metricflow/model/spec_converters.py
+++ b/metricflow/model/spec_converters.py
@@ -1,0 +1,99 @@
+"""Helper classes to convert model objects to spec object representations
+
+In some cases we need to take a model object and convert it to a spec for use in a DataflowPlan or similar.
+This fundamentally requires us to combine a model object with a spec object and, in some cases, follow semantic
+metadata about linked specs in order to resolve dimension names and the like.
+
+Since model objects and specs should not depend on each other, we do these conversions separately via external
+classes, rather than the perhaps more natural approach of adding a to_spec() method on the model objects. These
+shims likely point to the need for a bit of an internal refactor, but that's a concern for another time.
+"""
+
+from typing import List
+
+from metricflow.dataset.dataset import DataSet
+from metricflow.model.objects.constraints.where import WhereClauseConstraint
+from metricflow.model.objects.elements.dimension import DimensionType
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
+from metricflow.query.query_exceptions import InvalidQueryException
+from metricflow.specs import (
+    DimensionSpec,
+    IdentifierSpec,
+    LinkableSpecSet,
+    SpecWhereClauseConstraint,
+    StructuredLinkableSpecName,
+    TimeDimensionSpec,
+)
+
+
+class WhereConstraintConverter:
+    """Static class for converting WhereClauseConstraint objects to a SpecWhereClauseConstraint representation.
+
+    The WhereClauseConstraint model object contains a parsed set of element names, and as such conversion to
+    a SpecWhereClauseConstraint requires semantic resolution of linkable specs across data sources. This resolution
+    has to happen for metrics and measures independently, as both can be constrained, so bolting this on
+    to something like DataSourceSemantics will not be adequate.
+    """
+
+    @staticmethod
+    def _convert_to_linkable_specs(
+        data_source_semantics: DataSourceSemanticsAccessor, where_constraint_names: List[str]
+    ) -> LinkableSpecSet:
+        """Processes where_clause_constraint.linkable_names into associated LinkableInstanceSpecs (dims, times, ids)
+
+        where_constraint_names: WhereConstraintClause.linkable_names
+        data_source_semantics: DataSourceSemanticsAccessor from the instantiated class
+
+        output: InstanceSpecSet of Tuple(DimensionSpec), Tuple(TimeDimensionSpec), Tuple(IdentifierSpec)
+        """
+        where_constraint_dimensions = []
+        where_constraint_time_dimensions = []
+        where_constraint_identifiers = []
+        linkable_spec_names = [
+            StructuredLinkableSpecName.from_name(linkable_name) for linkable_name in where_constraint_names
+        ]
+        dimension_references = {
+            dimension_reference.element_name: dimension_reference
+            for dimension_reference in data_source_semantics.get_dimension_references()
+        }
+        identifier_references = {
+            identifier_reference.element_name: identifier_reference
+            for identifier_reference in data_source_semantics.get_identifier_references()
+        }
+
+        for spec_name in linkable_spec_names:
+            if spec_name.element_name == DataSet.metric_time_dimension_name():
+                where_constraint_time_dimensions.append(TimeDimensionSpec.from_name(spec_name.qualified_name))
+            elif spec_name.element_name in dimension_references:
+                dimension = data_source_semantics.get_dimension(dimension_references[spec_name.element_name])
+                if dimension.type == DimensionType.CATEGORICAL:
+                    where_constraint_dimensions.append(DimensionSpec.from_name(spec_name.qualified_name))
+                elif dimension.type == DimensionType.TIME:
+                    where_constraint_time_dimensions.append(TimeDimensionSpec.from_name(spec_name.qualified_name))
+                else:
+                    raise RuntimeError(f"Unhandled type: {dimension.type}")
+            elif spec_name.element_name in identifier_references:
+                where_constraint_identifiers.append(IdentifierSpec.from_name(spec_name.qualified_name))
+            else:
+                raise InvalidQueryException(f"Unknown element: {spec_name}")
+
+        return LinkableSpecSet(
+            dimension_specs=tuple(where_constraint_dimensions),
+            time_dimension_specs=tuple(where_constraint_time_dimensions),
+            identifier_specs=tuple(where_constraint_identifiers),
+        )
+
+    @staticmethod
+    def convert_to_spec_where_constraint(
+        data_source_semantics: DataSourceSemanticsAccessor, where_constraint: WhereClauseConstraint
+    ) -> SpecWhereClauseConstraint:
+        """Converts a where constraint to one using specs."""
+        return SpecWhereClauseConstraint(
+            where_condition=where_constraint.where,
+            linkable_names=tuple(where_constraint.linkable_names),
+            linkable_spec_set=WhereConstraintConverter._convert_to_linkable_specs(
+                data_source_semantics=data_source_semantics,
+                where_constraint_names=where_constraint.linkable_names,
+            ),
+            execution_parameters=where_constraint.sql_params,
+        )

--- a/metricflow/model/transformations/boolean_measure.py
+++ b/metricflow/model/transformations/boolean_measure.py
@@ -1,6 +1,6 @@
 import logging
 
-from metricflow.model.objects.elements.measure import AggregationType
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.transformations.transform_rule import ModelTransformRule
 

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -57,7 +57,7 @@ class DataSourceSemanticsAccessor(Protocol):
 
     @property
     @abstractmethod
-    def non_additive_dimensions_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:
+    def non_additive_dimension_specs_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:
         """Return a mapping from all semi-additive measures to their corresponding non additive dimension parameters
 
         This includes all measures with non-additive dimension parameters, if any, from the collection of data sources.

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -15,12 +15,12 @@ from metricflow.instances import DataSourceElementReference, DataSourceReference
 from metricflow.model.objects.data_source import DataSource, DataSourceOrigin
 from metricflow.model.objects.elements.dimension import Dimension
 from metricflow.model.objects.elements.identifier import Identifier
-from metricflow.model.objects.elements.measure import Measure, NonAdditiveDimensionParameters
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import Metric
 from metricflow.model.semantics.element_group import ElementGrouper
 from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
 from metricflow.references import DimensionReference, IdentifierReference, MeasureReference, TimeDimensionReference
-from metricflow.specs import LinkableInstanceSpec, MeasureSpec, MetricSpec
+from metricflow.specs import LinkableInstanceSpec, MeasureSpec, MetricSpec, NonAdditiveDimensionSpec
 
 
 class DataSourceSemanticsAccessor(Protocol):
@@ -57,7 +57,7 @@ class DataSourceSemanticsAccessor(Protocol):
 
     @property
     @abstractmethod
-    def non_additive_dimension_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionParameters]:
+    def non_additive_dimensions_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:
         """Return a mapping from all semi-additive measures to their corresponding non additive dimension parameters
 
         This includes all measures with non-additive dimension parameters, if any, from the collection of data sources.

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -14,13 +14,13 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple, TypeVar, Generic, Any
+from metricflow.aggregation_properties import AggregationType
 
 from metricflow.column_assoc import ColumnAssociation
 from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.dataclass_serialization import SerializableDataclass
-from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
-from metricflow.object_utils import assert_exactly_one_arg_set
+from metricflow.object_utils import assert_exactly_one_arg_set, hash_strings
 from metricflow.references import DimensionReference, MeasureReference, TimeDimensionReference, IdentifierReference
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.time.time_granularity import TimeGranularity
@@ -278,9 +278,29 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
 
 
 @dataclass(frozen=True)
+class NonAdditiveDimensionSpec(SerializableDataclass):
+    """Spec representing non-additive dimension parameters for use within a MeasureSpec
+
+    This is sourced from the NonAdditiveDimensionParameters model object, which provides the parsed parameter set,
+    while the spec contains the information needed for dataflow plan operations
+    """
+
+    name: str
+    window_choice: AggregationType
+    window_groupings: Tuple[str, ...] = ()
+
+    @property
+    def bucket_hash(self) -> str:
+        """Returns the hash value used for grouping equivalent params."""
+        values = [self.window_choice.name, self.name]
+        values.extend(sorted(self.window_groupings))
+        return hash_strings(values)
+
+
+@dataclass(frozen=True)
 class MeasureSpec(InstanceSpec):  # noqa: D
     element_name: str
-    non_additive_dimension: Optional[NonAdditiveDimensionParameters] = None
+    non_additive_dimension: Optional[NonAdditiveDimensionSpec] = None
 
     def column_associations(self, resolver: ColumnAssociationResolver) -> Tuple[ColumnAssociation, ...]:  # noqa: D
         return (resolver.resolve_measure_spec(self),)

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -300,7 +300,7 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
 @dataclass(frozen=True)
 class MeasureSpec(InstanceSpec):  # noqa: D
     element_name: str
-    non_additive_dimension: Optional[NonAdditiveDimensionSpec] = None
+    non_additive_dimension_spec: Optional[NonAdditiveDimensionSpec] = None
 
     def column_associations(self, resolver: ColumnAssociationResolver) -> Tuple[ColumnAssociation, ...]:  # noqa: D
         return (resolver.resolve_measure_spec(self),)

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Generic, Sequence, Optional, Tuple, Dict
 
-from metricflow.model.objects.elements.measure import AggregationType
+from metricflow.aggregation_properties import AggregationType
 from metricflow.dag.mf_dag import DagNode, DisplayedProperty, NodeId
 from metricflow.dag.id_generation import (
     SQL_EXPR_COLUMN_REFERENCE_ID_PREFIX,

--- a/metricflow/test/dataflow/builder/test_measure_additiveness.py
+++ b/metricflow/test/dataflow/builder/test_measure_additiveness.py
@@ -1,14 +1,13 @@
 from metricflow.dataflow.builder.measure_additiveness import group_measure_specs_by_additiveness
 from metricflow.aggregation_properties import AggregationType
-from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
-from metricflow.specs import MeasureSpec
+from metricflow.specs import MeasureSpec, NonAdditiveDimensionSpec
 
 
 def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D
     # Semi-additive Bucket 1
     measure_1 = MeasureSpec(
         element_name="measure_1",
-        non_additive_dimension=NonAdditiveDimensionParameters(
+        non_additive_dimension=NonAdditiveDimensionSpec(
             name="ds",
             window_choice=AggregationType.MIN,
         ),
@@ -17,18 +16,18 @@ def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D
     # Semi-additive Bucket 2
     measure_2 = MeasureSpec(
         element_name="measure_2",
-        non_additive_dimension=NonAdditiveDimensionParameters(
+        non_additive_dimension=NonAdditiveDimensionSpec(
             name="ds",
             window_choice=AggregationType.MIN,
-            window_groupings=["id_1", "id_2"],
+            window_groupings=("id_1", "id_2"),
         ),
     )
     measure_3 = MeasureSpec(
         element_name="measure_3",
-        non_additive_dimension=NonAdditiveDimensionParameters(
+        non_additive_dimension=NonAdditiveDimensionSpec(
             name="ds",
             window_choice=AggregationType.MIN,
-            window_groupings=["id_2", "id_1"],
+            window_groupings=("id_2", "id_1"),
         ),
     )
 

--- a/metricflow/test/dataflow/builder/test_measure_additiveness.py
+++ b/metricflow/test/dataflow/builder/test_measure_additiveness.py
@@ -7,7 +7,7 @@ def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D
     # Semi-additive Bucket 1
     measure_1 = MeasureSpec(
         element_name="measure_1",
-        non_additive_dimension=NonAdditiveDimensionSpec(
+        non_additive_dimension_spec=NonAdditiveDimensionSpec(
             name="ds",
             window_choice=AggregationType.MIN,
         ),
@@ -16,7 +16,7 @@ def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D
     # Semi-additive Bucket 2
     measure_2 = MeasureSpec(
         element_name="measure_2",
-        non_additive_dimension=NonAdditiveDimensionSpec(
+        non_additive_dimension_spec=NonAdditiveDimensionSpec(
             name="ds",
             window_choice=AggregationType.MIN,
             window_groupings=("id_1", "id_2"),
@@ -24,7 +24,7 @@ def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D
     )
     measure_3 = MeasureSpec(
         element_name="measure_3",
-        non_additive_dimension=NonAdditiveDimensionSpec(
+        non_additive_dimension_spec=NonAdditiveDimensionSpec(
             name="ds",
             window_choice=AggregationType.MIN,
             window_groupings=("id_2", "id_1"),

--- a/metricflow/test/dataflow/builder/test_measure_additiveness.py
+++ b/metricflow/test/dataflow/builder/test_measure_additiveness.py
@@ -1,5 +1,6 @@
 from metricflow.dataflow.builder.measure_additiveness import group_measure_specs_by_additiveness
-from metricflow.model.objects.elements.measure import AggregationType, NonAdditiveDimensionParameters
+from metricflow.aggregation_properties import AggregationType
+from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
 from metricflow.specs import MeasureSpec
 
 

--- a/metricflow/test/model/parsing/test_data_source_parsing.py
+++ b/metricflow/test/model/parsing/test_data_source_parsing.py
@@ -1,9 +1,9 @@
 import textwrap
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.objects.common import YamlConfigFile
 from metricflow.model.objects.data_source import DataSourceOrigin, MutabilityType
 from metricflow.model.objects.elements.identifier import IdentifierType
-from metricflow.model.objects.elements.measure import AggregationType
 from metricflow.model.objects.elements.dimension import DimensionType
 from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_model
 from metricflow.time.time_granularity import TimeGranularity

--- a/metricflow/test/model/validations/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/validations/test_data_warehouse_tasks.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import pytest
 from _pytest.fixtures import FixtureRequest
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.data_warehouse_model_validator import (
     DataWarehouseModelValidator,
     DataWarehouseTaskBuilder,
@@ -13,7 +14,7 @@ from metricflow.model.model_transformer import ModelTransformer
 from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.elements.identifier import Identifier, IdentifierType
-from metricflow.model.objects.elements.measure import AggregationType, Measure
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.sql_bind_parameters import SqlBindParameters

--- a/metricflow/test/model/validations/test_dimension_const.py
+++ b/metricflow/test/model/validations/test_dimension_const.py
@@ -1,9 +1,10 @@
 import pytest
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.data_source import Mutability, MutabilityType, DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
-from metricflow.model.objects.elements.measure import Measure, AggregationType
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import MetricType, MetricTypeParams, Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -1,9 +1,10 @@
 import pytest
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
-from metricflow.model.objects.elements.measure import Measure, AggregationType
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -4,11 +4,12 @@ from typing import Callable
 
 import pytest
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.data_source import DataSource, Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.elements.identifier import IdentifierType, Identifier, CompositeSubIdentifier
-from metricflow.model.objects.elements.measure import Measure, AggregationType
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -1,10 +1,11 @@
 import pytest
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.data_source import Mutability, MutabilityType
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.elements.identifier import Identifier, IdentifierType
-from metricflow.model.objects.elements.measure import Measure, AggregationType
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.validator_helpers import ModelValidationException

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 from _pytest.fixtures import FixtureRequest
 
+from metricflow.aggregation_properties import AggregationType
 from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataflow.dataflow_plan import (
@@ -21,7 +22,7 @@ from metricflow.dataflow.dataflow_plan import (
     SemiAdditiveJoinNode,
 )
 from metricflow.dataflow.dataflow_plan_to_text import dataflow_plan_as_text
-from metricflow.model.objects.elements.measure import AggregationType, NonAdditiveDimensionParameters
+from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -22,7 +22,6 @@ from metricflow.dataflow.dataflow_plan import (
     SemiAdditiveJoinNode,
 )
 from metricflow.dataflow.dataflow_plan_to_text import dataflow_plan_as_text
-from metricflow.model.objects.elements.measure import NonAdditiveDimensionParameters
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
@@ -37,6 +36,7 @@ from metricflow.specs import (
     MetricSpec,
     LinklessIdentifierSpec,
     MetricFlowQuerySpec,
+    NonAdditiveDimensionSpec,
     OrderBySpec,
     TimeDimensionSpec,
     SpecWhereClauseConstraint,
@@ -1148,7 +1148,7 @@ def test_semi_additive_join_node(
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode."""
-    non_additive_dimension = NonAdditiveDimensionParameters(name="ds", window_choice=AggregationType.MIN)
+    non_additive_dimension = NonAdditiveDimensionSpec(name="ds", window_choice=AggregationType.MIN)
     measure_spec = MeasureSpec(
         element_name="total_account_balance_first_day", non_additive_dimension=non_additive_dimension
     )
@@ -1181,10 +1181,10 @@ def test_semi_additive_join_node_with_grouping(
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode with a window_grouping."""
-    non_additive_dimension = NonAdditiveDimensionParameters(
+    non_additive_dimension = NonAdditiveDimensionSpec(
         name="ds",
         window_choice=AggregationType.MAX,
-        window_groupings=["user"],
+        window_groupings=("user",),
     )
     measure_spec = MeasureSpec(
         element_name="current_account_balance_by_user", non_additive_dimension=non_additive_dimension

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -1148,9 +1148,9 @@ def test_semi_additive_join_node(
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode."""
-    non_additive_dimension = NonAdditiveDimensionSpec(name="ds", window_choice=AggregationType.MIN)
+    non_additive_dimension_spec = NonAdditiveDimensionSpec(name="ds", window_choice=AggregationType.MIN)
     measure_spec = MeasureSpec(
-        element_name="total_account_balance_first_day", non_additive_dimension=non_additive_dimension
+        element_name="total_account_balance_first_day", non_additive_dimension_spec=non_additive_dimension_spec
     )
     time_dimension_spec = TimeDimensionSpec(element_name="ds", identifier_links=())
 
@@ -1162,7 +1162,7 @@ def test_semi_additive_join_node(
         parent_node=filtered_measure_node,
         identifier_specs=tuple(),
         time_dimension_spec=time_dimension_spec,
-        agg_by_function=non_additive_dimension.window_choice,
+        agg_by_function=non_additive_dimension_spec.window_choice,
     )
     convert_and_check(
         request=request,
@@ -1181,13 +1181,13 @@ def test_semi_additive_join_node_with_grouping(
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode with a window_grouping."""
-    non_additive_dimension = NonAdditiveDimensionSpec(
+    non_additive_dimension_spec = NonAdditiveDimensionSpec(
         name="ds",
         window_choice=AggregationType.MAX,
         window_groupings=("user",),
     )
     measure_spec = MeasureSpec(
-        element_name="current_account_balance_by_user", non_additive_dimension=non_additive_dimension
+        element_name="current_account_balance_by_user", non_additive_dimension_spec=non_additive_dimension_spec
     )
     identifier_spec = LinklessIdentifierSpec(element_name="user", identifier_links=())
     time_dimension_spec = TimeDimensionSpec(element_name="ds", identifier_links=())
@@ -1200,7 +1200,7 @@ def test_semi_additive_join_node_with_grouping(
         parent_node=filtered_measure_node,
         identifier_specs=(identifier_spec,),
         time_dimension_spec=time_dimension_spec,
-        agg_by_function=non_additive_dimension.window_choice,
+        agg_by_function=non_additive_dimension_spec.window_choice,
     )
     convert_and_check(
         request=request,

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric__dfp_0.xml
@@ -17,10 +17,10 @@
                         <!--   Pass Only Elements:                      -->
                         <!--     ['txn_revenue', 'metric_time__month']  -->
                         <!-- node_id = pfe_0 -->
-                        <!-- include_spec =                      -->
-                        <!--   {'class': 'MeasureSpec',          -->
-                        <!--    'element_name': 'txn_revenue',   -->
-                        <!--    'non_additive_dimension': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'txn_revenue',        -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                                 -->
                         <!--   {'class': 'TimeDimensionSpec',               -->
                         <!--    'element_name': 'metric_time',              -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -38,10 +38,10 @@
                             <!--   Pass Only Elements:                        -->
                             <!--     ['bookings', 'listing__country_latest']  -->
                             <!-- node_id = pfe_2 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookings',      -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                                            -->
                             <!--   {'class': 'DimensionSpec',                              -->
                             <!--    'element_name': 'country_latest',                      -->
@@ -63,10 +63,10 @@
                                     <!--   Pass Only Elements:        -->
                                     <!--     ['bookings', 'listing']  -->
                                     <!-- node_id = pfe_0 -->
-                                    <!-- include_spec =                      -->
-                                    <!--   {'class': 'MeasureSpec',          -->
-                                    <!--    'element_name': 'bookings',      -->
-                                    <!--    'non_additive_dimension': None}  -->
+                                    <!-- include_spec =                           -->
+                                    <!--   {'class': 'MeasureSpec',               -->
+                                    <!--    'element_name': 'bookings',           -->
+                                    <!--    'non_additive_dimension_spec': None}  -->
                                     <!-- include_spec =                         -->
                                     <!--   {'class': 'LinklessIdentifierSpec',  -->
                                     <!--    'element_name': 'listing',          -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_expr_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_expr_metrics_plan__dfp_0.xml
@@ -14,10 +14,10 @@
                     <!--   Pass Only Elements:                                            -->
                     <!--     ['booking_value', 'listing__country_latest', 'metric_time']  -->
                     <!-- node_id = pfe_2 -->
-                    <!-- include_spec =                       -->
-                    <!--   {'class': 'MeasureSpec',           -->
-                    <!--    'element_name': 'booking_value',  -->
-                    <!--    'non_additive_dimension': None}   -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'booking_value',      -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                            -->
                     <!--   {'class': 'DimensionSpec',                              -->
                     <!--    'element_name': 'country_latest',                      -->
@@ -44,10 +44,10 @@
                             <!--   Pass Only Elements:                            -->
                             <!--     ['booking_value', 'metric_time', 'listing']  -->
                             <!-- node_id = pfe_0 -->
-                            <!-- include_spec =                       -->
-                            <!--   {'class': 'MeasureSpec',           -->
-                            <!--    'element_name': 'booking_value',  -->
-                            <!--    'non_additive_dimension': None}   -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'booking_value',      -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                               -->
                             <!--   {'class': 'TimeDimensionSpec',             -->
                             <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
@@ -14,10 +14,10 @@
                     <!--   Pass Only Elements:                                      -->
                     <!--     ['bookings', 'is_instant', 'listing__country_latest']  -->
                     <!-- node_id = pfe_2 -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'bookings',      -->
-                    <!--    'non_additive_dimension': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'bookings',           -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                                                      -->
                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                     <!-- include_spec =                                            -->
@@ -41,10 +41,10 @@
                             <!--   Pass Only Elements:                      -->
                             <!--     ['bookings', 'is_instant', 'listing']  -->
                             <!-- node_id = pfe_0 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookings',      -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                                                                      -->
                             <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                             <!-- include_spec =                         -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
@@ -18,10 +18,10 @@
                         <!--   Pass Only Elements:            -->
                         <!--     ['bookings', 'metric_time']  -->
                         <!-- node_id = pfe_0 -->
-                        <!-- include_spec =                      -->
-                        <!--   {'class': 'MeasureSpec',          -->
-                        <!--    'element_name': 'bookings',      -->
-                        <!--    'non_additive_dimension': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookings',           -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                               -->
                         <!--   {'class': 'TimeDimensionSpec',             -->
                         <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_data_source_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_data_source_ratio_metrics_plan__dfp_0.xml
@@ -21,14 +21,14 @@
                 <!--    'element_name': 'metric_time',            -->
                 <!--    'identifier_links': (),                   -->
                 <!--    'time_granularity': TimeGranularity.DAY}  -->
-                <!-- include_spec =                      -->
-                <!--   {'class': 'MeasureSpec',          -->
-                <!--    'element_name': 'bookings',      -->
-                <!--    'non_additive_dimension': None}  -->
-                <!-- include_spec =                      -->
-                <!--   {'class': 'MeasureSpec',          -->
-                <!--    'element_name': 'views',         -->
-                <!--    'non_additive_dimension': None}  -->
+                <!-- include_spec =                           -->
+                <!--   {'class': 'MeasureSpec',               -->
+                <!--    'element_name': 'bookings',           -->
+                <!--    'non_additive_dimension_spec': None}  -->
+                <!-- include_spec =                           -->
+                <!--   {'class': 'MeasureSpec',               -->
+                <!--    'element_name': 'views',              -->
+                <!--    'non_additive_dimension_spec': None}  -->
                 <JoinAggregatedMeasuresByGroupByColumnsNode>
                     <!-- description = Join Aggregated Measures with Standard Outputs -->
                     <!-- node_id = jamgc_0 -->
@@ -41,10 +41,10 @@
                             <!--   Pass Only Elements:                                       -->
                             <!--     ['bookings', 'listing__country_latest', 'metric_time']  -->
                             <!-- node_id = pfe_2 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookings',      -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                                            -->
                             <!--   {'class': 'DimensionSpec',                              -->
                             <!--    'element_name': 'country_latest',                      -->
@@ -71,10 +71,10 @@
                                     <!--   Pass Only Elements:                       -->
                                     <!--     ['bookings', 'metric_time', 'listing']  -->
                                     <!-- node_id = pfe_0 -->
-                                    <!-- include_spec =                      -->
-                                    <!--   {'class': 'MeasureSpec',          -->
-                                    <!--    'element_name': 'bookings',      -->
-                                    <!--    'non_additive_dimension': None}  -->
+                                    <!-- include_spec =                           -->
+                                    <!--   {'class': 'MeasureSpec',               -->
+                                    <!--    'element_name': 'bookings',           -->
+                                    <!--    'non_additive_dimension_spec': None}  -->
                                     <!-- include_spec =                               -->
                                     <!--   {'class': 'TimeDimensionSpec',             -->
                                     <!--    'element_name': 'metric_time',            -->
@@ -142,10 +142,10 @@
                             <!--   Pass Only Elements:                                    -->
                             <!--     ['views', 'listing__country_latest', 'metric_time']  -->
                             <!-- node_id = pfe_5 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'views',         -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'views',              -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                                            -->
                             <!--   {'class': 'DimensionSpec',                              -->
                             <!--    'element_name': 'country_latest',                      -->
@@ -172,10 +172,10 @@
                                     <!--   Pass Only Elements:                    -->
                                     <!--     ['views', 'metric_time', 'listing']  -->
                                     <!-- node_id = pfe_3 -->
-                                    <!-- include_spec =                      -->
-                                    <!--   {'class': 'MeasureSpec',          -->
-                                    <!--    'element_name': 'views',         -->
-                                    <!--    'non_additive_dimension': None}  -->
+                                    <!-- include_spec =                           -->
+                                    <!--   {'class': 'MeasureSpec',               -->
+                                    <!--    'element_name': 'views',              -->
+                                    <!--    'non_additive_dimension_spec': None}  -->
                                     <!-- include_spec =                               -->
                                     <!--   {'class': 'TimeDimensionSpec',             -->
                                     <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
@@ -14,10 +14,10 @@
                     <!--   Pass Only Elements:                                        -->
                     <!--     ['txn_count', 'account_id__customer_id__customer_name']  -->
                     <!-- node_id = pfe_4 -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'txn_count',     -->
-                    <!--    'non_additive_dimension': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'txn_count',          -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                             -->
                     <!--   {'class': 'DimensionSpec',                               -->
                     <!--    'element_name': 'customer_name',                        -->
@@ -49,10 +49,10 @@
                             <!--   Pass Only Elements:                              -->
                             <!--     ['txn_count', 'account_id', 'ds_partitioned']  -->
                             <!-- node_id = pfe_2 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'txn_count',     -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'txn_count',          -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                         -->
                             <!--   {'class': 'LinklessIdentifierSpec',  -->
                             <!--    'element_name': 'account_id',       -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
@@ -17,10 +17,10 @@
                         <!--   Pass Only Elements:                          -->
                         <!--     ['bookings', 'is_instant', 'metric_time']  -->
                         <!-- node_id = pfe_0 -->
-                        <!-- include_spec =                      -->
-                        <!--   {'class': 'MeasureSpec',          -->
-                        <!--    'element_name': 'bookings',      -->
-                        <!--    'non_additive_dimension': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookings',           -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                                                                      -->
                         <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                         <!-- include_spec =                               -->
@@ -59,10 +59,10 @@
                         <!--   Pass Only Elements:                               -->
                         <!--     ['booking_value', 'is_instant', 'metric_time']  -->
                         <!-- node_id = pfe_1 -->
-                        <!-- include_spec =                       -->
-                        <!--   {'class': 'MeasureSpec',           -->
-                        <!--    'element_name': 'booking_value',  -->
-                        <!--    'non_additive_dimension': None}   -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'booking_value',      -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                                                                      -->
                         <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                         <!-- include_spec =                               -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -35,10 +35,10 @@
                         <!--   Pass Only Elements:            -->
                         <!--     ['bookings', 'metric_time']  -->
                         <!-- node_id = pfe_0 -->
-                        <!-- include_spec =                      -->
-                        <!--   {'class': 'MeasureSpec',          -->
-                        <!--    'element_name': 'bookings',      -->
-                        <!--    'non_additive_dimension': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookings',           -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                               -->
                         <!--   {'class': 'TimeDimensionSpec',             -->
                         <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_simple_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_simple_plan__dfp_0.xml
@@ -14,10 +14,10 @@
                     <!--   Pass Only Elements:           -->
                     <!--     ['bookings', 'is_instant']  -->
                     <!-- node_id = pfe_0 -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'bookings',      -->
-                    <!--    'non_additive_dimension': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'bookings',           -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                                                      -->
                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                     <MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_data_source_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_data_source_ratio_metrics_plan__dfp_0.xml
@@ -14,14 +14,14 @@
                     <!--   Pass Only Elements:                                                  -->
                     <!--     ['bookings', 'bookers', 'listing__country_latest', 'metric_time']  -->
                     <!-- node_id = pfe_2 -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'bookings',      -->
-                    <!--    'non_additive_dimension': None}  -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'bookers',       -->
-                    <!--    'non_additive_dimension': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'bookings',           -->
+                    <!--    'non_additive_dimension_spec': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'bookers',            -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                            -->
                     <!--   {'class': 'DimensionSpec',                              -->
                     <!--    'element_name': 'country_latest',                      -->
@@ -48,14 +48,14 @@
                             <!--   Pass Only Elements:                                  -->
                             <!--     ['bookings', 'bookers', 'metric_time', 'listing']  -->
                             <!-- node_id = pfe_0 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookings',      -->
-                            <!--    'non_additive_dimension': None}  -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookers',       -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookers',            -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                               -->
                             <!--   {'class': 'TimeDimensionSpec',             -->
                             <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -14,10 +14,10 @@
                     <!--   Pass Only Elements:           -->
                     <!--     ['bookings', 'is_instant']  -->
                     <!-- node_id = pfe_3 -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'bookings',      -->
-                    <!--    'non_additive_dimension': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'bookings',           -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                                                      -->
                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                     <WhereConstraintNode>
@@ -40,10 +40,10 @@
                             <!--   Pass Only Elements:                                      -->
                             <!--     ['bookings', 'is_instant', 'listing__country_latest']  -->
                             <!-- node_id = pfe_2 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookings',      -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                                                                      -->
                             <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                             <!-- include_spec =                                            -->
@@ -67,10 +67,10 @@
                                     <!--   Pass Only Elements:                      -->
                                     <!--     ['bookings', 'is_instant', 'listing']  -->
                                     <!-- node_id = pfe_0 -->
-                                    <!-- include_spec =                      -->
-                                    <!--   {'class': 'MeasureSpec',          -->
-                                    <!--    'element_name': 'bookings',      -->
-                                    <!--    'non_additive_dimension': None}  -->
+                                    <!-- include_spec =                           -->
+                                    <!--   {'class': 'MeasureSpec',               -->
+                                    <!--    'element_name': 'bookings',           -->
+                                    <!--    'non_additive_dimension_spec': None}  -->
                                     <!-- include_spec =                                                                      -->
                                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                                     <!-- include_spec =                         -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -14,10 +14,10 @@
                     <!--   Pass Only Elements:           -->
                     <!--     ['bookings', 'is_instant']  -->
                     <!-- node_id = pfe_1 -->
-                    <!-- include_spec =                      -->
-                    <!--   {'class': 'MeasureSpec',          -->
-                    <!--    'element_name': 'bookings',      -->
-                    <!--    'non_additive_dimension': None}  -->
+                    <!-- include_spec =                           -->
+                    <!--   {'class': 'MeasureSpec',               -->
+                    <!--    'element_name': 'bookings',           -->
+                    <!--    'non_additive_dimension_spec': None}  -->
                     <!-- include_spec =                                                                      -->
                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                     <WhereConstraintNode>
@@ -40,10 +40,10 @@
                             <!--   Pass Only Elements:                          -->
                             <!--     ['bookings', 'is_instant', 'metric_time']  -->
                             <!-- node_id = pfe_0 -->
-                            <!-- include_spec =                      -->
-                            <!--   {'class': 'MeasureSpec',          -->
-                            <!--    'element_name': 'bookings',      -->
-                            <!--    'non_additive_dimension': None}  -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None}  -->
                             <!-- include_spec =                                                                      -->
                             <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                             <!-- include_spec =                               -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -29,10 +29,10 @@
                         <!--   Pass Only Elements:                        -->
                         <!--     ['bookings', 'listing__country_latest']  -->
                         <!-- node_id = pfe_2 -->
-                        <!-- include_spec =                      -->
-                        <!--   {'class': 'MeasureSpec',          -->
-                        <!--    'element_name': 'bookings',      -->
-                        <!--    'non_additive_dimension': None}  -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookings',           -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                                            -->
                         <!--   {'class': 'DimensionSpec',                              -->
                         <!--    'element_name': 'country_latest',                      -->
@@ -54,10 +54,10 @@
                                 <!--   Pass Only Elements:        -->
                                 <!--     ['bookings', 'listing']  -->
                                 <!-- node_id = pfe_0 -->
-                                <!-- include_spec =                      -->
-                                <!--   {'class': 'MeasureSpec',          -->
-                                <!--    'element_name': 'bookings',      -->
-                                <!--    'non_additive_dimension': None}  -->
+                                <!-- include_spec =                           -->
+                                <!--   {'class': 'MeasureSpec',               -->
+                                <!--    'element_name': 'bookings',           -->
+                                <!--    'non_additive_dimension_spec': None}  -->
                                 <!-- include_spec =                         -->
                                 <!--   {'class': 'LinklessIdentifierSpec',  -->
                                 <!--    'element_name': 'listing',          -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -25,10 +25,10 @@
                         <!--   Pass Only Elements:             -->
                         <!--     ['booking_value', 'listing']  -->
                         <!-- node_id = pfe_0 -->
-                        <!-- include_spec =                       -->
-                        <!--   {'class': 'MeasureSpec',           -->
-                        <!--    'element_name': 'booking_value',  -->
-                        <!--    'non_additive_dimension': None}   -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'booking_value',      -->
+                        <!--    'non_additive_dimension_spec': None}  -->
                         <!-- include_spec =                         -->
                         <!--   {'class': 'LinklessIdentifierSpec',  -->
                         <!--    'element_name': 'listing',          -->


### PR DESCRIPTION
We have a number of slightly wonky organizational artifacts in our
codebase which have been cropping up as circular imports of late.
Most recently, issues with conversion between WhereClauseConstraint
and SpecWhereClauseConstraint are blocking update and merge on
#153 , but that's not the only issue we've been encountering.

This PR does the following in order to tidy things up and bring us 
a bit closer to the layout described in #214:

- Move WhereClauseConstraint conversion out of the query parser
- Move AggregationType to a root module
- Split NonAdditiveDimensionParams into a model object/spec pair
- - Clean up naming and update plan files