### PR TITLE
Format core yaml config files

### DIFF
--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -2,8 +2,8 @@ name: Publish Metricflow Release
 on:
   workflow_dispatch:
   push:
-    tags:        
-      - '*'
+    tags:
+      - "*"
 
 jobs:
   poetry-publish:
@@ -24,4 +24,4 @@ jobs:
         run: make install
 
       - name: Poetry Publish
-        run: poetry build && poetry publish -u transform_data -p ${{ secrets.PYPI_PASSWORD }} 
+        run: poetry build && poetry publish -u transform_data -p ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ labeled ]
+    types: [labeled]
 
 jobs:
   snowflake-tests:
@@ -155,10 +155,9 @@ jobs:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres
 
-
   slack-failure:
     environment: DW_INTEGRATION_TESTS
-    needs: [ snowflake-tests, redshift-tests, bigquery-tests]
+    needs: [snowflake-tests, redshift-tests, bigquery-tests]
     if: ${{ github.event_name != 'pull_request' && failure() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -10,10 +10,10 @@ on:
       - reopened
       - synchronize
     paths:
-      - 'metricflow/model/parsing/**'
+      - "metricflow/model/parsing/**"
 
 jobs:
-   json-schema-consistency-check:
+  json-schema-consistency-check:
     name: Schema Consistency Check
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install Metricflow
         run: poetry install
-      
+
       - name: Generate JSON Schema
         run: python3 metricflow/model/parsing/explicit_schema.py
 
@@ -51,4 +51,3 @@ jobs:
           else
             echo 'Success: JSON schema and generated schema match.'
           fi
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
-    -   id: black
+      - id: black
         verbose: true
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
@@ -13,9 +13,22 @@ repos:
 
   - repo: https://github.com/pre-commit/mirrors-mypy # configured via mypy.ini
     rev: v0.931
-    hooks:  # passing args: [] ensures we do not silently ignore imports (default) and instead explicitly configure in mypy.ini
+    hooks: # passing args: [] ensures we do not silently ignore imports (default) and instead explicitly configure in mypy.ini
       - id: mypy
         name: mypy_metricflow
         args: [--ignore-missing-imports, --show-error-codes]
         verbose: true
-        additional_dependencies: [sqlalchemy,sqlalchemy2-stubs,types-flask,types-requests,types-PyYAML,types-jinja2,types-attrs,types-tabulate,pytest, python-dateutil, types-python-dateutil]
+        additional_dependencies:
+          [
+            sqlalchemy,
+            sqlalchemy2-stubs,
+            types-flask,
+            types-requests,
+            types-PyYAML,
+            types-jinja2,
+            types-attrs,
+            types-tabulate,
+            pytest,
+            python-dateutil,
+            types-python-dateutil,
+          ]

--- a/metricflow/test/fixtures/model_yamls/composite_identifier_model/materializations.yaml
+++ b/metricflow/test/fixtures/model_yamls/composite_identifier_model/materializations.yaml
@@ -10,7 +10,6 @@ materialization:
     - ds
     - user_team
     - user_team__country
-
 ---
 materialization:
   name: messages_with_user_team_and_team

--- a/metricflow/test/fixtures/model_yamls/composite_identifier_model/more_users_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/composite_identifier_model/more_users_source.yaml
@@ -7,7 +7,6 @@ data_source:
 
   sql_table: $fct_users_more_table
 
-
   dimensions:
     - name: user_element
       type: categorical

--- a/metricflow/test/fixtures/model_yamls/composite_identifier_model/users_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/composite_identifier_model/users_source.yaml
@@ -7,7 +7,6 @@ data_source:
 
   sql_table: $fct_users_table
 
-
   dimensions:
     - name: ds
       expr: created_at

--- a/metricflow/test/fixtures/model_yamls/join_types_model/bookings_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/join_types_model/bookings_source.yaml
@@ -25,6 +25,5 @@ data_source:
       type: foreign
       expr: listing_id
 
-
   mutability:
     type: immutable

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/bridge_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/bridge_table.yaml
@@ -1,4 +1,4 @@
---- 
+---
 data_source:
   name: bridge_table
   description: bridge_table
@@ -25,5 +25,3 @@ data_source:
 
   mutability:
     type: immutable
-
-

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/customer_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/customer_table.yaml
@@ -1,4 +1,4 @@
---- 
+---
 data_source:
   name: customer_table
   description: customer_table

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/third_hop_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/partitioned_data_sources/third_hop_table.yaml
@@ -1,4 +1,4 @@
---- 
+---
 data_source:
   name: third_hop_table
   description: third_hop_table

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/bridge_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/bridge_table.yaml
@@ -1,4 +1,4 @@
---- 
+---
 data_source:
   name: bridge_table
   description: bridge_table
@@ -19,5 +19,3 @@ data_source:
 
   mutability:
     type: immutable
-
-

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/customer_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/customer_table.yaml
@@ -1,4 +1,4 @@
---- 
+---
 data_source:
   name: customer_table
   description: customer_table

--- a/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/third_hop_table.yaml
+++ b/metricflow/test/fixtures/model_yamls/multi_hop_join_model/unpartitioned_data_sources/third_hop_table.yaml
@@ -1,4 +1,4 @@
---- 
+---
 data_source:
   name: third_hop_table
   description: third_hop_table

--- a/metricflow/test/fixtures/model_yamls/non_ds_model/bookings_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/non_ds_model/bookings_source.yaml
@@ -32,6 +32,6 @@ data_source:
     type: append_only
     type_params:
       along: dt
-      min: '2020-01-01'
-      max: '2020-01-31'
+      min: "2020-01-01"
+      max: "2020-01-31"
       update_cron: manual

--- a/metricflow/test/fixtures/model_yamls/non_ds_model/listings_latest.yaml
+++ b/metricflow/test/fixtures/model_yamls/non_ds_model/listings_latest.yaml
@@ -32,6 +32,5 @@ data_source:
       type: primary
       expr: listing_id
 
-
   mutability:
     type: immutable

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/id_verifications.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/id_verifications.yaml
@@ -34,6 +34,5 @@ data_source:
       type: foreign
       expr: user_id
 
-
   mutability:
     type: immutable

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/lux_listing_mapping.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/lux_listing_mapping.yaml
@@ -15,6 +15,5 @@ data_source:
       type: foreign
       expr: lux_listing_id
 
-
   mutability:
     type: immutable

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/user_ds_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/user_ds_source.yaml
@@ -30,6 +30,5 @@ data_source:
       type: primary
       expr: user_id
 
-
   mutability:
     type: immutable

--- a/metricflow/test/fixtures/model_yamls/simple_model/materializations.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/materializations.yaml
@@ -9,7 +9,6 @@ materialization:
   dimensions:
     - metric_time
     - listing
-
 ---
 materialization:
   name: test_materialization
@@ -21,7 +20,6 @@ materialization:
   dimensions:
     - metric_time
     - is_instant
-
 ---
 materialization:
   name: test_materialization_ds_only
@@ -32,7 +30,6 @@ materialization:
     - booking_value
   dimensions:
     - metric_time
-
 ---
 materialization:
   name: test_materialization2
@@ -44,7 +41,6 @@ materialization:
   dimensions:
     - metric_time
     - is_instant
-
 ---
 materialization:
   name: test_materialization3
@@ -56,7 +52,6 @@ materialization:
   dimensions:
     - metric_time
     - listing__country_latest
-
 ---
 materialization:
   name: test_materialization_custom_destination
@@ -69,7 +64,6 @@ materialization:
   dimensions:
     - metric_time
     - is_instant
-
 ---
 materialization:
   name: test_materialization2_custom_destination
@@ -82,7 +76,6 @@ materialization:
   dimensions:
     - metric_time
     - is_instant
-
 ---
 materialization:
   name: test_materialization3_custom_destination
@@ -95,7 +88,6 @@ materialization:
   dimensions:
     - metric_time
     - listing__country_latest
-
 ---
 materialization:
   name: test_materialization_with_join
@@ -107,7 +99,6 @@ materialization:
   dimensions:
     - metric_time
     - listing__country_latest
-
 ---
 materialization:
   name: test_materialization_fast_cache
@@ -127,7 +118,6 @@ materialization:
       format: WIDE
       rollups:
         - ["metric_time", "*"]
-
 ---
 materialization:
   name: materialization_with_ds_month

--- a/metricflow/test/integration/test_cases/itest_constraints.yaml
+++ b/metricflow/test/integration/test_cases/itest_constraints.yaml
@@ -4,7 +4,7 @@ integration_test:
   description: Query a metric with a constraint that was requested as a dimension
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
-  group_bys: ["metric_time","is_instant"]
+  group_bys: ["metric_time", "is_instant"]
   where_constraint: "is_instant"
   check_query: |
     SELECT  SUM(booking_value) AS booking_value
@@ -58,9 +58,8 @@ integration_test:
       , ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
     WHERE ds = '2020-01-01'
-    GROUP BY 
+    GROUP BY
       ds
-
 ---
 integration_test:
   name: test_time_constraint_with_addition_dimension
@@ -74,7 +73,7 @@ integration_test:
     SELECT  SUM(booking_value) AS booking_value
       , ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
-    WHERE is_instant 
+    WHERE is_instant
       and ds = '2020-01-01'
     GROUP BY ds
 ---
@@ -83,14 +82,14 @@ integration_test:
   description: Test a time constraint with a boolean
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
-  group_bys: ["metric_time","is_instant"]
+  group_bys: ["metric_time", "is_instant"]
   where_constraint: "is_instant"
   check_query: |
     SELECT  SUM(booking_value) AS booking_value
       , is_instant
       , ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
-    WHERE is_instant 
+    WHERE is_instant
     GROUP BY ds
       ,is_instant
 ---
@@ -108,7 +107,6 @@ integration_test:
     JOIN  {{ source_schema }}.dim_listings_latest l ON b.listing_id = l.listing_id
     WHERE l.capacity >= 4
     GROUP BY  b.ds
-
 ---
 integration_test:
   name: test_time_constraint_on_time_dimension_with_an_expression
@@ -123,7 +121,6 @@ integration_test:
     FROM  {{source_schema}}.dim_listings_latest l
     WHERE {{ render_time_constraint("created_at", "2020-01-01", "2021-01-01") }}
     GROUP BY  created_at
-
 ---
 integration_test:
   name: test_metric_time_in_where

--- a/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
+++ b/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
@@ -26,7 +26,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: windowed_cumulative_metric_with_joined_dim
@@ -60,7 +59,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
     GROUP BY a.ds, user__home_state_latest
     ORDER by a.ds, user__home_state_latest
-
 ---
 integration_test:
   name: cumulative_metric_by_ds
@@ -88,7 +86,6 @@ integration_test:
     ON b.created_at <= a.ds
     GROUP BY a.ds
     ORDER by a.ds
-
 ---
 integration_test:
   name: cumulative_metric_without_ds
@@ -99,7 +96,6 @@ integration_test:
     SELECT
       SUM(revenue) AS revenue_all_time
     FROM {{ source_schema }}.fct_revenue
-
 ---
 integration_test:
   name: multiple_cumulative_metrics
@@ -155,7 +151,6 @@ integration_test:
     ) b
     ON a.ds = b.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: windowed_cumulative_metric_by_time_dimension_with_granularity
@@ -184,7 +179,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: cumulative_metric_by_ds_and_limited_time
@@ -212,7 +206,6 @@ integration_test:
     ON b.created_at <= a.ds
     GROUP BY a.ds
     ORDER by a.ds
-
 ---
 integration_test:
   name: non_additive_cumulative_metric_by_ds
@@ -240,9 +233,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.DAY) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
-
-
 ---
 integration_test:
   name: non_additive_cumulative_metric_by_ds_and_limited_time
