### PR TITLE
Clean up measures_by_additiveness behavior

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -527,9 +527,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             measures_by_additiveness = grouped_measures_by_additiveness.measures_by_additiveness
 
             # Build output nodes for each distinct non-additive dimension spec
-            for measure_specs in measures_by_additiveness:
-                assert len(measure_specs) > 0, "received empy set of measure specs, this should not happen!"
-                non_additive_spec = measure_specs[0].non_additive_dimension_spec
+            for non_additive_spec, measure_specs in measures_by_additiveness.items():
                 logger.info(
                     f"Building aggregated measures for {data_source} with non-additive dimension spec: {non_additive_spec}"
                 )

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -526,11 +526,13 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             )
             measures_by_additiveness = grouped_measures_by_additiveness.measures_by_additiveness
 
-            # Build output nodes for each distinct non-additive dimension spec
+            # Build output nodes for each distinct non-additive dimension spec, including the None case
             for non_additive_spec, measure_specs in measures_by_additiveness.items():
-                logger.info(
-                    f"Building aggregated measures for {data_source} with non-additive dimension spec: {non_additive_spec}"
-                )
+                non_additive_message = ""
+                if non_additive_spec is not None:
+                    non_additive_message = f" with non-additive dimension spec: {non_additive_spec}"
+
+                logger.info(f"Building aggregated measures for {data_source}{non_additive_message}")
                 input_specs = tuple(input_specs_by_measure_spec[measure_spec] for measure_spec in measure_specs)
                 output_nodes.append(
                     self._build_aggregated_measures_from_measure_source_node(


### PR DESCRIPTION
An earlier commit added a property for getting measures by additiveness,
and returned a tuple of tuples, which made it a bit unclear at the
callsite that these inner tuples were grouped by a particular key.
We change it to a dict to make that relationship more obvious.
