### PR TITLE
Add validation for constrained measure aliases

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -6,10 +6,7 @@ from typing import List, Sequence
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
 from metricflow.model.validations.agg_time_dimension import AggregationTimeDimensionRule
-from metricflow.model.validations.data_sources import (
-    DataSourceMeasuresUniqueRule,
-    DataSourceTimeDimensionWarningsRule,
-)
+from metricflow.model.validations.data_sources import DataSourceTimeDimensionWarningsRule
 from metricflow.model.validations.dimension_const import DimensionConsistencyRule
 from metricflow.model.validations.element_const import ElementConsistencyRule
 from metricflow.model.validations.identifiers import (
@@ -18,7 +15,8 @@ from metricflow.model.validations.identifiers import (
     IdentifierConsistencyRule,
 )
 from metricflow.model.validations.materializations import ValidMaterializationRule
-from metricflow.model.validations.metrics import MetricMeasuresRule, CumulativeMetricRule
+from metricflow.model.validations.measures import DataSourceMeasuresUniqueRule, MetricMeasuresRule
+from metricflow.model.validations.metrics import CumulativeMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.reserved_keywords import ReservedKeywordsRule
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -15,7 +15,11 @@ from metricflow.model.validations.identifiers import (
     IdentifierConsistencyRule,
 )
 from metricflow.model.validations.materializations import ValidMaterializationRule
-from metricflow.model.validations.measures import DataSourceMeasuresUniqueRule, MetricMeasuresRule
+from metricflow.model.validations.measures import (
+    DataSourceMeasuresUniqueRule,
+    MeasureConstraintAliasesRule,
+    MetricMeasuresRule,
+)
 from metricflow.model.validations.metrics import CumulativeMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.reserved_keywords import ReservedKeywordsRule
@@ -40,6 +44,7 @@ class ModelValidator:
         IdentifierConfigRule(),
         IdentifierConsistencyRule(),
         OnePrimaryIdentifierPerDataSourceRule(),
+        MeasureConstraintAliasesRule(),
         MetricMeasuresRule(),
         CumulativeMetricRule(),
         NonEmptyRule(),

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -1,6 +1,5 @@
 import logging
-from collections import defaultdict
-from typing import List, Dict
+from typing import List
 from metricflow.instances import DataSourceElementReference, DataSourceReference
 
 from metricflow.model.objects.data_source import DataSource
@@ -16,42 +15,9 @@ from metricflow.model.validations.validator_helpers import (
     ValidationError,
     validate_safely,
 )
-from metricflow.references import MeasureReference
 from metricflow.time.time_constants import SUPPORTED_GRANULARITIES
 
 logger = logging.getLogger(__name__)
-
-
-class DataSourceMeasuresUniqueRule(ModelValidationRule):
-    """Asserts all measure names are unique across the model."""
-
-    @staticmethod
-    @validate_safely(
-        whats_being_done="running model validation ensuring measures exist in only one configured data source"
-    )
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
-
-        measure_references_to_data_sources: Dict[MeasureReference, List] = defaultdict(list)
-        for data_source in model.data_sources:
-            for measure in data_source.measures:
-                if measure.reference in measure_references_to_data_sources:
-                    issues.append(
-                        ValidationError(
-                            context=DataSourceElementContext(
-                                file_context=FileContext.from_metadata(metadata=data_source.metadata),
-                                data_source_element=DataSourceElementReference(
-                                    data_source_name=data_source.name, element_name=measure.name
-                                ),
-                                element_type=DataSourceElementType.MEASURE,
-                            ),
-                            message=f"Found measure with name {measure.name} in multiple data sources with names "
-                            f"({measure_references_to_data_sources[measure.reference]})",
-                        )
-                    )
-                measure_references_to_data_sources[measure.reference].append(data_source.name)
-
-        return issues
 
 
 class DataSourceTimeDimensionWarningsRule(ModelValidationRule):

--- a/metricflow/model/validations/measures.py
+++ b/metricflow/model/validations/measures.py
@@ -67,7 +67,10 @@ class MetricMeasuresRule(ModelValidationRule):
                             file_context=FileContext.from_metadata(metadata=metric.metadata),
                             metric=MetricModelReference(metric_name=metric.name),
                         ),
