### PR TITLE
Handle exception during building SemanticModel in materializations validation

### DIFF
--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -109,7 +109,18 @@ class ValidMaterializationRule(ModelValidationRule):
         """Check that all of the metrics and dimensions listed in a materialization are valid."""
         issues: List[ValidationIssueType] = []
 
-        semantic_model = SemanticModel(model)
+        try:
+            semantic_model = SemanticModel(model)
+        except Exception as e:
+            return [
+                ValidationError(
+                    message="Unable to run materialization validations as the building of the semantic model failed. "
+                    "If running the suite of validation rules, the underlying cause should be covered by another "
+                    "validation error.",
+                    extra_detail="".join(traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)),
+                )
+            ]
+
         source_data_sets: List[DataSourceDataSet] = []
         converter = DataSourceToDataSetConverter(
             column_association_resolver=DefaultColumnAssociationResolver(semantic_model)

--- a/metricflow/model/validations/materializations.py
+++ b/metricflow/model/validations/materializations.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import traceback
 from typing import List
+from metricflow.errors.errors import SemanticException
 from metricflow.instances import MaterializationModelReference
 
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
@@ -111,7 +112,7 @@ class ValidMaterializationRule(ModelValidationRule):
 
         try:
             semantic_model = SemanticModel(model)
-        except Exception as e:
+        except (AssertionError, SemanticException) as e:
             return [
                 ValidationError(
                     message="Unable to run materialization validations as the building of the semantic model failed. "


### PR DESCRIPTION
Many things can cause building of the `SemanticModel` from the `UserConfiguredModel`
to blow up. Notably, if a dimension/measure referenced by a metric doesn't exist.
This has caused the Materializations Validation to fail, even if the issue is
unrelated to materializations. Additionally, a very arcane error message was being
output because part of the issue raised includes the arguments to the called
function, which in this case was the entire `UserConfiguredModel`.

This PR aims to fix the problem by handling the error and letting the user
know what went wrong in a friendly manner.