@@ -270,7 +260,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.DAY) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: grain_to_date_cumulative_metric
@@ -299,8 +288,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds >= {{ render_date_trunc("a.ds", TimeGranularity.MONTH) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
-
 ---
 integration_test:
   name: cumulative_metric_by_ds_with_granularity

--- a/metricflow/test/integration/test_cases/itest_dimensions.yaml
+++ b/metricflow/test/integration/test_cases/itest_dimensions.yaml
@@ -102,4 +102,3 @@ integration_test:
     GROUP BY
       v.ds
       , u.home_state
-

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -203,26 +203,26 @@ integration_test:
     ON a.ds = b.ds
 ---
 integration_test:
- name: min_measure_proxy
- description: Test measure_proxy metric with a min.
- model: SIMPLE_MODEL
- metrics: ["min_booking_value"]
- group_bys: []
- check_query: |
-   SELECT
-     min(booking_value) AS min_booking_value
-   FROM {{ source_schema }}.fct_bookings
+  name: min_measure_proxy
+  description: Test measure_proxy metric with a min.
+  model: SIMPLE_MODEL
+  metrics: ["min_booking_value"]
+  group_bys: []
+  check_query: |
+    SELECT
+      min(booking_value) AS min_booking_value
+    FROM {{ source_schema }}.fct_bookings
 ---
 integration_test:
- name: max_measure_proxy
- description: Test measure_proxy metric with a max.
- model: SIMPLE_MODEL
- metrics: ["max_booking_value"]
- group_bys: []
- check_query: |
-   SELECT
-     max(booking_value) AS max_booking_value
-   FROM {{ source_schema }}.fct_bookings
+  name: max_measure_proxy
+  description: Test measure_proxy metric with a max.
+  model: SIMPLE_MODEL
+  metrics: ["max_booking_value"]
+  group_bys: []
+  check_query: |
+    SELECT
+      max(booking_value) AS max_booking_value
+    FROM {{ source_schema }}.fct_bookings
 ---
 integration_test:
   name: count_distinct
@@ -430,7 +430,7 @@ integration_test:
     Tests query with 3 metrics, and also checks an optimizing issue when there is a expression metric that is joined.
   model: SIMPLE_MODEL
   required_features: ["FULL_OUTER_JOIN"]
-  metrics: ["bookings", "bookings_per_booker", "booking_value",]
+  metrics: ["bookings", "bookings_per_booker", "booking_value"]
   group_bys: ["metric_time"]
   check_query: |
     SELECT

--- a/metricflow/test/integration/test_cases/itest_multi_hop_join.yaml
+++ b/metricflow/test/integration/test_cases/itest_multi_hop_join.yaml
@@ -22,7 +22,11 @@ integration_test:
   description: Tests a query requesting mulitple multi-hop join dims that dont come from the same data source
   model: UNPARTITIONED_MULTI_HOP_JOIN_MODEL
   metrics: ["txn_count"]
-  group_bys: ["account_id__customer_id__customer_name", "account_id__customer_id__country"]
+  group_bys:
+    [
+      "account_id__customer_id__customer_name",
+      "account_id__customer_id__country",
+    ]
   check_query: |
     SELECT
       dim_src0.customer_name as account_id__customer_id__customer_name
@@ -52,7 +56,11 @@ integration_test:
   description: Tests a query requesting mulitple multi-hop join dims from the same source
   model: UNPARTITIONED_MULTI_HOP_JOIN_MODEL
   metrics: ["txn_count"]
-  group_bys: ["account_id__customer_id__customer_name", "account_id__customer_id__customer_atomic_weight"]
+  group_bys:
+    [
+      "account_id__customer_id__customer_name",
+      "account_id__customer_id__customer_atomic_weight",
+    ]
   check_query: |
     SELECT
       ct.customer_name as account_id__customer_id__customer_name
@@ -72,7 +80,12 @@ integration_test:
   description: Tests a query with multihop and single hop join dimensions
   model: UNPARTITIONED_MULTI_HOP_JOIN_MODEL
   metrics: ["txn_count"]
-  group_bys: ["account_id__customer_id__customer_name", "account_id__customer_id__country", "account_id__extra_dim"]
+  group_bys:
+    [
+      "account_id__customer_id__customer_name",
+      "account_id__customer_id__country",
+      "account_id__extra_dim",
+    ]
   check_query: |
     SELECT
       dim_src0.customer_name as account_id__customer_id__customer_name

--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -58,11 +58,11 @@ integration_test:
 integration_test:
   name: semi_additive_measure_query_with_join_linkable_specs
   description: |
-    Tests semi-additive measure with a path hitting join linkable specs. 
+    Tests semi-additive measure with a path hitting join linkable specs.
     There are cases (like this query where we have a non-local linkable spec "user__home_state_latest") where
     we are directly copying a MeasureSpec via constructing it. Previously, this led to a code path not passing all the attributes,
     then somewhere along the path it would end up throwing a MeasureSpec not in [List of MeasureSpec] due to an attribute
-    being missing. This test case hits that path and ensures that we are copying attributes correctly.  
+    being missing. This test case hits that path and ensures that we are copying attributes correctly.
   model: SIMPLE_MODEL
   metrics: ["current_account_balance_by_user"]
   group_bys: ["user"]


### PR DESCRIPTION
The Metricflow model authoring extension has opinions about how YAML
should be formatted, so let's format everything here instead of
polluting unrelated changes with a bunch of whitespace and quote
replacements. Even non-configs get formatted because the extension
pulls in its underlying YAML extension library, so this covers things that
aren't strictly model files.

Note this does not include model templates because we're not likely to change
them, happy to run the formatter there if it seems worthwhile.