### PR TITLE
Allow updates to SqlBindParameters if item is same

### DIFF
--- a/metricflow/sql/sql_bind_parameters.py
+++ b/metricflow/sql/sql_bind_parameters.py
@@ -17,7 +17,7 @@ class SqlBindParameters(HashableBaseModel):
     def update(self, additional_params: SqlBindParameters) -> None:
         """Add the parameters to this set, mutating it."""
         for key, value in additional_params.param_dict.items():
-            if key in self.param_dict:
+            if key in self.param_dict and self.param_dict[key] != value:
                 raise RuntimeError(
                     f"Conflict with key {key} in merging parameters. "
                     f"Existing params: {self.param_dict} Additional params: {additional_params}"

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -189,3 +189,18 @@ def test_cancel_submitted_queries(  # noqa: D
     with pytest.raises(ProgrammingError):
         if sql_client.sql_engine_attributes.sql_engine_type == SupportedSqlEngine.SNOWFLAKE:
             _issue_sleep_query(sql_client, 5)
+
+
+def test_update_params_with_same_item() -> None:  # noqa: D
+    bind_params0 = SqlBindParameters(param_dict=OrderedDict({"key": "value"}))
+    bind_params1 = SqlBindParameters(param_dict=OrderedDict({"key": "value"}))
+
+    bind_params0.update(bind_params1)
+
+
+def test_update_params_with_same_key_different_values() -> None:  # noqa: D
+    bind_params0 = SqlBindParameters(param_dict=OrderedDict({"key": "value0"}))
+    bind_params1 = SqlBindParameters(param_dict=OrderedDict({"key": "value1"}))
+
+    with pytest.raises(RuntimeError):
+        bind_params0.update(bind_params1)


### PR DESCRIPTION
During the construction of queries where a constrained measure is used multiple times, it's possible for the SQL tree to use the same bind parameters multiple times.