-                        message=f"Invalid measure {measure_reference.element_name} in metric {metric.name}",
+                        message=(
+                            f"Measure {measure_reference.element_name} referenced in metric {metric.name} is not "
+                            f"defined in the model!"
+                        ),
                     )
                 )
         return issues

--- a/metricflow/model/validations/measures.py
+++ b/metricflow/model/validations/measures.py
@@ -1,0 +1,88 @@
+from collections import defaultdict
+from typing import List, Dict
+from metricflow.instances import MetricModelReference
+from metricflow.model.objects.metric import Metric
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.validator_helpers import (
+    DataSourceElementContext,
+    DataSourceElementReference,
+    DataSourceElementType,
+    FileContext,
+    MetricContext,
+    ModelValidationRule,
+    ValidationIssueType,
+    ValidationError,
+    validate_safely,
+)
+from metricflow.references import MeasureReference
+
+
+class DataSourceMeasuresUniqueRule(ModelValidationRule):
+    """Asserts all measure names are unique across the model."""
+
+    @staticmethod
+    @validate_safely(
+        whats_being_done="running model validation ensuring measures exist in only one configured data source"
+    )
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+        issues: List[ValidationIssueType] = []
+
+        measure_references_to_data_sources: Dict[MeasureReference, List] = defaultdict(list)
+        for data_source in model.data_sources:
+            for measure in data_source.measures:
+                if measure.reference in measure_references_to_data_sources:
+                    issues.append(
+                        ValidationError(
+                            context=DataSourceElementContext(
+                                file_context=FileContext.from_metadata(metadata=data_source.metadata),
+                                data_source_element=DataSourceElementReference(
+                                    data_source_name=data_source.name, element_name=measure.name
+                                ),
+                                element_type=DataSourceElementType.MEASURE,
+                            ),
+                            message=f"Found measure with name {measure.name} in multiple data sources with names "
+                            f"({measure_references_to_data_sources[measure.reference]})",
+                        )
+                    )
+                measure_references_to_data_sources[measure.reference].append(data_source.name)
+
+        return issues
+
+
+class MetricMeasuresRule(ModelValidationRule):
+    """Checks that the measures referenced in the metrics exist."""
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking all measures referenced by the metric exist")
+    def _validate_metric_measure_references(
+        metric: Metric, valid_measure_names: List[str]
+    ) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+
+        for measure_reference in metric.measure_references:
+            if measure_reference.element_name not in valid_measure_names:
+                issues.append(
+                    ValidationError(
+                        context=MetricContext(
+                            file_context=FileContext.from_metadata(metadata=metric.metadata),
+                            metric=MetricModelReference(metric_name=metric.name),
+                        ),
+                        message=f"Invalid measure {measure_reference.element_name} in metric {metric.name}",
+                    )
+                )
+        return issues
+
+    @staticmethod
+    @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
+        issues: List[ValidationIssueType] = []
+        valid_measure_names = []
+        for data_source in model.data_sources:
+            for measure in data_source.measures:
+                valid_measure_names.append(measure.reference.element_name)
+
+        for metric in model.metrics or []:
+            issues += MetricMeasuresRule._validate_metric_measure_references(
+                metric=metric, valid_measure_names=valid_measure_names
+            )
+        return issues

--- a/metricflow/model/validations/measures.py
+++ b/metricflow/model/validations/measures.py
@@ -1,8 +1,12 @@
 from collections import defaultdict
