### PR TITLE
Fix the names of the top level objects in the generated schema.json

### DIFF
--- a/metricflow/model/parsing/explicit_schema.py
+++ b/metricflow/model/parsing/explicit_schema.py
@@ -7,10 +7,10 @@ from typing import Dict, List, Union
 from metricflow.model.parsing import schemas_internal
 
 TOP_LEVEL_SCHEMAS = {
-    "metric",
-    "data_source",
-    "derived_group_by_element_schema",
-    "materialization_schema",
+    "metric": "metric",
+    "data_source": "data_source",
+    "derived_group_by_element_schema": "derived_identifier",
+    "materialization_schema": "materialization",
 }
 
 BASE_SCHEMA = {
@@ -39,8 +39,8 @@ def generate_explict_schema(schema_store: Dict) -> Dict:
         definitions[schema_name] = rewritten_schema
 
     properties = {}
-    for schema_name in TOP_LEVEL_SCHEMAS:
-        properties[schema_name] = {"$ref": ref_to_definition_mapping[schema_name]}
+    for schema_name, object_name in TOP_LEVEL_SCHEMAS.items():
+        properties[object_name] = {"$ref": ref_to_definition_mapping[schema_name]}
 
     full_schema: Dict = deepcopy(BASE_SCHEMA)
     full_schema["properties"] = properties

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -713,10 +713,10 @@
         "data_source": {
             "$ref": "#/definitions/data_source"
         },
-        "derived_group_by_element_schema": {
+        "derived_identifier": {
             "$ref": "#/definitions/derived_group_by_element_schema"
         },
-        "materialization_schema": {
+        "materialization": {
             "$ref": "#/definitions/materialization_schema"
         },
         "metric": {


### PR DESCRIPTION
In https://github.com/transform-data/metricflow/pull/211 (generating an explicit JSON schema), I made the mistake of using the schema names as the names of the properties at the top level of the generated Metricflow schema. 

Materialization objects are defined by a schema named `materialization_schema`, so right now the schema matches `materialization_schema` for materialization definitions as opposed to the correct `materialization`. This fixes the schema to match materializations properly. (I also fixed `derived_identifier`, but it appears this may not no longer be in use)
 