### PR TITLE
Improve clarity of model-level element naming validation operations

### DIFF
--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class DataSourceMeasuresUniqueRule(ModelValidationRule):
-    """Checks time dimensions in data sources."""
+    """Asserts all measure names are unique across the model."""
 
     @staticmethod
     @validate_safely(

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -1,53 +1,70 @@
+import copy
 import pytest
+from typing import Tuple
 
-from metricflow.aggregation_properties import AggregationType
 from metricflow.model.model_validator import ModelValidator
-from metricflow.model.objects.data_source import Mutability, MutabilityType
-from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
-from metricflow.model.objects.elements.measure import Measure
-from metricflow.model.objects.metric import MetricType, MetricTypeParams
+from metricflow.model.objects.data_source import DataSource
+from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.model.validations.validator_helpers import ModelValidationException
-from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta, metric_with_guaranteed_meta
-from metricflow.time.time_granularity import TimeGranularity
+from metricflow.model.validations.validator_helpers import DataSourceElementType, ModelValidationException
+from metricflow.test.test_utils import find_data_source_with
 
 
-@pytest.mark.skip("TODO: Will convert to validation rule")
-def test_inconsistent_elements() -> None:  # noqa:D
-    dim_name = "ename"
-    measure_name = "ename"
-    with pytest.raises(ModelValidationException):
-        ModelValidator().checked_validations(
-            UserConfiguredModel(
-                data_sources=[
-                    data_source_with_guaranteed_meta(
-                        name="s1",
-                        sql_query="SELECT foo FROM bar",
-                        dimensions=[
-                            Dimension(
-                                name=dim_name,
-                                type=DimensionType.TIME,
-                                type_params=DimensionTypeParams(
-                                    time_granularity=TimeGranularity.DAY,
-                                ),
-                            )
-                        ],
-                        mutability=Mutability(type=MutabilityType.IMMUTABLE),
-                    ),
-                    data_source_with_guaranteed_meta(
-                        name="s2",
-                        sql_query="SELECT foo FROM bar",
-                        measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
-                        mutability=Mutability(type=MutabilityType.IMMUTABLE),
-                    ),
-                ],
-                metrics=[
-                    metric_with_guaranteed_meta(
-                        name=measure_name,
-                        type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure_name]),
-                    )
-                ],
-                materializations=[],
-            )
-        )
+def _categorical_dimensions(data_source: DataSource) -> Tuple[Dimension, ...]:
+    return tuple(dim for dim in data_source.dimensions if dim.type == DimensionType.CATEGORICAL)
+
+
+def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copy.deepcopy(simple_model__pre_transforms)
+
+    # ensure we have a usable data source for the test
+    usable_ds, usable_ds_index = find_data_source_with(
+        model,
+        lambda data_source: len(data_source.measures) > 0
+        and len(data_source.identifiers) > 0
+        and len(_categorical_dimensions(data_source=data_source)) > 0,
+    )
+
+    measure_reference = usable_ds.measures[0].reference
+    # If the matching dimension is a time dimension we can accidentally create two primary time dimensions, and then
+    # the validation will throw a different error and fail the test
+    dimension_reference = _categorical_dimensions(data_source=usable_ds)[0].reference
+
+    ds_measure_x_dimension = copy.deepcopy(usable_ds)
+    ds_measure_x_identifier = copy.deepcopy(usable_ds)
+    ds_dimension_x_identifier = copy.deepcopy(usable_ds)
+
+    # We update the matching categorical dimension by reference for convenience
+    ds_measure_x_dimension.get_dimension(dimension_reference).name = measure_reference.element_name
+    ds_measure_x_identifier.identifiers[1].name = measure_reference.element_name
+    ds_dimension_x_identifier.identifiers[1].name = dimension_reference.element_name
+
+    model.data_sources[usable_ds_index] = ds_measure_x_dimension
+    with pytest.raises(
+        ModelValidationException,
+        match=(
+            f"element `{measure_reference.element_name}` is of type {DataSourceElementType.DIMENSION}, but it is used as "
+            f"types .*?DataSourceElementType.DIMENSION.*?DataSourceElementType.MEASURE.*? across the model"
+        ),
+    ):
+        ModelValidator().checked_validations(model)
+
+    model.data_sources[usable_ds_index] = ds_measure_x_identifier
+    with pytest.raises(
+        ModelValidationException,
+        match=(
+            f"element `{measure_reference.element_name}` is of type {DataSourceElementType.IDENTIFIER}, but it is used as "
+            f"types .*?DataSourceElementType.IDENTIFIER.*?DataSourceElementType.MEASURE.*? across the model"
+        ),
+    ):
+        ModelValidator().checked_validations(model)
+
+    model.data_sources[usable_ds_index] = ds_dimension_x_identifier
+    with pytest.raises(
+        ModelValidationException,
+        match=(
+            f"element `{dimension_reference.element_name}` is of type {DataSourceElementType.DIMENSION}, but it is used as "
+            f"types .*?DataSourceElementType.DIMENSION.*?DataSourceElementType.IDENTIFIER.*? across the model"
+        ),
+    ):
+        ModelValidator().checked_validations(model)

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -5,7 +5,7 @@ import copy
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
-from metricflow.model.validations.validator_helpers import ModelValidationException
+from metricflow.model.validations.validator_helpers import DataSourceElementType, ModelValidationException
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords, UniqueAndValidNameRule
 from metricflow.object_utils import flatten_nested_sequence
