### PR TITLE
Add metadata context info to dimensions and identifiers

### DIFF
--- a/metricflow/model/objects/elements/dimension.py
+++ b/metricflow/model/objects/elements/dimension.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
-from metricflow.model.objects.base import HashableBaseModel
+from metricflow.model.objects.base import HashableBaseModel, ModelWithMetadataParsing
+from metricflow.model.objects.common import Metadata
 from metricflow.references import DimensionReference, TimeDimensionReference
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.object_utils import ExtendedEnum
@@ -30,7 +31,7 @@ class DimensionTypeParams(HashableBaseModel):
     time_granularity: TimeGranularity
 
 
-class Dimension(HashableBaseModel):
+class Dimension(HashableBaseModel, ModelWithMetadataParsing):
     """Describes a dimension"""
 
     name: str
@@ -39,6 +40,7 @@ class Dimension(HashableBaseModel):
     is_partition: bool = False
     type_params: Optional[DimensionTypeParams]
     expr: Optional[str] = None
+    metadata: Optional[Metadata]
 
     @property
     def is_primary_time(self) -> bool:  # noqa: D

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pydantic import validator
 from typing import Any, Optional, List
 
-from metricflow.model.objects.base import HashableBaseModel
+from metricflow.model.objects.base import HashableBaseModel, ModelWithMetadataParsing
+from metricflow.model.objects.common import Metadata
 from metricflow.object_utils import ExtendedEnum
 from metricflow.references import IdentifierReference, CompositeSubIdentifierReference
 
@@ -32,7 +33,7 @@ class CompositeSubIdentifier(HashableBaseModel):
         return CompositeSubIdentifierReference(element_name=self.name)
 
 
-class Identifier(HashableBaseModel):
+class Identifier(HashableBaseModel, ModelWithMetadataParsing):
     """Describes a identifier"""
 
     name: str
@@ -42,6 +43,7 @@ class Identifier(HashableBaseModel):
     entity: Optional[str]
     identifiers: List[CompositeSubIdentifier] = []
     expr: Optional[str] = None
+    metadata: Optional[Metadata]
 
     @validator("entity", always=True)
     @classmethod

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional, List, Dict, Any
+from pydantic import validator
+from typing import Any, Optional, List
 
 from metricflow.model.objects.base import HashableBaseModel
 from metricflow.object_utils import ExtendedEnum
@@ -42,30 +43,25 @@ class Identifier(HashableBaseModel):
     identifiers: List[CompositeSubIdentifier] = []
     expr: Optional[str] = None
 
-    def __init__(  # type: ignore
-        self,
-        name: str,
-        type: IdentifierType,
-        role: Optional[str] = None,
-        entity: Optional[str] = None,
-        identifiers: Optional[List[CompositeSubIdentifier]] = None,
-        expr: Optional[str] = None,
-        **kwargs: Dict[str, Any],  # the parser may instantiate objects with additional fields (eg __parsing_context__)
-    ) -> None:
-        """Normal pydantic initializer except we set entity to name"""
+    @validator("entity", always=True)
+    @classmethod
+    def default_entity_value(cls, value: Any, values: Any) -> str:  # type: ignore[misc]
+        """Defaulting the value of the identifier 'entity' value using pydantic validator
 
-        identifiers = identifiers or []
+        If an entity value is provided that is a string, that will become the value of
+        entity. If the provifed entity value is None, the entity value becomes the
+        element_name representation of the identifier's name.
+        """
 
-        super().__init__(
-            name=name,
-            type=type,
-            role=role,
-            entity=entity,
-            identifiers=identifiers,
-            expr=expr,
-        )
-        if self.entity is None:
-            self.entity = self.reference.element_name
+        if value is None:
+            if "name" not in values:
+                raise ValueError("Failed to default entity value because objects name value was not defined")
+            return IdentifierReference(element_name=values["name"]).element_name
+
+        # guarantee value is string
+        if not isinstance(value, str):
+            raise ValueError(f"Entity value should be a string (str) type, but got {type(value)} with value: {value}")
+        return value
 
     @property
     def is_primary_time(self) -> bool:  # noqa: D

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -58,7 +58,7 @@ class Identifier(HashableBaseModel, ModelWithMetadataParsing):
         if value is None:
             if "name" not in values:
                 raise ValueError("Failed to default entity value because objects name value was not defined")
-            return IdentifierReference(element_name=values["name"]).element_name
+            value = values["name"]
 
         # guarantee value is string
         if not isinstance(value, str):

--- a/metricflow/test/model/parsing/test_data_source_parsing.py
+++ b/metricflow/test/model/parsing/test_data_source_parsing.py
@@ -161,6 +161,42 @@ def test_data_source_identifier_parsing() -> None:
     assert identifier.expr == "example_id"
 
 
+def test_data_source_identifier_metadata_parsing() -> None:
+    """Test for parsing metadata for an identifier object defined in a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: identifier_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          identifiers:
+            - name: example_identifier
+              type: primary
+              role: test_role
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_model(files=[file])
+
+    assert len(build_result.model.data_sources) == 1
+    data_source = build_result.model.data_sources[0]
+    assert len(data_source.identifiers) == 1
+    identifier = data_source.identifiers[0]
+    assert identifier.metadata is not None
+    assert identifier.metadata.repo_file_path == "test_dir/inline_for_test"
+    assert identifier.metadata.file_slice.filename == "inline_for_test"
+    expected_metadata_content = textwrap.dedent(
+        """\
+      name: example_identifier
+      type: primary
+      role: test_role
+      """
+    )
+    assert identifier.metadata.file_slice.content == expected_metadata_content
+
+
 def test_data_source_identifier_default_entity_parsing() -> None:
     """Test for parsing an identifier with no entity specified out of a data source specification"""
     yaml_contents = textwrap.dedent(
@@ -457,3 +493,39 @@ def test_data_source_primary_time_dimension_parsing() -> None:
     assert dimension.type is DimensionType.TIME
     assert dimension.type_params is not None
     assert dimension.type_params.is_primary is True
+
+
+def test_data_source_dimension_metadata_parsing() -> None:
+    """Test for parsing metadata for an dimension object defined in a data source specification"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: dimension_parsing_test
+          mutability:
+            type: immutable
+          sql_table: some_schema.source_table
+          dimensions:
+            - name: example_categorical_dimension
+              type: categorical
+              expr: dimension_input
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_model(files=[file])
+
+    assert len(build_result.model.data_sources) == 1
+    data_source = build_result.model.data_sources[0]
+    assert len(data_source.dimensions) == 1
+    dimension = data_source.dimensions[0]
+    assert dimension.metadata is not None
+    assert dimension.metadata.repo_file_path == "test_dir/inline_for_test"
+    assert dimension.metadata.file_slice.filename == "inline_for_test"
+    expected_metadata_content = textwrap.dedent(
+        """\
+      name: example_categorical_dimension
+      type: categorical
+      expr: dimension_input
+      """
+    )
+    assert dimension.metadata.file_slice.content == expected_metadata_content


### PR DESCRIPTION
Previously we hadn't been tracking the metadata/config file context for dimensions and identifiers. Doing so allows us to provide better context during validations (giving line numbers). Additionally it's useful for model investigating/debugging for projects using MetricFlow.

Additionally we this PR refactors the initialization of identifier objects to use pydantic's initializer and validators instead of a custom `__init__` method which clobbers pydantic initialization. This was necessary as part of this PR because it was required for metadata parsing to work for identifiers.