-from typing import List, Dict
+from typing import DefaultDict, Dict, List, Set
+
+from more_itertools import bucket
+
 from metricflow.instances import MetricModelReference
 from metricflow.model.objects.metric import Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
 from metricflow.model.validations.validator_helpers import (
     DataSourceElementContext,
     DataSourceElementReference,
@@ -12,6 +16,7 @@ from metricflow.model.validations.validator_helpers import (
     ModelValidationRule,
     ValidationIssueType,
     ValidationError,
+    ValidationWarning,
     validate_safely,
 )
 from metricflow.references import MeasureReference
@@ -49,14 +54,137 @@ class DataSourceMeasuresUniqueRule(ModelValidationRule):
         return issues
 
 
+class MeasureConstraintAliasesRule(ModelValidationRule):
+    """Checks that aliases are configured correctly for constrained measure references
+
+    These are, currently, only applicable for Metric types, since the MetricInputMeasure is only
+    """
+
+    @staticmethod
+    @validate_safely(whats_being_done="ensuring measures aliases are set when required")
+    def _validate_required_aliases_are_set(metric: Metric, metric_context: MetricContext) -> List[ValidationIssueType]:
+        """Checks if valid aliases are set on the input measure references where they are required
+
+        Aliases are required whenever there are 2 or more input measures with the same measure
+        reference with different constraints. When this happens, we require aliases for all
+        constrained measures for the sake of clarity. Any unconstrained measure does not
+        need an alias, since it always relies on the original measure specification.
+
+        At this time aliases are required for ratio metrics, but eventually we could relax that requirement
+        if we can find an automatic aliasing scheme for numerator/denominator that we feel comfortable using.
+        """
+        issues: List[ValidationIssueType] = []
+
+        if len(metric.measure_references) == len(set(metric.measure_references)):
+            # All measure references are unique, so disambiguation via aliasing is not necessary
+            return issues
+
+        # Note: more_itertools.bucket does not produce empty groups
+        input_measures_by_name = bucket(metric.input_measures, lambda x: x.name)
+        for name in input_measures_by_name:
+            input_measures = list(input_measures_by_name[name])
+
+            if len(input_measures) == 1:
+                continue
+
+            distinct_input_measures = set(input_measures)
+            if len(distinct_input_measures) == 1:
+                # Warn whenever multiple identical references exist - we will consolidate these but it might be
+                # a meaningful oversight if constraints and aliases are specified
+                issues.append(
+                    ValidationWarning(
+                        context=metric_context,
+                        message=(
+                            f"Metric {metric.name} has multiple identical input measures specifications for measure "
+                            f"{name}. This might be hiding a semantic error. Input measure specification: "
+                            f"{input_measures[0]}."
+                        ),
+                    )
+                )
+                continue
+
+            constrained_measures_without_aliases = [
+                measure for measure in input_measures if measure.constraint is not None and measure.alias is None
+            ]
+            if constrained_measures_without_aliases:
+                issues.append(
+                    ValidationError(
+                        context=metric_context,
+                        message=(
+                            f"Metric {metric.name} depends on multiple different constrained versions of measure "
+                            f"{name}. In such cases, aliases must be provided, but the following input measures have "
+                            f"constraints specified without an alias: {constrained_measures_without_aliases}."
+                        ),
+                    )
+                )
+
+        return issues
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking constrained measures are aliased properly")
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:
+        """Ensures measures that might need an alias have one set, and that the alias is distinct
+
+        We do not allow aliases to collide with other alias or measure names, since that could create
+        ambiguity at query time or cause issues if users ever restructure their models.
+        """
+        issues: List[ValidationIssueType] = []
+
+        measure_names = _get_measure_names_from_model(model)
+        measure_alias_to_metrics: DefaultDict[str, List[str]] = defaultdict(list)
+        for metric in model.metrics:
+            metric_context = MetricContext(
+                file_context=FileContext.from_metadata(metadata=metric.metadata),
+                metric=MetricModelReference(metric_name=metric.name),
+            )
+
+            issues += MeasureConstraintAliasesRule._validate_required_aliases_are_set(
+                metric=metric, metric_context=metric_context
+            )
+
+            aliased_measures = [
+                input_measure for input_measure in metric.input_measures if input_measure.alias is not None
+            ]
+
+            for measure in aliased_measures:
+                assert measure.alias, "Type refinement assertion, previous filter should ensure this is true"
+                issues += UniqueAndValidNameRule.check_valid_name(measure.alias, metric_context)
+                if measure.alias in measure_names:
+                    issues.append(
+                        ValidationError(
+                            context=metric_context,
+                            message=(
+                                f"Alias `{measure.alias}` for measure `{measure.name}` conflicts with measure names "
+                                f"defined elsewhere in the model! This can cause ambiguity for certain types of "
+                                f"query. Please choose another alias."
+                            ),
+                        )
+                    )
+                if measure.alias in measure_alias_to_metrics:
+                    issues.append(
+                        ValidationError(
+                            context=metric_context,
+                            message=(
+                                f"Measure alias {measure.alias} conflicts with a measure alias used elsewhere in the "
+                                f"model! This can cause ambiguity for certain types of query. Please choose another "
+                                f"alias, or, if the measures are constrained in the same way, consider centralizing "
+                                f"that definition in a new data source. Measure specification: {measure}. Existing "
+                                f"metrics with that measure alias used: {measure_alias_to_metrics[measure.alias]}"
+                            ),
+                        )
+                    )
+
+                measure_alias_to_metrics[measure.alias].append(metric.name)
+
+        return issues
+
+
 class MetricMeasuresRule(ModelValidationRule):
     """Checks that the measures referenced in the metrics exist."""
 
     @staticmethod
     @validate_safely(whats_being_done="checking all measures referenced by the metric exist")
-    def _validate_metric_measure_references(
-        metric: Metric, valid_measure_names: List[str]
-    ) -> List[ValidationIssueType]:
+    def _validate_metric_measure_references(metric: Metric, valid_measure_names: Set[str]) -> List[ValidationIssueType]:
         issues: List[ValidationIssueType] = []
 
         for measure_reference in metric.measure_references:
@@ -79,13 +207,20 @@ class MetricMeasuresRule(ModelValidationRule):
     @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
     def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
         issues: List[ValidationIssueType] = []
-        valid_measure_names = []
-        for data_source in model.data_sources:
-            for measure in data_source.measures:
-                valid_measure_names.append(measure.reference.element_name)
+        valid_measure_names = _get_measure_names_from_model(model)
 
         for metric in model.metrics or []:
             issues += MetricMeasuresRule._validate_metric_measure_references(
                 metric=metric, valid_measure_names=valid_measure_names
             )
         return issues
+
+
+def _get_measure_names_from_model(model: UserConfiguredModel) -> Set[str]:
+    """Return every distinct measure name specified in the model"""
+    measure_names = set()
+    for data_source in model.data_sources:
+        for measure in data_source.measures:
+            measure_names.add(measure.reference.element_name)
+
+    return measure_names

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -15,45 +15,6 @@ from metricflow.model.validations.validator_helpers import (
 )
 
 
-class MetricMeasuresRule(ModelValidationRule):
-    """Checks that the measures referenced in the metrics exist."""
-
-    @staticmethod
-    @validate_safely(whats_being_done="checking all measures referenced by the metric exist")
-    def _validate_metric_measure_references(
-        metric: Metric, valid_measure_names: List[str]
-    ) -> List[ValidationIssueType]:
-        issues: List[ValidationIssueType] = []
-
-        for measure_reference in metric.measure_references:
-            if measure_reference.element_name not in valid_measure_names:
-                issues.append(
-                    ValidationError(
-                        context=MetricContext(
-                            file_context=FileContext.from_metadata(metadata=metric.metadata),
-                            metric=MetricModelReference(metric_name=metric.name),
-                        ),
-                        message=f"Invalid measure {measure_reference.element_name} in metric {metric.name}",
-                    )
-                )
-        return issues
-
-    @staticmethod
-    @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
-    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:  # noqa: D
-        issues: List[ValidationIssueType] = []
-        valid_measure_names = []
-        for data_source in model.data_sources:
-            for measure in data_source.measures:
-                valid_measure_names.append(measure.reference.element_name)
-
-        for metric in model.metrics or []:
-            issues += MetricMeasuresRule._validate_metric_measure_references(
-                metric=metric, valid_measure_names=valid_measure_names
-            )
-        return issues
-
-
 class CumulativeMetricRule(ModelValidationRule):
     """Checks that cumulative sum metrics are configured properly"""
 

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -24,7 +24,7 @@ def test_can_configure_model_validator_rules(simple_model__pre_transforms: UserC
     issues = ModelValidator().validate_model(model).issues
     assert len(issues.all_issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
 
-    # confirm that a custom configuration excluding DataSourceMeasuresUniqueRule, no issue is raised
+    # confirm that a custom configuration excluding ValidMaterializationRule, no issue is raised
     rules = [rule for rule in ModelValidator.DEFAULT_RULES if rule.__class__ is not ValidMaterializationRule]
     issues = ModelValidator(rules=rules).validate_model(model).issues
     assert len(issues.all_issues) == 0, f"ModelValidator without ValidMaterializationRule returned issues {issues}"

--- a/metricflow/test/model/validations/test_measures.py
+++ b/metricflow/test/model/validations/test_measures.py
@@ -2,7 +2,6 @@ import copy
 import re
 
 import pytest
-
 from metricflow.model.objects.metric import Metric, MetricInputMeasure, MetricType, MetricTypeParams
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.model_validator import ModelValidator
@@ -67,3 +66,158 @@ def test_measures_only_exist_in_one_data_source(simple_model__pre_transforms: Us
                 found_issue = True
 
     assert found_issue is True
+
+
+def test_measure_alias_is_set_when_required(simple_model__pre_transforms: UserConfiguredModel) -> None:
+    """Tests to ensure that an appropriate error appears when a required alias is missing"""
+    model = copy.deepcopy(simple_model__pre_transforms)
+    measure_name = find_data_source_with(model, lambda data_source: len(data_source.measures) > 0)[0].measures[0].name
+    model.metrics.append(
+        Metric(
+            name="metric1",
+            type=MetricType.EXPR,
+            type_params=MetricTypeParams(
+                measures=[
+                    MetricInputMeasure(name=measure_name),
+                    MetricInputMeasure(name=measure_name, constraint="is_instant"),
+                ]
+            ),
+        )
+    )
+
+    build = ModelValidator().validate_model(model)
+
+    assert len(build.issues.errors) == 1
+    expected_error_substring = f"depends on multiple different constrained versions of measure {measure_name}"
+    actual_error = build.issues.errors[0].as_readable_str()
+    assert (
+        actual_error.find(expected_error_substring) != -1
+    ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
+
+
+def test_invalid_measure_alias_name(simple_model__pre_transforms: UserConfiguredModel) -> None:
+    """Tests measures with aliases that don't pass the unique and valid name rule"""
+    model = copy.deepcopy(simple_model__pre_transforms)
+    measure_name = find_data_source_with(model, lambda data_source: len(data_source.measures) > 0)[0].measures[0].name
+    invalid_alias = "_can't_do_this_"
+    model.metrics.append(
+        Metric(
+            name="metric1",
+            type=MetricType.EXPR,
+            type_params=MetricTypeParams(
+                measures=[MetricInputMeasure(name=measure_name, constraint="is_instant", alias=invalid_alias)]
+            ),
+        )
+    )
+
+    build = ModelValidator().validate_model(model)
+
+    assert len(build.issues.errors) == 1
+    expected_error_substring = f"Invalid name `{invalid_alias}` - names should only consist of"
+    actual_error = build.issues.errors[0].as_readable_str()
+    assert (
+        actual_error.find(expected_error_substring) != -1
+    ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
+
+
+def test_measure_alias_measure_name_conflict(simple_model__pre_transforms: UserConfiguredModel) -> None:
+    """Tests measures with aliases that already exist as measure names"""
+    model = copy.deepcopy(simple_model__pre_transforms)
+    measures = find_data_source_with(model, lambda data_source: len(data_source.measures) > 1)[0].measures
+    measure_name = measures[0].name
+    invalid_alias = measures[1].name
+    model.metrics.append(
+        Metric(
+            name="metric1",
+            type=MetricType.EXPR,
+            type_params=MetricTypeParams(
+                measures=[MetricInputMeasure(name=measure_name, constraint="is_instant", alias=invalid_alias)]
+            ),
+        )
+    )
+
+    build = ModelValidator().validate_model(model)
+
+    assert len(build.issues.errors) == 1
+    expected_error_substring = (
+        f"Alias `{invalid_alias}` for measure `{measure_name}` conflicts with measure names "
+        f"defined elsewhere in the model!"
+    )
+    actual_error = build.issues.errors[0].as_readable_str()
+    assert (
+        actual_error.find(expected_error_substring) != -1
+    ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
+
+
+def test_reused_measure_alias(simple_model__pre_transforms: UserConfiguredModel) -> None:
+    """Tests measures with aliases that have been used as measure aliases elsewhere in the model"""
+    model = copy.deepcopy(simple_model__pre_transforms)
+    measures = find_data_source_with(model, lambda data_source: len(data_source.measures) > 1)[0].measures
+    first_measure_name = measures[0].name
+    second_measure_name = measures[1].name
+    invalid_alias = "duplicate_alias"
+    model.metrics.append(
+        Metric(
+            name="metric1",
+            type=MetricType.EXPR,
+            type_params=MetricTypeParams(
+                measures=[MetricInputMeasure(name=first_measure_name, constraint="is_instant", alias=invalid_alias)]
+            ),
+        ),
+    )
+    model.metrics.append(
+        Metric(
+            name="metric2",
+            type=MetricType.EXPR,
+            type_params=MetricTypeParams(
+                measures=[MetricInputMeasure(name=second_measure_name, constraint="is_instant", alias=invalid_alias)]
+            ),
+        ),
+    )
+
+    build = ModelValidator().validate_model(model)
+
+    assert len(build.issues.errors) == 1
+    expected_error_substring = (
+        f"Measure alias {invalid_alias} conflicts with a measure alias used elsewhere in the model!"
+    )
+    actual_error = build.issues.errors[0].as_readable_str()
+    assert (
+        actual_error.find(expected_error_substring) != -1
+    ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"
+
+
+def test_reused_measure_alias_within_metric(simple_model__pre_transforms: UserConfiguredModel) -> None:
+    """Tests measures with aliases that have been used as measure aliases in the same metric spec
+
+    This covers a boundary case in the logic where alias checking must always include aliases from the current
+    metric under consideration, instead of simply checking against the previous seen values
+    """
+    model = copy.deepcopy(simple_model__pre_transforms)
+    measures = find_data_source_with(model, lambda data_source: len(data_source.measures) > 1)[0].measures
+    first_measure_name = measures[0].name
+    second_measure_name = measures[1].name
+    invalid_alias = "duplicate_alias"
+    model.metrics.append(
+        Metric(
+            name="metric1",
+            type=MetricType.EXPR,
+            type_params=MetricTypeParams(
+                measures=[
+                    MetricInputMeasure(name=first_measure_name, constraint="is_instant", alias=invalid_alias),
+                    MetricInputMeasure(name=second_measure_name, constraint="is_instant", alias=invalid_alias),
+                ]
+            ),
+        ),
+    )
+
+    build = ModelValidator().validate_model(model)
+
+    assert len(build.issues.errors) == 1
+    expected_error_substring = (
+        f"Measure alias {invalid_alias} conflicts with a measure alias used elsewhere in the model!"
+    )
+    actual_error = build.issues.errors[0].as_readable_str()
+    assert (
+        actual_error.find(expected_error_substring) != -1
+    ), f"Expected error {expected_error_substring} not found in error string! Instead got {actual_error}"

--- a/metricflow/test/model/validations/test_metrics.py
+++ b/metricflow/test/model/validations/test_metrics.py
@@ -15,33 +15,6 @@ from metricflow.test.model.validations.helpers import data_source_with_guarantee
 from metricflow.time.time_granularity import TimeGranularity
 
 
-@pytest.mark.skip("TODO: Will convert to validation rule")
-def test_metric_missing_measure() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException):
-        measure_name = "my_measure"
-        measure2_name = "nonexistent_measure"
-        model_validator = ModelValidator()
-        model_validator.checked_validations(
-            UserConfiguredModel(
-                data_sources=[
-                    data_source_with_guaranteed_meta(
-                        name="sum_measure",
-                        sql_query="SELECT foo FROM bar",
-                        measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
-                        mutability=Mutability(type=MutabilityType.IMMUTABLE),
-                    )
-                ],
-                metrics=[
-                    metric_with_guaranteed_meta(
-                        name="metric_with_nonexistent_measure",
-                        type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure2_name]),
-                    )
-                ],
-            )
-        )
-
-
 def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
     dim_name = "country"
     dim2_name = "ename"


### PR DESCRIPTION
The addition of measure constraints opens up the possibility of
two different variations on the same measure. When this happens users
must provide an alias for each distinctly constrained variation of
the input measure.

This adds a validator to enforce that model contract, and to provide
better user-facing error messages than whatever inscrutable SQL
errors might arise as a result of rendering two different measure
inputs with the same alias. We also enforce our standard naming
constraints, including that aliases must not collide with measure
names. This last is potentially unnecessary, but until we get more
experience with our query layouts and address possible downstream
optimizations it is prudent to apply a more restrictive policy.