@@ -137,8 +137,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     with pytest.raises(
         ModelValidationException,
         match=(
-            f"element `{measure_reference.element_name}` is of type DataSourceElementType.MEASURE, but it was previously "
-            f"used earlier in the model as DataSourceElementType.DIMENSION"
+            f"element `{measure_reference.element_name}` is of type {DataSourceElementType.DIMENSION}, but it is used as "
+            f"types .*?DataSourceElementType.DIMENSION.*?DataSourceElementType.MEASURE.*? across the model"
         ),
     ):
         ModelValidator().checked_validations(model)
@@ -147,8 +147,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     with pytest.raises(
         ModelValidationException,
         match=(
-            f"element `{measure_reference.element_name}` is of type DataSourceElementType.MEASURE, but it was previously "
-            f"used earlier in the model as DataSourceElementType.IDENTIFIER"
+            f"element `{measure_reference.element_name}` is of type {DataSourceElementType.IDENTIFIER}, but it is used as "
+            f"types .*?DataSourceElementType.IDENTIFIER.*?DataSourceElementType.MEASURE.*? across the model"
         ),
     ):
         ModelValidator().checked_validations(model)
@@ -157,8 +157,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
     with pytest.raises(
         ModelValidationException,
         match=(
-            f"element `{dimension_reference.element_name}` is of type DataSourceElementType.DIMENSION, but it was previously "
-            f"used earlier in the model as DataSourceElementType.IDENTIFIER"
+            f"element `{dimension_reference.element_name}` is of type {DataSourceElementType.DIMENSION}, but it is used as "
+            f"types .*?DataSourceElementType.DIMENSION.*?DataSourceElementType.IDENTIFIER.*? across the model"
         ),
     ):
         ModelValidator().checked_validations(model)

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -1,11 +1,8 @@
-from typing import Tuple
 import pytest
 import copy
 
 from metricflow.model.model_validator import ModelValidator
-from metricflow.model.objects.data_source import DataSource
-from metricflow.model.objects.elements.dimension import Dimension, DimensionType
-from metricflow.model.validations.validator_helpers import DataSourceElementType, ModelValidationException
+from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords, UniqueAndValidNameRule
 from metricflow.object_utils import flatten_nested_sequence
@@ -14,10 +11,6 @@ from metricflow.test.test_utils import find_data_source_with
 
 def copied_model(simple_model__pre_transforms: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
     return copy.deepcopy(simple_model__pre_transforms)
-
-
-def _categorical_dimensions(data_source: DataSource) -> Tuple[Dimension, ...]:
-    return tuple(dim for dim in data_source.dimensions if dim.type == DimensionType.CATEGORICAL)
 
 
 """
@@ -106,62 +99,6 @@ def test_top_level_elements_cant_share_names_except_with_metrics(
     A name for any of these elements must be unique to all other element names
     for the given data source.
 """
-
-
-def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copied_model(simple_model__pre_transforms)
-
-    # ensure we have a usable data source for the test
-    usable_ds, usable_ds_index = find_data_source_with(
-        model,
-        lambda data_source: len(data_source.measures) > 0
-        and len(data_source.identifiers) > 0
-        and len(_categorical_dimensions(data_source=data_source)) > 0,
-    )
-
-    measure_reference = usable_ds.measures[0].reference
-    # If the matching dimension is a time dimension we can accidentally create two primary time dimensions, and then
-    # the validation will throw a different error and fail the test
-    dimension_reference = _categorical_dimensions(data_source=usable_ds)[0].reference
-
-    ds_measure_x_dimension = copy.deepcopy(usable_ds)
-    ds_measure_x_identifier = copy.deepcopy(usable_ds)
-    ds_dimension_x_identifier = copy.deepcopy(usable_ds)
-
-    # We update the matching categorical dimension by reference for convenience
-    ds_measure_x_dimension.get_dimension(dimension_reference).name = measure_reference.element_name
-    ds_measure_x_identifier.identifiers[1].name = measure_reference.element_name
-    ds_dimension_x_identifier.identifiers[1].name = dimension_reference.element_name
-
-    model.data_sources[usable_ds_index] = ds_measure_x_dimension
-    with pytest.raises(
-        ModelValidationException,
-        match=(
-            f"element `{measure_reference.element_name}` is of type {DataSourceElementType.DIMENSION}, but it is used as "
-            f"types .*?DataSourceElementType.DIMENSION.*?DataSourceElementType.MEASURE.*? across the model"
-        ),
-    ):
-        ModelValidator().checked_validations(model)
-
-    model.data_sources[usable_ds_index] = ds_measure_x_identifier
-    with pytest.raises(
-        ModelValidationException,
-        match=(
-            f"element `{measure_reference.element_name}` is of type {DataSourceElementType.IDENTIFIER}, but it is used as "
-            f"types .*?DataSourceElementType.IDENTIFIER.*?DataSourceElementType.MEASURE.*? across the model"
-        ),
-    ):
-        ModelValidator().checked_validations(model)
-
-    model.data_sources[usable_ds_index] = ds_dimension_x_identifier
-    with pytest.raises(
-        ModelValidationException,
-        match=(
-            f"element `{dimension_reference.element_name}` is of type {DataSourceElementType.DIMENSION}, but it is used as "
-            f"types .*?DataSourceElementType.DIMENSION.*?DataSourceElementType.IDENTIFIER.*? across the model"
-        ),
-    ):
-        ModelValidator().checked_validations(model)
 
 
 def test_duplicate_measure_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D


### PR DESCRIPTION
Our model-level element naming validation is enforced primarily through two
validators today - the ElementConsistencyRule and the
DataSourceMeasuresUnique rule.

This PR clarifies their relationship via updates to documentation and test layout,
and restructures the behavior of the ElementConsistencyRule to be more
clear as to its purpose.