### PR TITLE
Semi-additive (Support alternate granularity)

### DIFF
--- a/metricflow/aggregation_properties.py
+++ b/metricflow/aggregation_properties.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from enum import Enum
+
 from metricflow.object_utils import ExtendedEnum
 
 
@@ -37,3 +39,15 @@ class AggregationType(ExtendedEnum):
         2. We can calculate the "other" column in the postprocessor (meaning the metric is expansive)
         """
         return self in (AggregationType.SUM, AggregationType.SUM_BOOLEAN)
+
+
+class AggregationState(Enum):
+    """Represents how the measure is aggregated."""
+
+    # When reading from the source, the measure is considered non-aggregated.
+    NON_AGGREGATED = "NON_AGGREGATED"
+    PARTIAL = "PARTIAL"
+    COMPLETE = "COMPLETE"
+
+    def __repr__(self) -> str:  # noqa: D
+        return f"{self.__class__.__name__}.{self.name}"

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -2,59 +2,25 @@ from typing import Sequence, List
 
 from metricflow.dataflow.dataflow_plan import (
     BaseOutput,
-    FilterElementsNode,
     MetricTimeDimensionTransformNode,
     ReadSqlSourceNode,
-    SemiAdditiveJoinNode,
 )
-from metricflow.dataflow.builder.measure_additiveness import group_measure_specs_by_additiveness
 from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.specs import LinklessIdentifierSpec, NonAdditiveDimensionSpec, TimeDimensionSpec, InstanceSpec
-from metricflow.plan_conversion.instance_converters import RemoveMeasures
 
 
 class SourceNodeBuilder:
     """Helps build source nodes to use in the dataflow plan builder.
 
     The current use case is for creating a set of input nodes from a data set to support multiple aggregation time
-    dimensions. Each data set is converted into k DataFlowPlan nodes, one per distinct
-    (aggregation time dimension, additive_group_property) pair used in the definition of a measure.
+    dimensions. Each data set is converted into k DataFlowPlan nodes.
     """
 
     def __init__(self, semantic_model: SemanticModel) -> None:  # noqa: D
         self._semantic_model = semantic_model
 
-    def _build_semi_additive_source_node(
-        self,
-        parent_node: BaseOutput[DataSourceDataSet],
-        non_additive_dimension_spec: NonAdditiveDimensionSpec,
-        filter_specs: Sequence[InstanceSpec],
-    ) -> SemiAdditiveJoinNode[DataSourceDataSet]:
-        """Builds a SemiAdditiveJoinNode given measures and non-additive dimension attributes."""
-        filter_semi_additive_measure_node = FilterElementsNode[DataSourceDataSet](
-            parent_node=parent_node,
-            include_specs=filter_specs,
-            replace_description="Pass Only Semi-additive Measures",
-        )
-
-        time_dimension_spec = TimeDimensionSpec.from_name(non_additive_dimension_spec.name)
-        window_groupings = tuple(
-            LinklessIdentifierSpec.from_element_name(name) for name in non_additive_dimension_spec.window_groupings
-        )
-        return SemiAdditiveJoinNode[DataSourceDataSet](
-            parent_node=filter_semi_additive_measure_node,
-            identifier_specs=window_groupings,
-            time_dimension_spec=time_dimension_spec,
-            agg_by_function=non_additive_dimension_spec.window_choice,
-        )
-
     def create_from_data_sets(self, data_sets: Sequence[DataSourceDataSet]) -> Sequence[BaseOutput[DataSourceDataSet]]:
-        """Creates source nodes from DataSourceDataSets.
-
-        Semi-additive measures are handled by grouping all measures with the same non-additive dimension attribute
-        into one DataFlowPlan node.
-        """
+        """Creates source nodes from DataSourceDataSets."""
         source_nodes: List[BaseOutput[DataSourceDataSet]] = []
         for data_set in data_sets:
             read_node = ReadSqlSourceNode[DataSourceDataSet](data_set)
@@ -63,7 +29,6 @@ class SourceNodeBuilder:
                     data_set.data_source_reference
                 )
             )
-            instance_set_with_no_measures = data_set.instance_set.transform(RemoveMeasures())
 
             # Dimension sources may not have any measures -> no aggregation time dimensions.
             time_dimension_references = agg_time_dim_to_measures_grouper.keys
@@ -72,39 +37,10 @@ class SourceNodeBuilder:
             else:
                 # Splits the measures by distinct aggregate time dimension.
                 for time_dimension_reference in time_dimension_references:
-                    measures = agg_time_dim_to_measures_grouper.get_values(time_dimension_reference)
-                    grouped_measures_by_additiveness = group_measure_specs_by_additiveness(measures)
-                    additive_measure_specs = grouped_measures_by_additiveness.additive_measures
-
-                    # Build source node for additive measures
-                    if additive_measure_specs:
-                        filter_elements_node = FilterElementsNode[DataSourceDataSet](
+                    source_nodes.append(
+                        MetricTimeDimensionTransformNode[DataSourceDataSet](
                             parent_node=read_node,
-                            include_specs=tuple(instance_set_with_no_measures.spec_set.all_specs)
-                            + additive_measure_specs,
-                            replace_description="Pass Only Additive Measures",
+                            aggregation_time_dimension_reference=time_dimension_reference,
                         )
-                        source_nodes.append(
-                            MetricTimeDimensionTransformNode[DataSourceDataSet](
-                                parent_node=filter_elements_node,
-                                aggregation_time_dimension_reference=time_dimension_reference,
-                            )
-                        )
-
-                    # Build a SemiAdditiveJoinNode for each semi-additive measure grouping.
-                    grouped_semi_additive_measures = grouped_measures_by_additiveness.grouped_semi_additive_measures
-                    for measure_group in grouped_semi_additive_measures:
-                        non_additive_dimension_spec = measure_group[0].non_additive_dimension_spec
-                        assert non_additive_dimension_spec
-                        semi_additive_join_node = self._build_semi_additive_source_node(
-                            parent_node=read_node,
-                            non_additive_dimension_spec=non_additive_dimension_spec,
-                            filter_specs=tuple(instance_set_with_no_measures.spec_set.all_specs) + measure_group,
-                        )
-                        source_nodes.append(
-                            MetricTimeDimensionTransformNode[DataSourceDataSet](
-                                parent_node=semi_additive_join_node,
-                                aggregation_time_dimension_reference=time_dimension_reference,
-                            )
-                        )
+                    )
         return source_nodes

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -3,6 +3,7 @@ import re
 from dataclasses import dataclass
 from typing import Optional, List, Tuple, Sequence
 
+from metricflow.aggregation_properties import AggregationState
 from metricflow.dag.id_generation import IdGeneratorRegistry
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.data_source_adapter import DataSourceDataSet
@@ -14,7 +15,6 @@ from metricflow.instances import (
     IdentifierInstance,
     InstanceSet,
     DataSourceReference,
-    AggregationState,
 )
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType

--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import Enum
 from typing import List, TypeVar, Generic, Tuple
 
+from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import ColumnAssociation
 from metricflow.dataclass_serialization import SerializableDataclass
 from metricflow.specs import (
@@ -102,18 +102,6 @@ class MdoInstance(ABC, Generic[SpecT]):
 class DataSourceElementInstance(SerializableDataclass):  # noqa: D
     # This instance is derived from something defined in a data source.
     defined_from: Tuple[DataSourceElementReference, ...]
-
-
-class AggregationState(Enum):
-    """Represents how the measure is aggregated."""
-
-    # When reading from the source, the measure is considered non-aggregated.
-    NON_AGGREGATED = "NON_AGGREGATED"
-    PARTIAL = "PARTIAL"
-    COMPLETE = "COMPLETE"
-
-    def __repr__(self) -> str:  # noqa: D
-        return f"{self.__class__.__name__}.{self.name}"
 
 
 @dataclass(frozen=True)

--- a/metricflow/model/objects/elements/measure.py
+++ b/metricflow/model/objects/elements/measure.py
@@ -14,7 +14,9 @@ class NonAdditiveDimensionParameters(HashableBaseModel):
     """
 
     name: str
-    window_choice: AggregationType
+
+    # Optional Fields
+    window_choice: AggregationType = AggregationType.MIN
     window_groupings: List[str] = []
 
 

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -155,7 +155,7 @@ non_additive_dimension_schema = {
         },
     },
     "additionalProperties": False,
-    "required": ["name", "window_choice"],
+    "required": ["name"],
 }
 
 measure_schema = {

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -26,6 +26,9 @@ identifier_type_enum_values += [x.lower() for x in identifier_type_enum_values]
 aggregation_type_values = ["SUM", "MIN", "MAX", "AVERAGE", "COUNT_DISTINCT", "BOOLEAN", "SUM_BOOLEAN"]
 aggregation_type_values += [x.lower() for x in aggregation_type_values]
 
+window_aggregation_type_values = ["MIN", "MAX"]
+window_aggregation_type_values += [x.lower() for x in window_aggregation_type_values]
+
 time_granularity_values = ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
 time_granularity_values += [x.lower() for x in time_granularity_values]
 
@@ -148,7 +151,7 @@ non_additive_dimension_schema = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},
-        "window_choice": {"enum": aggregation_type_values},
+        "window_choice": {"enum": window_aggregation_type_values},
         "window_groupings": {
             "type": "array",
             "items": {"type": "string"},

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -685,20 +685,10 @@
                 },
                 "window_choice": {
                     "enum": [
-                        "SUM",
                         "MIN",
                         "MAX",
-                        "AVERAGE",
-                        "COUNT_DISTINCT",
-                        "BOOLEAN",
-                        "SUM_BOOLEAN",
-                        "sum",
                         "min",
-                        "max",
-                        "average",
-                        "count_distinct",
-                        "boolean",
-                        "sum_boolean"
+                        "max"
                     ]
                 },
                 "window_groupings": {

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -709,8 +709,7 @@
                 }
             },
             "required": [
-                "name",
-                "window_choice"
+                "name"
             ],
             "type": "object"
         }

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -171,6 +171,7 @@ class DataSourceSemantics:
         self._measure_aggs: Dict[
             MeasureReference, AggregationType
         ] = {}  # maps measures to their one consistent aggregation
+        self._measure_agg_time_dimension: Dict[MeasureReference, TimeDimensionReference] = {}
         self._measure_non_additive_dimension_specs: Dict[MeasureReference, NonAdditiveDimensionSpec] = {}
         self._dimension_index: Dict[DimensionReference, List[DataSource]] = defaultdict(list)
         self._linkable_reference_index: Dict[LinkableElementReference, List[DataSource]] = defaultdict(list)
@@ -251,6 +252,11 @@ class DataSourceSemantics:
     def get_data_sources_for_measure(self, measure_reference: MeasureReference) -> List[DataSource]:  # noqa: D
         return self._measure_index[measure_reference]
 
+    def get_agg_time_dimension_for_measure(  # noqa: D
+        self, measure_reference: MeasureReference
+    ) -> TimeDimensionReference:
+        return self._measure_agg_time_dimension[measure_reference]
+
     def get_identifier_in_data_source(self, ref: DataSourceElementReference) -> Optional[Identifier]:  # Noqa: d
         data_source = self.get(ref.data_source_name)
         if not data_source:
@@ -318,6 +324,7 @@ class DataSourceSemantics:
                 key=agg_time_dimension,
                 value=MeasureConverter.convert_to_measure_spec(measure=measure),
             )
+            self._measure_agg_time_dimension[measure.reference] = agg_time_dimension
             if measure.non_additive_dimension:
                 non_additive_dimension_spec = NonAdditiveDimensionSpec(
                     name=measure.non_additive_dimension.name,

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
 from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import (
@@ -49,7 +49,9 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
-    def resolve_time_dimension_spec(self, time_dimension_spec: TimeDimensionSpec) -> ColumnAssociation:  # noqa: D
+    def resolve_time_dimension_spec(  # noqa: D
+        self, time_dimension_spec: TimeDimensionSpec, aggregation_state: Optional[AggregationState] = None
+    ) -> ColumnAssociation:
         if time_dimension_spec.time_granularity == TimeGranularity.DAY:
             column_name = StructuredLinkableSpecName(
                 identifier_link_names=tuple(x.element_name for x in time_dimension_spec.identifier_links),
@@ -63,7 +65,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
             ).qualified_name
 
         return ColumnAssociation(
-            column_name=column_name,
+            column_name=column_name + (f"__{aggregation_state.value.lower()}" if aggregation_state else ""),
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Tuple
 
+from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import (
     SingleColumnCorrelationKey,
     ColumnAssociation,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1429,39 +1429,43 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         specified dimension that is non-additive. Then that dataset would be joined with the input data
         on that dimension along with grouping by identifiers that are also passed in.
         """
-        input_data_set: SqlDataSet = node.parent_node.accept(self)
+        from_data_set: SqlDataSet = node.parent_node.accept(self)
 
         from_data_set_alias = self._next_unique_table_alias()
 
         # Get the output_instance_set of the parent_node
-        output_instance_set = input_data_set.instance_set
+        output_instance_set = from_data_set.instance_set
         output_instance_set = output_instance_set.transform(ChangeAssociatedColumns(self._column_association_resolver))
 
         # Build the JoinDescriptions to handle the row base filtering on the output_data_set
-        join_data_set_alias = self._next_unique_table_alias()
+        inner_join_data_set_alias = self._next_unique_table_alias()
 
         column_equality_descriptions: List[ColumnEqualityDescription] = []
 
         # Build Time Dimension SqlSelectColumn
         time_dimension_column_name = self.column_association_resolver.resolve_time_dimension_spec(
-            node.time_dimension_spec
+            time_dimension_spec=node.time_dimension_spec
+        ).column_name
+        join_time_dimension_column_name = self.column_association_resolver.resolve_time_dimension_spec(
+            time_dimension_spec=node.time_dimension_spec,
+            aggregation_state=AggregationState.COMPLETE,
         ).column_name
         time_dimension_select_column = SqlSelectColumn(
             expr=SqlFunctionExpression.from_aggregation_type(
                 node.agg_by_function,
                 SqlColumnReferenceExpression(
                     SqlColumnReference(
-                        table_alias=join_data_set_alias,
+                        table_alias=inner_join_data_set_alias,
                         column_name=time_dimension_column_name,
                     ),
                 ),
             ),
-            column_alias=f"{time_dimension_column_name}__{node.agg_by_function.value}",
+            column_alias=join_time_dimension_column_name,
         )
         column_equality_descriptions.append(
             ColumnEqualityDescription(
                 left_column_alias=time_dimension_column_name,
-                right_column_alias=time_dimension_select_column.column_alias,
+                right_column_alias=join_time_dimension_column_name,
             )
         )
 
@@ -1475,7 +1479,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                 SqlSelectColumn(
                     expr=SqlColumnReferenceExpression(
                         SqlColumnReference(
-                            table_alias=join_data_set_alias,
+                            table_alias=inner_join_data_set_alias,
                             column_name=identifier_column_name,
                         ),
                     ),
@@ -1498,7 +1502,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
             queried_time_dimension_select_column = SqlSelectColumn(
                 expr=SqlColumnReferenceExpression(
                     SqlColumnReference(
-                        table_alias=join_data_set_alias,
+                        table_alias=inner_join_data_set_alias,
                         column_name=query_time_dimension_column_name,
                     ),
                 ),
@@ -1512,14 +1516,15 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         row_filter_sql_select_node = SqlSelectStatementNode(
             description=f"Filter row on {node.agg_by_function.name}({time_dimension_column_name})",
             select_columns=tuple(identifier_select_columns) + (time_dimension_select_column,),
-            from_source=input_data_set.sql_select_node,
-            from_source_alias=join_data_set_alias,
+            from_source=from_data_set.sql_select_node,
+            from_source_alias=inner_join_data_set_alias,
             joins_descs=(),
             group_bys=row_filter_group_bys,
             where=None,
             order_bys=(),
         )
 
+        join_data_set_alias = self._next_unique_table_alias()
         sql_join_desc = make_equijoin_description(
             right_source_node=row_filter_sql_select_node,
             left_source_alias=from_data_set_alias,
@@ -1534,7 +1539,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                 select_columns=output_instance_set.transform(
                     CreateSelectColumnsForInstances(from_data_set_alias, self._column_association_resolver)
                 ).as_tuple(),
-                from_source=input_data_set.sql_select_node,
+                from_source=from_data_set.sql_select_node,
                 from_source_alias=from_data_set_alias,
                 joins_descs=(sql_join_desc,),
                 group_bys=(),

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TypeVar, Generic, Union, List, Sequence, Optional
 
+from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import ColumnAssociation, SingleColumnCorrelationKey
 from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.dag.id_generation import IdGeneratorRegistry
@@ -31,7 +32,6 @@ from metricflow.dataflow.dataflow_plan import (
 )
 from metricflow.dataset.dataset import DataSet
 from metricflow.instances import (
-    AggregationState,
     InstanceSet,
     MetricInstance,
     MetricModelReference,

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -7,8 +7,8 @@ from collections import OrderedDict
 from itertools import chain
 from typing import List, Sequence, Optional, Dict, Tuple
 
+from metricflow.aggregation_properties import AggregationState
 from metricflow.instances import (
-    AggregationState,
     MdoInstance,
     DimensionInstance,
     IdentifierInstance,

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -86,6 +86,10 @@ class DataSourceSemanticsAccessor(Protocol):
         raise NotImplementedError
 
     @abstractmethod
+    def get_agg_time_dimension_for_measure(self, measure_reference: MeasureReference) -> TimeDimensionReference:
+        """Retrieves the aggregate time dimension that is associated with the measure reference"""
+
+    @abstractmethod
     def get_identifier_in_data_source(self, ref: DataSourceElementReference) -> Optional[Identifier]:
         """Retrieve the identifier matching the element -> data source mapping, if any"""
         raise NotImplementedError

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -1,5 +1,6 @@
 import logging
 
+from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import ColumnAssociation, SingleColumnCorrelationKey
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.dataflow_plan import ReadSqlSourceNode, JoinToBaseOutputNode, JoinDescription
@@ -8,7 +9,6 @@ from metricflow.instances import (
     InstanceSet,
     MeasureInstance,
     DataSourceElementReference,
-    AggregationState,
 )
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver

--- a/metricflow/test/fixtures/model_yamls/simple_model/data_sources/accounts_source.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/data_sources/accounts_source.yaml
@@ -35,6 +35,8 @@ data_source:
       type_params:
         is_primary: True
         time_granularity: day
+    - name: account_type
+      type: categorical
 
   identifiers:
     - name: user

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -246,18 +246,21 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
     )
 
     accounts_data = [
-        ("u0004114", 2135, "2020-01-01"),
-        ("u0005432", 5234, "2020-01-03"),
-        ("u0003141", 24634, "2020-01-01"),
-        ("u0003154", 23452, "2020-01-01"),
-        ("u0004114", 1213, "2020-01-06"),
-        ("u1612112", 5123, "2020-01-02"),
-        ("u0004114", 523, "2020-01-07"),
-        ("u0004114", 7434, "2020-01-10"),
-        ("u0005432", 8456, "2020-01-02"),
-        ("u0003141", 12939, "2020-01-12"),
-        ("u0003452", 6939, "2020-01-02"),
-        ("u0003452", 35, "2020-01-12"),
+        ("u0004114", 2135, "2020-01-01", "checking"),
+        ("u0004114", 1234, "2020-01-01", "savings"),
+        ("u0005432", 5234, "2020-01-03", "checking"),
+        ("u0005432", 234, "2020-01-03", "savings"),
+        ("u0003141", 24634, "2020-01-01", "checking"),
+        ("u0003154", 23452, "2020-01-01", "checking"),
+        ("u0004114", 1213, "2020-01-06", "savings"),
+        ("u1612112", 5123, "2020-01-02", "checking"),
+        ("u0004114", 523, "2020-01-07", "checking"),
+        ("u0004114", 7434, "2020-01-10", "checkings"),
+        ("u0005432", 8456, "2020-01-02", "savings"),
+        ("u0003141", 12939, "2020-01-12", "checking"),
+        ("u0003452", 6939, "2020-01-02", "checking"),
+        ("u0003452", 35, "2020-01-12", "checking"),
+        ("u0005414", 5582, "2020-01-04", "savings"),
     ]
 
     create_table(
@@ -265,7 +268,7 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
         sql_table=SqlTable(schema_name=schema, table_name="fct_accounts"),
         df=make_df(
             sql_client=sql_client,
-            columns=["user_id", "account_balance", DEFAULT_DS],
+            columns=["user_id", "account_balance", DEFAULT_DS, "account_type"],
             time_columns={DEFAULT_DS},
             data=accounts_data,
         ),

--- a/metricflow/test/integration/test_cases/itest_measure_constraints.yaml
+++ b/metricflow/test/integration/test_cases/itest_measure_constraints.yaml
@@ -135,26 +135,56 @@ integration_test:
     FROM (
       SELECT
         CAST(SUM(account_balance) AS {{ double_data_type_name }}) AS total_account_balance_first_day
-        , fa_west.ds
-      FROM {{ source_schema }}.fct_accounts fa_west
+        , fa_west_filtered.ds
+      FROM (
+        SELECT 
+          fa_west.ds
+          , fa_west.ds AS metric_time
+          , user_id AS user
+          , account_balance
+        FROM {{ source_schema }}.fct_accounts fa_west
+        INNER JOIN (
+          SELECT
+            MIN(ds) AS ds__min
+          FROM {{ source_schema }}.fct_accounts
+          GROUP BY
+            ds
+        ) c
+        ON
+          fa_west.ds = c.ds__min
+      ) fa_west_filtered
       LEFT OUTER JOIN {{ source_schema }}.dim_users_latest dul_west
-      ON fa_west.user_id = dul_west.user_id
+      ON fa_west_filtered.user = dul_west.user_id
       WHERE dul_west.home_state_latest IN ('CA', 'HI', 'WA')
-      GROUP BY fa_west.ds
+      GROUP BY fa_west_filtered.ds
     ) a
     JOIN (
       SELECT
         CAST(SUM(account_balance) AS {{ double_data_type_name }}) AS total_account_balance_first_day
-        , fa_east.ds
-      FROM {{ source_schema }}.fct_accounts fa_east
+        , fa_east_filtered.ds
+      FROM (
+        SELECT 
+          fa_east.ds
+          , fa_east.ds AS metric_time
+          , user_id AS user
+          , account_balance
+        FROM {{ source_schema }}.fct_accounts fa_east
+        INNER JOIN (
+          SELECT
+            MIN(ds) AS ds__min
+          FROM {{ source_schema }}.fct_accounts
+          GROUP BY
+            ds
+        ) d
+        ON
+          fa_east.ds = d.ds__min
+      ) fa_east_filtered
       LEFT OUTER JOIN {{ source_schema }}.dim_users_latest dul_east
-      ON fa_east.user_id = dul_east.user_id
+      ON fa_east_filtered.user = dul_east.user_id
       WHERE dul_east.home_state_latest IN ('MD', 'NY', 'TX')
-      GROUP BY fa_east.ds
+      GROUP BY fa_east_filtered.ds
     ) b
     ON a.ds = b.ds
-    -- Patch to cover current behavior of only considering the min value in the time constraint regional_starting_balance_ratios
-    WHERE COALESCE(a.ds, b.ds) = '2020-01-01'
 ---
 integration_test:
   name: expr_with_single_constrained_and_aliased_measure

--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -1,6 +1,6 @@
 ---
 integration_test:
-  name: semi_additive_measure_query_with_grouping
+  name: semi_additive_measure_query_with_identifier_grouping
   description: Tests selecting a measure with semi additive properties with a window_grouping
   model: SIMPLE_MODEL
   metrics: ["current_account_balance_by_user"]
@@ -48,7 +48,10 @@ integration_test:
     INNER JOIN (
       SELECT
         MIN(ds) AS ds
+        , {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time
       FROM {{ source_schema }}.fct_accounts
+      GROUP BY
+        metric_time
     ) b
     ON
       a.ds = b.ds
@@ -106,3 +109,119 @@ integration_test:
     WHERE user__home_state_latest = 'CA'
     GROUP BY
       e.user
+---
+integration_test:
+  name: semi_additive_measure_query_with_group_by_window
+  description: Tests selecting a semi-additive measure with a group by window
+  model: SIMPLE_MODEL
+  metrics: ["total_account_balance_first_day"]
+  group_bys: ["ds__week"]
+  check_query: |
+    SELECT
+      a.ds__week
+      , SUM(a.total_account_balance_first_day) AS total_account_balance_first_day
+    FROM (
+      SELECT
+        ds
+        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS ds__week
+        , account_balance AS total_account_balance_first_day
+      FROM {{ source_schema }}.fct_accounts
+    ) a
+    INNER JOIN (
+      SELECT
+        MIN(ds) AS ds
+        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS ds__week
+      FROM {{ source_schema }}.fct_accounts
+      GROUP BY
+        ds__week
+    ) b
+    ON
+      a.ds = b.ds
+    GROUP BY
+      a.ds__week
+---
+integration_test:
+  name: semi_additive_measure_query_with_where_constraint
+  description: Tests selecting a semi-additive measure with where_constraint
+  model: SIMPLE_MODEL
+  metrics: ["current_account_balance_by_user"]
+  group_bys: ["user"]
+  where_constraint: "account_type = 'savings'"
+  check_query: |
+    SELECT
+      b.user AS user
+      , SUM(b.current_account_balance_by_user) AS current_account_balance_by_user
+    FROM (
+      SELECT
+        ds
+        , a.user
+        , current_account_balance_by_user
+      FROM (
+        SELECT
+          ds
+          , user_id AS user
+          , account_type
+          , account_balance AS current_account_balance_by_user
+        FROM {{ source_schema }}.fct_accounts
+      ) a
+      WHERE account_type = 'savings'
+    ) b
+    INNER JOIN (
+      SELECT
+        c.user
+        , MAX(ds) AS ds__complete
+      FROM (
+        SELECT
+          ds
+          , user_id AS user
+          , account_type
+        FROM {{ source_schema }}.fct_accounts
+      ) c
+      WHERE account_type = 'savings'
+      GROUP BY
+        c.user
+    ) d
+    ON
+      (b.ds = d.ds__complete) AND (b.user = d.user)
+    GROUP BY
+      b.user
+---
+integration_test:
+  name: semi_additive_measure_query_with_where_time_constraint
+  description: Tests selecting a semi-additive measure with a time constraint written as a where clause
+  model: SIMPLE_MODEL
+  metrics: ["total_account_balance_first_day"]
+  group_bys: ["account_type"]
+  where_constraint: "ds >= '2020-01-03'"
+  check_query: |
+    SELECT
+      b.account_type AS account_type
+      , SUM(b.total_account_balance_first_day) AS total_account_balance_first_day
+    FROM (
+      SELECT
+        ds
+        , account_type
+        , total_account_balance_first_day
+      FROM (
+        SELECT
+          ds
+          , account_type
+          , account_balance AS total_account_balance_first_day
+        FROM {{ source_schema }}.fct_accounts
+      ) a
+      WHERE ds >= '2020-01-03'
+    ) b
+    INNER JOIN (
+      SELECT
+        MIN(ds) AS ds__complete
+      FROM (
+        SELECT
+          ds
+        FROM {{ source_schema }}.fct_accounts
+      ) c
+      WHERE ds >= '2020-01-03'
+    ) d
+    ON
+      b.ds = d.ds__complete
+    GROUP BY
+      b.account_type

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -205,7 +205,8 @@ def test_case(
     )
 
     actual = query_result.result_df
-
+    print(actual)
+    print(query_result.sql)
     expected = sql_client.query(
         jinja2.Template(case.check_query, undefined=jinja2.StrictUndefined,).render(
             source_schema=mf_test_session_state.mf_source_schema,

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -32,6 +32,7 @@ def new_metric_semantics(  # Noqa: D
 
 def test_get_names(new_data_source_semantics: DataSourceSemantics) -> None:  # noqa: D
     expected = [
+        "account_type",
         "booking_paid_at",
         "capacity_latest",
         "company_name",

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -36,8 +36,8 @@ def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) 
 
     # We update the matching categorical dimension by reference for convenience
     ds_measure_x_dimension.get_dimension(dimension_reference).name = measure_reference.element_name
-    ds_measure_x_identifier.identifiers[1].name = measure_reference.element_name
-    ds_dimension_x_identifier.identifiers[1].name = dimension_reference.element_name
+    ds_measure_x_identifier.identifiers[0].name = measure_reference.element_name
+    ds_dimension_x_identifier.identifiers[0].name = dimension_reference.element_name
 
     model.data_sources[usable_ds_index] = ds_measure_x_dimension
     with pytest.raises(

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/BigQuerySqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/BigQuerySqlClient/test_build_metric_tasks__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time']
@@ -15,6 +14,6 @@ FROM (
   FROM (
     SELECT * FROM ***************************.fct_animals
   ) animals_src_0
-) subq_3
+) subq_2
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/DuckDbSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/DuckDbSqlClient/test_build_metric_tasks__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time']
@@ -15,6 +14,6 @@ FROM (
   FROM (
     SELECT * FROM ***************************.fct_animals
   ) animals_src_0
-) subq_3
+) subq_2
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/PostgresSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/PostgresSqlClient/test_build_metric_tasks__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time']
@@ -15,6 +14,6 @@ FROM (
   FROM (
     SELECT * FROM ***************************.fct_animals
   ) animals_src_0
-) subq_3
+) subq_2
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/RedshiftSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/RedshiftSqlClient/test_build_metric_tasks__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time']
@@ -15,6 +14,6 @@ FROM (
   FROM (
     SELECT * FROM ***************************.fct_animals
   ) animals_src_0
-) subq_3
+) subq_2
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/SnowflakeSqlClient/test_build_metric_tasks__query0.sql
+++ b/metricflow/test/snapshots/test_data_warehouse_tasks.py/data_warehouse_validation_model/SnowflakeSqlClient/test_build_metric_tasks__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(count_dogs) AS count_dogs
 FROM (
   -- Read Elements From Data Source 'animals'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['count_dogs', 'metric_time']
@@ -15,6 +14,6 @@ FROM (
   FROM (
     SELECT * FROM ***************************.fct_animals
   ) animals_src_0
-) subq_3
+) subq_2
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric__dfp_0.xml
@@ -28,19 +28,15 @@
                         <!--    'time_granularity': TimeGranularity.MONTH}  -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10007 -->
+                            <!-- node_id = sma_10005 -->
                             <!-- aggregation_time_dimension = ds -->
-                            <FilterElementsNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = pfe_10007 -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                   -->
-                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='revenue'))  -->
-                                    <!-- node_id = rss_10016 -->
-                                    <!-- data_set =                                                            -->
-                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='revenue'))  -->
-                                </ReadSqlSourceNode>
-                            </FilterElementsNode>
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                   -->
+                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='revenue'))  -->
+                                <!-- node_id = rss_10016 -->
+                                <!-- data_set =                                                            -->
+                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='revenue'))  -->
+                            </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
                     </FilterElementsNode>
                 </JoinOverTimeRangeNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -73,19 +73,15 @@
                                     <!--    'identifier_links': ()}             -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10003 -->
+                                        <!-- node_id = sma_10001 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10003 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                                <!-- node_id = rss_10011 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                                 <FilterElementsNode>
@@ -103,19 +99,15 @@
                                     <!--    'identifier_links': ()}            -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10006 -->
+                                        <!-- node_id = sma_10004 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10006 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                                <!-- node_id = rss_10014 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                            <!-- node_id = rss_10014 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                             </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_expr_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_expr_metrics_plan__dfp_0.xml
@@ -59,19 +59,15 @@
                             <!--    'identifier_links': ()}             -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10003 -->
+                                <!-- node_id = sma_10001 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10003 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        <!-- node_id = rss_10011 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                         <FilterElementsNode>
@@ -89,19 +85,15 @@
                             <!--    'identifier_links': ()}            -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10006 -->
+                                <!-- node_id = sma_10004 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10006 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                        <!-- node_id = rss_10014 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                    <!-- node_id = rss_10014 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
@@ -53,19 +53,15 @@
                             <!--    'identifier_links': ()}             -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10003 -->
+                                <!-- node_id = sma_10001 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10003 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        <!-- node_id = rss_10011 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                         <FilterElementsNode>
@@ -83,19 +79,15 @@
                             <!--    'identifier_links': ()}            -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10006 -->
+                                <!-- node_id = sma_10004 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10006 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                        <!-- node_id = rss_10014 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                    <!-- node_id = rss_10014 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
@@ -29,19 +29,15 @@
                         <!--    'time_granularity': TimeGranularity.DAY}  -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10003 -->
+                            <!-- node_id = sma_10001 -->
                             <!-- aggregation_time_dimension = ds -->
-                            <FilterElementsNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = pfe_10003 -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                           -->
-                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
-                                    <!-- data_set =                                                                    -->
-                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                </ReadSqlSourceNode>
-                            </FilterElementsNode>
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                           -->
+                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                <!-- node_id = rss_10011 -->
+                                <!-- data_set =                                                                    -->
+                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                            </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
                     </FilterElementsNode>
                 </AggregateMeasuresNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -126,19 +126,15 @@
                                             <!--    'identifier_links': ()}             -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = Metric Time Dimension 'ds' -->
-                                                <!-- node_id = sma_10003 -->
+                                                <!-- node_id = sma_10001 -->
                                                 <!-- aggregation_time_dimension = ds -->
-                                                <FilterElementsNode>
-                                                    <!-- description = Pass Only Additive Measures -->
-                                                    <!-- node_id = pfe_10003 -->
-                                                    <ReadSqlSourceNode>
-                                                        <!-- description =                                                                           -->
-                                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                                        <!-- node_id = rss_10011 -->
-                                                        <!-- data_set =                                                                    -->
-                                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                                    </ReadSqlSourceNode>
-                                                </FilterElementsNode>
+                                                <ReadSqlSourceNode>
+                                                    <!-- description =                                                                           -->
+                                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                                    <!-- node_id = rss_10011 -->
+                                                    <!-- data_set =                                                                    -->
+                                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                                </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
                                         </FilterElementsNode>
                                         <FilterElementsNode>
@@ -156,19 +152,15 @@
                                             <!--    'identifier_links': ()}           -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = Metric Time Dimension 'ds' -->
-                                                <!-- node_id = sma_10006 -->
+                                                <!-- node_id = sma_10004 -->
                                                 <!-- aggregation_time_dimension = ds -->
-                                                <FilterElementsNode>
-                                                    <!-- description = Pass Only Additive Measures -->
-                                                    <!-- node_id = pfe_10006 -->
-                                                    <ReadSqlSourceNode>
-                                                        <!-- description =                                                                           -->
-                                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                                        <!-- node_id = rss_10014 -->
-                                                        <!-- data_set =                                                                    -->
-                                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                                    </ReadSqlSourceNode>
-                                                </FilterElementsNode>
+                                                <ReadSqlSourceNode>
+                                                    <!-- description =                                                                           -->
+                                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                                    <!-- node_id = rss_10014 -->
+                                                    <!-- data_set =                                                                    -->
+                                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                                </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
                                         </FilterElementsNode>
                                     </JoinToBaseOutputNode>
@@ -195,19 +187,15 @@
                             <!--    'time_granularity': TimeGranularity.DAY}  -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10003 -->
+                                <!-- node_id = sma_10001 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10003 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        <!-- node_id = rss_10011 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -77,19 +77,15 @@
                                     <!--    'time_granularity': TimeGranularity.DAY}  -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10003 -->
+                                        <!-- node_id = sma_10001 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10003 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                                <!-- node_id = rss_10011 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                             </WhereConstraintNode>
@@ -114,19 +110,15 @@
                             <!--    'time_granularity': TimeGranularity.DAY}  -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10003 -->
+                                <!-- node_id = sma_10001 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10003 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        <!-- node_id = rss_10011 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_data_source_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_data_source_ratio_metrics_plan__dfp_0.xml
@@ -86,19 +86,15 @@
                                     <!--    'identifier_links': ()}             -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10003 -->
+                                        <!-- node_id = sma_10001 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10003 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                                <!-- node_id = rss_10011 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                                 <FilterElementsNode>
@@ -116,19 +112,15 @@
                                     <!--    'identifier_links': ()}            -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10006 -->
+                                        <!-- node_id = sma_10004 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10006 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                                <!-- node_id = rss_10014 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                            <!-- node_id = rss_10014 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                             </JoinToBaseOutputNode>
@@ -187,19 +179,15 @@
                                     <!--    'identifier_links': ()}             -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10008 -->
+                                        <!-- node_id = sma_10006 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10008 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                        -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='views_source'))  -->
-                                                <!-- node_id = rss_10019 -->
-                                                <!-- data_set =                                                                 -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='views_source'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                        -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='views_source'))  -->
+                                            <!-- node_id = rss_10019 -->
+                                            <!-- data_set =                                                                 -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='views_source'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                                 <FilterElementsNode>
@@ -217,19 +205,15 @@
                                     <!--    'identifier_links': ()}            -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10006 -->
+                                        <!-- node_id = sma_10004 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10006 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                                <!-- node_id = rss_10014 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                            <!-- node_id = rss_10014 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                             </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
@@ -64,19 +64,15 @@
                             <!--    'time_granularity': TimeGranularity.DAY}  -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10009 -->
+                                <!-- node_id = sma_10007 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10009 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                              -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='account_month_txns'))  -->
-                                        <!-- node_id = rss_10025 -->
-                                        <!-- data_set =                                                                       -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='account_month_txns'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                              -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='account_month_txns'))  -->
+                                    <!-- node_id = rss_10025 -->
+                                    <!-- data_set =                                                                       -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='account_month_txns'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                         <FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
@@ -30,19 +30,15 @@
                         <!--    'time_granularity': TimeGranularity.DAY}  -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10003 -->
+                            <!-- node_id = sma_10001 -->
                             <!-- aggregation_time_dimension = ds -->
-                            <FilterElementsNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = pfe_10003 -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                           -->
-                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
-                                    <!-- data_set =                                                                    -->
-                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                </ReadSqlSourceNode>
-                            </FilterElementsNode>
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                           -->
+                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                <!-- node_id = rss_10011 -->
+                                <!-- data_set =                                                                    -->
+                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                            </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
                     </FilterElementsNode>
                 </AggregateMeasuresNode>
@@ -72,19 +68,15 @@
                         <!--    'time_granularity': TimeGranularity.DAY}  -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10003 -->
+                            <!-- node_id = sma_10001 -->
                             <!-- aggregation_time_dimension = ds -->
-                            <FilterElementsNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = pfe_10003 -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                           -->
-                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
-                                    <!-- data_set =                                                                    -->
-                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                </ReadSqlSourceNode>
-                            </FilterElementsNode>
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                           -->
+                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                <!-- node_id = rss_10011 -->
+                                <!-- data_set =                                                                    -->
+                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                            </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
                     </FilterElementsNode>
                 </AggregateMeasuresNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -46,19 +46,15 @@
                         <!--    'time_granularity': TimeGranularity.DAY}  -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = sma_10003 -->
+                            <!-- node_id = sma_10001 -->
                             <!-- aggregation_time_dimension = ds -->
-                            <FilterElementsNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = pfe_10003 -->
-                                <ReadSqlSourceNode>
-                                    <!-- description =                                                                           -->
-                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
-                                    <!-- data_set =                                                                    -->
-                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                </ReadSqlSourceNode>
-                            </FilterElementsNode>
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                           -->
+                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                <!-- node_id = rss_10011 -->
+                                <!-- data_set =                                                                    -->
+                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                            </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
                     </FilterElementsNode>
                 </AggregateMeasuresNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_simple_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_simple_plan__dfp_0.xml
@@ -22,19 +22,15 @@
                     <!--   {'class': 'DimensionSpec', 'element_name': 'is_instant', 'identifier_links': ()}  -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = sma_10003 -->
+                        <!-- node_id = sma_10001 -->
                         <!-- aggregation_time_dimension = ds -->
-                        <FilterElementsNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = pfe_10003 -->
-                            <ReadSqlSourceNode>
-                                <!-- description =                                                                           -->
-                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                <!-- node_id = rss_10011 -->
-                                <!-- data_set =                                                                    -->
-                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                            </ReadSqlSourceNode>
-                        </FilterElementsNode>
+                        <ReadSqlSourceNode>
+                            <!-- description =                                                                           -->
+                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                            <!-- node_id = rss_10011 -->
+                            <!-- data_set =                                                                    -->
+                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                        </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>
                 </FilterElementsNode>
             </AggregateMeasuresNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_data_source_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_data_source_ratio_metrics_plan__dfp_0.xml
@@ -67,19 +67,15 @@
                             <!--    'identifier_links': ()}             -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10003 -->
+                                <!-- node_id = sma_10001 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10003 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        <!-- node_id = rss_10011 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                         <FilterElementsNode>
@@ -97,19 +93,15 @@
                             <!--    'identifier_links': ()}            -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10006 -->
+                                <!-- node_id = sma_10004 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10006 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                        <!-- node_id = rss_10014 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                    <!-- node_id = rss_10014 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -79,19 +79,15 @@
                                     <!--    'identifier_links': ()}             -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10003 -->
+                                        <!-- node_id = sma_10001 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10003 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                                <!-- node_id = rss_10011 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                                 <FilterElementsNode>
@@ -109,19 +105,15 @@
                                     <!--    'identifier_links': ()}            -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = Metric Time Dimension 'ds' -->
-                                        <!-- node_id = sma_10006 -->
+                                        <!-- node_id = sma_10004 -->
                                         <!-- aggregation_time_dimension = ds -->
-                                        <FilterElementsNode>
-                                            <!-- description = Pass Only Additive Measures -->
-                                            <!-- node_id = pfe_10006 -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description =                                                                           -->
-                                                <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                                <!-- node_id = rss_10014 -->
-                                                <!-- data_set =                                                                    -->
-                                                <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                            </ReadSqlSourceNode>
-                                        </FilterElementsNode>
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                           -->
+                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                            <!-- node_id = rss_10014 -->
+                                            <!-- data_set =                                                                    -->
+                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                        </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                             </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -53,19 +53,15 @@
                             <!--    'time_granularity': TimeGranularity.DAY}  -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = Metric Time Dimension 'ds' -->
-                                <!-- node_id = sma_10003 -->
+                                <!-- node_id = sma_10001 -->
                                 <!-- aggregation_time_dimension = ds -->
-                                <FilterElementsNode>
-                                    <!-- description = Pass Only Additive Measures -->
-                                    <!-- node_id = pfe_10003 -->
-                                    <ReadSqlSourceNode>
-                                        <!-- description =                                                                           -->
-                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        <!-- node_id = rss_10011 -->
-                                        <!-- data_set =                                                                    -->
-                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                    </ReadSqlSourceNode>
-                                </FilterElementsNode>
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                           -->
+                                    <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                    -->
+                                    <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                         </FilterElementsNode>
                     </WhereConstraintNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -64,19 +64,15 @@
                                 <!--    'identifier_links': ()}             -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = sma_10003 -->
+                                    <!-- node_id = sma_10001 -->
                                     <!-- aggregation_time_dimension = ds -->
-                                    <FilterElementsNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = pfe_10003 -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description =                                                                           -->
-                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                            <!-- node_id = rss_10011 -->
-                                            <!-- data_set =                                                                    -->
-                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
-                                        </ReadSqlSourceNode>
-                                    </FilterElementsNode>
+                                    <ReadSqlSourceNode>
+                                        <!-- description =                                                                           -->
+                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                        <!-- node_id = rss_10011 -->
+                                        <!-- data_set =                                                                    -->
+                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='bookings_source'))  -->
+                                    </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
                             </FilterElementsNode>
                             <FilterElementsNode>
@@ -94,19 +90,15 @@
                                 <!--    'identifier_links': ()}            -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = sma_10006 -->
+                                    <!-- node_id = sma_10004 -->
                                     <!-- aggregation_time_dimension = ds -->
-                                    <FilterElementsNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = pfe_10006 -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description =                                                                           -->
-                                            <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                            <!-- node_id = rss_10014 -->
-                                            <!-- data_set =                                                                    -->
-                                            <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
-                                        </ReadSqlSourceNode>
-                                    </FilterElementsNode>
+                                    <ReadSqlSourceNode>
+                                        <!-- description =                                                                           -->
+                                        <!--   Read From DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                        <!-- node_id = rss_10014 -->
+                                        <!-- data_set =                                                                    -->
+                                        <!--   DataSourceDataSet(DataSourceReference(data_source_name='listings_latest'))  -->
+                                    </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
                             </FilterElementsNode>
                         </JoinToBaseOutputNode>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,11 +5,11 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_15.ds, subq_16.ds, subq_17.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_15.is_instant, subq_16.is_instant, subq_17.is_instant) AS is_instant  -->
-        <!--     , subq_15.bookings AS bookings                                                        -->
-        <!--     , subq_16.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_17.booking_value AS booking_value                                              -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
+        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
+        <!--     , subq_14.booking_value AS booking_value                                              -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -19,7 +19,6 @@
         <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
@@ -31,11 +30,11 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_3                                                                              -->
+        <!--     ) subq_2                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_15                                                                               -->
+        <!--   ) subq_12                                                                               -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -45,7 +44,6 @@
         <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
@@ -57,20 +55,19 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_8                                                                              -->
+        <!--     ) subq_6                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_16                                                                               -->
+        <!--   ) subq_13                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       subq_15.is_instant = subq_16.is_instant                                             -->
+        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
         <!--     ) AND (                                                                               -->
-        <!--       subq_15.ds = subq_16.ds                                                             -->
+        <!--       subq_12.ds = subq_13.ds                                                             -->
         <!--     )                                                                                     -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Pass Only Additive Measures                                                        -->
         <!--     -- Metric Time Dimension 'ds'                                                         -->
         <!--     -- Pass Only Elements:                                                                -->
         <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
@@ -87,12 +84,12 @@
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_17                                                                               -->
+        <!--   ) subq_14                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       COALESCE(subq_15.is_instant, subq_16.is_instant) = subq_17.is_instant               -->
+        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
         <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_15.ds, subq_16.ds) = subq_17.ds                                       -->
+        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_joined_plan__ep_0.xml
@@ -9,12 +9,11 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     subq_3.is_instant AS is_instant                                            -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10004.country AS listing__country_latest             -->
-        <!--     , SUM(subq_3.bookings) AS bookings                                         -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
-        <!--     -- Pass Only Additive Measures                                             -->
         <!--     -- Metric Time Dimension 'ds'                                              -->
         <!--     -- Pass Only Elements:                                                     -->
         <!--     --   ['bookings', 'is_instant', 'listing']                                 -->
@@ -26,11 +25,11 @@
         <!--       -- User Defined SQL Query                                                -->
         <!--       SELECT * FROM ***************************.fct_bookings                   -->
         <!--     ) bookings_source_src_10001                                                -->
-        <!--   ) subq_3                                                                     -->
+        <!--   ) subq_2                                                                     -->
         <!--   LEFT OUTER JOIN                                                              -->
         <!--     ***************************.dim_listings_latest listings_latest_src_10004  -->
         <!--   ON                                                                           -->
-        <!--     subq_3.listing = listings_latest_src_10004.listing_id                      -->
+        <!--     subq_2.listing = listings_latest_src_10004.listing_id                      -->
         <!--   GROUP BY                                                                     -->
         <!--     is_instant                                                                 -->
         <!--     , listing__country_latest                                                  -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,7 +9,7 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     subq_8.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
         <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
@@ -29,12 +29,12 @@
         <!--       ) AND (                                                                            -->
         <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
         <!--       )                                                                                  -->
-        <!--   ) subq_8                                                                               -->
+        <!--   ) subq_7                                                                               -->
         <!--   ON                                                                                     -->
         <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_8.account_id                        -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
         <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_8.ds_partitioned                -->
+        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned                -->
         <!--     )                                                                                    -->
         <!--   GROUP BY                                                                               -->
         <!--     account_id__customer_id__customer_name                                               -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,54 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     COALESCE(subq_10.is_instant, subq_11.is_instant) AS is_instant  -->
-        <!--     , subq_10.bookings AS bookings                                  -->
-        <!--     , subq_11.booking_value AS booking_value                        -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(bookings) AS bookings                                   -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Pass Only Additive Measures                                -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10001                                   -->
-        <!--     ) subq_3                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_10                                                         -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Pass Only Additive Measures                                  -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(booking_value) AS booking_value                         -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10001                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_11                                                         -->
-        <!--   ON                                                                -->
-        <!--     subq_10.is_instant = subq_11.is_instant                         -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10001                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10001                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,11 +5,11 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_15.ds, subq_16.ds, subq_17.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_15.is_instant, subq_16.is_instant, subq_17.is_instant) AS is_instant  -->
-        <!--     , subq_15.bookings AS bookings                                                        -->
-        <!--     , subq_16.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_17.booking_value AS booking_value                                              -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
+        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
+        <!--     , subq_14.booking_value AS booking_value                                              -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -19,7 +19,6 @@
         <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
@@ -31,11 +30,11 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_3                                                                              -->
+        <!--     ) subq_2                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_15                                                                               -->
+        <!--   ) subq_12                                                                               -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -45,7 +44,6 @@
         <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
@@ -57,20 +55,19 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_8                                                                              -->
+        <!--     ) subq_6                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_16                                                                               -->
+        <!--   ) subq_13                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       subq_15.is_instant = subq_16.is_instant                                             -->
+        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
         <!--     ) AND (                                                                               -->
-        <!--       subq_15.ds = subq_16.ds                                                             -->
+        <!--       subq_12.ds = subq_13.ds                                                             -->
         <!--     )                                                                                     -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Pass Only Additive Measures                                                        -->
         <!--     -- Metric Time Dimension 'ds'                                                         -->
         <!--     -- Pass Only Elements:                                                                -->
         <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
@@ -87,12 +84,12 @@
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_17                                                                               -->
+        <!--   ) subq_14                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       COALESCE(subq_15.is_instant, subq_16.is_instant) = subq_17.is_instant               -->
+        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
         <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_15.ds, subq_16.ds) = subq_17.ds                                       -->
+        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_joined_plan__ep_0.xml
@@ -9,12 +9,11 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     subq_3.is_instant AS is_instant                                            -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10004.country AS listing__country_latest             -->
-        <!--     , SUM(subq_3.bookings) AS bookings                                         -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
-        <!--     -- Pass Only Additive Measures                                             -->
         <!--     -- Metric Time Dimension 'ds'                                              -->
         <!--     -- Pass Only Elements:                                                     -->
         <!--     --   ['bookings', 'is_instant', 'listing']                                 -->
@@ -26,13 +25,13 @@
         <!--       -- User Defined SQL Query                                                -->
         <!--       SELECT * FROM ***************************.fct_bookings                   -->
         <!--     ) bookings_source_src_10001                                                -->
-        <!--   ) subq_3                                                                     -->
+        <!--   ) subq_2                                                                     -->
         <!--   LEFT OUTER JOIN                                                              -->
         <!--     ***************************.dim_listings_latest listings_latest_src_10004  -->
         <!--   ON                                                                           -->
-        <!--     subq_3.listing = listings_latest_src_10004.listing_id                      -->
+        <!--     subq_2.listing = listings_latest_src_10004.listing_id                      -->
         <!--   GROUP BY                                                                     -->
-        <!--     subq_3.is_instant                                                          -->
+        <!--     subq_2.is_instant                                                          -->
         <!--     , listings_latest_src_10004.country                                        -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,7 +9,7 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     subq_8.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
         <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
@@ -29,14 +29,14 @@
         <!--       ) AND (                                                                            -->
         <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
         <!--       )                                                                                  -->
-        <!--   ) subq_8                                                                               -->
+        <!--   ) subq_7                                                                               -->
         <!--   ON                                                                                     -->
         <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_8.account_id                        -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
         <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_8.ds_partitioned                -->
+        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned                -->
         <!--     )                                                                                    -->
         <!--   GROUP BY                                                                               -->
-        <!--     subq_8.customer_id__customer_name                                                    -->
+        <!--     subq_7.customer_id__customer_name                                                    -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,54 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     COALESCE(subq_10.is_instant, subq_11.is_instant) AS is_instant  -->
-        <!--     , subq_10.bookings AS bookings                                  -->
-        <!--     , subq_11.booking_value AS booking_value                        -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(bookings) AS bookings                                   -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Pass Only Additive Measures                                -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10001                                   -->
-        <!--     ) subq_3                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_10                                                         -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Pass Only Additive Measures                                  -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(booking_value) AS booking_value                         -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10001                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_11                                                         -->
-        <!--   ON                                                                -->
-        <!--     subq_10.is_instant = subq_11.is_instant                         -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10001                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10001                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,11 +5,11 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_15.ds, subq_16.ds, subq_17.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_15.is_instant, subq_16.is_instant, subq_17.is_instant) AS is_instant  -->
-        <!--     , subq_15.bookings AS bookings                                                        -->
-        <!--     , subq_16.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_17.booking_value AS booking_value                                              -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
+        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
+        <!--     , subq_14.booking_value AS booking_value                                              -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -19,7 +19,6 @@
         <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
@@ -31,11 +30,11 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_3                                                                              -->
+        <!--     ) subq_2                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_15                                                                               -->
+        <!--   ) subq_12                                                                               -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -45,7 +44,6 @@
         <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
@@ -57,20 +55,19 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_8                                                                              -->
+        <!--     ) subq_6                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_16                                                                               -->
+        <!--   ) subq_13                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       subq_15.is_instant = subq_16.is_instant                                             -->
+        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
         <!--     ) AND (                                                                               -->
-        <!--       subq_15.ds = subq_16.ds                                                             -->
+        <!--       subq_12.ds = subq_13.ds                                                             -->
         <!--     )                                                                                     -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Pass Only Additive Measures                                                        -->
         <!--     -- Metric Time Dimension 'ds'                                                         -->
         <!--     -- Pass Only Elements:                                                                -->
         <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
@@ -87,12 +84,12 @@
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_17                                                                               -->
+        <!--   ) subq_14                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       COALESCE(subq_15.is_instant, subq_16.is_instant) = subq_17.is_instant               -->
+        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
         <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_15.ds, subq_16.ds) = subq_17.ds                                       -->
+        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_joined_plan__ep_0.xml
@@ -9,12 +9,11 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     subq_3.is_instant AS is_instant                                            -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10004.country AS listing__country_latest             -->
-        <!--     , SUM(subq_3.bookings) AS bookings                                         -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
-        <!--     -- Pass Only Additive Measures                                             -->
         <!--     -- Metric Time Dimension 'ds'                                              -->
         <!--     -- Pass Only Elements:                                                     -->
         <!--     --   ['bookings', 'is_instant', 'listing']                                 -->
@@ -26,13 +25,13 @@
         <!--       -- User Defined SQL Query                                                -->
         <!--       SELECT * FROM ***************************.fct_bookings                   -->
         <!--     ) bookings_source_src_10001                                                -->
-        <!--   ) subq_3                                                                     -->
+        <!--   ) subq_2                                                                     -->
         <!--   LEFT OUTER JOIN                                                              -->
         <!--     ***************************.dim_listings_latest listings_latest_src_10004  -->
         <!--   ON                                                                           -->
-        <!--     subq_3.listing = listings_latest_src_10004.listing_id                      -->
+        <!--     subq_2.listing = listings_latest_src_10004.listing_id                      -->
         <!--   GROUP BY                                                                     -->
-        <!--     subq_3.is_instant                                                          -->
+        <!--     subq_2.is_instant                                                          -->
         <!--     , listings_latest_src_10004.country                                        -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,7 +9,7 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     subq_8.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
         <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
@@ -29,14 +29,14 @@
         <!--       ) AND (                                                                            -->
         <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
         <!--       )                                                                                  -->
-        <!--   ) subq_8                                                                               -->
+        <!--   ) subq_7                                                                               -->
         <!--   ON                                                                                     -->
         <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_8.account_id                        -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
         <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_8.ds_partitioned                -->
+        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned                -->
         <!--     )                                                                                    -->
         <!--   GROUP BY                                                                               -->
-        <!--     subq_8.customer_id__customer_name                                                    -->
+        <!--     subq_7.customer_id__customer_name                                                    -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,54 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     COALESCE(subq_10.is_instant, subq_11.is_instant) AS is_instant  -->
-        <!--     , subq_10.bookings AS bookings                                  -->
-        <!--     , subq_11.booking_value AS booking_value                        -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(bookings) AS bookings                                   -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Pass Only Additive Measures                                -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10001                                   -->
-        <!--     ) subq_3                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_10                                                         -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Pass Only Additive Measures                                  -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(booking_value) AS booking_value                         -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10001                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_11                                                         -->
-        <!--   ON                                                                -->
-        <!--     subq_10.is_instant = subq_11.is_instant                         -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10001                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10001                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,11 +5,11 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_15.ds, subq_16.ds, subq_17.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_15.is_instant, subq_16.is_instant, subq_17.is_instant) AS is_instant  -->
-        <!--     , subq_15.bookings AS bookings                                                        -->
-        <!--     , subq_16.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_17.booking_value AS booking_value                                              -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
+        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
+        <!--     , subq_14.booking_value AS booking_value                                              -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -19,7 +19,6 @@
         <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
@@ -31,11 +30,11 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_3                                                                              -->
+        <!--     ) subq_2                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_15                                                                               -->
+        <!--   ) subq_12                                                                               -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -45,7 +44,6 @@
         <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
@@ -57,20 +55,19 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_8                                                                              -->
+        <!--     ) subq_6                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_16                                                                               -->
+        <!--   ) subq_13                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       subq_15.is_instant = subq_16.is_instant                                             -->
+        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
         <!--     ) AND (                                                                               -->
-        <!--       subq_15.ds = subq_16.ds                                                             -->
+        <!--       subq_12.ds = subq_13.ds                                                             -->
         <!--     )                                                                                     -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Pass Only Additive Measures                                                        -->
         <!--     -- Metric Time Dimension 'ds'                                                         -->
         <!--     -- Pass Only Elements:                                                                -->
         <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
@@ -87,12 +84,12 @@
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_17                                                                               -->
+        <!--   ) subq_14                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       COALESCE(subq_15.is_instant, subq_16.is_instant) = subq_17.is_instant               -->
+        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
         <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_15.ds, subq_16.ds) = subq_17.ds                                       -->
+        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_joined_plan__ep_0.xml
@@ -9,12 +9,11 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     subq_3.is_instant AS is_instant                                            -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10004.country AS listing__country_latest             -->
-        <!--     , SUM(subq_3.bookings) AS bookings                                         -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
-        <!--     -- Pass Only Additive Measures                                             -->
         <!--     -- Metric Time Dimension 'ds'                                              -->
         <!--     -- Pass Only Elements:                                                     -->
         <!--     --   ['bookings', 'is_instant', 'listing']                                 -->
@@ -26,13 +25,13 @@
         <!--       -- User Defined SQL Query                                                -->
         <!--       SELECT * FROM ***************************.fct_bookings                   -->
         <!--     ) bookings_source_src_10001                                                -->
-        <!--   ) subq_3                                                                     -->
+        <!--   ) subq_2                                                                     -->
         <!--   LEFT OUTER JOIN                                                              -->
         <!--     ***************************.dim_listings_latest listings_latest_src_10004  -->
         <!--   ON                                                                           -->
-        <!--     subq_3.listing = listings_latest_src_10004.listing_id                      -->
+        <!--     subq_2.listing = listings_latest_src_10004.listing_id                      -->
         <!--   GROUP BY                                                                     -->
-        <!--     subq_3.is_instant                                                          -->
+        <!--     subq_2.is_instant                                                          -->
         <!--     , listings_latest_src_10004.country                                        -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,7 +9,7 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     subq_8.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
         <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
@@ -29,14 +29,14 @@
         <!--       ) AND (                                                                            -->
         <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
         <!--       )                                                                                  -->
-        <!--   ) subq_8                                                                               -->
+        <!--   ) subq_7                                                                               -->
         <!--   ON                                                                                     -->
         <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_8.account_id                        -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
         <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_8.ds_partitioned                -->
+        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned                -->
         <!--     )                                                                                    -->
         <!--   GROUP BY                                                                               -->
-        <!--     subq_8.customer_id__customer_name                                                    -->
+        <!--     subq_7.customer_id__customer_name                                                    -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,54 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     COALESCE(subq_10.is_instant, subq_11.is_instant) AS is_instant  -->
-        <!--     , subq_10.bookings AS bookings                                  -->
-        <!--     , subq_11.booking_value AS booking_value                        -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(bookings) AS bookings                                   -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Pass Only Additive Measures                                -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10001                                   -->
-        <!--     ) subq_3                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_10                                                         -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Pass Only Additive Measures                                  -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(booking_value) AS booking_value                         -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10001                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_11                                                         -->
-        <!--   ON                                                                -->
-        <!--     subq_10.is_instant = subq_11.is_instant                         -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10001                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10001                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -5,11 +5,11 @@
         <!-- sql_query =                                                                               -->
         <!--   -- Combine Metrics                                                                      -->
         <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_15.ds, subq_16.ds, subq_17.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_15.is_instant, subq_16.is_instant, subq_17.is_instant) AS is_instant  -->
-        <!--     , subq_15.bookings AS bookings                                                        -->
-        <!--     , subq_16.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_17.booking_value AS booking_value                                              -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , subq_12.bookings AS bookings                                                        -->
+        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
+        <!--     , subq_14.booking_value AS booking_value                                              -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -19,7 +19,6 @@
         <!--       , SUM(bookings) AS bookings                                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
@@ -31,11 +30,11 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_3                                                                              -->
+        <!--     ) subq_2                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_15                                                                               -->
+        <!--   ) subq_12                                                                               -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -45,7 +44,6 @@
         <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
         <!--     FROM (                                                                                -->
         <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Pass Only Additive Measures                                                      -->
         <!--       -- Metric Time Dimension 'ds'                                                       -->
         <!--       -- Pass Only Elements:                                                              -->
         <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
@@ -57,20 +55,19 @@
         <!--         -- User Defined SQL Query                                                         -->
         <!--         SELECT * FROM ***************************.fct_bookings                            -->
         <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_8                                                                              -->
+        <!--     ) subq_6                                                                              -->
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_16                                                                               -->
+        <!--   ) subq_13                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       subq_15.is_instant = subq_16.is_instant                                             -->
+        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
         <!--     ) AND (                                                                               -->
-        <!--       subq_15.ds = subq_16.ds                                                             -->
+        <!--       subq_12.ds = subq_13.ds                                                             -->
         <!--     )                                                                                     -->
         <!--   FULL OUTER JOIN (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Pass Only Additive Measures                                                        -->
         <!--     -- Metric Time Dimension 'ds'                                                         -->
         <!--     -- Pass Only Elements:                                                                -->
         <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
@@ -87,12 +84,12 @@
         <!--     GROUP BY                                                                              -->
         <!--       ds                                                                                  -->
         <!--       , is_instant                                                                        -->
-        <!--   ) subq_17                                                                               -->
+        <!--   ) subq_14                                                                               -->
         <!--   ON                                                                                      -->
         <!--     (                                                                                     -->
-        <!--       COALESCE(subq_15.is_instant, subq_16.is_instant) = subq_17.is_instant               -->
+        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
         <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_15.ds, subq_16.ds) = subq_17.ds                                       -->
+        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_joined_plan__ep_0.xml
@@ -9,12 +9,11 @@
         <!--   -- Aggregate Measures                                                        -->
         <!--   -- Compute Metrics via Expressions                                           -->
         <!--   SELECT                                                                       -->
-        <!--     subq_3.is_instant AS is_instant                                            -->
+        <!--     subq_2.is_instant AS is_instant                                            -->
         <!--     , listings_latest_src_10004.country AS listing__country_latest             -->
-        <!--     , SUM(subq_3.bookings) AS bookings                                         -->
+        <!--     , SUM(subq_2.bookings) AS bookings                                         -->
         <!--   FROM (                                                                       -->
         <!--     -- Read Elements From Data Source 'bookings_source'                        -->
-        <!--     -- Pass Only Additive Measures                                             -->
         <!--     -- Metric Time Dimension 'ds'                                              -->
         <!--     -- Pass Only Elements:                                                     -->
         <!--     --   ['bookings', 'is_instant', 'listing']                                 -->
@@ -26,13 +25,13 @@
         <!--       -- User Defined SQL Query                                                -->
         <!--       SELECT * FROM ***************************.fct_bookings                   -->
         <!--     ) bookings_source_src_10001                                                -->
-        <!--   ) subq_3                                                                     -->
+        <!--   ) subq_2                                                                     -->
         <!--   LEFT OUTER JOIN                                                              -->
         <!--     ***************************.dim_listings_latest listings_latest_src_10004  -->
         <!--   ON                                                                           -->
-        <!--     subq_3.listing = listings_latest_src_10004.listing_id                      -->
+        <!--     subq_2.listing = listings_latest_src_10004.listing_id                      -->
         <!--   GROUP BY                                                                     -->
-        <!--     subq_3.is_instant                                                          -->
+        <!--     subq_2.is_instant                                                          -->
         <!--     , listings_latest_src_10004.country                                        -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_multihop_joined_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_multihop_joined_plan__ep_0.xml
@@ -9,7 +9,7 @@
         <!--   -- Aggregate Measures                                                                  -->
         <!--   -- Compute Metrics via Expressions                                                     -->
         <!--   SELECT                                                                                 -->
-        <!--     subq_8.customer_id__customer_name AS account_id__customer_id__customer_name          -->
+        <!--     subq_7.customer_id__customer_name AS account_id__customer_id__customer_name          -->
         <!--     , SUM(account_month_txns_src_10010.txn_count) AS txn_count                           -->
         <!--   FROM ***************************.account_month_txns account_month_txns_src_10010       -->
         <!--   LEFT OUTER JOIN (                                                                      -->
@@ -29,14 +29,14 @@
         <!--       ) AND (                                                                            -->
         <!--         bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned  -->
         <!--       )                                                                                  -->
-        <!--   ) subq_8                                                                               -->
+        <!--   ) subq_7                                                                               -->
         <!--   ON                                                                                     -->
         <!--     (                                                                                    -->
-        <!--       account_month_txns_src_10010.account_id = subq_8.account_id                        -->
+        <!--       account_month_txns_src_10010.account_id = subq_7.account_id                        -->
         <!--     ) AND (                                                                              -->
-        <!--       account_month_txns_src_10010.ds_partitioned = subq_8.ds_partitioned                -->
+        <!--       account_month_txns_src_10010.ds_partitioned = subq_7.ds_partitioned                -->
         <!--     )                                                                                    -->
         <!--   GROUP BY                                                                               -->
-        <!--     subq_8.customer_id__customer_name                                                    -->
+        <!--     subq_7.customer_id__customer_name                                                    -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -2,54 +2,52 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                         -->
-        <!--   -- Combine Metrics                                                -->
-        <!--   SELECT                                                            -->
-        <!--     COALESCE(subq_10.is_instant, subq_11.is_instant) AS is_instant  -->
-        <!--     , subq_10.bookings AS bookings                                  -->
-        <!--     , subq_11.booking_value AS booking_value                        -->
-        <!--   FROM (                                                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(bookings) AS bookings                                   -->
-        <!--     FROM (                                                          -->
-        <!--       -- Read Elements From Data Source 'bookings_source'           -->
-        <!--       -- Pass Only Additive Measures                                -->
-        <!--       -- Metric Time Dimension 'ds'                                 -->
-        <!--       -- Pass Only Elements:                                        -->
-        <!--       --   ['bookings', 'is_instant']                               -->
-        <!--       SELECT                                                        -->
-        <!--         is_instant                                                  -->
-        <!--         , 1 AS bookings                                             -->
-        <!--       FROM (                                                        -->
-        <!--         -- User Defined SQL Query                                   -->
-        <!--         SELECT * FROM ***************************.fct_bookings      -->
-        <!--       ) bookings_source_src_10001                                   -->
-        <!--     ) subq_3                                                        -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_10                                                         -->
-        <!--   FULL OUTER JOIN (                                                 -->
-        <!--     -- Read Elements From Data Source 'bookings_source'             -->
-        <!--     -- Pass Only Additive Measures                                  -->
-        <!--     -- Metric Time Dimension 'ds'                                   -->
-        <!--     -- Pass Only Elements:                                          -->
-        <!--     --   ['booking_value', 'is_instant']                            -->
-        <!--     -- Aggregate Measures                                           -->
-        <!--     -- Compute Metrics via Expressions                              -->
-        <!--     SELECT                                                          -->
-        <!--       is_instant                                                    -->
-        <!--       , SUM(booking_value) AS booking_value                         -->
-        <!--     FROM (                                                          -->
-        <!--       -- User Defined SQL Query                                     -->
-        <!--       SELECT * FROM ***************************.fct_bookings        -->
-        <!--     ) bookings_source_src_10001                                     -->
-        <!--     GROUP BY                                                        -->
-        <!--       is_instant                                                    -->
-        <!--   ) subq_11                                                         -->
-        <!--   ON                                                                -->
-        <!--     subq_10.is_instant = subq_11.is_instant                         -->
+        <!-- sql_query =                                                       -->
+        <!--   -- Combine Metrics                                              -->
+        <!--   SELECT                                                          -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , subq_8.bookings AS bookings                                 -->
+        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--   FROM (                                                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(bookings) AS bookings                                 -->
+        <!--     FROM (                                                        -->
+        <!--       -- Read Elements From Data Source 'bookings_source'         -->
+        <!--       -- Metric Time Dimension 'ds'                               -->
+        <!--       -- Pass Only Elements:                                      -->
+        <!--       --   ['bookings', 'is_instant']                             -->
+        <!--       SELECT                                                      -->
+        <!--         is_instant                                                -->
+        <!--         , 1 AS bookings                                           -->
+        <!--       FROM (                                                      -->
+        <!--         -- User Defined SQL Query                                 -->
+        <!--         SELECT * FROM ***************************.fct_bookings    -->
+        <!--       ) bookings_source_src_10001                                 -->
+        <!--     ) subq_2                                                      -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_8                                                        -->
+        <!--   FULL OUTER JOIN (                                               -->
+        <!--     -- Read Elements From Data Source 'bookings_source'           -->
+        <!--     -- Metric Time Dimension 'ds'                                 -->
+        <!--     -- Pass Only Elements:                                        -->
+        <!--     --   ['booking_value', 'is_instant']                          -->
+        <!--     -- Aggregate Measures                                         -->
+        <!--     -- Compute Metrics via Expressions                            -->
+        <!--     SELECT                                                        -->
+        <!--       is_instant                                                  -->
+        <!--       , SUM(booking_value) AS booking_value                       -->
+        <!--     FROM (                                                        -->
+        <!--       -- User Defined SQL Query                                   -->
+        <!--       SELECT * FROM ***************************.fct_bookings      -->
+        <!--     ) bookings_source_src_10001                                   -->
+        <!--     GROUP BY                                                      -->
+        <!--       is_instant                                                  -->
+        <!--   ) subq_9                                                        -->
+        <!--   ON                                                              -->
+        <!--     subq_8.is_instant = subq_9.is_instant                         -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0.sql
@@ -1,95 +1,73 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.user_team___team_id
-  , subq_4.user_team___user_id
-  , subq_4.messages
+  subq_3.user_team___team_id
+  , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-    , SUM(subq_3.messages) AS messages
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+    , SUM(subq_2.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team']
     SELECT
-      subq_2.user_team___team_id
-      , subq_2.user_team___user_id
-      , subq_2.messages
+      subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+      , subq_1.messages
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.user_id__ds
-        , subq_1.user_id__ds__week
-        , subq_1.user_id__ds__month
-        , subq_1.user_id__ds__quarter
-        , subq_1.user_id__ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user_id
-        , subq_1.user_team___team_id
-        , subq_1.user_team___user_id
-        , subq_1.user_id__user_team___team_id
-        , subq_1.user_id__user_team___user_id
-        , subq_1.team_id
-        , subq_1.user_id__team_id
-        , subq_1.messages
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.user_id__ds
+        , subq_0.user_id__ds__week
+        , subq_0.user_id__ds__month
+        , subq_0.user_id__ds__quarter
+        , subq_0.user_id__ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user_id
+        , subq_0.user_team___team_id
+        , subq_0.user_team___user_id
+        , subq_0.user_id__user_team___team_id
+        , subq_0.user_id__user_team___user_id
+        , subq_0.team_id
+        , subq_0.user_id__team_id
+        , subq_0.messages
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'messages_source'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user_id__ds
-          , subq_0.user_id__ds__week
-          , subq_0.user_id__ds__month
-          , subq_0.user_id__ds__quarter
-          , subq_0.user_id__ds__year
-          , subq_0.user_id
-          , subq_0.user_team___team_id
-          , subq_0.user_team___user_id
-          , subq_0.user_id__user_team___team_id
-          , subq_0.user_id__user_team___user_id
-          , subq_0.team_id
-          , subq_0.user_id__team_id
-          , subq_0.messages
-        FROM (
-          -- Read Elements From Data Source 'messages_source'
-          SELECT
-            1 AS messages
-            , messages_source_src_10015.ds
-            , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS ds__week
-            , DATE_TRUNC(messages_source_src_10015.ds, month) AS ds__month
-            , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS ds__year
-            , messages_source_src_10015.team_id
-            , messages_source_src_10015.ds AS user_id__ds
-            , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS user_id__ds__week
-            , DATE_TRUNC(messages_source_src_10015.ds, month) AS user_id__ds__month
-            , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS user_id__ds__quarter
-            , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS user_id__ds__year
-            , messages_source_src_10015.team_id AS user_id__team_id
-            , messages_source_src_10015.user_id
-            , messages_source_src_10015.team_id AS user_team___team_id
-            , messages_source_src_10015.user_id AS user_team___user_id
-            , messages_source_src_10015.team_id AS user_id__user_team___team_id
-            , messages_source_src_10015.user_id AS user_id__user_team___user_id
-          FROM ***************************.fct_messages messages_source_src_10015
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS messages
+          , messages_source_src_10015.ds
+          , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS ds__week
+          , DATE_TRUNC(messages_source_src_10015.ds, month) AS ds__month
+          , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS ds__quarter
+          , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS ds__year
+          , messages_source_src_10015.team_id
+          , messages_source_src_10015.ds AS user_id__ds
+          , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS user_id__ds__week
+          , DATE_TRUNC(messages_source_src_10015.ds, month) AS user_id__ds__month
+          , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS user_id__ds__quarter
+          , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS user_id__ds__year
+          , messages_source_src_10015.team_id AS user_id__team_id
+          , messages_source_src_10015.user_id
+          , messages_source_src_10015.team_id AS user_team___team_id
+          , messages_source_src_10015.user_id AS user_team___user_id
+          , messages_source_src_10015.team_id AS user_id__user_team___team_id
+          , messages_source_src_10015.user_id AS user_id__user_team___user_id
+        FROM ***************************.fct_messages messages_source_src_10015
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-) subq_4
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -15,7 +14,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_8
+) subq_6
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,118 +1,96 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user_team___team_id
-  , subq_8.user_team___user_id
-  , subq_8.user_team__country
-  , subq_8.messages
+  subq_7.user_team___team_id
+  , subq_7.user_team___user_id
+  , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-    , SUM(subq_7.messages) AS messages
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+    , SUM(subq_6.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team__country', 'user_team']
     SELECT
-      subq_6.user_team___team_id
-      , subq_6.user_team___user_id
-      , subq_6.user_team__country
-      , subq_6.messages
+      subq_5.user_team___team_id
+      , subq_5.user_team___user_id
+      , subq_5.user_team__country
+      , subq_5.messages
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.user_team___team_id AS user_team___team_id
-        , subq_3.user_team___user_id AS user_team___user_id
-        , subq_5.country AS user_team__country
-        , subq_3.messages AS messages
+        subq_2.user_team___team_id AS user_team___team_id
+        , subq_2.user_team___user_id AS user_team___user_id
+        , subq_4.country AS user_team__country
+        , subq_2.messages AS messages
       FROM (
         -- Pass Only Elements:
         --   ['messages', 'user_team', 'user_team']
         SELECT
-          subq_2.user_team___team_id
-          , subq_2.user_team___user_id
-          , subq_2.messages
+          subq_1.user_team___team_id
+          , subq_1.user_team___user_id
+          , subq_1.messages
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.user_id__ds
-            , subq_1.user_id__ds__week
-            , subq_1.user_id__ds__month
-            , subq_1.user_id__ds__quarter
-            , subq_1.user_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.user_id
-            , subq_1.user_team___team_id
-            , subq_1.user_team___user_id
-            , subq_1.user_id__user_team___team_id
-            , subq_1.user_id__user_team___user_id
-            , subq_1.team_id
-            , subq_1.user_id__team_id
-            , subq_1.messages
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user_id__ds
+            , subq_0.user_id__ds__week
+            , subq_0.user_id__ds__month
+            , subq_0.user_id__ds__quarter
+            , subq_0.user_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.user_id
+            , subq_0.user_team___team_id
+            , subq_0.user_team___user_id
+            , subq_0.user_id__user_team___team_id
+            , subq_0.user_id__user_team___user_id
+            , subq_0.team_id
+            , subq_0.user_id__team_id
+            , subq_0.messages
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'messages_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.user_id__ds
-              , subq_0.user_id__ds__week
-              , subq_0.user_id__ds__month
-              , subq_0.user_id__ds__quarter
-              , subq_0.user_id__ds__year
-              , subq_0.user_id
-              , subq_0.user_team___team_id
-              , subq_0.user_team___user_id
-              , subq_0.user_id__user_team___team_id
-              , subq_0.user_id__user_team___user_id
-              , subq_0.team_id
-              , subq_0.user_id__team_id
-              , subq_0.messages
-            FROM (
-              -- Read Elements From Data Source 'messages_source'
-              SELECT
-                1 AS messages
-                , messages_source_src_10015.ds
-                , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS ds__week
-                , DATE_TRUNC(messages_source_src_10015.ds, month) AS ds__month
-                , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS ds__year
-                , messages_source_src_10015.team_id
-                , messages_source_src_10015.ds AS user_id__ds
-                , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS user_id__ds__week
-                , DATE_TRUNC(messages_source_src_10015.ds, month) AS user_id__ds__month
-                , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS user_id__ds__quarter
-                , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS user_id__ds__year
-                , messages_source_src_10015.team_id AS user_id__team_id
-                , messages_source_src_10015.user_id
-                , messages_source_src_10015.team_id AS user_team___team_id
-                , messages_source_src_10015.user_id AS user_team___user_id
-                , messages_source_src_10015.team_id AS user_id__user_team___team_id
-                , messages_source_src_10015.user_id AS user_id__user_team___user_id
-              FROM ***************************.fct_messages messages_source_src_10015
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS messages
+              , messages_source_src_10015.ds
+              , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS ds__week
+              , DATE_TRUNC(messages_source_src_10015.ds, month) AS ds__month
+              , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS ds__year
+              , messages_source_src_10015.team_id
+              , messages_source_src_10015.ds AS user_id__ds
+              , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS user_id__ds__week
+              , DATE_TRUNC(messages_source_src_10015.ds, month) AS user_id__ds__month
+              , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS user_id__ds__quarter
+              , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS user_id__ds__year
+              , messages_source_src_10015.team_id AS user_id__team_id
+              , messages_source_src_10015.user_id
+              , messages_source_src_10015.team_id AS user_team___team_id
+              , messages_source_src_10015.user_id AS user_team___user_id
+              , messages_source_src_10015.team_id AS user_id__user_team___team_id
+              , messages_source_src_10015.user_id AS user_id__user_team___user_id
+            FROM ***************************.fct_messages messages_source_src_10015
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user_team', 'country']
         SELECT
-          subq_4.user_team___team_id
-          , subq_4.user_team___user_id
-          , subq_4.country
+          subq_3.user_team___team_id
+          , subq_3.user_team___user_id
+          , subq_3.country
         FROM (
           -- Read Elements From Data Source 'users_source'
           SELECT
@@ -160,18 +138,18 @@ FROM (
             , users_source_src_10017.ident_2 AS user_team__user_composite_ident_2___ident_2
             , users_source_src_10017.id AS user_team__user_composite_ident_2___user_id
           FROM ***************************.fct_users users_source_src_10017
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user_team___team_id = subq_5.user_team___team_id
+          subq_2.user_team___team_id = subq_4.user_team___team_id
         ) AND (
-          subq_3.user_team___user_id = subq_5.user_team___user_id
+          subq_2.user_team___user_id = subq_4.user_team___user_id
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-) subq_8
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,13 +4,12 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user_team___team_id AS user_team___team_id
-  , subq_12.user_team___user_id AS user_team___user_id
+  subq_10.user_team___team_id AS user_team___team_id
+  , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10017.country AS user_team__country
-  , SUM(subq_12.messages) AS messages
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team', 'user_team']
@@ -19,14 +18,14 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.fct_users users_source_src_10017
 ON
   (
-    subq_12.user_team___team_id = users_source_src_10017.team_id
+    subq_10.user_team___team_id = users_source_src_10017.team_id
   ) AND (
-    subq_12.user_team___user_id = users_source_src_10017.id
+    subq_10.user_team___user_id = users_source_src_10017.id
   )
 GROUP BY
   user_team___team_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -1,103 +1,81 @@
 -- Order By ['user_team']
 SELECT
-  subq_5.user_team___team_id
-  , subq_5.user_team___user_id
-  , subq_5.messages
+  subq_4.user_team___team_id
+  , subq_4.user_team___user_id
+  , subq_4.messages
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.user_team___team_id
-    , subq_4.user_team___user_id
-    , subq_4.messages
+    subq_3.user_team___team_id
+    , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-      , SUM(subq_3.messages) AS messages
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+      , SUM(subq_2.messages) AS messages
     FROM (
       -- Pass Only Elements:
       --   ['messages', 'user_team']
       SELECT
-        subq_2.user_team___team_id
-        , subq_2.user_team___user_id
-        , subq_2.messages
+        subq_1.user_team___team_id
+        , subq_1.user_team___user_id
+        , subq_1.messages
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.user_id__ds
-          , subq_1.user_id__ds__week
-          , subq_1.user_id__ds__month
-          , subq_1.user_id__ds__quarter
-          , subq_1.user_id__ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user_id
-          , subq_1.user_team___team_id
-          , subq_1.user_team___user_id
-          , subq_1.user_id__user_team___team_id
-          , subq_1.user_id__user_team___user_id
-          , subq_1.team_id
-          , subq_1.user_id__team_id
-          , subq_1.messages
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.user_id__ds
+          , subq_0.user_id__ds__week
+          , subq_0.user_id__ds__month
+          , subq_0.user_id__ds__quarter
+          , subq_0.user_id__ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user_id
+          , subq_0.user_team___team_id
+          , subq_0.user_team___user_id
+          , subq_0.user_id__user_team___team_id
+          , subq_0.user_id__user_team___user_id
+          , subq_0.team_id
+          , subq_0.user_id__team_id
+          , subq_0.messages
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'messages_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user_id__ds
-            , subq_0.user_id__ds__week
-            , subq_0.user_id__ds__month
-            , subq_0.user_id__ds__quarter
-            , subq_0.user_id__ds__year
-            , subq_0.user_id
-            , subq_0.user_team___team_id
-            , subq_0.user_team___user_id
-            , subq_0.user_id__user_team___team_id
-            , subq_0.user_id__user_team___user_id
-            , subq_0.team_id
-            , subq_0.user_id__team_id
-            , subq_0.messages
-          FROM (
-            -- Read Elements From Data Source 'messages_source'
-            SELECT
-              1 AS messages
-              , messages_source_src_10015.ds
-              , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS ds__week
-              , DATE_TRUNC(messages_source_src_10015.ds, month) AS ds__month
-              , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS ds__year
-              , messages_source_src_10015.team_id
-              , messages_source_src_10015.ds AS user_id__ds
-              , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS user_id__ds__week
-              , DATE_TRUNC(messages_source_src_10015.ds, month) AS user_id__ds__month
-              , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS user_id__ds__quarter
-              , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS user_id__ds__year
-              , messages_source_src_10015.team_id AS user_id__team_id
-              , messages_source_src_10015.user_id
-              , messages_source_src_10015.team_id AS user_team___team_id
-              , messages_source_src_10015.user_id AS user_team___user_id
-              , messages_source_src_10015.team_id AS user_id__user_team___team_id
-              , messages_source_src_10015.user_id AS user_id__user_team___user_id
-            FROM ***************************.fct_messages messages_source_src_10015
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            1 AS messages
+            , messages_source_src_10015.ds
+            , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS ds__week
+            , DATE_TRUNC(messages_source_src_10015.ds, month) AS ds__month
+            , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS ds__quarter
+            , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS ds__year
+            , messages_source_src_10015.team_id
+            , messages_source_src_10015.ds AS user_id__ds
+            , DATE_TRUNC(messages_source_src_10015.ds, isoweek) AS user_id__ds__week
+            , DATE_TRUNC(messages_source_src_10015.ds, month) AS user_id__ds__month
+            , DATE_TRUNC(messages_source_src_10015.ds, quarter) AS user_id__ds__quarter
+            , DATE_TRUNC(messages_source_src_10015.ds, isoyear) AS user_id__ds__year
+            , messages_source_src_10015.team_id AS user_id__team_id
+            , messages_source_src_10015.user_id
+            , messages_source_src_10015.team_id AS user_team___team_id
+            , messages_source_src_10015.user_id AS user_team___user_id
+            , messages_source_src_10015.team_id AS user_id__user_team___team_id
+            , messages_source_src_10015.user_id AS user_id__user_team___user_id
+          FROM ***************************.fct_messages messages_source_src_10015
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-  ) subq_4
-) subq_5
-ORDER BY subq_5.user_team___team_id DESC, subq_5.user_team___user_id DESC
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+  ) subq_3
+) subq_4
+ORDER BY subq_4.user_team___team_id DESC, subq_4.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
@@ -7,7 +7,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -16,7 +15,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_9
+) subq_7
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,367 +1,357 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_23.ds
-  , subq_23.listing__country_latest
-  , CAST(subq_23.bookings AS FLOAT64) / CAST(NULLIF(subq_23.views, 0) AS FLOAT64) AS bookings_per_view
+  subq_19.ds
+  , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS FLOAT64) / CAST(NULLIF(subq_19.views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']
   SELECT
-    subq_22.ds
-    , subq_22.listing__country_latest
-    , subq_22.bookings
-    , subq_22.views
+    subq_18.ds
+    , subq_18.listing__country_latest
+    , subq_18.bookings
+    , subq_18.views
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_10.ds AS ds
-      , subq_10.listing__country_latest AS listing__country_latest
-      , subq_10.bookings AS bookings
-      , subq_21.views AS views
+      subq_8.ds AS ds
+      , subq_8.listing__country_latest AS listing__country_latest
+      , subq_8.bookings AS bookings
+      , subq_17.views AS views
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.ds
-        , subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.ds
+        , subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest', 'ds']
         SELECT
-          subq_8.ds
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.ds
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.ds AS ds
-            , subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.ds AS ds
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'ds', 'listing']
             SELECT
-              subq_2.ds
-              , subq_2.listing
-              , subq_2.bookings
+              subq_1.ds
+              , subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.ds
-        , subq_9.listing__country_latest
-    ) subq_10
+        subq_7.ds
+        , subq_7.listing__country_latest
+    ) subq_8
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_20.ds
-        , subq_20.listing__country_latest
-        , SUM(subq_20.views) AS views
+        subq_16.ds
+        , subq_16.listing__country_latest
+        , SUM(subq_16.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_19.ds
-          , subq_19.listing__country_latest
-          , subq_19.views
+          subq_15.ds
+          , subq_15.listing__country_latest
+          , subq_15.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.ds AS ds
-            , subq_14.listing AS listing
-            , subq_18.country_latest AS listing__country_latest
-            , subq_14.views AS views
+            subq_11.ds AS ds
+            , subq_11.listing AS listing
+            , subq_14.country_latest AS listing__country_latest
+            , subq_11.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_13.ds
-              , subq_13.listing
-              , subq_13.views
+              subq_10.ds
+              , subq_10.listing
+              , subq_10.views
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_9.ds
+                , subq_9.ds__week
+                , subq_9.ds__month
+                , subq_9.ds__quarter
+                , subq_9.ds__year
+                , subq_9.ds_partitioned
+                , subq_9.ds_partitioned__week
+                , subq_9.ds_partitioned__month
+                , subq_9.ds_partitioned__quarter
+                , subq_9.ds_partitioned__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds
+                , subq_9.create_a_cycle_in_the_join_graph__ds__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_9.ds AS metric_time
+                , subq_9.ds__week AS metric_time__week
+                , subq_9.ds__month AS metric_time__month
+                , subq_9.ds__quarter AS metric_time__quarter
+                , subq_9.ds__year AS metric_time__year
+                , subq_9.listing
+                , subq_9.user
+                , subq_9.create_a_cycle_in_the_join_graph
+                , subq_9.create_a_cycle_in_the_join_graph__listing
+                , subq_9.create_a_cycle_in_the_join_graph__user
+                , subq_9.views
+              FROM (
+                -- Read Elements From Data Source 'views_source'
+                SELECT
+                  1 AS views
+                  , views_source_src_10009.ds
+                  , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(views_source_src_10009.ds, month) AS ds__month
+                  , DATE_TRUNC(views_source_src_10009.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS ds__year
+                  , views_source_src_10009.ds_partitioned
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC(views_source_src_10009.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC(views_source_src_10009.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , views_source_src_10009.listing_id AS listing
+                  , views_source_src_10009.user_id AS user
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
+                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
+                FROM (
+                  -- User Defined SQL Query
+                  SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+                ) views_source_src_10009
+              ) subq_9
+            ) subq_10
+          ) subq_11
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_13.listing
+              , subq_13.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
@@ -370,21 +360,21 @@ FROM (
                 , subq_12.ds__month
                 , subq_12.ds__quarter
                 , subq_12.ds__year
-                , subq_12.ds_partitioned
-                , subq_12.ds_partitioned__week
-                , subq_12.ds_partitioned__month
-                , subq_12.ds_partitioned__quarter
-                , subq_12.ds_partitioned__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds
-                , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_12.created_at
+                , subq_12.created_at__week
+                , subq_12.created_at__month
+                , subq_12.created_at__quarter
+                , subq_12.created_at__year
+                , subq_12.listing__ds
+                , subq_12.listing__ds__week
+                , subq_12.listing__ds__month
+                , subq_12.listing__ds__quarter
+                , subq_12.listing__ds__year
+                , subq_12.listing__created_at
+                , subq_12.listing__created_at__week
+                , subq_12.listing__created_at__month
+                , subq_12.listing__created_at__quarter
+                , subq_12.listing__created_at__year
                 , subq_12.ds AS metric_time
                 , subq_12.ds__week AS metric_time__week
                 , subq_12.ds__month AS metric_time__month
@@ -392,222 +382,80 @@ FROM (
                 , subq_12.ds__year AS metric_time__year
                 , subq_12.listing
                 , subq_12.user
-                , subq_12.create_a_cycle_in_the_join_graph
-                , subq_12.create_a_cycle_in_the_join_graph__listing
-                , subq_12.create_a_cycle_in_the_join_graph__user
-                , subq_12.views
+                , subq_12.listing__user
+                , subq_12.country_latest
+                , subq_12.is_lux_latest
+                , subq_12.capacity_latest
+                , subq_12.listing__country_latest
+                , subq_12.listing__is_lux_latest
+                , subq_12.listing__capacity_latest
+                , subq_12.listings
+                , subq_12.largest_listing
+                , subq_12.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_11.ds
-                  , subq_11.ds__week
-                  , subq_11.ds__month
-                  , subq_11.ds__quarter
-                  , subq_11.ds__year
-                  , subq_11.ds_partitioned
-                  , subq_11.ds_partitioned__week
-                  , subq_11.ds_partitioned__month
-                  , subq_11.ds_partitioned__quarter
-                  , subq_11.ds_partitioned__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_11.listing
-                  , subq_11.user
-                  , subq_11.create_a_cycle_in_the_join_graph
-                  , subq_11.create_a_cycle_in_the_join_graph__listing
-                  , subq_11.create_a_cycle_in_the_join_graph__user
-                  , subq_11.views
-                FROM (
-                  -- Read Elements From Data Source 'views_source'
-                  SELECT
-                    1 AS views
-                    , views_source_src_10009.ds
-                    , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS ds__week
-                    , DATE_TRUNC(views_source_src_10009.ds, month) AS ds__month
-                    , DATE_TRUNC(views_source_src_10009.ds, quarter) AS ds__quarter
-                    , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS ds__year
-                    , views_source_src_10009.ds_partitioned
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS ds_partitioned__month
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS ds_partitioned__year
-                    , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC(views_source_src_10009.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC(views_source_src_10009.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC(views_source_src_10009.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC(views_source_src_10009.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                    , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC(views_source_src_10009.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , views_source_src_10009.listing_id AS listing
-                    , views_source_src_10009.user_id AS user
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                    , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
-                  ) views_source_src_10009
-                ) subq_11
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
               ) subq_12
             ) subq_13
           ) subq_14
-          LEFT OUTER JOIN (
-            -- Pass Only Elements:
-            --   ['listing', 'country_latest']
-            SELECT
-              subq_17.listing
-              , subq_17.country_latest
-            FROM (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_16.ds
-                , subq_16.ds__week
-                , subq_16.ds__month
-                , subq_16.ds__quarter
-                , subq_16.ds__year
-                , subq_16.created_at
-                , subq_16.created_at__week
-                , subq_16.created_at__month
-                , subq_16.created_at__quarter
-                , subq_16.created_at__year
-                , subq_16.listing__ds
-                , subq_16.listing__ds__week
-                , subq_16.listing__ds__month
-                , subq_16.listing__ds__quarter
-                , subq_16.listing__ds__year
-                , subq_16.listing__created_at
-                , subq_16.listing__created_at__week
-                , subq_16.listing__created_at__month
-                , subq_16.listing__created_at__quarter
-                , subq_16.listing__created_at__year
-                , subq_16.ds AS metric_time
-                , subq_16.ds__week AS metric_time__week
-                , subq_16.ds__month AS metric_time__month
-                , subq_16.ds__quarter AS metric_time__quarter
-                , subq_16.ds__year AS metric_time__year
-                , subq_16.listing
-                , subq_16.user
-                , subq_16.listing__user
-                , subq_16.country_latest
-                , subq_16.is_lux_latest
-                , subq_16.capacity_latest
-                , subq_16.listing__country_latest
-                , subq_16.listing__is_lux_latest
-                , subq_16.listing__capacity_latest
-                , subq_16.listings
-                , subq_16.largest_listing
-                , subq_16.smallest_listing
-              FROM (
-                -- Pass Only Additive Measures
-                SELECT
-                  subq_15.ds
-                  , subq_15.ds__week
-                  , subq_15.ds__month
-                  , subq_15.ds__quarter
-                  , subq_15.ds__year
-                  , subq_15.created_at
-                  , subq_15.created_at__week
-                  , subq_15.created_at__month
-                  , subq_15.created_at__quarter
-                  , subq_15.created_at__year
-                  , subq_15.listing__ds
-                  , subq_15.listing__ds__week
-                  , subq_15.listing__ds__month
-                  , subq_15.listing__ds__quarter
-                  , subq_15.listing__ds__year
-                  , subq_15.listing__created_at
-                  , subq_15.listing__created_at__week
-                  , subq_15.listing__created_at__month
-                  , subq_15.listing__created_at__quarter
-                  , subq_15.listing__created_at__year
-                  , subq_15.listing
-                  , subq_15.user
-                  , subq_15.listing__user
-                  , subq_15.country_latest
-                  , subq_15.is_lux_latest
-                  , subq_15.capacity_latest
-                  , subq_15.listing__country_latest
-                  , subq_15.listing__is_lux_latest
-                  , subq_15.listing__capacity_latest
-                  , subq_15.listings
-                  , subq_15.largest_listing
-                  , subq_15.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_15
-              ) subq_16
-            ) subq_17
-          ) subq_18
           ON
-            subq_14.listing = subq_18.listing
-        ) subq_19
-      ) subq_20
+            subq_11.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       GROUP BY
-        subq_20.ds
-        , subq_20.listing__country_latest
-    ) subq_21
+        subq_16.ds
+        , subq_16.listing__country_latest
+    ) subq_17
     ON
       (
         (
-          subq_10.listing__country_latest = subq_21.listing__country_latest
+          subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
-            subq_10.listing__country_latest IS NULL
+            subq_8.listing__country_latest IS NULL
           ) AND (
-            subq_21.listing__country_latest IS NULL
+            subq_17.listing__country_latest IS NULL
           )
         )
       ) AND (
         (
-          subq_10.ds = subq_21.ds
+          subq_8.ds = subq_17.ds
         ) OR (
-          (subq_10.ds IS NULL) AND (subq_21.ds IS NULL)
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
-  ) subq_22
-) subq_23
+  ) subq_18
+) subq_19

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,21 +3,20 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  subq_34.ds AS ds
-  , subq_34.listing__country_latest AS listing__country_latest
-  , CAST(subq_34.bookings AS FLOAT64) / CAST(NULLIF(subq_45.views, 0) AS FLOAT64) AS bookings_per_view
+  subq_28.ds AS ds
+  , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS FLOAT64) / CAST(NULLIF(subq_37.views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_27.ds AS ds
+    subq_22.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_27.bookings) AS bookings
+    , SUM(subq_22.bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds', 'listing']
@@ -29,27 +28,26 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_27
+  ) subq_22
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_27.listing = listings_latest_src_10004.listing_id
+    subq_22.listing = listings_latest_src_10004.listing_id
   GROUP BY
     ds
     , listing__country_latest
-) subq_34
+) subq_28
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_38.ds AS ds
+    subq_31.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_38.views) AS views
+    , SUM(subq_31.views) AS views
   FROM (
     -- Read Elements From Data Source 'views_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['views', 'ds', 'listing']
@@ -61,30 +59,30 @@ INNER JOIN (
       -- User Defined SQL Query
       SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
     ) views_source_src_10009
-  ) subq_38
+  ) subq_31
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_38.listing = listings_latest_src_10004.listing_id
+    subq_31.listing = listings_latest_src_10004.listing_id
   GROUP BY
     ds
     , listing__country_latest
-) subq_45
+) subq_37
 ON
   (
     (
-      subq_34.listing__country_latest = subq_45.listing__country_latest
+      subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
-        subq_34.listing__country_latest IS NULL
+        subq_28.listing__country_latest IS NULL
       ) AND (
-        subq_45.listing__country_latest IS NULL
+        subq_37.listing__country_latest IS NULL
       )
     )
   ) AND (
     (
-      subq_34.ds = subq_45.ds
+      subq_28.ds = subq_37.ds
     ) OR (
-      (subq_34.ds IS NULL) AND (subq_45.ds IS NULL)
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+          , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+          , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_mtd
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+          , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+          , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_ds__plan0.sql
@@ -1,56 +1,45 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_4.txn_revenue) AS txn_revenue
+    SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue']
     SELECT
-      subq_2.txn_revenue
+      subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+          , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+          , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
-) subq_5
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_all_time
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+          , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+          , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+          , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS revenue_all_time
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-              , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-              , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-              , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2000-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2000-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS trailing_2_months_revenue
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+            , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-              , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-              , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-              , DATE_TRUNC(revenue_src_10006.created_at, isoyear) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2019-12-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2019-12-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_distinct_values__plan0.sql
@@ -1,329 +1,243 @@
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
-  subq_12.listing__country_latest
+  subq_10.listing__country_latest
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest']
   SELECT
-    subq_11.listing__country_latest
+    subq_9.listing__country_latest
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_10.listing__country_latest
-      , subq_10.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest']
         SELECT
-          subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.listing__country_latest
-    ) subq_10
-  ) subq_11
-) subq_12
-ORDER BY subq_12.listing__country_latest
+        subq_7.listing__country_latest
+    ) subq_8
+  ) subq_9
+) subq_10
+ORDER BY subq_10.listing__country_latest
 LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,334 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.is_instant
-  , subq_12.bookings
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.is_instant
-    , SUM(subq_11.bookings) AS bookings
+    subq_9.is_instant
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'is_instant']
     SELECT
-      subq_10.is_instant
-      , subq_10.bookings
+      subq_8.is_instant
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.is_instant
-        , subq_9.listing__country_latest
-        , subq_9.bookings
+        subq_7.is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'listing__country_latest']
         SELECT
-          subq_8.is_instant
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.is_instant AS is_instant
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.is_instant AS is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.is_instant
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                    , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
+                  , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE listing__country_latest = 'us'
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.is_instant
-) subq_12
+    subq_9.is_instant
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -11,12 +11,11 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'listing__country_latest']
   SELECT
-    subq_16.is_instant AS is_instant
+    subq_13.is_instant AS is_instant
     , listings_latest_src_10004.country AS listing__country_latest
-    , subq_16.bookings AS bookings
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'listing']
@@ -28,12 +27,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_16
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_16.listing = listings_latest_src_10004.listing_id
-) subq_22
+    subq_13.listing = listings_latest_src_10004.listing_id
+) subq_18
 WHERE listing__country_latest = 'us'
 GROUP BY
   is_instant

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0.sql
@@ -1,186 +1,136 @@
 -- Order By [] Limit 1
 SELECT
-  subq_5.ds
-  , subq_5.bookings
+  subq_4.ds
+  , subq_4.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.ds
-    , subq_4.bookings
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.ds
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.ds
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'ds']
       SELECT
-        subq_2.ds
-        , subq_2.bookings
+        subq_1.ds
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.ds
-  ) subq_4
-) subq_5
+      subq_2.ds
+  ) subq_3
+) subq_4
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
-) subq_9
+) subq_7
 GROUP BY
   ds
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,133 +1,97 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.listing__country_latest
-  , subq_4.listings
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.listing__country_latest
-    , SUM(subq_3.listings) AS listings
+    subq_2.listing__country_latest
+    , SUM(subq_2.listings) AS listings
   FROM (
     -- Pass Only Elements:
     --   ['listings', 'listing__country_latest']
     SELECT
-      subq_2.listing__country_latest
-      , subq_2.listings
+      subq_1.listing__country_latest
+      , subq_1.listings
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.created_at
-        , subq_1.created_at__week
-        , subq_1.created_at__month
-        , subq_1.created_at__quarter
-        , subq_1.created_at__year
-        , subq_1.listing__ds
-        , subq_1.listing__ds__week
-        , subq_1.listing__ds__month
-        , subq_1.listing__ds__quarter
-        , subq_1.listing__ds__year
-        , subq_1.listing__created_at
-        , subq_1.listing__created_at__week
-        , subq_1.listing__created_at__month
-        , subq_1.listing__created_at__quarter
-        , subq_1.listing__created_at__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.listing
-        , subq_1.user
-        , subq_1.listing__user
-        , subq_1.country_latest
-        , subq_1.is_lux_latest
-        , subq_1.capacity_latest
-        , subq_1.listing__country_latest
-        , subq_1.listing__is_lux_latest
-        , subq_1.listing__capacity_latest
-        , subq_1.listings
-        , subq_1.largest_listing
-        , subq_1.smallest_listing
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.created_at
+        , subq_0.created_at__week
+        , subq_0.created_at__month
+        , subq_0.created_at__quarter
+        , subq_0.created_at__year
+        , subq_0.listing__ds
+        , subq_0.listing__ds__week
+        , subq_0.listing__ds__month
+        , subq_0.listing__ds__quarter
+        , subq_0.listing__ds__year
+        , subq_0.listing__created_at
+        , subq_0.listing__created_at__week
+        , subq_0.listing__created_at__month
+        , subq_0.listing__created_at__quarter
+        , subq_0.listing__created_at__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.listing
+        , subq_0.user
+        , subq_0.listing__user
+        , subq_0.country_latest
+        , subq_0.is_lux_latest
+        , subq_0.capacity_latest
+        , subq_0.listing__country_latest
+        , subq_0.listing__is_lux_latest
+        , subq_0.listing__capacity_latest
+        , subq_0.listings
+        , subq_0.largest_listing
+        , subq_0.smallest_listing
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'listings_latest'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.created_at
-          , subq_0.created_at__week
-          , subq_0.created_at__month
-          , subq_0.created_at__quarter
-          , subq_0.created_at__year
-          , subq_0.listing__ds
-          , subq_0.listing__ds__week
-          , subq_0.listing__ds__month
-          , subq_0.listing__ds__quarter
-          , subq_0.listing__ds__year
-          , subq_0.listing__created_at
-          , subq_0.listing__created_at__week
-          , subq_0.listing__created_at__month
-          , subq_0.listing__created_at__quarter
-          , subq_0.listing__created_at__year
-          , subq_0.listing
-          , subq_0.user
-          , subq_0.listing__user
-          , subq_0.country_latest
-          , subq_0.is_lux_latest
-          , subq_0.capacity_latest
-          , subq_0.listing__country_latest
-          , subq_0.listing__is_lux_latest
-          , subq_0.listing__capacity_latest
-          , subq_0.listings
-          , subq_0.largest_listing
-          , subq_0.smallest_listing
-        FROM (
-          -- Read Elements From Data Source 'listings_latest'
-          SELECT
-            1 AS listings
-            , listings_latest_src_10004.capacity AS largest_listing
-            , listings_latest_src_10004.capacity AS smallest_listing
-            , listings_latest_src_10004.created_at AS ds
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
-            , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
-            , listings_latest_src_10004.created_at
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
-            , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
-            , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
-            , listings_latest_src_10004.country AS country_latest
-            , listings_latest_src_10004.is_lux AS is_lux_latest
-            , listings_latest_src_10004.capacity AS capacity_latest
-            , listings_latest_src_10004.created_at AS listing__ds
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
-            , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
-            , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
-            , listings_latest_src_10004.created_at AS listing__created_at
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
-            , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
-            , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-            , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
-            , listings_latest_src_10004.country AS listing__country_latest
-            , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-            , listings_latest_src_10004.capacity AS listing__capacity_latest
-            , listings_latest_src_10004.listing_id AS listing
-            , listings_latest_src_10004.user_id AS user
-            , listings_latest_src_10004.user_id AS listing__user
-          FROM ***************************.dim_listings_latest listings_latest_src_10004
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS listings
+          , listings_latest_src_10004.capacity AS largest_listing
+          , listings_latest_src_10004.capacity AS smallest_listing
+          , listings_latest_src_10004.created_at AS ds
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
+          , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
+          , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+          , listings_latest_src_10004.created_at
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
+          , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
+          , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+          , listings_latest_src_10004.country AS country_latest
+          , listings_latest_src_10004.is_lux AS is_lux_latest
+          , listings_latest_src_10004.capacity AS capacity_latest
+          , listings_latest_src_10004.created_at AS listing__ds
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
+          , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
+          , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+          , listings_latest_src_10004.created_at AS listing__created_at
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
+          , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
+          , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
+          , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+          , listings_latest_src_10004.country AS listing__country_latest
+          , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10004.capacity AS listing__capacity_latest
+          , listings_latest_src_10004.listing_id AS listing
+          , listings_latest_src_10004.user_id AS user
+          , listings_latest_src_10004.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10004
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.listing__country_latest
-) subq_4
+    subq_2.listing__country_latest
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings', 'listing__country_latest']
@@ -13,6 +12,6 @@ FROM (
     country AS listing__country_latest
     , 1 AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_8
+) subq_6
 GROUP BY
   listing__country_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0.sql
@@ -1,540 +1,404 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time
+  subq_16.metric_time
   , average_booking_value * bookings / NULLIF(booking_value, 0) AS lux_booking_value_rate_expr
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_18.metric_time
-    , subq_18.bookings
-    , subq_18.average_booking_value
-    , subq_18.booking_value
+    subq_15.metric_time
+    , subq_15.bookings
+    , subq_15.average_booking_value
+    , subq_15.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_12.metric_time AS metric_time
-      , subq_12.bookings AS bookings
-      , subq_12.average_booking_value AS average_booking_value
-      , subq_17.booking_value AS booking_value
+      subq_10.metric_time AS metric_time
+      , subq_10.bookings AS bookings
+      , subq_10.average_booking_value AS average_booking_value
+      , subq_14.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_11.metric_time
-        , SUM(subq_11.bookings) AS bookings
-        , AVG(subq_11.average_booking_value) AS average_booking_value
+        subq_9.metric_time
+        , SUM(subq_9.bookings) AS bookings
+        , AVG(subq_9.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time']
         SELECT
-          subq_10.metric_time
-          , subq_10.bookings
-          , subq_10.average_booking_value
+          subq_8.metric_time
+          , subq_8.bookings
+          , subq_8.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time
-            , subq_9.listing__is_lux_latest
-            , subq_9.bookings
-            , subq_9.average_booking_value
+            subq_7.metric_time
+            , subq_7.listing__is_lux_latest
+            , subq_7.bookings
+            , subq_7.average_booking_value
           FROM (
             -- Pass Only Elements:
             --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
             SELECT
-              subq_8.metric_time
-              , subq_8.listing__is_lux_latest
-              , subq_8.bookings
-              , subq_8.average_booking_value
+              subq_6.metric_time
+              , subq_6.listing__is_lux_latest
+              , subq_6.bookings
+              , subq_6.average_booking_value
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_3.metric_time AS metric_time
-                , subq_3.listing AS listing
-                , subq_7.is_lux_latest AS listing__is_lux_latest
-                , subq_3.bookings AS bookings
-                , subq_3.average_booking_value AS average_booking_value
+                subq_2.metric_time AS metric_time
+                , subq_2.listing AS listing
+                , subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.bookings AS bookings
+                , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements:
                 --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
                 SELECT
-                  subq_2.metric_time
-                  , subq_2.listing
-                  , subq_2.bookings
-                  , subq_2.average_booking_value
+                  subq_1.metric_time
+                  , subq_1.listing
+                  , subq_1.bookings
+                  , subq_1.average_booking_value
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_1.ds
-                    , subq_1.ds__week
-                    , subq_1.ds__month
-                    , subq_1.ds__quarter
-                    , subq_1.ds__year
-                    , subq_1.ds_partitioned
-                    , subq_1.ds_partitioned__week
-                    , subq_1.ds_partitioned__month
-                    , subq_1.ds_partitioned__quarter
-                    , subq_1.ds_partitioned__year
-                    , subq_1.booking_paid_at
-                    , subq_1.booking_paid_at__week
-                    , subq_1.booking_paid_at__month
-                    , subq_1.booking_paid_at__quarter
-                    , subq_1.booking_paid_at__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , subq_1.ds AS metric_time
-                    , subq_1.ds__week AS metric_time__week
-                    , subq_1.ds__month AS metric_time__month
-                    , subq_1.ds__quarter AS metric_time__quarter
-                    , subq_1.ds__year AS metric_time__year
-                    , subq_1.listing
-                    , subq_1.guest
-                    , subq_1.host
-                    , subq_1.create_a_cycle_in_the_join_graph
-                    , subq_1.create_a_cycle_in_the_join_graph__listing
-                    , subq_1.create_a_cycle_in_the_join_graph__guest
-                    , subq_1.create_a_cycle_in_the_join_graph__host
-                    , subq_1.is_instant
-                    , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                    , subq_1.bookings
-                    , subq_1.instant_bookings
-                    , subq_1.booking_value
-                    , subq_1.max_booking_value
-                    , subq_1.min_booking_value
-                    , subq_1.bookers
-                    , subq_1.average_booking_value
+                    subq_0.ds
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds_partitioned
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.booking_paid_at
+                    , subq_0.booking_paid_at__week
+                    , subq_0.booking_paid_at__month
+                    , subq_0.booking_paid_at__quarter
+                    , subq_0.booking_paid_at__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                    , subq_0.ds AS metric_time
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.create_a_cycle_in_the_join_graph
+                    , subq_0.create_a_cycle_in_the_join_graph__listing
+                    , subq_0.create_a_cycle_in_the_join_graph__guest
+                    , subq_0.create_a_cycle_in_the_join_graph__host
+                    , subq_0.is_instant
+                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'bookings_source'
                     SELECT
-                      subq_0.ds
-                      , subq_0.ds__week
-                      , subq_0.ds__month
-                      , subq_0.ds__quarter
-                      , subq_0.ds__year
-                      , subq_0.ds_partitioned
-                      , subq_0.ds_partitioned__week
-                      , subq_0.ds_partitioned__month
-                      , subq_0.ds_partitioned__quarter
-                      , subq_0.ds_partitioned__year
-                      , subq_0.booking_paid_at
-                      , subq_0.booking_paid_at__week
-                      , subq_0.booking_paid_at__month
-                      , subq_0.booking_paid_at__quarter
-                      , subq_0.booking_paid_at__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                      , subq_0.listing
-                      , subq_0.guest
-                      , subq_0.host
-                      , subq_0.create_a_cycle_in_the_join_graph
-                      , subq_0.create_a_cycle_in_the_join_graph__listing
-                      , subq_0.create_a_cycle_in_the_join_graph__guest
-                      , subq_0.create_a_cycle_in_the_join_graph__host
-                      , subq_0.is_instant
-                      , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                      , subq_0.bookings
-                      , subq_0.instant_bookings
-                      , subq_0.booking_value
-                      , subq_0.max_booking_value
-                      , subq_0.min_booking_value
-                      , subq_0.bookers
-                      , subq_0.average_booking_value
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_10001.booking_value
+                      , bookings_source_src_10001.booking_value AS max_booking_value
+                      , bookings_source_src_10001.booking_value AS min_booking_value
+                      , bookings_source_src_10001.guest_id AS bookers
+                      , bookings_source_src_10001.booking_value AS average_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_payments
+                      , bookings_source_src_10001.is_instant
+                      , bookings_source_src_10001.ds
+                      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                      , bookings_source_src_10001.ds_partitioned
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                      , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                      , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                      , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                      , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                      , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                      , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                      , bookings_source_src_10001.listing_id AS listing
+                      , bookings_source_src_10001.guest_id AS guest
+                      , bookings_source_src_10001.host_id AS host
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM (
-                      -- Read Elements From Data Source 'bookings_source'
-                      SELECT
-                        1 AS bookings
-                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                        , bookings_source_src_10001.booking_value
-                        , bookings_source_src_10001.booking_value AS max_booking_value
-                        , bookings_source_src_10001.booking_value AS min_booking_value
-                        , bookings_source_src_10001.guest_id AS bookers
-                        , bookings_source_src_10001.booking_value AS average_booking_value
-                        , bookings_source_src_10001.booking_value AS booking_payments
-                        , bookings_source_src_10001.is_instant
-                        , bookings_source_src_10001.ds
-                        , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                        , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                        , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                        , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                        , bookings_source_src_10001.ds_partitioned
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                        , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                        , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                        , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                        , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                        , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                        , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                        , bookings_source_src_10001.listing_id AS listing
-                        , bookings_source_src_10001.guest_id AS guest
-                        , bookings_source_src_10001.host_id AS host
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                      FROM (
-                        -- User Defined SQL Query
-                        SELECT * FROM ***************************.fct_bookings
-                      ) bookings_source_src_10001
-                    ) subq_0
-                  ) subq_1
-                ) subq_2
-              ) subq_3
+                      -- User Defined SQL Query
+                      SELECT * FROM ***************************.fct_bookings
+                    ) bookings_source_src_10001
+                  ) subq_0
+                ) subq_1
+              ) subq_2
               LEFT OUTER JOIN (
                 -- Pass Only Elements:
                 --   ['listing', 'is_lux_latest']
                 SELECT
-                  subq_6.listing
-                  , subq_6.is_lux_latest
+                  subq_4.listing
+                  , subq_4.is_lux_latest
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_5.ds
-                    , subq_5.ds__week
-                    , subq_5.ds__month
-                    , subq_5.ds__quarter
-                    , subq_5.ds__year
-                    , subq_5.created_at
-                    , subq_5.created_at__week
-                    , subq_5.created_at__month
-                    , subq_5.created_at__quarter
-                    , subq_5.created_at__year
-                    , subq_5.listing__ds
-                    , subq_5.listing__ds__week
-                    , subq_5.listing__ds__month
-                    , subq_5.listing__ds__quarter
-                    , subq_5.listing__ds__year
-                    , subq_5.listing__created_at
-                    , subq_5.listing__created_at__week
-                    , subq_5.listing__created_at__month
-                    , subq_5.listing__created_at__quarter
-                    , subq_5.listing__created_at__year
-                    , subq_5.ds AS metric_time
-                    , subq_5.ds__week AS metric_time__week
-                    , subq_5.ds__month AS metric_time__month
-                    , subq_5.ds__quarter AS metric_time__quarter
-                    , subq_5.ds__year AS metric_time__year
-                    , subq_5.listing
-                    , subq_5.user
-                    , subq_5.listing__user
-                    , subq_5.country_latest
-                    , subq_5.is_lux_latest
-                    , subq_5.capacity_latest
-                    , subq_5.listing__country_latest
-                    , subq_5.listing__is_lux_latest
-                    , subq_5.listing__capacity_latest
-                    , subq_5.listings
-                    , subq_5.largest_listing
-                    , subq_5.smallest_listing
+                    subq_3.ds
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.created_at
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.listing__ds
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__created_at
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.ds AS metric_time
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'listings_latest'
                     SELECT
-                      subq_4.ds
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.created_at
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.listing__ds
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__created_at
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
-                    FROM (
-                      -- Read Elements From Data Source 'listings_latest'
-                      SELECT
-                        1 AS listings
-                        , listings_latest_src_10004.capacity AS largest_listing
-                        , listings_latest_src_10004.capacity AS smallest_listing
-                        , listings_latest_src_10004.created_at AS ds
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
-                        , listings_latest_src_10004.created_at
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
-                        , listings_latest_src_10004.country AS country_latest
-                        , listings_latest_src_10004.is_lux AS is_lux_latest
-                        , listings_latest_src_10004.capacity AS capacity_latest
-                        , listings_latest_src_10004.created_at AS listing__ds
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
-                        , listings_latest_src_10004.created_at AS listing__created_at
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
-                        , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
-                        , listings_latest_src_10004.country AS listing__country_latest
-                        , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                        , listings_latest_src_10004.capacity AS listing__capacity_latest
-                        , listings_latest_src_10004.listing_id AS listing
-                        , listings_latest_src_10004.user_id AS user
-                        , listings_latest_src_10004.user_id AS listing__user
-                      FROM ***************************.dim_listings_latest listings_latest_src_10004
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
-              ) subq_7
+                      1 AS listings
+                      , listings_latest_src_10004.capacity AS largest_listing
+                      , listings_latest_src_10004.capacity AS smallest_listing
+                      , listings_latest_src_10004.created_at AS ds
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS ds__week
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS ds__month
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS ds__quarter
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS ds__year
+                      , listings_latest_src_10004.created_at
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS created_at__week
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS created_at__month
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS created_at__quarter
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS created_at__year
+                      , listings_latest_src_10004.country AS country_latest
+                      , listings_latest_src_10004.is_lux AS is_lux_latest
+                      , listings_latest_src_10004.capacity AS capacity_latest
+                      , listings_latest_src_10004.created_at AS listing__ds
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__ds__week
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__ds__month
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__ds__quarter
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__ds__year
+                      , listings_latest_src_10004.created_at AS listing__created_at
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoweek) AS listing__created_at__week
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, month) AS listing__created_at__month
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, quarter) AS listing__created_at__quarter
+                      , DATE_TRUNC(listings_latest_src_10004.created_at, isoyear) AS listing__created_at__year
+                      , listings_latest_src_10004.country AS listing__country_latest
+                      , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_10004.capacity AS listing__capacity_latest
+                      , listings_latest_src_10004.listing_id AS listing
+                      , listings_latest_src_10004.user_id AS user
+                      , listings_latest_src_10004.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_10004
+                  ) subq_3
+                ) subq_4
+              ) subq_5
               ON
-                subq_3.listing = subq_7.listing
-            ) subq_8
-          ) subq_9
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
           WHERE listing__is_lux_latest
-        ) subq_10
-      ) subq_11
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_11.metric_time
-    ) subq_12
+        subq_9.metric_time
+    ) subq_10
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_16.metric_time
-        , SUM(subq_16.booking_value) AS booking_value
+        subq_13.metric_time
+        , SUM(subq_13.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_15.metric_time
-          , subq_15.booking_value
+          subq_12.metric_time
+          , subq_12.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_14.ds
-            , subq_14.ds__week
-            , subq_14.ds__month
-            , subq_14.ds__quarter
-            , subq_14.ds__year
-            , subq_14.ds_partitioned
-            , subq_14.ds_partitioned__week
-            , subq_14.ds_partitioned__month
-            , subq_14.ds_partitioned__quarter
-            , subq_14.ds_partitioned__year
-            , subq_14.booking_paid_at
-            , subq_14.booking_paid_at__week
-            , subq_14.booking_paid_at__month
-            , subq_14.booking_paid_at__quarter
-            , subq_14.booking_paid_at__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds
-            , subq_14.create_a_cycle_in_the_join_graph__ds__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_14.ds AS metric_time
-            , subq_14.ds__week AS metric_time__week
-            , subq_14.ds__month AS metric_time__month
-            , subq_14.ds__quarter AS metric_time__quarter
-            , subq_14.ds__year AS metric_time__year
-            , subq_14.listing
-            , subq_14.guest
-            , subq_14.host
-            , subq_14.create_a_cycle_in_the_join_graph
-            , subq_14.create_a_cycle_in_the_join_graph__listing
-            , subq_14.create_a_cycle_in_the_join_graph__guest
-            , subq_14.create_a_cycle_in_the_join_graph__host
-            , subq_14.is_instant
-            , subq_14.create_a_cycle_in_the_join_graph__is_instant
-            , subq_14.bookings
-            , subq_14.instant_bookings
-            , subq_14.booking_value
-            , subq_14.max_booking_value
-            , subq_14.min_booking_value
-            , subq_14.bookers
-            , subq_14.average_booking_value
+            subq_11.ds
+            , subq_11.ds__week
+            , subq_11.ds__month
+            , subq_11.ds__quarter
+            , subq_11.ds__year
+            , subq_11.ds_partitioned
+            , subq_11.ds_partitioned__week
+            , subq_11.ds_partitioned__month
+            , subq_11.ds_partitioned__quarter
+            , subq_11.ds_partitioned__year
+            , subq_11.booking_paid_at
+            , subq_11.booking_paid_at__week
+            , subq_11.booking_paid_at__month
+            , subq_11.booking_paid_at__quarter
+            , subq_11.booking_paid_at__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds
+            , subq_11.create_a_cycle_in_the_join_graph__ds__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_11.ds AS metric_time
+            , subq_11.ds__week AS metric_time__week
+            , subq_11.ds__month AS metric_time__month
+            , subq_11.ds__quarter AS metric_time__quarter
+            , subq_11.ds__year AS metric_time__year
+            , subq_11.listing
+            , subq_11.guest
+            , subq_11.host
+            , subq_11.create_a_cycle_in_the_join_graph
+            , subq_11.create_a_cycle_in_the_join_graph__listing
+            , subq_11.create_a_cycle_in_the_join_graph__guest
+            , subq_11.create_a_cycle_in_the_join_graph__host
+            , subq_11.is_instant
+            , subq_11.create_a_cycle_in_the_join_graph__is_instant
+            , subq_11.bookings
+            , subq_11.instant_bookings
+            , subq_11.booking_value
+            , subq_11.max_booking_value
+            , subq_11.min_booking_value
+            , subq_11.bookers
+            , subq_11.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_13.ds
-              , subq_13.ds__week
-              , subq_13.ds__month
-              , subq_13.ds__quarter
-              , subq_13.ds__year
-              , subq_13.ds_partitioned
-              , subq_13.ds_partitioned__week
-              , subq_13.ds_partitioned__month
-              , subq_13.ds_partitioned__quarter
-              , subq_13.ds_partitioned__year
-              , subq_13.booking_paid_at
-              , subq_13.booking_paid_at__week
-              , subq_13.booking_paid_at__month
-              , subq_13.booking_paid_at__quarter
-              , subq_13.booking_paid_at__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds
-              , subq_13.create_a_cycle_in_the_join_graph__ds__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_13.listing
-              , subq_13.guest
-              , subq_13.host
-              , subq_13.create_a_cycle_in_the_join_graph
-              , subq_13.create_a_cycle_in_the_join_graph__listing
-              , subq_13.create_a_cycle_in_the_join_graph__guest
-              , subq_13.create_a_cycle_in_the_join_graph__host
-              , subq_13.is_instant
-              , subq_13.create_a_cycle_in_the_join_graph__is_instant
-              , subq_13.bookings
-              , subq_13.instant_bookings
-              , subq_13.booking_value
-              , subq_13.max_booking_value
-              , subq_13.min_booking_value
-              , subq_13.bookers
-              , subq_13.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_13
-          ) subq_14
-        ) subq_15
-      ) subq_16
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_11
+        ) subq_12
+      ) subq_13
       GROUP BY
-        subq_16.metric_time
-    ) subq_17
+        subq_13.metric_time
+    ) subq_14
     ON
       (
         (
-          subq_12.metric_time = subq_17.metric_time
+          subq_10.metric_time = subq_14.metric_time
         ) OR (
-          (subq_12.metric_time IS NULL) AND (subq_17.metric_time IS NULL)
+          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
         )
       )
-  ) subq_18
-) subq_19
+  ) subq_15
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0_optimized.sql
@@ -7,10 +7,10 @@ FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_32.metric_time AS metric_time
-    , subq_32.bookings AS bookings
-    , subq_32.average_booking_value AS average_booking_value
-    , subq_37.booking_value AS booking_value
+    subq_27.metric_time AS metric_time
+    , subq_27.bookings AS bookings
+    , subq_27.average_booking_value AS average_booking_value
+    , subq_31.booking_value AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
@@ -25,13 +25,12 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
       SELECT
-        subq_23.metric_time AS metric_time
+        subq_19.metric_time AS metric_time
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-        , subq_23.bookings AS bookings
-        , subq_23.average_booking_value AS average_booking_value
+        , subq_19.bookings AS bookings
+        , subq_19.average_booking_value AS average_booking_value
       FROM (
         -- Read Elements From Data Source 'bookings_source'
-        -- Pass Only Additive Measures
         -- Metric Time Dimension 'ds'
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
@@ -44,19 +43,18 @@ FROM (
           -- User Defined SQL Query
           SELECT * FROM ***************************.fct_bookings
         ) bookings_source_src_10001
-      ) subq_23
+      ) subq_19
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_10004
       ON
-        subq_23.listing = listings_latest_src_10004.listing_id
-    ) subq_29
+        subq_19.listing = listings_latest_src_10004.listing_id
+    ) subq_24
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time
-  ) subq_32
+  ) subq_27
   INNER JOIN (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'metric_time']
@@ -70,13 +68,13 @@ FROM (
     ) bookings_source_src_10001
     GROUP BY
       metric_time
-  ) subq_37
+  ) subq_31
   ON
     (
       (
-        subq_32.metric_time = subq_37.metric_time
+        subq_27.metric_time = subq_31.metric_time
       ) OR (
-        (subq_32.metric_time IS NULL) AND (subq_37.metric_time IS NULL)
+        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
       )
     )
-) subq_39
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,393 +1,293 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_13.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
+  subq_11.metric_time
+  , CAST(subq_11.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_11.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
   SELECT
-    subq_12.metric_time
-    , subq_12.booking_value_with_is_instant_constraint
-    , subq_12.booking_value
+    subq_10.metric_time
+    , subq_10.booking_value_with_is_instant_constraint
+    , subq_10.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_6.metric_time AS metric_time
-      , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_11.booking_value AS booking_value
+      subq_5.metric_time AS metric_time
+      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+      , subq_9.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time
-        , SUM(subq_5.booking_value) AS booking_value_with_is_instant_constraint
+        subq_4.metric_time
+        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_4.metric_time
-          , subq_4.booking_value
+          subq_3.metric_time
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time
-            , subq_3.is_instant
-            , subq_3.booking_value
+            subq_2.metric_time
+            , subq_2.is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements:
             --   ['booking_value', 'is_instant', 'metric_time']
             SELECT
-              subq_2.metric_time
-              , subq_2.is_instant
-              , subq_2.booking_value
+              subq_1.metric_time
+              , subq_1.is_instant
+              , subq_1.booking_value
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time
-    ) subq_6
+        subq_4.metric_time
+    ) subq_5
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_8.metric_time
+        , SUM(subq_8.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_9.metric_time
-          , subq_9.booking_value
+          subq_7.metric_time
+          , subq_7.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds_partitioned
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.booking_paid_at
-            , subq_8.booking_paid_at__week
-            , subq_8.booking_paid_at__month
-            , subq_8.booking_paid_at__quarter
-            , subq_8.booking_paid_at__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds
-            , subq_8.create_a_cycle_in_the_join_graph__ds__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_8.ds AS metric_time
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.create_a_cycle_in_the_join_graph
-            , subq_8.create_a_cycle_in_the_join_graph__listing
-            , subq_8.create_a_cycle_in_the_join_graph__guest
-            , subq_8.create_a_cycle_in_the_join_graph__host
-            , subq_8.is_instant
-            , subq_8.create_a_cycle_in_the_join_graph__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds_partitioned
+            , subq_6.ds_partitioned__week
+            , subq_6.ds_partitioned__month
+            , subq_6.ds_partitioned__quarter
+            , subq_6.ds_partitioned__year
+            , subq_6.booking_paid_at
+            , subq_6.booking_paid_at__week
+            , subq_6.booking_paid_at__month
+            , subq_6.booking_paid_at__quarter
+            , subq_6.booking_paid_at__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds
+            , subq_6.create_a_cycle_in_the_join_graph__ds__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.guest
+            , subq_6.host
+            , subq_6.create_a_cycle_in_the_join_graph
+            , subq_6.create_a_cycle_in_the_join_graph__listing
+            , subq_6.create_a_cycle_in_the_join_graph__guest
+            , subq_6.create_a_cycle_in_the_join_graph__host
+            , subq_6.is_instant
+            , subq_6.create_a_cycle_in_the_join_graph__is_instant
+            , subq_6.bookings
+            , subq_6.instant_bookings
+            , subq_6.booking_value
+            , subq_6.max_booking_value
+            , subq_6.min_booking_value
+            , subq_6.bookers
+            , subq_6.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_7.ds
-              , subq_7.ds__week
-              , subq_7.ds__month
-              , subq_7.ds__quarter
-              , subq_7.ds__year
-              , subq_7.ds_partitioned
-              , subq_7.ds_partitioned__week
-              , subq_7.ds_partitioned__month
-              , subq_7.ds_partitioned__quarter
-              , subq_7.ds_partitioned__year
-              , subq_7.booking_paid_at
-              , subq_7.booking_paid_at__week
-              , subq_7.booking_paid_at__month
-              , subq_7.booking_paid_at__quarter
-              , subq_7.booking_paid_at__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds
-              , subq_7.create_a_cycle_in_the_join_graph__ds__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_7.listing
-              , subq_7.guest
-              , subq_7.host
-              , subq_7.create_a_cycle_in_the_join_graph
-              , subq_7.create_a_cycle_in_the_join_graph__listing
-              , subq_7.create_a_cycle_in_the_join_graph__guest
-              , subq_7.create_a_cycle_in_the_join_graph__host
-              , subq_7.is_instant
-              , subq_7.create_a_cycle_in_the_join_graph__is_instant
-              , subq_7.bookings
-              , subq_7.instant_bookings
-              , subq_7.booking_value
-              , subq_7.max_booking_value
-              , subq_7.min_booking_value
-              , subq_7.bookers
-              , subq_7.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_7
-          ) subq_8
-        ) subq_9
-      ) subq_10
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_6
+        ) subq_7
+      ) subq_8
       GROUP BY
-        subq_10.metric_time
-    ) subq_11
+        subq_8.metric_time
+    ) subq_9
     ON
       (
         (
-          subq_6.metric_time = subq_11.metric_time
+          subq_5.metric_time = subq_9.metric_time
         ) OR (
-          (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
         )
       )
-  ) subq_12
-) subq_13
+  ) subq_10
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,8 +3,8 @@
 --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time AS metric_time
-  , CAST(subq_20.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_25.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
+  subq_17.metric_time AS metric_time
+  , CAST(subq_17.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_21.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
@@ -15,7 +15,6 @@ FROM (
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'is_instant', 'metric_time']
@@ -27,14 +26,13 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_17
+  ) subq_14
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_20
+) subq_17
 INNER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
@@ -48,12 +46,12 @@ INNER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     metric_time
-) subq_25
+) subq_21
 ON
   (
     (
-      subq_20.metric_time = subq_25.metric_time
+      subq_17.metric_time = subq_21.metric_time
     ) OR (
-      (subq_20.metric_time IS NULL) AND (subq_25.metric_time IS NULL)
+      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,195 +1,145 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.metric_time
+  subq_5.metric_time
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.metric_time
-    , SUM(subq_5.bookings) AS delayed_bookings
+    subq_4.metric_time
+    , SUM(subq_4.bookings) AS delayed_bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
     SELECT
-      subq_4.metric_time
-      , subq_4.bookings
+      subq_3.metric_time
+      , subq_3.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_3.metric_time
-        , subq_3.is_instant
-        , subq_3.bookings
+        subq_2.metric_time
+        , subq_2.is_instant
+        , subq_2.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'metric_time']
         SELECT
-          subq_2.metric_time
-          , subq_2.is_instant
-          , subq_2.bookings
+          subq_1.metric_time
+          , subq_1.is_instant
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.booking_paid_at
-            , subq_1.booking_paid_at__week
-            , subq_1.booking_paid_at__month
-            , subq_1.booking_paid_at__quarter
-            , subq_1.booking_paid_at__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds
-            , subq_1.create_a_cycle_in_the_join_graph__ds__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.listing
-            , subq_1.guest
-            , subq_1.host
-            , subq_1.create_a_cycle_in_the_join_graph
-            , subq_1.create_a_cycle_in_the_join_graph__listing
-            , subq_1.create_a_cycle_in_the_join_graph__guest
-            , subq_1.create_a_cycle_in_the_join_graph__host
-            , subq_1.is_instant
-            , subq_1.create_a_cycle_in_the_join_graph__is_instant
-            , subq_1.bookings
-            , subq_1.instant_bookings
-            , subq_1.booking_value
-            , subq_1.max_booking_value
-            , subq_1.min_booking_value
-            , subq_1.bookers
-            , subq_1.average_booking_value
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.booking_paid_at
-              , subq_0.booking_paid_at__week
-              , subq_0.booking_paid_at__month
-              , subq_0.booking_paid_at__quarter
-              , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_0.listing
-              , subq_0.guest
-              , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
-              , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
-              , subq_0.bookings
-              , subq_0.instant_bookings
-              , subq_0.booking_value
-              , subq_0.max_booking_value
-              , subq_0.min_booking_value
-              , subq_0.bookers
-              , subq_0.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
       WHERE NOT is_instant
-    ) subq_4
-  ) subq_5
+    ) subq_3
+  ) subq_4
   GROUP BY
-    subq_5.metric_time
-) subq_6
+    subq_4.metric_time
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , SUM(bookings) AS delayed_bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'metric_time']
@@ -24,8 +23,8 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_10
+  ) subq_8
   WHERE NOT is_instant
   GROUP BY
     metric_time
-) subq_13
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0.sql
@@ -1,156 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.account_id__customer_id__customer_name
-  , subq_11.txn_count
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.account_id__customer_id__customer_name
-    , SUM(subq_10.txn_count) AS txn_count
+    subq_9.account_id__customer_id__customer_name
+    , SUM(subq_9.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements:
     --   ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_9.account_id__customer_id__customer_name
-      , subq_9.txn_count
+      subq_8.account_id__customer_id__customer_name
+      , subq_8.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_8.ds_partitioned AS account_id__ds_partitioned
-        , subq_3.account_id AS account_id
-        , subq_8.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_3.txn_count AS txn_count
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_7.ds_partitioned AS account_id__ds_partitioned
+        , subq_2.account_id AS account_id
+        , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements:
         --   ['txn_count', 'account_id', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.account_id
-          , subq_2.txn_count
+          subq_1.ds_partitioned
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.account_id__ds_partitioned
-            , subq_1.account_id__ds_partitioned__week
-            , subq_1.account_id__ds_partitioned__month
-            , subq_1.account_id__ds_partitioned__quarter
-            , subq_1.account_id__ds_partitioned__year
-            , subq_1.account_id__ds
-            , subq_1.account_id__ds__week
-            , subq_1.account_id__ds__month
-            , subq_1.account_id__ds__quarter
-            , subq_1.account_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.account_id
-            , subq_1.account_month
-            , subq_1.account_id__account_month
-            , subq_1.txn_count
+            subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.account_id__ds_partitioned
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'account_month_txns'
             SELECT
-              subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.account_id__ds_partitioned
-              , subq_0.account_id__ds_partitioned__week
-              , subq_0.account_id__ds_partitioned__month
-              , subq_0.account_id__ds_partitioned__quarter
-              , subq_0.account_id__ds_partitioned__year
-              , subq_0.account_id__ds
-              , subq_0.account_id__ds__week
-              , subq_0.account_id__ds__month
-              , subq_0.account_id__ds__quarter
-              , subq_0.account_id__ds__year
-              , subq_0.account_id
-              , subq_0.account_month
-              , subq_0.account_id__account_month
-              , subq_0.txn_count
-            FROM (
-              -- Read Elements From Data Source 'account_month_txns'
-              SELECT
-                account_month_txns_src_10010.txn_count
-                , account_month_txns_src_10010.ds_partitioned
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS ds_partitioned__week
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS ds_partitioned__month
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoyear) AS ds_partitioned__year
-                , account_month_txns_src_10010.ds
-                , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS ds__week
-                , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS ds__month
-                , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(account_month_txns_src_10010.ds, isoyear) AS ds__year
-                , account_month_txns_src_10010.account_month
-                , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS account_id__ds_partitioned__week
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS account_id__ds_partitioned__month
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS account_id__ds_partitioned__quarter
-                , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoyear) AS account_id__ds_partitioned__year
-                , account_month_txns_src_10010.ds AS account_id__ds
-                , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS account_id__ds__week
-                , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS account_id__ds__month
-                , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS account_id__ds__quarter
-                , DATE_TRUNC(account_month_txns_src_10010.ds, isoyear) AS account_id__ds__year
-                , account_month_txns_src_10010.account_month AS account_id__account_month
-                , account_month_txns_src_10010.account_id
-              FROM ***************************.account_month_txns account_month_txns_src_10010
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              account_month_txns_src_10010.txn_count
+              , account_month_txns_src_10010.ds_partitioned
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoyear) AS ds_partitioned__year
+              , account_month_txns_src_10010.ds
+              , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS ds__week
+              , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS ds__month
+              , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(account_month_txns_src_10010.ds, isoyear) AS ds__year
+              , account_month_txns_src_10010.account_month
+              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoweek) AS account_id__ds_partitioned__week
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, month) AS account_id__ds_partitioned__month
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, quarter) AS account_id__ds_partitioned__quarter
+              , DATE_TRUNC(account_month_txns_src_10010.ds_partitioned, isoyear) AS account_id__ds_partitioned__year
+              , account_month_txns_src_10010.ds AS account_id__ds
+              , DATE_TRUNC(account_month_txns_src_10010.ds, isoweek) AS account_id__ds__week
+              , DATE_TRUNC(account_month_txns_src_10010.ds, month) AS account_id__ds__month
+              , DATE_TRUNC(account_month_txns_src_10010.ds, quarter) AS account_id__ds__quarter
+              , DATE_TRUNC(account_month_txns_src_10010.ds, isoyear) AS account_id__ds__year
+              , account_month_txns_src_10010.account_month AS account_id__account_month
+              , account_month_txns_src_10010.account_id
+            FROM ***************************.account_month_txns account_month_txns_src_10010
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
         SELECT
-          subq_7.ds_partitioned
-          , subq_7.account_id
-          , subq_7.customer_id__customer_name
+          subq_6.ds_partitioned
+          , subq_6.account_id
+          , subq_6.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned AS ds_partitioned
-            , subq_4.ds_partitioned__week AS ds_partitioned__week
-            , subq_4.ds_partitioned__month AS ds_partitioned__month
-            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_4.ds_partitioned__year AS ds_partitioned__year
-            , subq_4.account_id__ds_partitioned AS account_id__ds_partitioned
-            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_6.ds_partitioned AS customer_id__ds_partitioned
-            , subq_6.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_6.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_6.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_6.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_4.account_id AS account_id
-            , subq_4.customer_id AS customer_id
-            , subq_4.account_id__customer_id AS account_id__customer_id
-            , subq_4.extra_dim AS extra_dim
-            , subq_4.account_id__extra_dim AS account_id__extra_dim
-            , subq_6.customer_name AS customer_id__customer_name
-            , subq_6.customer_atomic_weight AS customer_id__customer_atomic_weight
+            subq_3.ds_partitioned AS ds_partitioned
+            , subq_3.ds_partitioned__week AS ds_partitioned__week
+            , subq_3.ds_partitioned__month AS ds_partitioned__month
+            , subq_3.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_3.ds_partitioned__year AS ds_partitioned__year
+            , subq_3.account_id__ds_partitioned AS account_id__ds_partitioned
+            , subq_3.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_3.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_3.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_3.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_5.ds_partitioned AS customer_id__ds_partitioned
+            , subq_5.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_5.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_5.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_5.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_3.account_id AS account_id
+            , subq_3.customer_id AS customer_id
+            , subq_3.account_id__customer_id AS account_id__customer_id
+            , subq_3.extra_dim AS extra_dim
+            , subq_3.account_id__extra_dim AS account_id__extra_dim
+            , subq_5.customer_name AS customer_id__customer_name
+            , subq_5.customer_atomic_weight AS customer_id__customer_atomic_weight
           FROM (
             -- Read Elements From Data Source 'bridge_table'
             SELECT
@@ -170,7 +142,7 @@ FROM (
               , bridge_table_src_10011.customer_id
               , bridge_table_src_10011.customer_id AS account_id__customer_id
             FROM ***************************.bridge_table bridge_table_src_10011
-          ) subq_4
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['customer_name',
@@ -189,21 +161,21 @@ FROM (
             --    'customer_id__ds_partitioned__quarter',
             --    'customer_id__ds_partitioned__year']
             SELECT
-              subq_5.ds_partitioned
-              , subq_5.ds_partitioned__week
-              , subq_5.ds_partitioned__month
-              , subq_5.ds_partitioned__quarter
-              , subq_5.ds_partitioned__year
-              , subq_5.customer_id__ds_partitioned
-              , subq_5.customer_id__ds_partitioned__week
-              , subq_5.customer_id__ds_partitioned__month
-              , subq_5.customer_id__ds_partitioned__quarter
-              , subq_5.customer_id__ds_partitioned__year
-              , subq_5.customer_id
-              , subq_5.customer_name
-              , subq_5.customer_atomic_weight
-              , subq_5.customer_id__customer_name
-              , subq_5.customer_id__customer_atomic_weight
+              subq_4.ds_partitioned
+              , subq_4.ds_partitioned__week
+              , subq_4.ds_partitioned__month
+              , subq_4.ds_partitioned__quarter
+              , subq_4.ds_partitioned__year
+              , subq_4.customer_id__ds_partitioned
+              , subq_4.customer_id__ds_partitioned__week
+              , subq_4.customer_id__ds_partitioned__month
+              , subq_4.customer_id__ds_partitioned__quarter
+              , subq_4.customer_id__ds_partitioned__year
+              , subq_4.customer_id
+              , subq_4.customer_name
+              , subq_4.customer_atomic_weight
+              , subq_4.customer_id__customer_name
+              , subq_4.customer_id__customer_atomic_weight
             FROM (
               -- Read Elements From Data Source 'customer_table'
               SELECT
@@ -223,24 +195,24 @@ FROM (
                 , DATE_TRUNC(customer_table_src_10013.ds_partitioned, isoyear) AS customer_id__ds_partitioned__year
                 , customer_table_src_10013.customer_id
               FROM ***************************.customer_table customer_table_src_10013
-            ) subq_5
-          ) subq_6
+            ) subq_4
+          ) subq_5
           ON
             (
-              subq_4.customer_id = subq_6.customer_id
+              subq_3.customer_id = subq_5.customer_id
             ) AND (
-              subq_4.ds_partitioned = subq_6.ds_partitioned
+              subq_3.ds_partitioned = subq_5.ds_partitioned
             )
-        ) subq_7
-      ) subq_8
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_3.account_id = subq_8.account_id
+          subq_2.account_id = subq_7.account_id
         ) AND (
-          subq_3.ds_partitioned = subq_8.ds_partitioned
+          subq_2.ds_partitioned = subq_7.ds_partitioned
         )
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.account_id__customer_id__customer_name
-) subq_11
+    subq_9.account_id__customer_id__customer_name
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,7 +4,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_10010.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10010
 LEFT OUTER JOIN (
@@ -24,12 +24,12 @@ LEFT OUTER JOIN (
     ) AND (
       bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
     )
-) subq_20
+) subq_18
 ON
   (
-    account_month_txns_src_10010.account_id = subq_20.account_id
+    account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_20.ds_partitioned
+    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned
   )
 GROUP BY
   account_id__customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0.sql
@@ -1,137 +1,107 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user__home_state
-  , subq_8.identity_verifications
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user__home_state
-    , SUM(subq_7.identity_verifications) AS identity_verifications
+    subq_6.user__home_state
+    , SUM(subq_6.identity_verifications) AS identity_verifications
   FROM (
     -- Pass Only Elements:
     --   ['identity_verifications', 'user__home_state']
     SELECT
-      subq_6.user__home_state
-      , subq_6.identity_verifications
+      subq_5.user__home_state
+      , subq_5.identity_verifications
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_5.ds_partitioned AS user__ds_partitioned
-        , subq_3.user AS user
-        , subq_5.home_state AS user__home_state
-        , subq_3.identity_verifications AS identity_verifications
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_4.ds_partitioned AS user__ds_partitioned
+        , subq_2.user AS user
+        , subq_4.home_state AS user__home_state
+        , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements:
         --   ['identity_verifications', 'user', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.user
-          , subq_2.identity_verifications
+          subq_1.ds_partitioned
+          , subq_1.user
+          , subq_1.identity_verifications
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.verification__ds
-            , subq_1.verification__ds__week
-            , subq_1.verification__ds__month
-            , subq_1.verification__ds__quarter
-            , subq_1.verification__ds__year
-            , subq_1.verification__ds_partitioned
-            , subq_1.verification__ds_partitioned__week
-            , subq_1.verification__ds_partitioned__month
-            , subq_1.verification__ds_partitioned__quarter
-            , subq_1.verification__ds_partitioned__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.verification
-            , subq_1.user
-            , subq_1.verification__user
-            , subq_1.verification_type
-            , subq_1.verification__verification_type
-            , subq_1.identity_verifications
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.verification__ds
+            , subq_0.verification__ds__week
+            , subq_0.verification__ds__month
+            , subq_0.verification__ds__quarter
+            , subq_0.verification__ds__year
+            , subq_0.verification__ds_partitioned
+            , subq_0.verification__ds_partitioned__week
+            , subq_0.verification__ds_partitioned__month
+            , subq_0.verification__ds_partitioned__quarter
+            , subq_0.verification__ds_partitioned__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.verification
+            , subq_0.user
+            , subq_0.verification__user
+            , subq_0.verification_type
+            , subq_0.verification__verification_type
+            , subq_0.identity_verifications
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'id_verifications'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.verification__ds
-              , subq_0.verification__ds__week
-              , subq_0.verification__ds__month
-              , subq_0.verification__ds__quarter
-              , subq_0.verification__ds__year
-              , subq_0.verification__ds_partitioned
-              , subq_0.verification__ds_partitioned__week
-              , subq_0.verification__ds_partitioned__month
-              , subq_0.verification__ds_partitioned__quarter
-              , subq_0.verification__ds_partitioned__year
-              , subq_0.verification
-              , subq_0.user
-              , subq_0.verification__user
-              , subq_0.verification_type
-              , subq_0.verification__verification_type
-              , subq_0.identity_verifications
-            FROM (
-              -- Read Elements From Data Source 'id_verifications'
-              SELECT
-                1 AS identity_verifications
-                , id_verifications_src_10003.ds
-                , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS ds__week
-                , DATE_TRUNC(id_verifications_src_10003.ds, month) AS ds__month
-                , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS ds__year
-                , id_verifications_src_10003.ds_partitioned
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS ds_partitioned__week
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS ds_partitioned__month
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS ds_partitioned__quarter
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS ds_partitioned__year
-                , id_verifications_src_10003.verification_type
-                , id_verifications_src_10003.ds AS verification__ds
-                , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS verification__ds__week
-                , DATE_TRUNC(id_verifications_src_10003.ds, month) AS verification__ds__month
-                , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS verification__ds__quarter
-                , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS verification__ds__year
-                , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS verification__ds_partitioned__week
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS verification__ds_partitioned__month
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS verification__ds_partitioned__quarter
-                , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS verification__ds_partitioned__year
-                , id_verifications_src_10003.verification_type AS verification__verification_type
-                , id_verifications_src_10003.verification_id AS verification
-                , id_verifications_src_10003.user_id AS user
-                , id_verifications_src_10003.user_id AS verification__user
-              FROM ***************************.fct_id_verifications id_verifications_src_10003
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS identity_verifications
+              , id_verifications_src_10003.ds
+              , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS ds__week
+              , DATE_TRUNC(id_verifications_src_10003.ds, month) AS ds__month
+              , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS ds__year
+              , id_verifications_src_10003.ds_partitioned
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS ds_partitioned__year
+              , id_verifications_src_10003.verification_type
+              , id_verifications_src_10003.ds AS verification__ds
+              , DATE_TRUNC(id_verifications_src_10003.ds, isoweek) AS verification__ds__week
+              , DATE_TRUNC(id_verifications_src_10003.ds, month) AS verification__ds__month
+              , DATE_TRUNC(id_verifications_src_10003.ds, quarter) AS verification__ds__quarter
+              , DATE_TRUNC(id_verifications_src_10003.ds, isoyear) AS verification__ds__year
+              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoweek) AS verification__ds_partitioned__week
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, month) AS verification__ds_partitioned__month
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, quarter) AS verification__ds_partitioned__quarter
+              , DATE_TRUNC(id_verifications_src_10003.ds_partitioned, isoyear) AS verification__ds_partitioned__year
+              , id_verifications_src_10003.verification_type AS verification__verification_type
+              , id_verifications_src_10003.verification_id AS verification
+              , id_verifications_src_10003.user_id AS user
+              , id_verifications_src_10003.user_id AS verification__user
+            FROM ***************************.fct_id_verifications id_verifications_src_10003
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user', 'ds_partitioned', 'home_state']
         SELECT
-          subq_4.ds_partitioned
-          , subq_4.user
-          , subq_4.home_state
+          subq_3.ds_partitioned
+          , subq_3.user
+          , subq_3.home_state
         FROM (
           -- Read Elements From Data Source 'users_ds_source'
           SELECT
@@ -169,16 +139,16 @@ FROM (
             , users_ds_source_src_10007.home_state AS user__home_state
             , users_ds_source_src_10007.user_id AS user
           FROM ***************************.dim_users users_ds_source_src_10007
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user = subq_5.user
+          subq_2.user = subq_4.user
         ) AND (
-          subq_3.ds_partitioned = subq_5.ds_partitioned
+          subq_2.ds_partitioned = subq_4.ds_partitioned
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user__home_state
-) subq_8
+    subq_6.user__home_state
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0_optimized.sql
@@ -5,10 +5,9 @@
 -- Compute Metrics via Expressions
 SELECT
   users_ds_source_src_10007.home_state AS user__home_state
-  , SUM(subq_12.identity_verifications) AS identity_verifications
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['identity_verifications', 'user', 'ds_partitioned']
@@ -17,14 +16,14 @@ FROM (
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.dim_users users_ds_source_src_10007
 ON
   (
-    subq_12.user = users_ds_source_src_10007.user_id
+    subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_12.ds_partitioned = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned = users_ds_source_src_10007.ds_partitioned
   )
 GROUP BY
   user__home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node__plan0.sql
@@ -1,13 +1,37 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.total_account_balance_first_day AS total_account_balance_first_day
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.total_account_balance_first_day
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
+    , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
+    , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
+    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -19,41 +43,13 @@ FROM (
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
       , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MIN(ds)
-  SELECT
-    MIN(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['total_account_balance_first_day', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.total_account_balance_first_day
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
-        , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
-        , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-        , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
 ) subq_2
 ON
-  subq_1.ds = subq_2.ds
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node__plan0_optimized.sql
@@ -1,30 +1,42 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.total_account_balance_first_day AS total_account_balance_first_day
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   SELECT
-    ds
+    account_balance
     , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC(ds, isoweek) AS ds__week
+    , DATE_TRUNC(ds, month) AS ds__month
+    , DATE_TRUNC(ds, quarter) AS ds__quarter
+    , DATE_TRUNC(ds, isoyear) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds
+    MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
 ) subq_5
 ON
-  subq_4.ds = subq_5.ds
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -1,15 +1,38 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.user AS user
-  , subq_1.current_account_balance_by_user AS current_account_balance_by_user
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.user
-    , subq_0.current_account_balance_by_user
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
+    , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
+    , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
+    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MAX(ds)
+  SELECT
+    subq_1.user
+    , MAX(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -21,45 +44,15 @@ FROM (
       , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
       , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
       , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MAX(ds)
-  SELECT
-    subq_2.user
-    , MAX(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['current_account_balance_by_user', 'user', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.user
-      , subq_0.current_account_balance_by_user
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
-        , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
-        , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
-        , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
   GROUP BY
-    subq_2.user
+    subq_1.user
 ) subq_2
 ON
-  (subq_1.ds = subq_2.ds) AND (subq_1.user = subq_2.user)
+  (subq_0.ds = subq_2.ds__complete) AND (subq_0.user = subq_2.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -1,29 +1,39 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.user AS user
-  , subq_4.current_account_balance_by_user AS current_account_balance_by_user
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   SELECT
-    ds
-    , user_id AS user
+    account_balance
+    , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC(ds, isoweek) AS ds__week
+    , DATE_TRUNC(ds, month) AS ds__month
+    , DATE_TRUNC(ds, quarter) AS ds__quarter
+    , DATE_TRUNC(ds, isoyear) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   -- Filter row on MAX(ds)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds
+    , MAX(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
@@ -32,4 +42,4 @@ INNER JOIN (
     user_id
 ) subq_5
 ON
-  (subq_4.ds = subq_5.ds) AND (subq_4.user = subq_5.user)
+  (subq_3.ds = subq_5.ds__complete) AND (subq_3.user = subq_5.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -1,0 +1,57 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
+    , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
+    , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
+    , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
+  FROM (
+    -- Read Elements From Data Source 'accounts_source'
+    SELECT
+      accounts_source_src_10000.account_balance
+      , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+      , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+      , accounts_source_src_10000.ds
+      , DATE_TRUNC(accounts_source_src_10000.ds, isoweek) AS ds__week
+      , DATE_TRUNC(accounts_source_src_10000.ds, month) AS ds__month
+      , DATE_TRUNC(accounts_source_src_10000.ds, quarter) AS ds__quarter
+      , DATE_TRUNC(accounts_source_src_10000.ds, isoyear) AS ds__year
+      , accounts_source_src_10000.account_type
+      , accounts_source_src_10000.user_id AS user
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_accounts
+    ) accounts_source_src_10000
+  ) subq_1
+  GROUP BY
+    subq_1.ds__week
+) subq_2
+ON
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    account_balance
+    , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC(ds, isoweek) AS ds__week
+    , DATE_TRUNC(ds, month) AS ds__month
+    , DATE_TRUNC(ds, quarter) AS ds__quarter
+    , DATE_TRUNC(ds, isoyear) AS ds__year
+    , account_type
+    , user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_3
+INNER JOIN (
+  -- Read Elements From Data Source 'accounts_source'
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(ds) AS ds__complete
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+  GROUP BY
+    DATE_TRUNC(ds, isoweek)
+) subq_5
+ON
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0.sql
@@ -1,95 +1,73 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.user_team___team_id
-  , subq_4.user_team___user_id
-  , subq_4.messages
+  subq_3.user_team___team_id
+  , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-    , SUM(subq_3.messages) AS messages
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+    , SUM(subq_2.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team']
     SELECT
-      subq_2.user_team___team_id
-      , subq_2.user_team___user_id
-      , subq_2.messages
+      subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+      , subq_1.messages
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.user_id__ds
-        , subq_1.user_id__ds__week
-        , subq_1.user_id__ds__month
-        , subq_1.user_id__ds__quarter
-        , subq_1.user_id__ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user_id
-        , subq_1.user_team___team_id
-        , subq_1.user_team___user_id
-        , subq_1.user_id__user_team___team_id
-        , subq_1.user_id__user_team___user_id
-        , subq_1.team_id
-        , subq_1.user_id__team_id
-        , subq_1.messages
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.user_id__ds
+        , subq_0.user_id__ds__week
+        , subq_0.user_id__ds__month
+        , subq_0.user_id__ds__quarter
+        , subq_0.user_id__ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user_id
+        , subq_0.user_team___team_id
+        , subq_0.user_team___user_id
+        , subq_0.user_id__user_team___team_id
+        , subq_0.user_id__user_team___user_id
+        , subq_0.team_id
+        , subq_0.user_id__team_id
+        , subq_0.messages
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'messages_source'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user_id__ds
-          , subq_0.user_id__ds__week
-          , subq_0.user_id__ds__month
-          , subq_0.user_id__ds__quarter
-          , subq_0.user_id__ds__year
-          , subq_0.user_id
-          , subq_0.user_team___team_id
-          , subq_0.user_team___user_id
-          , subq_0.user_id__user_team___team_id
-          , subq_0.user_id__user_team___user_id
-          , subq_0.team_id
-          , subq_0.user_id__team_id
-          , subq_0.messages
-        FROM (
-          -- Read Elements From Data Source 'messages_source'
-          SELECT
-            1 AS messages
-            , messages_source_src_10015.ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-            , messages_source_src_10015.team_id
-            , messages_source_src_10015.ds AS user_id__ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-            , messages_source_src_10015.team_id AS user_id__team_id
-            , messages_source_src_10015.user_id
-            , messages_source_src_10015.team_id AS user_team___team_id
-            , messages_source_src_10015.user_id AS user_team___user_id
-            , messages_source_src_10015.team_id AS user_id__user_team___team_id
-            , messages_source_src_10015.user_id AS user_id__user_team___user_id
-          FROM ***************************.fct_messages messages_source_src_10015
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS messages
+          , messages_source_src_10015.ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+          , messages_source_src_10015.team_id
+          , messages_source_src_10015.ds AS user_id__ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+          , messages_source_src_10015.team_id AS user_id__team_id
+          , messages_source_src_10015.user_id
+          , messages_source_src_10015.team_id AS user_team___team_id
+          , messages_source_src_10015.user_id AS user_team___user_id
+          , messages_source_src_10015.team_id AS user_id__user_team___team_id
+          , messages_source_src_10015.user_id AS user_id__user_team___user_id
+        FROM ***************************.fct_messages messages_source_src_10015
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-) subq_4
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -15,7 +14,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_8
+) subq_6
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,118 +1,96 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user_team___team_id
-  , subq_8.user_team___user_id
-  , subq_8.user_team__country
-  , subq_8.messages
+  subq_7.user_team___team_id
+  , subq_7.user_team___user_id
+  , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-    , SUM(subq_7.messages) AS messages
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+    , SUM(subq_6.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team__country', 'user_team']
     SELECT
-      subq_6.user_team___team_id
-      , subq_6.user_team___user_id
-      , subq_6.user_team__country
-      , subq_6.messages
+      subq_5.user_team___team_id
+      , subq_5.user_team___user_id
+      , subq_5.user_team__country
+      , subq_5.messages
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.user_team___team_id AS user_team___team_id
-        , subq_3.user_team___user_id AS user_team___user_id
-        , subq_5.country AS user_team__country
-        , subq_3.messages AS messages
+        subq_2.user_team___team_id AS user_team___team_id
+        , subq_2.user_team___user_id AS user_team___user_id
+        , subq_4.country AS user_team__country
+        , subq_2.messages AS messages
       FROM (
         -- Pass Only Elements:
         --   ['messages', 'user_team', 'user_team']
         SELECT
-          subq_2.user_team___team_id
-          , subq_2.user_team___user_id
-          , subq_2.messages
+          subq_1.user_team___team_id
+          , subq_1.user_team___user_id
+          , subq_1.messages
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.user_id__ds
-            , subq_1.user_id__ds__week
-            , subq_1.user_id__ds__month
-            , subq_1.user_id__ds__quarter
-            , subq_1.user_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.user_id
-            , subq_1.user_team___team_id
-            , subq_1.user_team___user_id
-            , subq_1.user_id__user_team___team_id
-            , subq_1.user_id__user_team___user_id
-            , subq_1.team_id
-            , subq_1.user_id__team_id
-            , subq_1.messages
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user_id__ds
+            , subq_0.user_id__ds__week
+            , subq_0.user_id__ds__month
+            , subq_0.user_id__ds__quarter
+            , subq_0.user_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.user_id
+            , subq_0.user_team___team_id
+            , subq_0.user_team___user_id
+            , subq_0.user_id__user_team___team_id
+            , subq_0.user_id__user_team___user_id
+            , subq_0.team_id
+            , subq_0.user_id__team_id
+            , subq_0.messages
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'messages_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.user_id__ds
-              , subq_0.user_id__ds__week
-              , subq_0.user_id__ds__month
-              , subq_0.user_id__ds__quarter
-              , subq_0.user_id__ds__year
-              , subq_0.user_id
-              , subq_0.user_team___team_id
-              , subq_0.user_team___user_id
-              , subq_0.user_id__user_team___team_id
-              , subq_0.user_id__user_team___user_id
-              , subq_0.team_id
-              , subq_0.user_id__team_id
-              , subq_0.messages
-            FROM (
-              -- Read Elements From Data Source 'messages_source'
-              SELECT
-                1 AS messages
-                , messages_source_src_10015.ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-                , messages_source_src_10015.team_id
-                , messages_source_src_10015.ds AS user_id__ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-                , messages_source_src_10015.team_id AS user_id__team_id
-                , messages_source_src_10015.user_id
-                , messages_source_src_10015.team_id AS user_team___team_id
-                , messages_source_src_10015.user_id AS user_team___user_id
-                , messages_source_src_10015.team_id AS user_id__user_team___team_id
-                , messages_source_src_10015.user_id AS user_id__user_team___user_id
-              FROM ***************************.fct_messages messages_source_src_10015
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS messages
+              , messages_source_src_10015.ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+              , messages_source_src_10015.team_id
+              , messages_source_src_10015.ds AS user_id__ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+              , messages_source_src_10015.team_id AS user_id__team_id
+              , messages_source_src_10015.user_id
+              , messages_source_src_10015.team_id AS user_team___team_id
+              , messages_source_src_10015.user_id AS user_team___user_id
+              , messages_source_src_10015.team_id AS user_id__user_team___team_id
+              , messages_source_src_10015.user_id AS user_id__user_team___user_id
+            FROM ***************************.fct_messages messages_source_src_10015
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user_team', 'country']
         SELECT
-          subq_4.user_team___team_id
-          , subq_4.user_team___user_id
-          , subq_4.country
+          subq_3.user_team___team_id
+          , subq_3.user_team___user_id
+          , subq_3.country
         FROM (
           -- Read Elements From Data Source 'users_source'
           SELECT
@@ -160,18 +138,18 @@ FROM (
             , users_source_src_10017.ident_2 AS user_team__user_composite_ident_2___ident_2
             , users_source_src_10017.id AS user_team__user_composite_ident_2___user_id
           FROM ***************************.fct_users users_source_src_10017
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user_team___team_id = subq_5.user_team___team_id
+          subq_2.user_team___team_id = subq_4.user_team___team_id
         ) AND (
-          subq_3.user_team___user_id = subq_5.user_team___user_id
+          subq_2.user_team___user_id = subq_4.user_team___user_id
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-) subq_8
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,13 +4,12 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user_team___team_id AS user_team___team_id
-  , subq_12.user_team___user_id AS user_team___user_id
+  subq_10.user_team___team_id AS user_team___team_id
+  , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10017.country AS user_team__country
-  , SUM(subq_12.messages) AS messages
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team', 'user_team']
@@ -19,16 +18,16 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.fct_users users_source_src_10017
 ON
   (
-    subq_12.user_team___team_id = users_source_src_10017.team_id
+    subq_10.user_team___team_id = users_source_src_10017.team_id
   ) AND (
-    subq_12.user_team___user_id = users_source_src_10017.id
+    subq_10.user_team___user_id = users_source_src_10017.id
   )
 GROUP BY
-  subq_12.user_team___team_id
-  , subq_12.user_team___user_id
+  subq_10.user_team___team_id
+  , subq_10.user_team___user_id
   , users_source_src_10017.country

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -1,103 +1,81 @@
 -- Order By ['user_team']
 SELECT
-  subq_5.user_team___team_id
-  , subq_5.user_team___user_id
-  , subq_5.messages
+  subq_4.user_team___team_id
+  , subq_4.user_team___user_id
+  , subq_4.messages
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.user_team___team_id
-    , subq_4.user_team___user_id
-    , subq_4.messages
+    subq_3.user_team___team_id
+    , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-      , SUM(subq_3.messages) AS messages
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+      , SUM(subq_2.messages) AS messages
     FROM (
       -- Pass Only Elements:
       --   ['messages', 'user_team']
       SELECT
-        subq_2.user_team___team_id
-        , subq_2.user_team___user_id
-        , subq_2.messages
+        subq_1.user_team___team_id
+        , subq_1.user_team___user_id
+        , subq_1.messages
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.user_id__ds
-          , subq_1.user_id__ds__week
-          , subq_1.user_id__ds__month
-          , subq_1.user_id__ds__quarter
-          , subq_1.user_id__ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user_id
-          , subq_1.user_team___team_id
-          , subq_1.user_team___user_id
-          , subq_1.user_id__user_team___team_id
-          , subq_1.user_id__user_team___user_id
-          , subq_1.team_id
-          , subq_1.user_id__team_id
-          , subq_1.messages
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.user_id__ds
+          , subq_0.user_id__ds__week
+          , subq_0.user_id__ds__month
+          , subq_0.user_id__ds__quarter
+          , subq_0.user_id__ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user_id
+          , subq_0.user_team___team_id
+          , subq_0.user_team___user_id
+          , subq_0.user_id__user_team___team_id
+          , subq_0.user_id__user_team___user_id
+          , subq_0.team_id
+          , subq_0.user_id__team_id
+          , subq_0.messages
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'messages_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user_id__ds
-            , subq_0.user_id__ds__week
-            , subq_0.user_id__ds__month
-            , subq_0.user_id__ds__quarter
-            , subq_0.user_id__ds__year
-            , subq_0.user_id
-            , subq_0.user_team___team_id
-            , subq_0.user_team___user_id
-            , subq_0.user_id__user_team___team_id
-            , subq_0.user_id__user_team___user_id
-            , subq_0.team_id
-            , subq_0.user_id__team_id
-            , subq_0.messages
-          FROM (
-            -- Read Elements From Data Source 'messages_source'
-            SELECT
-              1 AS messages
-              , messages_source_src_10015.ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-              , messages_source_src_10015.team_id
-              , messages_source_src_10015.ds AS user_id__ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-              , messages_source_src_10015.team_id AS user_id__team_id
-              , messages_source_src_10015.user_id
-              , messages_source_src_10015.team_id AS user_team___team_id
-              , messages_source_src_10015.user_id AS user_team___user_id
-              , messages_source_src_10015.team_id AS user_id__user_team___team_id
-              , messages_source_src_10015.user_id AS user_id__user_team___user_id
-            FROM ***************************.fct_messages messages_source_src_10015
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            1 AS messages
+            , messages_source_src_10015.ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+            , messages_source_src_10015.team_id
+            , messages_source_src_10015.ds AS user_id__ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+            , messages_source_src_10015.team_id AS user_id__team_id
+            , messages_source_src_10015.user_id
+            , messages_source_src_10015.team_id AS user_team___team_id
+            , messages_source_src_10015.user_id AS user_team___user_id
+            , messages_source_src_10015.team_id AS user_id__user_team___team_id
+            , messages_source_src_10015.user_id AS user_id__user_team___user_id
+          FROM ***************************.fct_messages messages_source_src_10015
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-  ) subq_4
-) subq_5
-ORDER BY subq_5.user_team___team_id DESC, subq_5.user_team___user_id DESC
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+  ) subq_3
+) subq_4
+ORDER BY subq_4.user_team___team_id DESC, subq_4.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
@@ -7,7 +7,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -16,7 +15,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_9
+) subq_7
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,367 +1,357 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_23.ds
-  , subq_23.listing__country_latest
-  , CAST(subq_23.bookings AS DOUBLE) / CAST(NULLIF(subq_23.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_19.ds
+  , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']
   SELECT
-    subq_22.ds
-    , subq_22.listing__country_latest
-    , subq_22.bookings
-    , subq_22.views
+    subq_18.ds
+    , subq_18.listing__country_latest
+    , subq_18.bookings
+    , subq_18.views
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_10.ds AS ds
-      , subq_10.listing__country_latest AS listing__country_latest
-      , subq_10.bookings AS bookings
-      , subq_21.views AS views
+      subq_8.ds AS ds
+      , subq_8.listing__country_latest AS listing__country_latest
+      , subq_8.bookings AS bookings
+      , subq_17.views AS views
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.ds
-        , subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.ds
+        , subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest', 'ds']
         SELECT
-          subq_8.ds
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.ds
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.ds AS ds
-            , subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.ds AS ds
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'ds', 'listing']
             SELECT
-              subq_2.ds
-              , subq_2.listing
-              , subq_2.bookings
+              subq_1.ds
+              , subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.ds
-        , subq_9.listing__country_latest
-    ) subq_10
+        subq_7.ds
+        , subq_7.listing__country_latest
+    ) subq_8
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_20.ds
-        , subq_20.listing__country_latest
-        , SUM(subq_20.views) AS views
+        subq_16.ds
+        , subq_16.listing__country_latest
+        , SUM(subq_16.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_19.ds
-          , subq_19.listing__country_latest
-          , subq_19.views
+          subq_15.ds
+          , subq_15.listing__country_latest
+          , subq_15.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.ds AS ds
-            , subq_14.listing AS listing
-            , subq_18.country_latest AS listing__country_latest
-            , subq_14.views AS views
+            subq_11.ds AS ds
+            , subq_11.listing AS listing
+            , subq_14.country_latest AS listing__country_latest
+            , subq_11.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_13.ds
-              , subq_13.listing
-              , subq_13.views
+              subq_10.ds
+              , subq_10.listing
+              , subq_10.views
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_9.ds
+                , subq_9.ds__week
+                , subq_9.ds__month
+                , subq_9.ds__quarter
+                , subq_9.ds__year
+                , subq_9.ds_partitioned
+                , subq_9.ds_partitioned__week
+                , subq_9.ds_partitioned__month
+                , subq_9.ds_partitioned__quarter
+                , subq_9.ds_partitioned__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds
+                , subq_9.create_a_cycle_in_the_join_graph__ds__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_9.ds AS metric_time
+                , subq_9.ds__week AS metric_time__week
+                , subq_9.ds__month AS metric_time__month
+                , subq_9.ds__quarter AS metric_time__quarter
+                , subq_9.ds__year AS metric_time__year
+                , subq_9.listing
+                , subq_9.user
+                , subq_9.create_a_cycle_in_the_join_graph
+                , subq_9.create_a_cycle_in_the_join_graph__listing
+                , subq_9.create_a_cycle_in_the_join_graph__user
+                , subq_9.views
+              FROM (
+                -- Read Elements From Data Source 'views_source'
+                SELECT
+                  1 AS views
+                  , views_source_src_10009.ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
+                  , views_source_src_10009.ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
+                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , views_source_src_10009.listing_id AS listing
+                  , views_source_src_10009.user_id AS user
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
+                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
+                FROM (
+                  -- User Defined SQL Query
+                  SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+                ) views_source_src_10009
+              ) subq_9
+            ) subq_10
+          ) subq_11
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_13.listing
+              , subq_13.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
@@ -370,21 +360,21 @@ FROM (
                 , subq_12.ds__month
                 , subq_12.ds__quarter
                 , subq_12.ds__year
-                , subq_12.ds_partitioned
-                , subq_12.ds_partitioned__week
-                , subq_12.ds_partitioned__month
-                , subq_12.ds_partitioned__quarter
-                , subq_12.ds_partitioned__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds
-                , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_12.created_at
+                , subq_12.created_at__week
+                , subq_12.created_at__month
+                , subq_12.created_at__quarter
+                , subq_12.created_at__year
+                , subq_12.listing__ds
+                , subq_12.listing__ds__week
+                , subq_12.listing__ds__month
+                , subq_12.listing__ds__quarter
+                , subq_12.listing__ds__year
+                , subq_12.listing__created_at
+                , subq_12.listing__created_at__week
+                , subq_12.listing__created_at__month
+                , subq_12.listing__created_at__quarter
+                , subq_12.listing__created_at__year
                 , subq_12.ds AS metric_time
                 , subq_12.ds__week AS metric_time__week
                 , subq_12.ds__month AS metric_time__month
@@ -392,222 +382,80 @@ FROM (
                 , subq_12.ds__year AS metric_time__year
                 , subq_12.listing
                 , subq_12.user
-                , subq_12.create_a_cycle_in_the_join_graph
-                , subq_12.create_a_cycle_in_the_join_graph__listing
-                , subq_12.create_a_cycle_in_the_join_graph__user
-                , subq_12.views
+                , subq_12.listing__user
+                , subq_12.country_latest
+                , subq_12.is_lux_latest
+                , subq_12.capacity_latest
+                , subq_12.listing__country_latest
+                , subq_12.listing__is_lux_latest
+                , subq_12.listing__capacity_latest
+                , subq_12.listings
+                , subq_12.largest_listing
+                , subq_12.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_11.ds
-                  , subq_11.ds__week
-                  , subq_11.ds__month
-                  , subq_11.ds__quarter
-                  , subq_11.ds__year
-                  , subq_11.ds_partitioned
-                  , subq_11.ds_partitioned__week
-                  , subq_11.ds_partitioned__month
-                  , subq_11.ds_partitioned__quarter
-                  , subq_11.ds_partitioned__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_11.listing
-                  , subq_11.user
-                  , subq_11.create_a_cycle_in_the_join_graph
-                  , subq_11.create_a_cycle_in_the_join_graph__listing
-                  , subq_11.create_a_cycle_in_the_join_graph__user
-                  , subq_11.views
-                FROM (
-                  -- Read Elements From Data Source 'views_source'
-                  SELECT
-                    1 AS views
-                    , views_source_src_10009.ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
-                    , views_source_src_10009.ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                    , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , views_source_src_10009.listing_id AS listing
-                    , views_source_src_10009.user_id AS user
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                    , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
-                  ) views_source_src_10009
-                ) subq_11
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
               ) subq_12
             ) subq_13
           ) subq_14
-          LEFT OUTER JOIN (
-            -- Pass Only Elements:
-            --   ['listing', 'country_latest']
-            SELECT
-              subq_17.listing
-              , subq_17.country_latest
-            FROM (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_16.ds
-                , subq_16.ds__week
-                , subq_16.ds__month
-                , subq_16.ds__quarter
-                , subq_16.ds__year
-                , subq_16.created_at
-                , subq_16.created_at__week
-                , subq_16.created_at__month
-                , subq_16.created_at__quarter
-                , subq_16.created_at__year
-                , subq_16.listing__ds
-                , subq_16.listing__ds__week
-                , subq_16.listing__ds__month
-                , subq_16.listing__ds__quarter
-                , subq_16.listing__ds__year
-                , subq_16.listing__created_at
-                , subq_16.listing__created_at__week
-                , subq_16.listing__created_at__month
-                , subq_16.listing__created_at__quarter
-                , subq_16.listing__created_at__year
-                , subq_16.ds AS metric_time
-                , subq_16.ds__week AS metric_time__week
-                , subq_16.ds__month AS metric_time__month
-                , subq_16.ds__quarter AS metric_time__quarter
-                , subq_16.ds__year AS metric_time__year
-                , subq_16.listing
-                , subq_16.user
-                , subq_16.listing__user
-                , subq_16.country_latest
-                , subq_16.is_lux_latest
-                , subq_16.capacity_latest
-                , subq_16.listing__country_latest
-                , subq_16.listing__is_lux_latest
-                , subq_16.listing__capacity_latest
-                , subq_16.listings
-                , subq_16.largest_listing
-                , subq_16.smallest_listing
-              FROM (
-                -- Pass Only Additive Measures
-                SELECT
-                  subq_15.ds
-                  , subq_15.ds__week
-                  , subq_15.ds__month
-                  , subq_15.ds__quarter
-                  , subq_15.ds__year
-                  , subq_15.created_at
-                  , subq_15.created_at__week
-                  , subq_15.created_at__month
-                  , subq_15.created_at__quarter
-                  , subq_15.created_at__year
-                  , subq_15.listing__ds
-                  , subq_15.listing__ds__week
-                  , subq_15.listing__ds__month
-                  , subq_15.listing__ds__quarter
-                  , subq_15.listing__ds__year
-                  , subq_15.listing__created_at
-                  , subq_15.listing__created_at__week
-                  , subq_15.listing__created_at__month
-                  , subq_15.listing__created_at__quarter
-                  , subq_15.listing__created_at__year
-                  , subq_15.listing
-                  , subq_15.user
-                  , subq_15.listing__user
-                  , subq_15.country_latest
-                  , subq_15.is_lux_latest
-                  , subq_15.capacity_latest
-                  , subq_15.listing__country_latest
-                  , subq_15.listing__is_lux_latest
-                  , subq_15.listing__capacity_latest
-                  , subq_15.listings
-                  , subq_15.largest_listing
-                  , subq_15.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_15
-              ) subq_16
-            ) subq_17
-          ) subq_18
           ON
-            subq_14.listing = subq_18.listing
-        ) subq_19
-      ) subq_20
+            subq_11.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       GROUP BY
-        subq_20.ds
-        , subq_20.listing__country_latest
-    ) subq_21
+        subq_16.ds
+        , subq_16.listing__country_latest
+    ) subq_17
     ON
       (
         (
-          subq_10.listing__country_latest = subq_21.listing__country_latest
+          subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
-            subq_10.listing__country_latest IS NULL
+            subq_8.listing__country_latest IS NULL
           ) AND (
-            subq_21.listing__country_latest IS NULL
+            subq_17.listing__country_latest IS NULL
           )
         )
       ) AND (
         (
-          subq_10.ds = subq_21.ds
+          subq_8.ds = subq_17.ds
         ) OR (
-          (subq_10.ds IS NULL) AND (subq_21.ds IS NULL)
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
-  ) subq_22
-) subq_23
+  ) subq_18
+) subq_19

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,21 +3,20 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  subq_34.ds AS ds
-  , subq_34.listing__country_latest AS listing__country_latest
-  , CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_45.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_28.ds AS ds
+  , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_27.ds AS ds
+    subq_22.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_27.bookings) AS bookings
+    , SUM(subq_22.bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds', 'listing']
@@ -29,27 +28,26 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_27
+  ) subq_22
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_27.listing = listings_latest_src_10004.listing_id
+    subq_22.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_27.ds
+    subq_22.ds
     , listings_latest_src_10004.country
-) subq_34
+) subq_28
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_38.ds AS ds
+    subq_31.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_38.views) AS views
+    , SUM(subq_31.views) AS views
   FROM (
     -- Read Elements From Data Source 'views_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['views', 'ds', 'listing']
@@ -61,30 +59,30 @@ INNER JOIN (
       -- User Defined SQL Query
       SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
     ) views_source_src_10009
-  ) subq_38
+  ) subq_31
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_38.listing = listings_latest_src_10004.listing_id
+    subq_31.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_38.ds
+    subq_31.ds
     , listings_latest_src_10004.country
-) subq_45
+) subq_37
 ON
   (
     (
-      subq_34.listing__country_latest = subq_45.listing__country_latest
+      subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
-        subq_34.listing__country_latest IS NULL
+        subq_28.listing__country_latest IS NULL
       ) AND (
-        subq_45.listing__country_latest IS NULL
+        subq_37.listing__country_latest IS NULL
       )
     )
   ) AND (
     (
-      subq_34.ds = subq_45.ds
+      subq_28.ds = subq_37.ds
     ) OR (
-      (subq_34.ds IS NULL) AND (subq_45.ds IS NULL)
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_mtd
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0.sql
@@ -1,56 +1,45 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_4.txn_revenue) AS txn_revenue
+    SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue']
     SELECT
-      subq_2.txn_revenue
+      subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
-) subq_5
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_all_time
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS revenue_all_time
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS trailing_2_months_revenue
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_distinct_values__plan0.sql
@@ -1,329 +1,243 @@
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
-  subq_12.listing__country_latest
+  subq_10.listing__country_latest
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest']
   SELECT
-    subq_11.listing__country_latest
+    subq_9.listing__country_latest
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_10.listing__country_latest
-      , subq_10.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest']
         SELECT
-          subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.listing__country_latest
-    ) subq_10
-  ) subq_11
-) subq_12
-ORDER BY subq_12.listing__country_latest
+        subq_7.listing__country_latest
+    ) subq_8
+  ) subq_9
+) subq_10
+ORDER BY subq_10.listing__country_latest
 LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,334 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.is_instant
-  , subq_12.bookings
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.is_instant
-    , SUM(subq_11.bookings) AS bookings
+    subq_9.is_instant
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'is_instant']
     SELECT
-      subq_10.is_instant
-      , subq_10.bookings
+      subq_8.is_instant
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.is_instant
-        , subq_9.listing__country_latest
-        , subq_9.bookings
+        subq_7.is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'listing__country_latest']
         SELECT
-          subq_8.is_instant
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.is_instant AS is_instant
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.is_instant AS is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.is_instant
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE listing__country_latest = 'us'
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.is_instant
-) subq_12
+    subq_9.is_instant
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -11,12 +11,11 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'listing__country_latest']
   SELECT
-    subq_16.is_instant AS is_instant
+    subq_13.is_instant AS is_instant
     , listings_latest_src_10004.country AS listing__country_latest
-    , subq_16.bookings AS bookings
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'listing']
@@ -28,12 +27,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_16
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_16.listing = listings_latest_src_10004.listing_id
-) subq_22
+    subq_13.listing = listings_latest_src_10004.listing_id
+) subq_18
 WHERE listing__country_latest = 'us'
 GROUP BY
   is_instant

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0.sql
@@ -1,186 +1,136 @@
 -- Order By [] Limit 1
 SELECT
-  subq_5.ds
-  , subq_5.bookings
+  subq_4.ds
+  , subq_4.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.ds
-    , subq_4.bookings
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.ds
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.ds
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'ds']
       SELECT
-        subq_2.ds
-        , subq_2.bookings
+        subq_1.ds
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.ds
-  ) subq_4
-) subq_5
+      subq_2.ds
+  ) subq_3
+) subq_4
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_limit_rows__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
-) subq_9
+) subq_7
 GROUP BY
   ds
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,133 +1,97 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.listing__country_latest
-  , subq_4.listings
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.listing__country_latest
-    , SUM(subq_3.listings) AS listings
+    subq_2.listing__country_latest
+    , SUM(subq_2.listings) AS listings
   FROM (
     -- Pass Only Elements:
     --   ['listings', 'listing__country_latest']
     SELECT
-      subq_2.listing__country_latest
-      , subq_2.listings
+      subq_1.listing__country_latest
+      , subq_1.listings
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.created_at
-        , subq_1.created_at__week
-        , subq_1.created_at__month
-        , subq_1.created_at__quarter
-        , subq_1.created_at__year
-        , subq_1.listing__ds
-        , subq_1.listing__ds__week
-        , subq_1.listing__ds__month
-        , subq_1.listing__ds__quarter
-        , subq_1.listing__ds__year
-        , subq_1.listing__created_at
-        , subq_1.listing__created_at__week
-        , subq_1.listing__created_at__month
-        , subq_1.listing__created_at__quarter
-        , subq_1.listing__created_at__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.listing
-        , subq_1.user
-        , subq_1.listing__user
-        , subq_1.country_latest
-        , subq_1.is_lux_latest
-        , subq_1.capacity_latest
-        , subq_1.listing__country_latest
-        , subq_1.listing__is_lux_latest
-        , subq_1.listing__capacity_latest
-        , subq_1.listings
-        , subq_1.largest_listing
-        , subq_1.smallest_listing
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.created_at
+        , subq_0.created_at__week
+        , subq_0.created_at__month
+        , subq_0.created_at__quarter
+        , subq_0.created_at__year
+        , subq_0.listing__ds
+        , subq_0.listing__ds__week
+        , subq_0.listing__ds__month
+        , subq_0.listing__ds__quarter
+        , subq_0.listing__ds__year
+        , subq_0.listing__created_at
+        , subq_0.listing__created_at__week
+        , subq_0.listing__created_at__month
+        , subq_0.listing__created_at__quarter
+        , subq_0.listing__created_at__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.listing
+        , subq_0.user
+        , subq_0.listing__user
+        , subq_0.country_latest
+        , subq_0.is_lux_latest
+        , subq_0.capacity_latest
+        , subq_0.listing__country_latest
+        , subq_0.listing__is_lux_latest
+        , subq_0.listing__capacity_latest
+        , subq_0.listings
+        , subq_0.largest_listing
+        , subq_0.smallest_listing
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'listings_latest'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.created_at
-          , subq_0.created_at__week
-          , subq_0.created_at__month
-          , subq_0.created_at__quarter
-          , subq_0.created_at__year
-          , subq_0.listing__ds
-          , subq_0.listing__ds__week
-          , subq_0.listing__ds__month
-          , subq_0.listing__ds__quarter
-          , subq_0.listing__ds__year
-          , subq_0.listing__created_at
-          , subq_0.listing__created_at__week
-          , subq_0.listing__created_at__month
-          , subq_0.listing__created_at__quarter
-          , subq_0.listing__created_at__year
-          , subq_0.listing
-          , subq_0.user
-          , subq_0.listing__user
-          , subq_0.country_latest
-          , subq_0.is_lux_latest
-          , subq_0.capacity_latest
-          , subq_0.listing__country_latest
-          , subq_0.listing__is_lux_latest
-          , subq_0.listing__capacity_latest
-          , subq_0.listings
-          , subq_0.largest_listing
-          , subq_0.smallest_listing
-        FROM (
-          -- Read Elements From Data Source 'listings_latest'
-          SELECT
-            1 AS listings
-            , listings_latest_src_10004.capacity AS largest_listing
-            , listings_latest_src_10004.capacity AS smallest_listing
-            , listings_latest_src_10004.created_at AS ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-            , listings_latest_src_10004.created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-            , listings_latest_src_10004.country AS country_latest
-            , listings_latest_src_10004.is_lux AS is_lux_latest
-            , listings_latest_src_10004.capacity AS capacity_latest
-            , listings_latest_src_10004.created_at AS listing__ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-            , listings_latest_src_10004.created_at AS listing__created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-            , listings_latest_src_10004.country AS listing__country_latest
-            , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-            , listings_latest_src_10004.capacity AS listing__capacity_latest
-            , listings_latest_src_10004.listing_id AS listing
-            , listings_latest_src_10004.user_id AS user
-            , listings_latest_src_10004.user_id AS listing__user
-          FROM ***************************.dim_listings_latest listings_latest_src_10004
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS listings
+          , listings_latest_src_10004.capacity AS largest_listing
+          , listings_latest_src_10004.capacity AS smallest_listing
+          , listings_latest_src_10004.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+          , listings_latest_src_10004.created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+          , listings_latest_src_10004.country AS country_latest
+          , listings_latest_src_10004.is_lux AS is_lux_latest
+          , listings_latest_src_10004.capacity AS capacity_latest
+          , listings_latest_src_10004.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+          , listings_latest_src_10004.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+          , listings_latest_src_10004.country AS listing__country_latest
+          , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10004.capacity AS listing__capacity_latest
+          , listings_latest_src_10004.listing_id AS listing
+          , listings_latest_src_10004.user_id AS user
+          , listings_latest_src_10004.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10004
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.listing__country_latest
-) subq_4
+    subq_2.listing__country_latest
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings', 'listing__country_latest']
@@ -13,6 +12,6 @@ FROM (
     country AS listing__country_latest
     , 1 AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_8
+) subq_6
 GROUP BY
   listing__country_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0.sql
@@ -1,540 +1,404 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time
+  subq_16.metric_time
   , average_booking_value * bookings / NULLIF(booking_value, 0) AS lux_booking_value_rate_expr
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_18.metric_time
-    , subq_18.bookings
-    , subq_18.average_booking_value
-    , subq_18.booking_value
+    subq_15.metric_time
+    , subq_15.bookings
+    , subq_15.average_booking_value
+    , subq_15.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_12.metric_time AS metric_time
-      , subq_12.bookings AS bookings
-      , subq_12.average_booking_value AS average_booking_value
-      , subq_17.booking_value AS booking_value
+      subq_10.metric_time AS metric_time
+      , subq_10.bookings AS bookings
+      , subq_10.average_booking_value AS average_booking_value
+      , subq_14.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_11.metric_time
-        , SUM(subq_11.bookings) AS bookings
-        , AVG(subq_11.average_booking_value) AS average_booking_value
+        subq_9.metric_time
+        , SUM(subq_9.bookings) AS bookings
+        , AVG(subq_9.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time']
         SELECT
-          subq_10.metric_time
-          , subq_10.bookings
-          , subq_10.average_booking_value
+          subq_8.metric_time
+          , subq_8.bookings
+          , subq_8.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time
-            , subq_9.listing__is_lux_latest
-            , subq_9.bookings
-            , subq_9.average_booking_value
+            subq_7.metric_time
+            , subq_7.listing__is_lux_latest
+            , subq_7.bookings
+            , subq_7.average_booking_value
           FROM (
             -- Pass Only Elements:
             --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
             SELECT
-              subq_8.metric_time
-              , subq_8.listing__is_lux_latest
-              , subq_8.bookings
-              , subq_8.average_booking_value
+              subq_6.metric_time
+              , subq_6.listing__is_lux_latest
+              , subq_6.bookings
+              , subq_6.average_booking_value
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_3.metric_time AS metric_time
-                , subq_3.listing AS listing
-                , subq_7.is_lux_latest AS listing__is_lux_latest
-                , subq_3.bookings AS bookings
-                , subq_3.average_booking_value AS average_booking_value
+                subq_2.metric_time AS metric_time
+                , subq_2.listing AS listing
+                , subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.bookings AS bookings
+                , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements:
                 --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
                 SELECT
-                  subq_2.metric_time
-                  , subq_2.listing
-                  , subq_2.bookings
-                  , subq_2.average_booking_value
+                  subq_1.metric_time
+                  , subq_1.listing
+                  , subq_1.bookings
+                  , subq_1.average_booking_value
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_1.ds
-                    , subq_1.ds__week
-                    , subq_1.ds__month
-                    , subq_1.ds__quarter
-                    , subq_1.ds__year
-                    , subq_1.ds_partitioned
-                    , subq_1.ds_partitioned__week
-                    , subq_1.ds_partitioned__month
-                    , subq_1.ds_partitioned__quarter
-                    , subq_1.ds_partitioned__year
-                    , subq_1.booking_paid_at
-                    , subq_1.booking_paid_at__week
-                    , subq_1.booking_paid_at__month
-                    , subq_1.booking_paid_at__quarter
-                    , subq_1.booking_paid_at__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , subq_1.ds AS metric_time
-                    , subq_1.ds__week AS metric_time__week
-                    , subq_1.ds__month AS metric_time__month
-                    , subq_1.ds__quarter AS metric_time__quarter
-                    , subq_1.ds__year AS metric_time__year
-                    , subq_1.listing
-                    , subq_1.guest
-                    , subq_1.host
-                    , subq_1.create_a_cycle_in_the_join_graph
-                    , subq_1.create_a_cycle_in_the_join_graph__listing
-                    , subq_1.create_a_cycle_in_the_join_graph__guest
-                    , subq_1.create_a_cycle_in_the_join_graph__host
-                    , subq_1.is_instant
-                    , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                    , subq_1.bookings
-                    , subq_1.instant_bookings
-                    , subq_1.booking_value
-                    , subq_1.max_booking_value
-                    , subq_1.min_booking_value
-                    , subq_1.bookers
-                    , subq_1.average_booking_value
+                    subq_0.ds
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds_partitioned
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.booking_paid_at
+                    , subq_0.booking_paid_at__week
+                    , subq_0.booking_paid_at__month
+                    , subq_0.booking_paid_at__quarter
+                    , subq_0.booking_paid_at__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                    , subq_0.ds AS metric_time
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.create_a_cycle_in_the_join_graph
+                    , subq_0.create_a_cycle_in_the_join_graph__listing
+                    , subq_0.create_a_cycle_in_the_join_graph__guest
+                    , subq_0.create_a_cycle_in_the_join_graph__host
+                    , subq_0.is_instant
+                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'bookings_source'
                     SELECT
-                      subq_0.ds
-                      , subq_0.ds__week
-                      , subq_0.ds__month
-                      , subq_0.ds__quarter
-                      , subq_0.ds__year
-                      , subq_0.ds_partitioned
-                      , subq_0.ds_partitioned__week
-                      , subq_0.ds_partitioned__month
-                      , subq_0.ds_partitioned__quarter
-                      , subq_0.ds_partitioned__year
-                      , subq_0.booking_paid_at
-                      , subq_0.booking_paid_at__week
-                      , subq_0.booking_paid_at__month
-                      , subq_0.booking_paid_at__quarter
-                      , subq_0.booking_paid_at__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                      , subq_0.listing
-                      , subq_0.guest
-                      , subq_0.host
-                      , subq_0.create_a_cycle_in_the_join_graph
-                      , subq_0.create_a_cycle_in_the_join_graph__listing
-                      , subq_0.create_a_cycle_in_the_join_graph__guest
-                      , subq_0.create_a_cycle_in_the_join_graph__host
-                      , subq_0.is_instant
-                      , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                      , subq_0.bookings
-                      , subq_0.instant_bookings
-                      , subq_0.booking_value
-                      , subq_0.max_booking_value
-                      , subq_0.min_booking_value
-                      , subq_0.bookers
-                      , subq_0.average_booking_value
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_10001.booking_value
+                      , bookings_source_src_10001.booking_value AS max_booking_value
+                      , bookings_source_src_10001.booking_value AS min_booking_value
+                      , bookings_source_src_10001.guest_id AS bookers
+                      , bookings_source_src_10001.booking_value AS average_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_payments
+                      , bookings_source_src_10001.is_instant
+                      , bookings_source_src_10001.ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                      , bookings_source_src_10001.ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                      , bookings_source_src_10001.listing_id AS listing
+                      , bookings_source_src_10001.guest_id AS guest
+                      , bookings_source_src_10001.host_id AS host
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM (
-                      -- Read Elements From Data Source 'bookings_source'
-                      SELECT
-                        1 AS bookings
-                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                        , bookings_source_src_10001.booking_value
-                        , bookings_source_src_10001.booking_value AS max_booking_value
-                        , bookings_source_src_10001.booking_value AS min_booking_value
-                        , bookings_source_src_10001.guest_id AS bookers
-                        , bookings_source_src_10001.booking_value AS average_booking_value
-                        , bookings_source_src_10001.booking_value AS booking_payments
-                        , bookings_source_src_10001.is_instant
-                        , bookings_source_src_10001.ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                        , bookings_source_src_10001.ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                        , bookings_source_src_10001.listing_id AS listing
-                        , bookings_source_src_10001.guest_id AS guest
-                        , bookings_source_src_10001.host_id AS host
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                      FROM (
-                        -- User Defined SQL Query
-                        SELECT * FROM ***************************.fct_bookings
-                      ) bookings_source_src_10001
-                    ) subq_0
-                  ) subq_1
-                ) subq_2
-              ) subq_3
+                      -- User Defined SQL Query
+                      SELECT * FROM ***************************.fct_bookings
+                    ) bookings_source_src_10001
+                  ) subq_0
+                ) subq_1
+              ) subq_2
               LEFT OUTER JOIN (
                 -- Pass Only Elements:
                 --   ['listing', 'is_lux_latest']
                 SELECT
-                  subq_6.listing
-                  , subq_6.is_lux_latest
+                  subq_4.listing
+                  , subq_4.is_lux_latest
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_5.ds
-                    , subq_5.ds__week
-                    , subq_5.ds__month
-                    , subq_5.ds__quarter
-                    , subq_5.ds__year
-                    , subq_5.created_at
-                    , subq_5.created_at__week
-                    , subq_5.created_at__month
-                    , subq_5.created_at__quarter
-                    , subq_5.created_at__year
-                    , subq_5.listing__ds
-                    , subq_5.listing__ds__week
-                    , subq_5.listing__ds__month
-                    , subq_5.listing__ds__quarter
-                    , subq_5.listing__ds__year
-                    , subq_5.listing__created_at
-                    , subq_5.listing__created_at__week
-                    , subq_5.listing__created_at__month
-                    , subq_5.listing__created_at__quarter
-                    , subq_5.listing__created_at__year
-                    , subq_5.ds AS metric_time
-                    , subq_5.ds__week AS metric_time__week
-                    , subq_5.ds__month AS metric_time__month
-                    , subq_5.ds__quarter AS metric_time__quarter
-                    , subq_5.ds__year AS metric_time__year
-                    , subq_5.listing
-                    , subq_5.user
-                    , subq_5.listing__user
-                    , subq_5.country_latest
-                    , subq_5.is_lux_latest
-                    , subq_5.capacity_latest
-                    , subq_5.listing__country_latest
-                    , subq_5.listing__is_lux_latest
-                    , subq_5.listing__capacity_latest
-                    , subq_5.listings
-                    , subq_5.largest_listing
-                    , subq_5.smallest_listing
+                    subq_3.ds
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.created_at
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.listing__ds
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__created_at
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.ds AS metric_time
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'listings_latest'
                     SELECT
-                      subq_4.ds
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.created_at
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.listing__ds
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__created_at
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
-                    FROM (
-                      -- Read Elements From Data Source 'listings_latest'
-                      SELECT
-                        1 AS listings
-                        , listings_latest_src_10004.capacity AS largest_listing
-                        , listings_latest_src_10004.capacity AS smallest_listing
-                        , listings_latest_src_10004.created_at AS ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                        , listings_latest_src_10004.created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                        , listings_latest_src_10004.country AS country_latest
-                        , listings_latest_src_10004.is_lux AS is_lux_latest
-                        , listings_latest_src_10004.capacity AS capacity_latest
-                        , listings_latest_src_10004.created_at AS listing__ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                        , listings_latest_src_10004.created_at AS listing__created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                        , listings_latest_src_10004.country AS listing__country_latest
-                        , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                        , listings_latest_src_10004.capacity AS listing__capacity_latest
-                        , listings_latest_src_10004.listing_id AS listing
-                        , listings_latest_src_10004.user_id AS user
-                        , listings_latest_src_10004.user_id AS listing__user
-                      FROM ***************************.dim_listings_latest listings_latest_src_10004
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
-              ) subq_7
+                      1 AS listings
+                      , listings_latest_src_10004.capacity AS largest_listing
+                      , listings_latest_src_10004.capacity AS smallest_listing
+                      , listings_latest_src_10004.created_at AS ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                      , listings_latest_src_10004.created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                      , listings_latest_src_10004.country AS country_latest
+                      , listings_latest_src_10004.is_lux AS is_lux_latest
+                      , listings_latest_src_10004.capacity AS capacity_latest
+                      , listings_latest_src_10004.created_at AS listing__ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                      , listings_latest_src_10004.created_at AS listing__created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                      , listings_latest_src_10004.country AS listing__country_latest
+                      , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_10004.capacity AS listing__capacity_latest
+                      , listings_latest_src_10004.listing_id AS listing
+                      , listings_latest_src_10004.user_id AS user
+                      , listings_latest_src_10004.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_10004
+                  ) subq_3
+                ) subq_4
+              ) subq_5
               ON
-                subq_3.listing = subq_7.listing
-            ) subq_8
-          ) subq_9
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
           WHERE listing__is_lux_latest
-        ) subq_10
-      ) subq_11
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_11.metric_time
-    ) subq_12
+        subq_9.metric_time
+    ) subq_10
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_16.metric_time
-        , SUM(subq_16.booking_value) AS booking_value
+        subq_13.metric_time
+        , SUM(subq_13.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_15.metric_time
-          , subq_15.booking_value
+          subq_12.metric_time
+          , subq_12.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_14.ds
-            , subq_14.ds__week
-            , subq_14.ds__month
-            , subq_14.ds__quarter
-            , subq_14.ds__year
-            , subq_14.ds_partitioned
-            , subq_14.ds_partitioned__week
-            , subq_14.ds_partitioned__month
-            , subq_14.ds_partitioned__quarter
-            , subq_14.ds_partitioned__year
-            , subq_14.booking_paid_at
-            , subq_14.booking_paid_at__week
-            , subq_14.booking_paid_at__month
-            , subq_14.booking_paid_at__quarter
-            , subq_14.booking_paid_at__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds
-            , subq_14.create_a_cycle_in_the_join_graph__ds__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_14.ds AS metric_time
-            , subq_14.ds__week AS metric_time__week
-            , subq_14.ds__month AS metric_time__month
-            , subq_14.ds__quarter AS metric_time__quarter
-            , subq_14.ds__year AS metric_time__year
-            , subq_14.listing
-            , subq_14.guest
-            , subq_14.host
-            , subq_14.create_a_cycle_in_the_join_graph
-            , subq_14.create_a_cycle_in_the_join_graph__listing
-            , subq_14.create_a_cycle_in_the_join_graph__guest
-            , subq_14.create_a_cycle_in_the_join_graph__host
-            , subq_14.is_instant
-            , subq_14.create_a_cycle_in_the_join_graph__is_instant
-            , subq_14.bookings
-            , subq_14.instant_bookings
-            , subq_14.booking_value
-            , subq_14.max_booking_value
-            , subq_14.min_booking_value
-            , subq_14.bookers
-            , subq_14.average_booking_value
+            subq_11.ds
+            , subq_11.ds__week
+            , subq_11.ds__month
+            , subq_11.ds__quarter
+            , subq_11.ds__year
+            , subq_11.ds_partitioned
+            , subq_11.ds_partitioned__week
+            , subq_11.ds_partitioned__month
+            , subq_11.ds_partitioned__quarter
+            , subq_11.ds_partitioned__year
+            , subq_11.booking_paid_at
+            , subq_11.booking_paid_at__week
+            , subq_11.booking_paid_at__month
+            , subq_11.booking_paid_at__quarter
+            , subq_11.booking_paid_at__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds
+            , subq_11.create_a_cycle_in_the_join_graph__ds__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_11.ds AS metric_time
+            , subq_11.ds__week AS metric_time__week
+            , subq_11.ds__month AS metric_time__month
+            , subq_11.ds__quarter AS metric_time__quarter
+            , subq_11.ds__year AS metric_time__year
+            , subq_11.listing
+            , subq_11.guest
+            , subq_11.host
+            , subq_11.create_a_cycle_in_the_join_graph
+            , subq_11.create_a_cycle_in_the_join_graph__listing
+            , subq_11.create_a_cycle_in_the_join_graph__guest
+            , subq_11.create_a_cycle_in_the_join_graph__host
+            , subq_11.is_instant
+            , subq_11.create_a_cycle_in_the_join_graph__is_instant
+            , subq_11.bookings
+            , subq_11.instant_bookings
+            , subq_11.booking_value
+            , subq_11.max_booking_value
+            , subq_11.min_booking_value
+            , subq_11.bookers
+            , subq_11.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_13.ds
-              , subq_13.ds__week
-              , subq_13.ds__month
-              , subq_13.ds__quarter
-              , subq_13.ds__year
-              , subq_13.ds_partitioned
-              , subq_13.ds_partitioned__week
-              , subq_13.ds_partitioned__month
-              , subq_13.ds_partitioned__quarter
-              , subq_13.ds_partitioned__year
-              , subq_13.booking_paid_at
-              , subq_13.booking_paid_at__week
-              , subq_13.booking_paid_at__month
-              , subq_13.booking_paid_at__quarter
-              , subq_13.booking_paid_at__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds
-              , subq_13.create_a_cycle_in_the_join_graph__ds__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_13.listing
-              , subq_13.guest
-              , subq_13.host
-              , subq_13.create_a_cycle_in_the_join_graph
-              , subq_13.create_a_cycle_in_the_join_graph__listing
-              , subq_13.create_a_cycle_in_the_join_graph__guest
-              , subq_13.create_a_cycle_in_the_join_graph__host
-              , subq_13.is_instant
-              , subq_13.create_a_cycle_in_the_join_graph__is_instant
-              , subq_13.bookings
-              , subq_13.instant_bookings
-              , subq_13.booking_value
-              , subq_13.max_booking_value
-              , subq_13.min_booking_value
-              , subq_13.bookers
-              , subq_13.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_13
-          ) subq_14
-        ) subq_15
-      ) subq_16
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_11
+        ) subq_12
+      ) subq_13
       GROUP BY
-        subq_16.metric_time
-    ) subq_17
+        subq_13.metric_time
+    ) subq_14
     ON
       (
         (
-          subq_12.metric_time = subq_17.metric_time
+          subq_10.metric_time = subq_14.metric_time
         ) OR (
-          (subq_12.metric_time IS NULL) AND (subq_17.metric_time IS NULL)
+          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
         )
       )
-  ) subq_18
-) subq_19
+  ) subq_15
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -7,10 +7,10 @@ FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_32.metric_time AS metric_time
-    , subq_32.bookings AS bookings
-    , subq_32.average_booking_value AS average_booking_value
-    , subq_37.booking_value AS booking_value
+    subq_27.metric_time AS metric_time
+    , subq_27.bookings AS bookings
+    , subq_27.average_booking_value AS average_booking_value
+    , subq_31.booking_value AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
@@ -25,13 +25,12 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
       SELECT
-        subq_23.metric_time AS metric_time
+        subq_19.metric_time AS metric_time
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-        , subq_23.bookings AS bookings
-        , subq_23.average_booking_value AS average_booking_value
+        , subq_19.bookings AS bookings
+        , subq_19.average_booking_value AS average_booking_value
       FROM (
         -- Read Elements From Data Source 'bookings_source'
-        -- Pass Only Additive Measures
         -- Metric Time Dimension 'ds'
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
@@ -44,19 +43,18 @@ FROM (
           -- User Defined SQL Query
           SELECT * FROM ***************************.fct_bookings
         ) bookings_source_src_10001
-      ) subq_23
+      ) subq_19
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_10004
       ON
-        subq_23.listing = listings_latest_src_10004.listing_id
-    ) subq_29
+        subq_19.listing = listings_latest_src_10004.listing_id
+    ) subq_24
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time
-  ) subq_32
+  ) subq_27
   INNER JOIN (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'metric_time']
@@ -70,13 +68,13 @@ FROM (
     ) bookings_source_src_10001
     GROUP BY
       ds
-  ) subq_37
+  ) subq_31
   ON
     (
       (
-        subq_32.metric_time = subq_37.metric_time
+        subq_27.metric_time = subq_31.metric_time
       ) OR (
-        (subq_32.metric_time IS NULL) AND (subq_37.metric_time IS NULL)
+        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
       )
     )
-) subq_39
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,393 +1,293 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_11.metric_time
+  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
   SELECT
-    subq_12.metric_time
-    , subq_12.booking_value_with_is_instant_constraint
-    , subq_12.booking_value
+    subq_10.metric_time
+    , subq_10.booking_value_with_is_instant_constraint
+    , subq_10.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_6.metric_time AS metric_time
-      , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_11.booking_value AS booking_value
+      subq_5.metric_time AS metric_time
+      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+      , subq_9.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time
-        , SUM(subq_5.booking_value) AS booking_value_with_is_instant_constraint
+        subq_4.metric_time
+        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_4.metric_time
-          , subq_4.booking_value
+          subq_3.metric_time
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time
-            , subq_3.is_instant
-            , subq_3.booking_value
+            subq_2.metric_time
+            , subq_2.is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements:
             --   ['booking_value', 'is_instant', 'metric_time']
             SELECT
-              subq_2.metric_time
-              , subq_2.is_instant
-              , subq_2.booking_value
+              subq_1.metric_time
+              , subq_1.is_instant
+              , subq_1.booking_value
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time
-    ) subq_6
+        subq_4.metric_time
+    ) subq_5
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_8.metric_time
+        , SUM(subq_8.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_9.metric_time
-          , subq_9.booking_value
+          subq_7.metric_time
+          , subq_7.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds_partitioned
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.booking_paid_at
-            , subq_8.booking_paid_at__week
-            , subq_8.booking_paid_at__month
-            , subq_8.booking_paid_at__quarter
-            , subq_8.booking_paid_at__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds
-            , subq_8.create_a_cycle_in_the_join_graph__ds__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_8.ds AS metric_time
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.create_a_cycle_in_the_join_graph
-            , subq_8.create_a_cycle_in_the_join_graph__listing
-            , subq_8.create_a_cycle_in_the_join_graph__guest
-            , subq_8.create_a_cycle_in_the_join_graph__host
-            , subq_8.is_instant
-            , subq_8.create_a_cycle_in_the_join_graph__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds_partitioned
+            , subq_6.ds_partitioned__week
+            , subq_6.ds_partitioned__month
+            , subq_6.ds_partitioned__quarter
+            , subq_6.ds_partitioned__year
+            , subq_6.booking_paid_at
+            , subq_6.booking_paid_at__week
+            , subq_6.booking_paid_at__month
+            , subq_6.booking_paid_at__quarter
+            , subq_6.booking_paid_at__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds
+            , subq_6.create_a_cycle_in_the_join_graph__ds__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.guest
+            , subq_6.host
+            , subq_6.create_a_cycle_in_the_join_graph
+            , subq_6.create_a_cycle_in_the_join_graph__listing
+            , subq_6.create_a_cycle_in_the_join_graph__guest
+            , subq_6.create_a_cycle_in_the_join_graph__host
+            , subq_6.is_instant
+            , subq_6.create_a_cycle_in_the_join_graph__is_instant
+            , subq_6.bookings
+            , subq_6.instant_bookings
+            , subq_6.booking_value
+            , subq_6.max_booking_value
+            , subq_6.min_booking_value
+            , subq_6.bookers
+            , subq_6.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_7.ds
-              , subq_7.ds__week
-              , subq_7.ds__month
-              , subq_7.ds__quarter
-              , subq_7.ds__year
-              , subq_7.ds_partitioned
-              , subq_7.ds_partitioned__week
-              , subq_7.ds_partitioned__month
-              , subq_7.ds_partitioned__quarter
-              , subq_7.ds_partitioned__year
-              , subq_7.booking_paid_at
-              , subq_7.booking_paid_at__week
-              , subq_7.booking_paid_at__month
-              , subq_7.booking_paid_at__quarter
-              , subq_7.booking_paid_at__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds
-              , subq_7.create_a_cycle_in_the_join_graph__ds__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_7.listing
-              , subq_7.guest
-              , subq_7.host
-              , subq_7.create_a_cycle_in_the_join_graph
-              , subq_7.create_a_cycle_in_the_join_graph__listing
-              , subq_7.create_a_cycle_in_the_join_graph__guest
-              , subq_7.create_a_cycle_in_the_join_graph__host
-              , subq_7.is_instant
-              , subq_7.create_a_cycle_in_the_join_graph__is_instant
-              , subq_7.bookings
-              , subq_7.instant_bookings
-              , subq_7.booking_value
-              , subq_7.max_booking_value
-              , subq_7.min_booking_value
-              , subq_7.bookers
-              , subq_7.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_7
-          ) subq_8
-        ) subq_9
-      ) subq_10
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_6
+        ) subq_7
+      ) subq_8
       GROUP BY
-        subq_10.metric_time
-    ) subq_11
+        subq_8.metric_time
+    ) subq_9
     ON
       (
         (
-          subq_6.metric_time = subq_11.metric_time
+          subq_5.metric_time = subq_9.metric_time
         ) OR (
-          (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
         )
       )
-  ) subq_12
-) subq_13
+  ) subq_10
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,8 +3,8 @@
 --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time AS metric_time
-  , CAST(subq_20.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_25.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_17.metric_time AS metric_time
+  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
@@ -15,7 +15,6 @@ FROM (
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'is_instant', 'metric_time']
@@ -27,14 +26,13 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_17
+  ) subq_14
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_20
+) subq_17
 INNER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
@@ -48,12 +46,12 @@ INNER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     ds
-) subq_25
+) subq_21
 ON
   (
     (
-      subq_20.metric_time = subq_25.metric_time
+      subq_17.metric_time = subq_21.metric_time
     ) OR (
-      (subq_20.metric_time IS NULL) AND (subq_25.metric_time IS NULL)
+      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,195 +1,145 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.metric_time
+  subq_5.metric_time
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.metric_time
-    , SUM(subq_5.bookings) AS delayed_bookings
+    subq_4.metric_time
+    , SUM(subq_4.bookings) AS delayed_bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
     SELECT
-      subq_4.metric_time
-      , subq_4.bookings
+      subq_3.metric_time
+      , subq_3.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_3.metric_time
-        , subq_3.is_instant
-        , subq_3.bookings
+        subq_2.metric_time
+        , subq_2.is_instant
+        , subq_2.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'metric_time']
         SELECT
-          subq_2.metric_time
-          , subq_2.is_instant
-          , subq_2.bookings
+          subq_1.metric_time
+          , subq_1.is_instant
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.booking_paid_at
-            , subq_1.booking_paid_at__week
-            , subq_1.booking_paid_at__month
-            , subq_1.booking_paid_at__quarter
-            , subq_1.booking_paid_at__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds
-            , subq_1.create_a_cycle_in_the_join_graph__ds__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.listing
-            , subq_1.guest
-            , subq_1.host
-            , subq_1.create_a_cycle_in_the_join_graph
-            , subq_1.create_a_cycle_in_the_join_graph__listing
-            , subq_1.create_a_cycle_in_the_join_graph__guest
-            , subq_1.create_a_cycle_in_the_join_graph__host
-            , subq_1.is_instant
-            , subq_1.create_a_cycle_in_the_join_graph__is_instant
-            , subq_1.bookings
-            , subq_1.instant_bookings
-            , subq_1.booking_value
-            , subq_1.max_booking_value
-            , subq_1.min_booking_value
-            , subq_1.bookers
-            , subq_1.average_booking_value
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.booking_paid_at
-              , subq_0.booking_paid_at__week
-              , subq_0.booking_paid_at__month
-              , subq_0.booking_paid_at__quarter
-              , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_0.listing
-              , subq_0.guest
-              , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
-              , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
-              , subq_0.bookings
-              , subq_0.instant_bookings
-              , subq_0.booking_value
-              , subq_0.max_booking_value
-              , subq_0.min_booking_value
-              , subq_0.bookers
-              , subq_0.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
       WHERE NOT is_instant
-    ) subq_4
-  ) subq_5
+    ) subq_3
+  ) subq_4
   GROUP BY
-    subq_5.metric_time
-) subq_6
+    subq_4.metric_time
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , SUM(bookings) AS delayed_bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'metric_time']
@@ -24,8 +23,8 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_10
+  ) subq_8
   WHERE NOT is_instant
   GROUP BY
     metric_time
-) subq_13
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0.sql
@@ -1,156 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.account_id__customer_id__customer_name
-  , subq_11.txn_count
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.account_id__customer_id__customer_name
-    , SUM(subq_10.txn_count) AS txn_count
+    subq_9.account_id__customer_id__customer_name
+    , SUM(subq_9.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements:
     --   ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_9.account_id__customer_id__customer_name
-      , subq_9.txn_count
+      subq_8.account_id__customer_id__customer_name
+      , subq_8.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_8.ds_partitioned AS account_id__ds_partitioned
-        , subq_3.account_id AS account_id
-        , subq_8.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_3.txn_count AS txn_count
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_7.ds_partitioned AS account_id__ds_partitioned
+        , subq_2.account_id AS account_id
+        , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements:
         --   ['txn_count', 'account_id', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.account_id
-          , subq_2.txn_count
+          subq_1.ds_partitioned
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.account_id__ds_partitioned
-            , subq_1.account_id__ds_partitioned__week
-            , subq_1.account_id__ds_partitioned__month
-            , subq_1.account_id__ds_partitioned__quarter
-            , subq_1.account_id__ds_partitioned__year
-            , subq_1.account_id__ds
-            , subq_1.account_id__ds__week
-            , subq_1.account_id__ds__month
-            , subq_1.account_id__ds__quarter
-            , subq_1.account_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.account_id
-            , subq_1.account_month
-            , subq_1.account_id__account_month
-            , subq_1.txn_count
+            subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.account_id__ds_partitioned
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'account_month_txns'
             SELECT
-              subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.account_id__ds_partitioned
-              , subq_0.account_id__ds_partitioned__week
-              , subq_0.account_id__ds_partitioned__month
-              , subq_0.account_id__ds_partitioned__quarter
-              , subq_0.account_id__ds_partitioned__year
-              , subq_0.account_id__ds
-              , subq_0.account_id__ds__week
-              , subq_0.account_id__ds__month
-              , subq_0.account_id__ds__quarter
-              , subq_0.account_id__ds__year
-              , subq_0.account_id
-              , subq_0.account_month
-              , subq_0.account_id__account_month
-              , subq_0.txn_count
-            FROM (
-              -- Read Elements From Data Source 'account_month_txns'
-              SELECT
-                account_month_txns_src_10010.txn_count
-                , account_month_txns_src_10010.ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
-                , account_month_txns_src_10010.ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
-                , account_month_txns_src_10010.account_month
-                , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
-                , account_month_txns_src_10010.ds AS account_id__ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
-                , account_month_txns_src_10010.account_month AS account_id__account_month
-                , account_month_txns_src_10010.account_id
-              FROM ***************************.account_month_txns account_month_txns_src_10010
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              account_month_txns_src_10010.txn_count
+              , account_month_txns_src_10010.ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
+              , account_month_txns_src_10010.ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
+              , account_month_txns_src_10010.account_month
+              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
+              , account_month_txns_src_10010.ds AS account_id__ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
+              , account_month_txns_src_10010.account_month AS account_id__account_month
+              , account_month_txns_src_10010.account_id
+            FROM ***************************.account_month_txns account_month_txns_src_10010
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
         SELECT
-          subq_7.ds_partitioned
-          , subq_7.account_id
-          , subq_7.customer_id__customer_name
+          subq_6.ds_partitioned
+          , subq_6.account_id
+          , subq_6.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned AS ds_partitioned
-            , subq_4.ds_partitioned__week AS ds_partitioned__week
-            , subq_4.ds_partitioned__month AS ds_partitioned__month
-            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_4.ds_partitioned__year AS ds_partitioned__year
-            , subq_4.account_id__ds_partitioned AS account_id__ds_partitioned
-            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_6.ds_partitioned AS customer_id__ds_partitioned
-            , subq_6.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_6.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_6.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_6.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_4.account_id AS account_id
-            , subq_4.customer_id AS customer_id
-            , subq_4.account_id__customer_id AS account_id__customer_id
-            , subq_4.extra_dim AS extra_dim
-            , subq_4.account_id__extra_dim AS account_id__extra_dim
-            , subq_6.customer_name AS customer_id__customer_name
-            , subq_6.customer_atomic_weight AS customer_id__customer_atomic_weight
+            subq_3.ds_partitioned AS ds_partitioned
+            , subq_3.ds_partitioned__week AS ds_partitioned__week
+            , subq_3.ds_partitioned__month AS ds_partitioned__month
+            , subq_3.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_3.ds_partitioned__year AS ds_partitioned__year
+            , subq_3.account_id__ds_partitioned AS account_id__ds_partitioned
+            , subq_3.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_3.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_3.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_3.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_5.ds_partitioned AS customer_id__ds_partitioned
+            , subq_5.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_5.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_5.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_5.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_3.account_id AS account_id
+            , subq_3.customer_id AS customer_id
+            , subq_3.account_id__customer_id AS account_id__customer_id
+            , subq_3.extra_dim AS extra_dim
+            , subq_3.account_id__extra_dim AS account_id__extra_dim
+            , subq_5.customer_name AS customer_id__customer_name
+            , subq_5.customer_atomic_weight AS customer_id__customer_atomic_weight
           FROM (
             -- Read Elements From Data Source 'bridge_table'
             SELECT
@@ -170,7 +142,7 @@ FROM (
               , bridge_table_src_10011.customer_id
               , bridge_table_src_10011.customer_id AS account_id__customer_id
             FROM ***************************.bridge_table bridge_table_src_10011
-          ) subq_4
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['customer_name',
@@ -189,21 +161,21 @@ FROM (
             --    'customer_id__ds_partitioned__quarter',
             --    'customer_id__ds_partitioned__year']
             SELECT
-              subq_5.ds_partitioned
-              , subq_5.ds_partitioned__week
-              , subq_5.ds_partitioned__month
-              , subq_5.ds_partitioned__quarter
-              , subq_5.ds_partitioned__year
-              , subq_5.customer_id__ds_partitioned
-              , subq_5.customer_id__ds_partitioned__week
-              , subq_5.customer_id__ds_partitioned__month
-              , subq_5.customer_id__ds_partitioned__quarter
-              , subq_5.customer_id__ds_partitioned__year
-              , subq_5.customer_id
-              , subq_5.customer_name
-              , subq_5.customer_atomic_weight
-              , subq_5.customer_id__customer_name
-              , subq_5.customer_id__customer_atomic_weight
+              subq_4.ds_partitioned
+              , subq_4.ds_partitioned__week
+              , subq_4.ds_partitioned__month
+              , subq_4.ds_partitioned__quarter
+              , subq_4.ds_partitioned__year
+              , subq_4.customer_id__ds_partitioned
+              , subq_4.customer_id__ds_partitioned__week
+              , subq_4.customer_id__ds_partitioned__month
+              , subq_4.customer_id__ds_partitioned__quarter
+              , subq_4.customer_id__ds_partitioned__year
+              , subq_4.customer_id
+              , subq_4.customer_name
+              , subq_4.customer_atomic_weight
+              , subq_4.customer_id__customer_name
+              , subq_4.customer_id__customer_atomic_weight
             FROM (
               -- Read Elements From Data Source 'customer_table'
               SELECT
@@ -223,24 +195,24 @@ FROM (
                 , DATE_TRUNC('year', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__year
                 , customer_table_src_10013.customer_id
               FROM ***************************.customer_table customer_table_src_10013
-            ) subq_5
-          ) subq_6
+            ) subq_4
+          ) subq_5
           ON
             (
-              subq_4.customer_id = subq_6.customer_id
+              subq_3.customer_id = subq_5.customer_id
             ) AND (
-              subq_4.ds_partitioned = subq_6.ds_partitioned
+              subq_3.ds_partitioned = subq_5.ds_partitioned
             )
-        ) subq_7
-      ) subq_8
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_3.account_id = subq_8.account_id
+          subq_2.account_id = subq_7.account_id
         ) AND (
-          subq_3.ds_partitioned = subq_8.ds_partitioned
+          subq_2.ds_partitioned = subq_7.ds_partitioned
         )
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.account_id__customer_id__customer_name
-) subq_11
+    subq_9.account_id__customer_id__customer_name
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,7 +4,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_10010.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10010
 LEFT OUTER JOIN (
@@ -24,12 +24,12 @@ LEFT OUTER JOIN (
     ) AND (
       bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
     )
-) subq_20
+) subq_18
 ON
   (
-    account_month_txns_src_10010.account_id = subq_20.account_id
+    account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_20.ds_partitioned
+    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned
   )
 GROUP BY
-  subq_20.customer_id__customer_name
+  subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0.sql
@@ -1,137 +1,107 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user__home_state
-  , subq_8.identity_verifications
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user__home_state
-    , SUM(subq_7.identity_verifications) AS identity_verifications
+    subq_6.user__home_state
+    , SUM(subq_6.identity_verifications) AS identity_verifications
   FROM (
     -- Pass Only Elements:
     --   ['identity_verifications', 'user__home_state']
     SELECT
-      subq_6.user__home_state
-      , subq_6.identity_verifications
+      subq_5.user__home_state
+      , subq_5.identity_verifications
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_5.ds_partitioned AS user__ds_partitioned
-        , subq_3.user AS user
-        , subq_5.home_state AS user__home_state
-        , subq_3.identity_verifications AS identity_verifications
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_4.ds_partitioned AS user__ds_partitioned
+        , subq_2.user AS user
+        , subq_4.home_state AS user__home_state
+        , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements:
         --   ['identity_verifications', 'user', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.user
-          , subq_2.identity_verifications
+          subq_1.ds_partitioned
+          , subq_1.user
+          , subq_1.identity_verifications
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.verification__ds
-            , subq_1.verification__ds__week
-            , subq_1.verification__ds__month
-            , subq_1.verification__ds__quarter
-            , subq_1.verification__ds__year
-            , subq_1.verification__ds_partitioned
-            , subq_1.verification__ds_partitioned__week
-            , subq_1.verification__ds_partitioned__month
-            , subq_1.verification__ds_partitioned__quarter
-            , subq_1.verification__ds_partitioned__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.verification
-            , subq_1.user
-            , subq_1.verification__user
-            , subq_1.verification_type
-            , subq_1.verification__verification_type
-            , subq_1.identity_verifications
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.verification__ds
+            , subq_0.verification__ds__week
+            , subq_0.verification__ds__month
+            , subq_0.verification__ds__quarter
+            , subq_0.verification__ds__year
+            , subq_0.verification__ds_partitioned
+            , subq_0.verification__ds_partitioned__week
+            , subq_0.verification__ds_partitioned__month
+            , subq_0.verification__ds_partitioned__quarter
+            , subq_0.verification__ds_partitioned__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.verification
+            , subq_0.user
+            , subq_0.verification__user
+            , subq_0.verification_type
+            , subq_0.verification__verification_type
+            , subq_0.identity_verifications
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'id_verifications'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.verification__ds
-              , subq_0.verification__ds__week
-              , subq_0.verification__ds__month
-              , subq_0.verification__ds__quarter
-              , subq_0.verification__ds__year
-              , subq_0.verification__ds_partitioned
-              , subq_0.verification__ds_partitioned__week
-              , subq_0.verification__ds_partitioned__month
-              , subq_0.verification__ds_partitioned__quarter
-              , subq_0.verification__ds_partitioned__year
-              , subq_0.verification
-              , subq_0.user
-              , subq_0.verification__user
-              , subq_0.verification_type
-              , subq_0.verification__verification_type
-              , subq_0.identity_verifications
-            FROM (
-              -- Read Elements From Data Source 'id_verifications'
-              SELECT
-                1 AS identity_verifications
-                , id_verifications_src_10003.ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
-                , id_verifications_src_10003.ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
-                , id_verifications_src_10003.verification_type
-                , id_verifications_src_10003.ds AS verification__ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
-                , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
-                , id_verifications_src_10003.verification_type AS verification__verification_type
-                , id_verifications_src_10003.verification_id AS verification
-                , id_verifications_src_10003.user_id AS user
-                , id_verifications_src_10003.user_id AS verification__user
-              FROM ***************************.fct_id_verifications id_verifications_src_10003
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS identity_verifications
+              , id_verifications_src_10003.ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
+              , id_verifications_src_10003.ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
+              , id_verifications_src_10003.verification_type
+              , id_verifications_src_10003.ds AS verification__ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
+              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
+              , id_verifications_src_10003.verification_type AS verification__verification_type
+              , id_verifications_src_10003.verification_id AS verification
+              , id_verifications_src_10003.user_id AS user
+              , id_verifications_src_10003.user_id AS verification__user
+            FROM ***************************.fct_id_verifications id_verifications_src_10003
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user', 'ds_partitioned', 'home_state']
         SELECT
-          subq_4.ds_partitioned
-          , subq_4.user
-          , subq_4.home_state
+          subq_3.ds_partitioned
+          , subq_3.user
+          , subq_3.home_state
         FROM (
           -- Read Elements From Data Source 'users_ds_source'
           SELECT
@@ -169,16 +139,16 @@ FROM (
             , users_ds_source_src_10007.home_state AS user__home_state
             , users_ds_source_src_10007.user_id AS user
           FROM ***************************.dim_users users_ds_source_src_10007
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user = subq_5.user
+          subq_2.user = subq_4.user
         ) AND (
-          subq_3.ds_partitioned = subq_5.ds_partitioned
+          subq_2.ds_partitioned = subq_4.ds_partitioned
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user__home_state
-) subq_8
+    subq_6.user__home_state
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -5,10 +5,9 @@
 -- Compute Metrics via Expressions
 SELECT
   users_ds_source_src_10007.home_state AS user__home_state
-  , SUM(subq_12.identity_verifications) AS identity_verifications
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['identity_verifications', 'user', 'ds_partitioned']
@@ -17,14 +16,14 @@ FROM (
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.dim_users users_ds_source_src_10007
 ON
   (
-    subq_12.user = users_ds_source_src_10007.user_id
+    subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_12.ds_partitioned = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned = users_ds_source_src_10007.ds_partitioned
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node__plan0.sql
@@ -1,13 +1,37 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.total_account_balance_first_day AS total_account_balance_first_day
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.total_account_balance_first_day
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -19,41 +43,13 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MIN(ds)
-  SELECT
-    MIN(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['total_account_balance_first_day', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.total_account_balance_first_day
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
 ) subq_2
 ON
-  subq_1.ds = subq_2.ds
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node__plan0_optimized.sql
@@ -1,30 +1,42 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.total_account_balance_first_day AS total_account_balance_first_day
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   SELECT
-    ds
+    account_balance
     , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds
+    MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
 ) subq_5
 ON
-  subq_4.ds = subq_5.ds
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -1,15 +1,38 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.user AS user
-  , subq_1.current_account_balance_by_user AS current_account_balance_by_user
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.user
-    , subq_0.current_account_balance_by_user
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MAX(ds)
+  SELECT
+    subq_1.user
+    , MAX(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -21,45 +44,15 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MAX(ds)
-  SELECT
-    subq_2.user
-    , MAX(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['current_account_balance_by_user', 'user', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.user
-      , subq_0.current_account_balance_by_user
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
   GROUP BY
-    subq_2.user
+    subq_1.user
 ) subq_2
 ON
-  (subq_1.ds = subq_2.ds) AND (subq_1.user = subq_2.user)
+  (subq_0.ds = subq_2.ds__complete) AND (subq_0.user = subq_2.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -1,29 +1,39 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.user AS user
-  , subq_4.current_account_balance_by_user AS current_account_balance_by_user
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   SELECT
-    ds
-    , user_id AS user
+    account_balance
+    , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   -- Filter row on MAX(ds)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds
+    , MAX(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
@@ -32,4 +42,4 @@ INNER JOIN (
     user_id
 ) subq_5
 ON
-  (subq_4.ds = subq_5.ds) AND (subq_4.user = subq_5.user)
+  (subq_3.ds = subq_5.ds__complete) AND (subq_3.user = subq_5.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -1,0 +1,57 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
+  FROM (
+    -- Read Elements From Data Source 'accounts_source'
+    SELECT
+      accounts_source_src_10000.account_balance
+      , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+      , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+      , accounts_source_src_10000.ds
+      , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
+      , accounts_source_src_10000.user_id AS user
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_accounts
+    ) accounts_source_src_10000
+  ) subq_1
+  GROUP BY
+    subq_1.ds__week
+) subq_2
+ON
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    account_balance
+    , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_3
+INNER JOIN (
+  -- Read Elements From Data Source 'accounts_source'
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(ds) AS ds__complete
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5
+ON
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0.sql
@@ -1,95 +1,73 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.user_team___team_id
-  , subq_4.user_team___user_id
-  , subq_4.messages
+  subq_3.user_team___team_id
+  , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-    , SUM(subq_3.messages) AS messages
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+    , SUM(subq_2.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team']
     SELECT
-      subq_2.user_team___team_id
-      , subq_2.user_team___user_id
-      , subq_2.messages
+      subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+      , subq_1.messages
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.user_id__ds
-        , subq_1.user_id__ds__week
-        , subq_1.user_id__ds__month
-        , subq_1.user_id__ds__quarter
-        , subq_1.user_id__ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user_id
-        , subq_1.user_team___team_id
-        , subq_1.user_team___user_id
-        , subq_1.user_id__user_team___team_id
-        , subq_1.user_id__user_team___user_id
-        , subq_1.team_id
-        , subq_1.user_id__team_id
-        , subq_1.messages
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.user_id__ds
+        , subq_0.user_id__ds__week
+        , subq_0.user_id__ds__month
+        , subq_0.user_id__ds__quarter
+        , subq_0.user_id__ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user_id
+        , subq_0.user_team___team_id
+        , subq_0.user_team___user_id
+        , subq_0.user_id__user_team___team_id
+        , subq_0.user_id__user_team___user_id
+        , subq_0.team_id
+        , subq_0.user_id__team_id
+        , subq_0.messages
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'messages_source'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user_id__ds
-          , subq_0.user_id__ds__week
-          , subq_0.user_id__ds__month
-          , subq_0.user_id__ds__quarter
-          , subq_0.user_id__ds__year
-          , subq_0.user_id
-          , subq_0.user_team___team_id
-          , subq_0.user_team___user_id
-          , subq_0.user_id__user_team___team_id
-          , subq_0.user_id__user_team___user_id
-          , subq_0.team_id
-          , subq_0.user_id__team_id
-          , subq_0.messages
-        FROM (
-          -- Read Elements From Data Source 'messages_source'
-          SELECT
-            1 AS messages
-            , messages_source_src_10015.ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-            , messages_source_src_10015.team_id
-            , messages_source_src_10015.ds AS user_id__ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-            , messages_source_src_10015.team_id AS user_id__team_id
-            , messages_source_src_10015.user_id
-            , messages_source_src_10015.team_id AS user_team___team_id
-            , messages_source_src_10015.user_id AS user_team___user_id
-            , messages_source_src_10015.team_id AS user_id__user_team___team_id
-            , messages_source_src_10015.user_id AS user_id__user_team___user_id
-          FROM ***************************.fct_messages messages_source_src_10015
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS messages
+          , messages_source_src_10015.ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+          , messages_source_src_10015.team_id
+          , messages_source_src_10015.ds AS user_id__ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+          , messages_source_src_10015.team_id AS user_id__team_id
+          , messages_source_src_10015.user_id
+          , messages_source_src_10015.team_id AS user_team___team_id
+          , messages_source_src_10015.user_id AS user_team___user_id
+          , messages_source_src_10015.team_id AS user_id__user_team___team_id
+          , messages_source_src_10015.user_id AS user_id__user_team___user_id
+        FROM ***************************.fct_messages messages_source_src_10015
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-) subq_4
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -15,7 +14,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_8
+) subq_6
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,118 +1,96 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user_team___team_id
-  , subq_8.user_team___user_id
-  , subq_8.user_team__country
-  , subq_8.messages
+  subq_7.user_team___team_id
+  , subq_7.user_team___user_id
+  , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-    , SUM(subq_7.messages) AS messages
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+    , SUM(subq_6.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team__country', 'user_team']
     SELECT
-      subq_6.user_team___team_id
-      , subq_6.user_team___user_id
-      , subq_6.user_team__country
-      , subq_6.messages
+      subq_5.user_team___team_id
+      , subq_5.user_team___user_id
+      , subq_5.user_team__country
+      , subq_5.messages
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.user_team___team_id AS user_team___team_id
-        , subq_3.user_team___user_id AS user_team___user_id
-        , subq_5.country AS user_team__country
-        , subq_3.messages AS messages
+        subq_2.user_team___team_id AS user_team___team_id
+        , subq_2.user_team___user_id AS user_team___user_id
+        , subq_4.country AS user_team__country
+        , subq_2.messages AS messages
       FROM (
         -- Pass Only Elements:
         --   ['messages', 'user_team', 'user_team']
         SELECT
-          subq_2.user_team___team_id
-          , subq_2.user_team___user_id
-          , subq_2.messages
+          subq_1.user_team___team_id
+          , subq_1.user_team___user_id
+          , subq_1.messages
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.user_id__ds
-            , subq_1.user_id__ds__week
-            , subq_1.user_id__ds__month
-            , subq_1.user_id__ds__quarter
-            , subq_1.user_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.user_id
-            , subq_1.user_team___team_id
-            , subq_1.user_team___user_id
-            , subq_1.user_id__user_team___team_id
-            , subq_1.user_id__user_team___user_id
-            , subq_1.team_id
-            , subq_1.user_id__team_id
-            , subq_1.messages
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user_id__ds
+            , subq_0.user_id__ds__week
+            , subq_0.user_id__ds__month
+            , subq_0.user_id__ds__quarter
+            , subq_0.user_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.user_id
+            , subq_0.user_team___team_id
+            , subq_0.user_team___user_id
+            , subq_0.user_id__user_team___team_id
+            , subq_0.user_id__user_team___user_id
+            , subq_0.team_id
+            , subq_0.user_id__team_id
+            , subq_0.messages
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'messages_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.user_id__ds
-              , subq_0.user_id__ds__week
-              , subq_0.user_id__ds__month
-              , subq_0.user_id__ds__quarter
-              , subq_0.user_id__ds__year
-              , subq_0.user_id
-              , subq_0.user_team___team_id
-              , subq_0.user_team___user_id
-              , subq_0.user_id__user_team___team_id
-              , subq_0.user_id__user_team___user_id
-              , subq_0.team_id
-              , subq_0.user_id__team_id
-              , subq_0.messages
-            FROM (
-              -- Read Elements From Data Source 'messages_source'
-              SELECT
-                1 AS messages
-                , messages_source_src_10015.ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-                , messages_source_src_10015.team_id
-                , messages_source_src_10015.ds AS user_id__ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-                , messages_source_src_10015.team_id AS user_id__team_id
-                , messages_source_src_10015.user_id
-                , messages_source_src_10015.team_id AS user_team___team_id
-                , messages_source_src_10015.user_id AS user_team___user_id
-                , messages_source_src_10015.team_id AS user_id__user_team___team_id
-                , messages_source_src_10015.user_id AS user_id__user_team___user_id
-              FROM ***************************.fct_messages messages_source_src_10015
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS messages
+              , messages_source_src_10015.ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+              , messages_source_src_10015.team_id
+              , messages_source_src_10015.ds AS user_id__ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+              , messages_source_src_10015.team_id AS user_id__team_id
+              , messages_source_src_10015.user_id
+              , messages_source_src_10015.team_id AS user_team___team_id
+              , messages_source_src_10015.user_id AS user_team___user_id
+              , messages_source_src_10015.team_id AS user_id__user_team___team_id
+              , messages_source_src_10015.user_id AS user_id__user_team___user_id
+            FROM ***************************.fct_messages messages_source_src_10015
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user_team', 'country']
         SELECT
-          subq_4.user_team___team_id
-          , subq_4.user_team___user_id
-          , subq_4.country
+          subq_3.user_team___team_id
+          , subq_3.user_team___user_id
+          , subq_3.country
         FROM (
           -- Read Elements From Data Source 'users_source'
           SELECT
@@ -160,18 +138,18 @@ FROM (
             , users_source_src_10017.ident_2 AS user_team__user_composite_ident_2___ident_2
             , users_source_src_10017.id AS user_team__user_composite_ident_2___user_id
           FROM ***************************.fct_users users_source_src_10017
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user_team___team_id = subq_5.user_team___team_id
+          subq_2.user_team___team_id = subq_4.user_team___team_id
         ) AND (
-          subq_3.user_team___user_id = subq_5.user_team___user_id
+          subq_2.user_team___user_id = subq_4.user_team___user_id
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-) subq_8
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,13 +4,12 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user_team___team_id AS user_team___team_id
-  , subq_12.user_team___user_id AS user_team___user_id
+  subq_10.user_team___team_id AS user_team___team_id
+  , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10017.country AS user_team__country
-  , SUM(subq_12.messages) AS messages
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team', 'user_team']
@@ -19,16 +18,16 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.fct_users users_source_src_10017
 ON
   (
-    subq_12.user_team___team_id = users_source_src_10017.team_id
+    subq_10.user_team___team_id = users_source_src_10017.team_id
   ) AND (
-    subq_12.user_team___user_id = users_source_src_10017.id
+    subq_10.user_team___user_id = users_source_src_10017.id
   )
 GROUP BY
-  subq_12.user_team___team_id
-  , subq_12.user_team___user_id
+  subq_10.user_team___team_id
+  , subq_10.user_team___user_id
   , users_source_src_10017.country

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -1,103 +1,81 @@
 -- Order By ['user_team']
 SELECT
-  subq_5.user_team___team_id
-  , subq_5.user_team___user_id
-  , subq_5.messages
+  subq_4.user_team___team_id
+  , subq_4.user_team___user_id
+  , subq_4.messages
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.user_team___team_id
-    , subq_4.user_team___user_id
-    , subq_4.messages
+    subq_3.user_team___team_id
+    , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-      , SUM(subq_3.messages) AS messages
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+      , SUM(subq_2.messages) AS messages
     FROM (
       -- Pass Only Elements:
       --   ['messages', 'user_team']
       SELECT
-        subq_2.user_team___team_id
-        , subq_2.user_team___user_id
-        , subq_2.messages
+        subq_1.user_team___team_id
+        , subq_1.user_team___user_id
+        , subq_1.messages
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.user_id__ds
-          , subq_1.user_id__ds__week
-          , subq_1.user_id__ds__month
-          , subq_1.user_id__ds__quarter
-          , subq_1.user_id__ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user_id
-          , subq_1.user_team___team_id
-          , subq_1.user_team___user_id
-          , subq_1.user_id__user_team___team_id
-          , subq_1.user_id__user_team___user_id
-          , subq_1.team_id
-          , subq_1.user_id__team_id
-          , subq_1.messages
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.user_id__ds
+          , subq_0.user_id__ds__week
+          , subq_0.user_id__ds__month
+          , subq_0.user_id__ds__quarter
+          , subq_0.user_id__ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user_id
+          , subq_0.user_team___team_id
+          , subq_0.user_team___user_id
+          , subq_0.user_id__user_team___team_id
+          , subq_0.user_id__user_team___user_id
+          , subq_0.team_id
+          , subq_0.user_id__team_id
+          , subq_0.messages
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'messages_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user_id__ds
-            , subq_0.user_id__ds__week
-            , subq_0.user_id__ds__month
-            , subq_0.user_id__ds__quarter
-            , subq_0.user_id__ds__year
-            , subq_0.user_id
-            , subq_0.user_team___team_id
-            , subq_0.user_team___user_id
-            , subq_0.user_id__user_team___team_id
-            , subq_0.user_id__user_team___user_id
-            , subq_0.team_id
-            , subq_0.user_id__team_id
-            , subq_0.messages
-          FROM (
-            -- Read Elements From Data Source 'messages_source'
-            SELECT
-              1 AS messages
-              , messages_source_src_10015.ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-              , messages_source_src_10015.team_id
-              , messages_source_src_10015.ds AS user_id__ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-              , messages_source_src_10015.team_id AS user_id__team_id
-              , messages_source_src_10015.user_id
-              , messages_source_src_10015.team_id AS user_team___team_id
-              , messages_source_src_10015.user_id AS user_team___user_id
-              , messages_source_src_10015.team_id AS user_id__user_team___team_id
-              , messages_source_src_10015.user_id AS user_id__user_team___user_id
-            FROM ***************************.fct_messages messages_source_src_10015
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            1 AS messages
+            , messages_source_src_10015.ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+            , messages_source_src_10015.team_id
+            , messages_source_src_10015.ds AS user_id__ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+            , messages_source_src_10015.team_id AS user_id__team_id
+            , messages_source_src_10015.user_id
+            , messages_source_src_10015.team_id AS user_team___team_id
+            , messages_source_src_10015.user_id AS user_team___user_id
+            , messages_source_src_10015.team_id AS user_id__user_team___team_id
+            , messages_source_src_10015.user_id AS user_id__user_team___user_id
+          FROM ***************************.fct_messages messages_source_src_10015
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-  ) subq_4
-) subq_5
-ORDER BY subq_5.user_team___team_id DESC, subq_5.user_team___user_id DESC
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+  ) subq_3
+) subq_4
+ORDER BY subq_4.user_team___team_id DESC, subq_4.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
@@ -7,7 +7,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -16,7 +15,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_9
+) subq_7
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,367 +1,357 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_23.ds
-  , subq_23.listing__country_latest
-  , CAST(subq_23.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_23.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  subq_19.ds
+  , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']
   SELECT
-    subq_22.ds
-    , subq_22.listing__country_latest
-    , subq_22.bookings
-    , subq_22.views
+    subq_18.ds
+    , subq_18.listing__country_latest
+    , subq_18.bookings
+    , subq_18.views
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_10.ds AS ds
-      , subq_10.listing__country_latest AS listing__country_latest
-      , subq_10.bookings AS bookings
-      , subq_21.views AS views
+      subq_8.ds AS ds
+      , subq_8.listing__country_latest AS listing__country_latest
+      , subq_8.bookings AS bookings
+      , subq_17.views AS views
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.ds
-        , subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.ds
+        , subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest', 'ds']
         SELECT
-          subq_8.ds
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.ds
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.ds AS ds
-            , subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.ds AS ds
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'ds', 'listing']
             SELECT
-              subq_2.ds
-              , subq_2.listing
-              , subq_2.bookings
+              subq_1.ds
+              , subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.ds
-        , subq_9.listing__country_latest
-    ) subq_10
+        subq_7.ds
+        , subq_7.listing__country_latest
+    ) subq_8
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_20.ds
-        , subq_20.listing__country_latest
-        , SUM(subq_20.views) AS views
+        subq_16.ds
+        , subq_16.listing__country_latest
+        , SUM(subq_16.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_19.ds
-          , subq_19.listing__country_latest
-          , subq_19.views
+          subq_15.ds
+          , subq_15.listing__country_latest
+          , subq_15.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.ds AS ds
-            , subq_14.listing AS listing
-            , subq_18.country_latest AS listing__country_latest
-            , subq_14.views AS views
+            subq_11.ds AS ds
+            , subq_11.listing AS listing
+            , subq_14.country_latest AS listing__country_latest
+            , subq_11.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_13.ds
-              , subq_13.listing
-              , subq_13.views
+              subq_10.ds
+              , subq_10.listing
+              , subq_10.views
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_9.ds
+                , subq_9.ds__week
+                , subq_9.ds__month
+                , subq_9.ds__quarter
+                , subq_9.ds__year
+                , subq_9.ds_partitioned
+                , subq_9.ds_partitioned__week
+                , subq_9.ds_partitioned__month
+                , subq_9.ds_partitioned__quarter
+                , subq_9.ds_partitioned__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds
+                , subq_9.create_a_cycle_in_the_join_graph__ds__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_9.ds AS metric_time
+                , subq_9.ds__week AS metric_time__week
+                , subq_9.ds__month AS metric_time__month
+                , subq_9.ds__quarter AS metric_time__quarter
+                , subq_9.ds__year AS metric_time__year
+                , subq_9.listing
+                , subq_9.user
+                , subq_9.create_a_cycle_in_the_join_graph
+                , subq_9.create_a_cycle_in_the_join_graph__listing
+                , subq_9.create_a_cycle_in_the_join_graph__user
+                , subq_9.views
+              FROM (
+                -- Read Elements From Data Source 'views_source'
+                SELECT
+                  1 AS views
+                  , views_source_src_10009.ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
+                  , views_source_src_10009.ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
+                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , views_source_src_10009.listing_id AS listing
+                  , views_source_src_10009.user_id AS user
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
+                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
+                FROM (
+                  -- User Defined SQL Query
+                  SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+                ) views_source_src_10009
+              ) subq_9
+            ) subq_10
+          ) subq_11
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_13.listing
+              , subq_13.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
@@ -370,21 +360,21 @@ FROM (
                 , subq_12.ds__month
                 , subq_12.ds__quarter
                 , subq_12.ds__year
-                , subq_12.ds_partitioned
-                , subq_12.ds_partitioned__week
-                , subq_12.ds_partitioned__month
-                , subq_12.ds_partitioned__quarter
-                , subq_12.ds_partitioned__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds
-                , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_12.created_at
+                , subq_12.created_at__week
+                , subq_12.created_at__month
+                , subq_12.created_at__quarter
+                , subq_12.created_at__year
+                , subq_12.listing__ds
+                , subq_12.listing__ds__week
+                , subq_12.listing__ds__month
+                , subq_12.listing__ds__quarter
+                , subq_12.listing__ds__year
+                , subq_12.listing__created_at
+                , subq_12.listing__created_at__week
+                , subq_12.listing__created_at__month
+                , subq_12.listing__created_at__quarter
+                , subq_12.listing__created_at__year
                 , subq_12.ds AS metric_time
                 , subq_12.ds__week AS metric_time__week
                 , subq_12.ds__month AS metric_time__month
@@ -392,222 +382,80 @@ FROM (
                 , subq_12.ds__year AS metric_time__year
                 , subq_12.listing
                 , subq_12.user
-                , subq_12.create_a_cycle_in_the_join_graph
-                , subq_12.create_a_cycle_in_the_join_graph__listing
-                , subq_12.create_a_cycle_in_the_join_graph__user
-                , subq_12.views
+                , subq_12.listing__user
+                , subq_12.country_latest
+                , subq_12.is_lux_latest
+                , subq_12.capacity_latest
+                , subq_12.listing__country_latest
+                , subq_12.listing__is_lux_latest
+                , subq_12.listing__capacity_latest
+                , subq_12.listings
+                , subq_12.largest_listing
+                , subq_12.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_11.ds
-                  , subq_11.ds__week
-                  , subq_11.ds__month
-                  , subq_11.ds__quarter
-                  , subq_11.ds__year
-                  , subq_11.ds_partitioned
-                  , subq_11.ds_partitioned__week
-                  , subq_11.ds_partitioned__month
-                  , subq_11.ds_partitioned__quarter
-                  , subq_11.ds_partitioned__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_11.listing
-                  , subq_11.user
-                  , subq_11.create_a_cycle_in_the_join_graph
-                  , subq_11.create_a_cycle_in_the_join_graph__listing
-                  , subq_11.create_a_cycle_in_the_join_graph__user
-                  , subq_11.views
-                FROM (
-                  -- Read Elements From Data Source 'views_source'
-                  SELECT
-                    1 AS views
-                    , views_source_src_10009.ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
-                    , views_source_src_10009.ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                    , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , views_source_src_10009.listing_id AS listing
-                    , views_source_src_10009.user_id AS user
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                    , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
-                  ) views_source_src_10009
-                ) subq_11
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
               ) subq_12
             ) subq_13
           ) subq_14
-          LEFT OUTER JOIN (
-            -- Pass Only Elements:
-            --   ['listing', 'country_latest']
-            SELECT
-              subq_17.listing
-              , subq_17.country_latest
-            FROM (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_16.ds
-                , subq_16.ds__week
-                , subq_16.ds__month
-                , subq_16.ds__quarter
-                , subq_16.ds__year
-                , subq_16.created_at
-                , subq_16.created_at__week
-                , subq_16.created_at__month
-                , subq_16.created_at__quarter
-                , subq_16.created_at__year
-                , subq_16.listing__ds
-                , subq_16.listing__ds__week
-                , subq_16.listing__ds__month
-                , subq_16.listing__ds__quarter
-                , subq_16.listing__ds__year
-                , subq_16.listing__created_at
-                , subq_16.listing__created_at__week
-                , subq_16.listing__created_at__month
-                , subq_16.listing__created_at__quarter
-                , subq_16.listing__created_at__year
-                , subq_16.ds AS metric_time
-                , subq_16.ds__week AS metric_time__week
-                , subq_16.ds__month AS metric_time__month
-                , subq_16.ds__quarter AS metric_time__quarter
-                , subq_16.ds__year AS metric_time__year
-                , subq_16.listing
-                , subq_16.user
-                , subq_16.listing__user
-                , subq_16.country_latest
-                , subq_16.is_lux_latest
-                , subq_16.capacity_latest
-                , subq_16.listing__country_latest
-                , subq_16.listing__is_lux_latest
-                , subq_16.listing__capacity_latest
-                , subq_16.listings
-                , subq_16.largest_listing
-                , subq_16.smallest_listing
-              FROM (
-                -- Pass Only Additive Measures
-                SELECT
-                  subq_15.ds
-                  , subq_15.ds__week
-                  , subq_15.ds__month
-                  , subq_15.ds__quarter
-                  , subq_15.ds__year
-                  , subq_15.created_at
-                  , subq_15.created_at__week
-                  , subq_15.created_at__month
-                  , subq_15.created_at__quarter
-                  , subq_15.created_at__year
-                  , subq_15.listing__ds
-                  , subq_15.listing__ds__week
-                  , subq_15.listing__ds__month
-                  , subq_15.listing__ds__quarter
-                  , subq_15.listing__ds__year
-                  , subq_15.listing__created_at
-                  , subq_15.listing__created_at__week
-                  , subq_15.listing__created_at__month
-                  , subq_15.listing__created_at__quarter
-                  , subq_15.listing__created_at__year
-                  , subq_15.listing
-                  , subq_15.user
-                  , subq_15.listing__user
-                  , subq_15.country_latest
-                  , subq_15.is_lux_latest
-                  , subq_15.capacity_latest
-                  , subq_15.listing__country_latest
-                  , subq_15.listing__is_lux_latest
-                  , subq_15.listing__capacity_latest
-                  , subq_15.listings
-                  , subq_15.largest_listing
-                  , subq_15.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_15
-              ) subq_16
-            ) subq_17
-          ) subq_18
           ON
-            subq_14.listing = subq_18.listing
-        ) subq_19
-      ) subq_20
+            subq_11.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       GROUP BY
-        subq_20.ds
-        , subq_20.listing__country_latest
-    ) subq_21
+        subq_16.ds
+        , subq_16.listing__country_latest
+    ) subq_17
     ON
       (
         (
-          subq_10.listing__country_latest = subq_21.listing__country_latest
+          subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
-            subq_10.listing__country_latest IS NULL
+            subq_8.listing__country_latest IS NULL
           ) AND (
-            subq_21.listing__country_latest IS NULL
+            subq_17.listing__country_latest IS NULL
           )
         )
       ) AND (
         (
-          subq_10.ds = subq_21.ds
+          subq_8.ds = subq_17.ds
         ) OR (
-          (subq_10.ds IS NULL) AND (subq_21.ds IS NULL)
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
-  ) subq_22
-) subq_23
+  ) subq_18
+) subq_19

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,21 +3,20 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  subq_34.ds AS ds
-  , subq_34.listing__country_latest AS listing__country_latest
-  , CAST(subq_34.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_45.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  subq_28.ds AS ds
+  , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_27.ds AS ds
+    subq_22.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_27.bookings) AS bookings
+    , SUM(subq_22.bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds', 'listing']
@@ -29,27 +28,26 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_27
+  ) subq_22
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_27.listing = listings_latest_src_10004.listing_id
+    subq_22.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_27.ds
+    subq_22.ds
     , listings_latest_src_10004.country
-) subq_34
+) subq_28
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_38.ds AS ds
+    subq_31.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_38.views) AS views
+    , SUM(subq_31.views) AS views
   FROM (
     -- Read Elements From Data Source 'views_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['views', 'ds', 'listing']
@@ -61,30 +59,30 @@ INNER JOIN (
       -- User Defined SQL Query
       SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
     ) views_source_src_10009
-  ) subq_38
+  ) subq_31
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_38.listing = listings_latest_src_10004.listing_id
+    subq_31.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_38.ds
+    subq_31.ds
     , listings_latest_src_10004.country
-) subq_45
+) subq_37
 ON
   (
     (
-      subq_34.listing__country_latest = subq_45.listing__country_latest
+      subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
-        subq_34.listing__country_latest IS NULL
+        subq_28.listing__country_latest IS NULL
       ) AND (
-        subq_45.listing__country_latest IS NULL
+        subq_37.listing__country_latest IS NULL
       )
     )
   ) AND (
     (
-      subq_34.ds = subq_45.ds
+      subq_28.ds = subq_37.ds
     ) OR (
-      (subq_34.ds IS NULL) AND (subq_45.ds IS NULL)
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_mtd
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_ds__plan0.sql
@@ -1,56 +1,45 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_4.txn_revenue) AS txn_revenue
+    SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue']
     SELECT
-      subq_2.txn_revenue
+      subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
-) subq_5
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_all_time
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS revenue_all_time
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS trailing_2_months_revenue
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_distinct_values__plan0.sql
@@ -1,329 +1,243 @@
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
-  subq_12.listing__country_latest
+  subq_10.listing__country_latest
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest']
   SELECT
-    subq_11.listing__country_latest
+    subq_9.listing__country_latest
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_10.listing__country_latest
-      , subq_10.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest']
         SELECT
-          subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.listing__country_latest
-    ) subq_10
-  ) subq_11
-) subq_12
-ORDER BY subq_12.listing__country_latest
+        subq_7.listing__country_latest
+    ) subq_8
+  ) subq_9
+) subq_10
+ORDER BY subq_10.listing__country_latest
 LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,334 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.is_instant
-  , subq_12.bookings
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.is_instant
-    , SUM(subq_11.bookings) AS bookings
+    subq_9.is_instant
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'is_instant']
     SELECT
-      subq_10.is_instant
-      , subq_10.bookings
+      subq_8.is_instant
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.is_instant
-        , subq_9.listing__country_latest
-        , subq_9.bookings
+        subq_7.is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'listing__country_latest']
         SELECT
-          subq_8.is_instant
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.is_instant AS is_instant
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.is_instant AS is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.is_instant
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE listing__country_latest = 'us'
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.is_instant
-) subq_12
+    subq_9.is_instant
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -11,12 +11,11 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'listing__country_latest']
   SELECT
-    subq_16.is_instant AS is_instant
+    subq_13.is_instant AS is_instant
     , listings_latest_src_10004.country AS listing__country_latest
-    , subq_16.bookings AS bookings
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'listing']
@@ -28,12 +27,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_16
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_16.listing = listings_latest_src_10004.listing_id
-) subq_22
+    subq_13.listing = listings_latest_src_10004.listing_id
+) subq_18
 WHERE listing__country_latest = 'us'
 GROUP BY
   is_instant

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_limit_rows__plan0.sql
@@ -1,186 +1,136 @@
 -- Order By [] Limit 1
 SELECT
-  subq_5.ds
-  , subq_5.bookings
+  subq_4.ds
+  , subq_4.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.ds
-    , subq_4.bookings
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.ds
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.ds
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'ds']
       SELECT
-        subq_2.ds
-        , subq_2.bookings
+        subq_1.ds
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.ds
-  ) subq_4
-) subq_5
+      subq_2.ds
+  ) subq_3
+) subq_4
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_limit_rows__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
-) subq_9
+) subq_7
 GROUP BY
   ds
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,133 +1,97 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.listing__country_latest
-  , subq_4.listings
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.listing__country_latest
-    , SUM(subq_3.listings) AS listings
+    subq_2.listing__country_latest
+    , SUM(subq_2.listings) AS listings
   FROM (
     -- Pass Only Elements:
     --   ['listings', 'listing__country_latest']
     SELECT
-      subq_2.listing__country_latest
-      , subq_2.listings
+      subq_1.listing__country_latest
+      , subq_1.listings
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.created_at
-        , subq_1.created_at__week
-        , subq_1.created_at__month
-        , subq_1.created_at__quarter
-        , subq_1.created_at__year
-        , subq_1.listing__ds
-        , subq_1.listing__ds__week
-        , subq_1.listing__ds__month
-        , subq_1.listing__ds__quarter
-        , subq_1.listing__ds__year
-        , subq_1.listing__created_at
-        , subq_1.listing__created_at__week
-        , subq_1.listing__created_at__month
-        , subq_1.listing__created_at__quarter
-        , subq_1.listing__created_at__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.listing
-        , subq_1.user
-        , subq_1.listing__user
-        , subq_1.country_latest
-        , subq_1.is_lux_latest
-        , subq_1.capacity_latest
-        , subq_1.listing__country_latest
-        , subq_1.listing__is_lux_latest
-        , subq_1.listing__capacity_latest
-        , subq_1.listings
-        , subq_1.largest_listing
-        , subq_1.smallest_listing
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.created_at
+        , subq_0.created_at__week
+        , subq_0.created_at__month
+        , subq_0.created_at__quarter
+        , subq_0.created_at__year
+        , subq_0.listing__ds
+        , subq_0.listing__ds__week
+        , subq_0.listing__ds__month
+        , subq_0.listing__ds__quarter
+        , subq_0.listing__ds__year
+        , subq_0.listing__created_at
+        , subq_0.listing__created_at__week
+        , subq_0.listing__created_at__month
+        , subq_0.listing__created_at__quarter
+        , subq_0.listing__created_at__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.listing
+        , subq_0.user
+        , subq_0.listing__user
+        , subq_0.country_latest
+        , subq_0.is_lux_latest
+        , subq_0.capacity_latest
+        , subq_0.listing__country_latest
+        , subq_0.listing__is_lux_latest
+        , subq_0.listing__capacity_latest
+        , subq_0.listings
+        , subq_0.largest_listing
+        , subq_0.smallest_listing
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'listings_latest'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.created_at
-          , subq_0.created_at__week
-          , subq_0.created_at__month
-          , subq_0.created_at__quarter
-          , subq_0.created_at__year
-          , subq_0.listing__ds
-          , subq_0.listing__ds__week
-          , subq_0.listing__ds__month
-          , subq_0.listing__ds__quarter
-          , subq_0.listing__ds__year
-          , subq_0.listing__created_at
-          , subq_0.listing__created_at__week
-          , subq_0.listing__created_at__month
-          , subq_0.listing__created_at__quarter
-          , subq_0.listing__created_at__year
-          , subq_0.listing
-          , subq_0.user
-          , subq_0.listing__user
-          , subq_0.country_latest
-          , subq_0.is_lux_latest
-          , subq_0.capacity_latest
-          , subq_0.listing__country_latest
-          , subq_0.listing__is_lux_latest
-          , subq_0.listing__capacity_latest
-          , subq_0.listings
-          , subq_0.largest_listing
-          , subq_0.smallest_listing
-        FROM (
-          -- Read Elements From Data Source 'listings_latest'
-          SELECT
-            1 AS listings
-            , listings_latest_src_10004.capacity AS largest_listing
-            , listings_latest_src_10004.capacity AS smallest_listing
-            , listings_latest_src_10004.created_at AS ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-            , listings_latest_src_10004.created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-            , listings_latest_src_10004.country AS country_latest
-            , listings_latest_src_10004.is_lux AS is_lux_latest
-            , listings_latest_src_10004.capacity AS capacity_latest
-            , listings_latest_src_10004.created_at AS listing__ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-            , listings_latest_src_10004.created_at AS listing__created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-            , listings_latest_src_10004.country AS listing__country_latest
-            , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-            , listings_latest_src_10004.capacity AS listing__capacity_latest
-            , listings_latest_src_10004.listing_id AS listing
-            , listings_latest_src_10004.user_id AS user
-            , listings_latest_src_10004.user_id AS listing__user
-          FROM ***************************.dim_listings_latest listings_latest_src_10004
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS listings
+          , listings_latest_src_10004.capacity AS largest_listing
+          , listings_latest_src_10004.capacity AS smallest_listing
+          , listings_latest_src_10004.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+          , listings_latest_src_10004.created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+          , listings_latest_src_10004.country AS country_latest
+          , listings_latest_src_10004.is_lux AS is_lux_latest
+          , listings_latest_src_10004.capacity AS capacity_latest
+          , listings_latest_src_10004.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+          , listings_latest_src_10004.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+          , listings_latest_src_10004.country AS listing__country_latest
+          , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10004.capacity AS listing__capacity_latest
+          , listings_latest_src_10004.listing_id AS listing
+          , listings_latest_src_10004.user_id AS user
+          , listings_latest_src_10004.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10004
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.listing__country_latest
-) subq_4
+    subq_2.listing__country_latest
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings', 'listing__country_latest']
@@ -13,6 +12,6 @@ FROM (
     country AS listing__country_latest
     , 1 AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_8
+) subq_6
 GROUP BY
   listing__country_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0.sql
@@ -1,540 +1,404 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time
+  subq_16.metric_time
   , average_booking_value * bookings / NULLIF(booking_value, 0) AS lux_booking_value_rate_expr
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_18.metric_time
-    , subq_18.bookings
-    , subq_18.average_booking_value
-    , subq_18.booking_value
+    subq_15.metric_time
+    , subq_15.bookings
+    , subq_15.average_booking_value
+    , subq_15.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_12.metric_time AS metric_time
-      , subq_12.bookings AS bookings
-      , subq_12.average_booking_value AS average_booking_value
-      , subq_17.booking_value AS booking_value
+      subq_10.metric_time AS metric_time
+      , subq_10.bookings AS bookings
+      , subq_10.average_booking_value AS average_booking_value
+      , subq_14.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_11.metric_time
-        , SUM(subq_11.bookings) AS bookings
-        , AVG(subq_11.average_booking_value) AS average_booking_value
+        subq_9.metric_time
+        , SUM(subq_9.bookings) AS bookings
+        , AVG(subq_9.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time']
         SELECT
-          subq_10.metric_time
-          , subq_10.bookings
-          , subq_10.average_booking_value
+          subq_8.metric_time
+          , subq_8.bookings
+          , subq_8.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time
-            , subq_9.listing__is_lux_latest
-            , subq_9.bookings
-            , subq_9.average_booking_value
+            subq_7.metric_time
+            , subq_7.listing__is_lux_latest
+            , subq_7.bookings
+            , subq_7.average_booking_value
           FROM (
             -- Pass Only Elements:
             --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
             SELECT
-              subq_8.metric_time
-              , subq_8.listing__is_lux_latest
-              , subq_8.bookings
-              , subq_8.average_booking_value
+              subq_6.metric_time
+              , subq_6.listing__is_lux_latest
+              , subq_6.bookings
+              , subq_6.average_booking_value
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_3.metric_time AS metric_time
-                , subq_3.listing AS listing
-                , subq_7.is_lux_latest AS listing__is_lux_latest
-                , subq_3.bookings AS bookings
-                , subq_3.average_booking_value AS average_booking_value
+                subq_2.metric_time AS metric_time
+                , subq_2.listing AS listing
+                , subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.bookings AS bookings
+                , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements:
                 --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
                 SELECT
-                  subq_2.metric_time
-                  , subq_2.listing
-                  , subq_2.bookings
-                  , subq_2.average_booking_value
+                  subq_1.metric_time
+                  , subq_1.listing
+                  , subq_1.bookings
+                  , subq_1.average_booking_value
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_1.ds
-                    , subq_1.ds__week
-                    , subq_1.ds__month
-                    , subq_1.ds__quarter
-                    , subq_1.ds__year
-                    , subq_1.ds_partitioned
-                    , subq_1.ds_partitioned__week
-                    , subq_1.ds_partitioned__month
-                    , subq_1.ds_partitioned__quarter
-                    , subq_1.ds_partitioned__year
-                    , subq_1.booking_paid_at
-                    , subq_1.booking_paid_at__week
-                    , subq_1.booking_paid_at__month
-                    , subq_1.booking_paid_at__quarter
-                    , subq_1.booking_paid_at__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , subq_1.ds AS metric_time
-                    , subq_1.ds__week AS metric_time__week
-                    , subq_1.ds__month AS metric_time__month
-                    , subq_1.ds__quarter AS metric_time__quarter
-                    , subq_1.ds__year AS metric_time__year
-                    , subq_1.listing
-                    , subq_1.guest
-                    , subq_1.host
-                    , subq_1.create_a_cycle_in_the_join_graph
-                    , subq_1.create_a_cycle_in_the_join_graph__listing
-                    , subq_1.create_a_cycle_in_the_join_graph__guest
-                    , subq_1.create_a_cycle_in_the_join_graph__host
-                    , subq_1.is_instant
-                    , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                    , subq_1.bookings
-                    , subq_1.instant_bookings
-                    , subq_1.booking_value
-                    , subq_1.max_booking_value
-                    , subq_1.min_booking_value
-                    , subq_1.bookers
-                    , subq_1.average_booking_value
+                    subq_0.ds
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds_partitioned
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.booking_paid_at
+                    , subq_0.booking_paid_at__week
+                    , subq_0.booking_paid_at__month
+                    , subq_0.booking_paid_at__quarter
+                    , subq_0.booking_paid_at__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                    , subq_0.ds AS metric_time
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.create_a_cycle_in_the_join_graph
+                    , subq_0.create_a_cycle_in_the_join_graph__listing
+                    , subq_0.create_a_cycle_in_the_join_graph__guest
+                    , subq_0.create_a_cycle_in_the_join_graph__host
+                    , subq_0.is_instant
+                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'bookings_source'
                     SELECT
-                      subq_0.ds
-                      , subq_0.ds__week
-                      , subq_0.ds__month
-                      , subq_0.ds__quarter
-                      , subq_0.ds__year
-                      , subq_0.ds_partitioned
-                      , subq_0.ds_partitioned__week
-                      , subq_0.ds_partitioned__month
-                      , subq_0.ds_partitioned__quarter
-                      , subq_0.ds_partitioned__year
-                      , subq_0.booking_paid_at
-                      , subq_0.booking_paid_at__week
-                      , subq_0.booking_paid_at__month
-                      , subq_0.booking_paid_at__quarter
-                      , subq_0.booking_paid_at__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                      , subq_0.listing
-                      , subq_0.guest
-                      , subq_0.host
-                      , subq_0.create_a_cycle_in_the_join_graph
-                      , subq_0.create_a_cycle_in_the_join_graph__listing
-                      , subq_0.create_a_cycle_in_the_join_graph__guest
-                      , subq_0.create_a_cycle_in_the_join_graph__host
-                      , subq_0.is_instant
-                      , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                      , subq_0.bookings
-                      , subq_0.instant_bookings
-                      , subq_0.booking_value
-                      , subq_0.max_booking_value
-                      , subq_0.min_booking_value
-                      , subq_0.bookers
-                      , subq_0.average_booking_value
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_10001.booking_value
+                      , bookings_source_src_10001.booking_value AS max_booking_value
+                      , bookings_source_src_10001.booking_value AS min_booking_value
+                      , bookings_source_src_10001.guest_id AS bookers
+                      , bookings_source_src_10001.booking_value AS average_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_payments
+                      , bookings_source_src_10001.is_instant
+                      , bookings_source_src_10001.ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                      , bookings_source_src_10001.ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                      , bookings_source_src_10001.listing_id AS listing
+                      , bookings_source_src_10001.guest_id AS guest
+                      , bookings_source_src_10001.host_id AS host
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM (
-                      -- Read Elements From Data Source 'bookings_source'
-                      SELECT
-                        1 AS bookings
-                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                        , bookings_source_src_10001.booking_value
-                        , bookings_source_src_10001.booking_value AS max_booking_value
-                        , bookings_source_src_10001.booking_value AS min_booking_value
-                        , bookings_source_src_10001.guest_id AS bookers
-                        , bookings_source_src_10001.booking_value AS average_booking_value
-                        , bookings_source_src_10001.booking_value AS booking_payments
-                        , bookings_source_src_10001.is_instant
-                        , bookings_source_src_10001.ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                        , bookings_source_src_10001.ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                        , bookings_source_src_10001.listing_id AS listing
-                        , bookings_source_src_10001.guest_id AS guest
-                        , bookings_source_src_10001.host_id AS host
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                      FROM (
-                        -- User Defined SQL Query
-                        SELECT * FROM ***************************.fct_bookings
-                      ) bookings_source_src_10001
-                    ) subq_0
-                  ) subq_1
-                ) subq_2
-              ) subq_3
+                      -- User Defined SQL Query
+                      SELECT * FROM ***************************.fct_bookings
+                    ) bookings_source_src_10001
+                  ) subq_0
+                ) subq_1
+              ) subq_2
               LEFT OUTER JOIN (
                 -- Pass Only Elements:
                 --   ['listing', 'is_lux_latest']
                 SELECT
-                  subq_6.listing
-                  , subq_6.is_lux_latest
+                  subq_4.listing
+                  , subq_4.is_lux_latest
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_5.ds
-                    , subq_5.ds__week
-                    , subq_5.ds__month
-                    , subq_5.ds__quarter
-                    , subq_5.ds__year
-                    , subq_5.created_at
-                    , subq_5.created_at__week
-                    , subq_5.created_at__month
-                    , subq_5.created_at__quarter
-                    , subq_5.created_at__year
-                    , subq_5.listing__ds
-                    , subq_5.listing__ds__week
-                    , subq_5.listing__ds__month
-                    , subq_5.listing__ds__quarter
-                    , subq_5.listing__ds__year
-                    , subq_5.listing__created_at
-                    , subq_5.listing__created_at__week
-                    , subq_5.listing__created_at__month
-                    , subq_5.listing__created_at__quarter
-                    , subq_5.listing__created_at__year
-                    , subq_5.ds AS metric_time
-                    , subq_5.ds__week AS metric_time__week
-                    , subq_5.ds__month AS metric_time__month
-                    , subq_5.ds__quarter AS metric_time__quarter
-                    , subq_5.ds__year AS metric_time__year
-                    , subq_5.listing
-                    , subq_5.user
-                    , subq_5.listing__user
-                    , subq_5.country_latest
-                    , subq_5.is_lux_latest
-                    , subq_5.capacity_latest
-                    , subq_5.listing__country_latest
-                    , subq_5.listing__is_lux_latest
-                    , subq_5.listing__capacity_latest
-                    , subq_5.listings
-                    , subq_5.largest_listing
-                    , subq_5.smallest_listing
+                    subq_3.ds
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.created_at
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.listing__ds
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__created_at
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.ds AS metric_time
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'listings_latest'
                     SELECT
-                      subq_4.ds
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.created_at
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.listing__ds
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__created_at
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
-                    FROM (
-                      -- Read Elements From Data Source 'listings_latest'
-                      SELECT
-                        1 AS listings
-                        , listings_latest_src_10004.capacity AS largest_listing
-                        , listings_latest_src_10004.capacity AS smallest_listing
-                        , listings_latest_src_10004.created_at AS ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                        , listings_latest_src_10004.created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                        , listings_latest_src_10004.country AS country_latest
-                        , listings_latest_src_10004.is_lux AS is_lux_latest
-                        , listings_latest_src_10004.capacity AS capacity_latest
-                        , listings_latest_src_10004.created_at AS listing__ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                        , listings_latest_src_10004.created_at AS listing__created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                        , listings_latest_src_10004.country AS listing__country_latest
-                        , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                        , listings_latest_src_10004.capacity AS listing__capacity_latest
-                        , listings_latest_src_10004.listing_id AS listing
-                        , listings_latest_src_10004.user_id AS user
-                        , listings_latest_src_10004.user_id AS listing__user
-                      FROM ***************************.dim_listings_latest listings_latest_src_10004
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
-              ) subq_7
+                      1 AS listings
+                      , listings_latest_src_10004.capacity AS largest_listing
+                      , listings_latest_src_10004.capacity AS smallest_listing
+                      , listings_latest_src_10004.created_at AS ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                      , listings_latest_src_10004.created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                      , listings_latest_src_10004.country AS country_latest
+                      , listings_latest_src_10004.is_lux AS is_lux_latest
+                      , listings_latest_src_10004.capacity AS capacity_latest
+                      , listings_latest_src_10004.created_at AS listing__ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                      , listings_latest_src_10004.created_at AS listing__created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                      , listings_latest_src_10004.country AS listing__country_latest
+                      , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_10004.capacity AS listing__capacity_latest
+                      , listings_latest_src_10004.listing_id AS listing
+                      , listings_latest_src_10004.user_id AS user
+                      , listings_latest_src_10004.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_10004
+                  ) subq_3
+                ) subq_4
+              ) subq_5
               ON
-                subq_3.listing = subq_7.listing
-            ) subq_8
-          ) subq_9
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
           WHERE listing__is_lux_latest
-        ) subq_10
-      ) subq_11
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_11.metric_time
-    ) subq_12
+        subq_9.metric_time
+    ) subq_10
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_16.metric_time
-        , SUM(subq_16.booking_value) AS booking_value
+        subq_13.metric_time
+        , SUM(subq_13.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_15.metric_time
-          , subq_15.booking_value
+          subq_12.metric_time
+          , subq_12.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_14.ds
-            , subq_14.ds__week
-            , subq_14.ds__month
-            , subq_14.ds__quarter
-            , subq_14.ds__year
-            , subq_14.ds_partitioned
-            , subq_14.ds_partitioned__week
-            , subq_14.ds_partitioned__month
-            , subq_14.ds_partitioned__quarter
-            , subq_14.ds_partitioned__year
-            , subq_14.booking_paid_at
-            , subq_14.booking_paid_at__week
-            , subq_14.booking_paid_at__month
-            , subq_14.booking_paid_at__quarter
-            , subq_14.booking_paid_at__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds
-            , subq_14.create_a_cycle_in_the_join_graph__ds__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_14.ds AS metric_time
-            , subq_14.ds__week AS metric_time__week
-            , subq_14.ds__month AS metric_time__month
-            , subq_14.ds__quarter AS metric_time__quarter
-            , subq_14.ds__year AS metric_time__year
-            , subq_14.listing
-            , subq_14.guest
-            , subq_14.host
-            , subq_14.create_a_cycle_in_the_join_graph
-            , subq_14.create_a_cycle_in_the_join_graph__listing
-            , subq_14.create_a_cycle_in_the_join_graph__guest
-            , subq_14.create_a_cycle_in_the_join_graph__host
-            , subq_14.is_instant
-            , subq_14.create_a_cycle_in_the_join_graph__is_instant
-            , subq_14.bookings
-            , subq_14.instant_bookings
-            , subq_14.booking_value
-            , subq_14.max_booking_value
-            , subq_14.min_booking_value
-            , subq_14.bookers
-            , subq_14.average_booking_value
+            subq_11.ds
+            , subq_11.ds__week
+            , subq_11.ds__month
+            , subq_11.ds__quarter
+            , subq_11.ds__year
+            , subq_11.ds_partitioned
+            , subq_11.ds_partitioned__week
+            , subq_11.ds_partitioned__month
+            , subq_11.ds_partitioned__quarter
+            , subq_11.ds_partitioned__year
+            , subq_11.booking_paid_at
+            , subq_11.booking_paid_at__week
+            , subq_11.booking_paid_at__month
+            , subq_11.booking_paid_at__quarter
+            , subq_11.booking_paid_at__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds
+            , subq_11.create_a_cycle_in_the_join_graph__ds__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_11.ds AS metric_time
+            , subq_11.ds__week AS metric_time__week
+            , subq_11.ds__month AS metric_time__month
+            , subq_11.ds__quarter AS metric_time__quarter
+            , subq_11.ds__year AS metric_time__year
+            , subq_11.listing
+            , subq_11.guest
+            , subq_11.host
+            , subq_11.create_a_cycle_in_the_join_graph
+            , subq_11.create_a_cycle_in_the_join_graph__listing
+            , subq_11.create_a_cycle_in_the_join_graph__guest
+            , subq_11.create_a_cycle_in_the_join_graph__host
+            , subq_11.is_instant
+            , subq_11.create_a_cycle_in_the_join_graph__is_instant
+            , subq_11.bookings
+            , subq_11.instant_bookings
+            , subq_11.booking_value
+            , subq_11.max_booking_value
+            , subq_11.min_booking_value
+            , subq_11.bookers
+            , subq_11.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_13.ds
-              , subq_13.ds__week
-              , subq_13.ds__month
-              , subq_13.ds__quarter
-              , subq_13.ds__year
-              , subq_13.ds_partitioned
-              , subq_13.ds_partitioned__week
-              , subq_13.ds_partitioned__month
-              , subq_13.ds_partitioned__quarter
-              , subq_13.ds_partitioned__year
-              , subq_13.booking_paid_at
-              , subq_13.booking_paid_at__week
-              , subq_13.booking_paid_at__month
-              , subq_13.booking_paid_at__quarter
-              , subq_13.booking_paid_at__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds
-              , subq_13.create_a_cycle_in_the_join_graph__ds__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_13.listing
-              , subq_13.guest
-              , subq_13.host
-              , subq_13.create_a_cycle_in_the_join_graph
-              , subq_13.create_a_cycle_in_the_join_graph__listing
-              , subq_13.create_a_cycle_in_the_join_graph__guest
-              , subq_13.create_a_cycle_in_the_join_graph__host
-              , subq_13.is_instant
-              , subq_13.create_a_cycle_in_the_join_graph__is_instant
-              , subq_13.bookings
-              , subq_13.instant_bookings
-              , subq_13.booking_value
-              , subq_13.max_booking_value
-              , subq_13.min_booking_value
-              , subq_13.bookers
-              , subq_13.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_13
-          ) subq_14
-        ) subq_15
-      ) subq_16
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_11
+        ) subq_12
+      ) subq_13
       GROUP BY
-        subq_16.metric_time
-    ) subq_17
+        subq_13.metric_time
+    ) subq_14
     ON
       (
         (
-          subq_12.metric_time = subq_17.metric_time
+          subq_10.metric_time = subq_14.metric_time
         ) OR (
-          (subq_12.metric_time IS NULL) AND (subq_17.metric_time IS NULL)
+          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
         )
       )
-  ) subq_18
-) subq_19
+  ) subq_15
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -7,10 +7,10 @@ FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_32.metric_time AS metric_time
-    , subq_32.bookings AS bookings
-    , subq_32.average_booking_value AS average_booking_value
-    , subq_37.booking_value AS booking_value
+    subq_27.metric_time AS metric_time
+    , subq_27.bookings AS bookings
+    , subq_27.average_booking_value AS average_booking_value
+    , subq_31.booking_value AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
@@ -25,13 +25,12 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
       SELECT
-        subq_23.metric_time AS metric_time
+        subq_19.metric_time AS metric_time
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-        , subq_23.bookings AS bookings
-        , subq_23.average_booking_value AS average_booking_value
+        , subq_19.bookings AS bookings
+        , subq_19.average_booking_value AS average_booking_value
       FROM (
         -- Read Elements From Data Source 'bookings_source'
-        -- Pass Only Additive Measures
         -- Metric Time Dimension 'ds'
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
@@ -44,19 +43,18 @@ FROM (
           -- User Defined SQL Query
           SELECT * FROM ***************************.fct_bookings
         ) bookings_source_src_10001
-      ) subq_23
+      ) subq_19
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_10004
       ON
-        subq_23.listing = listings_latest_src_10004.listing_id
-    ) subq_29
+        subq_19.listing = listings_latest_src_10004.listing_id
+    ) subq_24
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time
-  ) subq_32
+  ) subq_27
   INNER JOIN (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'metric_time']
@@ -70,13 +68,13 @@ FROM (
     ) bookings_source_src_10001
     GROUP BY
       ds
-  ) subq_37
+  ) subq_31
   ON
     (
       (
-        subq_32.metric_time = subq_37.metric_time
+        subq_27.metric_time = subq_31.metric_time
       ) OR (
-        (subq_32.metric_time IS NULL) AND (subq_37.metric_time IS NULL)
+        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
       )
     )
-) subq_39
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,393 +1,293 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_11.metric_time
+  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
   SELECT
-    subq_12.metric_time
-    , subq_12.booking_value_with_is_instant_constraint
-    , subq_12.booking_value
+    subq_10.metric_time
+    , subq_10.booking_value_with_is_instant_constraint
+    , subq_10.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_6.metric_time AS metric_time
-      , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_11.booking_value AS booking_value
+      subq_5.metric_time AS metric_time
+      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+      , subq_9.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time
-        , SUM(subq_5.booking_value) AS booking_value_with_is_instant_constraint
+        subq_4.metric_time
+        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_4.metric_time
-          , subq_4.booking_value
+          subq_3.metric_time
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time
-            , subq_3.is_instant
-            , subq_3.booking_value
+            subq_2.metric_time
+            , subq_2.is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements:
             --   ['booking_value', 'is_instant', 'metric_time']
             SELECT
-              subq_2.metric_time
-              , subq_2.is_instant
-              , subq_2.booking_value
+              subq_1.metric_time
+              , subq_1.is_instant
+              , subq_1.booking_value
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time
-    ) subq_6
+        subq_4.metric_time
+    ) subq_5
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_8.metric_time
+        , SUM(subq_8.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_9.metric_time
-          , subq_9.booking_value
+          subq_7.metric_time
+          , subq_7.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds_partitioned
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.booking_paid_at
-            , subq_8.booking_paid_at__week
-            , subq_8.booking_paid_at__month
-            , subq_8.booking_paid_at__quarter
-            , subq_8.booking_paid_at__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds
-            , subq_8.create_a_cycle_in_the_join_graph__ds__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_8.ds AS metric_time
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.create_a_cycle_in_the_join_graph
-            , subq_8.create_a_cycle_in_the_join_graph__listing
-            , subq_8.create_a_cycle_in_the_join_graph__guest
-            , subq_8.create_a_cycle_in_the_join_graph__host
-            , subq_8.is_instant
-            , subq_8.create_a_cycle_in_the_join_graph__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds_partitioned
+            , subq_6.ds_partitioned__week
+            , subq_6.ds_partitioned__month
+            , subq_6.ds_partitioned__quarter
+            , subq_6.ds_partitioned__year
+            , subq_6.booking_paid_at
+            , subq_6.booking_paid_at__week
+            , subq_6.booking_paid_at__month
+            , subq_6.booking_paid_at__quarter
+            , subq_6.booking_paid_at__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds
+            , subq_6.create_a_cycle_in_the_join_graph__ds__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.guest
+            , subq_6.host
+            , subq_6.create_a_cycle_in_the_join_graph
+            , subq_6.create_a_cycle_in_the_join_graph__listing
+            , subq_6.create_a_cycle_in_the_join_graph__guest
+            , subq_6.create_a_cycle_in_the_join_graph__host
+            , subq_6.is_instant
+            , subq_6.create_a_cycle_in_the_join_graph__is_instant
+            , subq_6.bookings
+            , subq_6.instant_bookings
+            , subq_6.booking_value
+            , subq_6.max_booking_value
+            , subq_6.min_booking_value
+            , subq_6.bookers
+            , subq_6.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_7.ds
-              , subq_7.ds__week
-              , subq_7.ds__month
-              , subq_7.ds__quarter
-              , subq_7.ds__year
-              , subq_7.ds_partitioned
-              , subq_7.ds_partitioned__week
-              , subq_7.ds_partitioned__month
-              , subq_7.ds_partitioned__quarter
-              , subq_7.ds_partitioned__year
-              , subq_7.booking_paid_at
-              , subq_7.booking_paid_at__week
-              , subq_7.booking_paid_at__month
-              , subq_7.booking_paid_at__quarter
-              , subq_7.booking_paid_at__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds
-              , subq_7.create_a_cycle_in_the_join_graph__ds__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_7.listing
-              , subq_7.guest
-              , subq_7.host
-              , subq_7.create_a_cycle_in_the_join_graph
-              , subq_7.create_a_cycle_in_the_join_graph__listing
-              , subq_7.create_a_cycle_in_the_join_graph__guest
-              , subq_7.create_a_cycle_in_the_join_graph__host
-              , subq_7.is_instant
-              , subq_7.create_a_cycle_in_the_join_graph__is_instant
-              , subq_7.bookings
-              , subq_7.instant_bookings
-              , subq_7.booking_value
-              , subq_7.max_booking_value
-              , subq_7.min_booking_value
-              , subq_7.bookers
-              , subq_7.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_7
-          ) subq_8
-        ) subq_9
-      ) subq_10
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_6
+        ) subq_7
+      ) subq_8
       GROUP BY
-        subq_10.metric_time
-    ) subq_11
+        subq_8.metric_time
+    ) subq_9
     ON
       (
         (
-          subq_6.metric_time = subq_11.metric_time
+          subq_5.metric_time = subq_9.metric_time
         ) OR (
-          (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
         )
       )
-  ) subq_12
-) subq_13
+  ) subq_10
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,8 +3,8 @@
 --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time AS metric_time
-  , CAST(subq_20.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_25.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_17.metric_time AS metric_time
+  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
@@ -15,7 +15,6 @@ FROM (
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'is_instant', 'metric_time']
@@ -27,14 +26,13 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_17
+  ) subq_14
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_20
+) subq_17
 INNER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
@@ -48,12 +46,12 @@ INNER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     ds
-) subq_25
+) subq_21
 ON
   (
     (
-      subq_20.metric_time = subq_25.metric_time
+      subq_17.metric_time = subq_21.metric_time
     ) OR (
-      (subq_20.metric_time IS NULL) AND (subq_25.metric_time IS NULL)
+      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,195 +1,145 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.metric_time
+  subq_5.metric_time
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.metric_time
-    , SUM(subq_5.bookings) AS delayed_bookings
+    subq_4.metric_time
+    , SUM(subq_4.bookings) AS delayed_bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
     SELECT
-      subq_4.metric_time
-      , subq_4.bookings
+      subq_3.metric_time
+      , subq_3.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_3.metric_time
-        , subq_3.is_instant
-        , subq_3.bookings
+        subq_2.metric_time
+        , subq_2.is_instant
+        , subq_2.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'metric_time']
         SELECT
-          subq_2.metric_time
-          , subq_2.is_instant
-          , subq_2.bookings
+          subq_1.metric_time
+          , subq_1.is_instant
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.booking_paid_at
-            , subq_1.booking_paid_at__week
-            , subq_1.booking_paid_at__month
-            , subq_1.booking_paid_at__quarter
-            , subq_1.booking_paid_at__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds
-            , subq_1.create_a_cycle_in_the_join_graph__ds__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.listing
-            , subq_1.guest
-            , subq_1.host
-            , subq_1.create_a_cycle_in_the_join_graph
-            , subq_1.create_a_cycle_in_the_join_graph__listing
-            , subq_1.create_a_cycle_in_the_join_graph__guest
-            , subq_1.create_a_cycle_in_the_join_graph__host
-            , subq_1.is_instant
-            , subq_1.create_a_cycle_in_the_join_graph__is_instant
-            , subq_1.bookings
-            , subq_1.instant_bookings
-            , subq_1.booking_value
-            , subq_1.max_booking_value
-            , subq_1.min_booking_value
-            , subq_1.bookers
-            , subq_1.average_booking_value
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.booking_paid_at
-              , subq_0.booking_paid_at__week
-              , subq_0.booking_paid_at__month
-              , subq_0.booking_paid_at__quarter
-              , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_0.listing
-              , subq_0.guest
-              , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
-              , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
-              , subq_0.bookings
-              , subq_0.instant_bookings
-              , subq_0.booking_value
-              , subq_0.max_booking_value
-              , subq_0.min_booking_value
-              , subq_0.bookers
-              , subq_0.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
       WHERE NOT is_instant
-    ) subq_4
-  ) subq_5
+    ) subq_3
+  ) subq_4
   GROUP BY
-    subq_5.metric_time
-) subq_6
+    subq_4.metric_time
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , SUM(bookings) AS delayed_bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'metric_time']
@@ -24,8 +23,8 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_10
+  ) subq_8
   WHERE NOT is_instant
   GROUP BY
     metric_time
-) subq_13
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0.sql
@@ -1,156 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.account_id__customer_id__customer_name
-  , subq_11.txn_count
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.account_id__customer_id__customer_name
-    , SUM(subq_10.txn_count) AS txn_count
+    subq_9.account_id__customer_id__customer_name
+    , SUM(subq_9.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements:
     --   ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_9.account_id__customer_id__customer_name
-      , subq_9.txn_count
+      subq_8.account_id__customer_id__customer_name
+      , subq_8.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_8.ds_partitioned AS account_id__ds_partitioned
-        , subq_3.account_id AS account_id
-        , subq_8.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_3.txn_count AS txn_count
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_7.ds_partitioned AS account_id__ds_partitioned
+        , subq_2.account_id AS account_id
+        , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements:
         --   ['txn_count', 'account_id', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.account_id
-          , subq_2.txn_count
+          subq_1.ds_partitioned
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.account_id__ds_partitioned
-            , subq_1.account_id__ds_partitioned__week
-            , subq_1.account_id__ds_partitioned__month
-            , subq_1.account_id__ds_partitioned__quarter
-            , subq_1.account_id__ds_partitioned__year
-            , subq_1.account_id__ds
-            , subq_1.account_id__ds__week
-            , subq_1.account_id__ds__month
-            , subq_1.account_id__ds__quarter
-            , subq_1.account_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.account_id
-            , subq_1.account_month
-            , subq_1.account_id__account_month
-            , subq_1.txn_count
+            subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.account_id__ds_partitioned
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'account_month_txns'
             SELECT
-              subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.account_id__ds_partitioned
-              , subq_0.account_id__ds_partitioned__week
-              , subq_0.account_id__ds_partitioned__month
-              , subq_0.account_id__ds_partitioned__quarter
-              , subq_0.account_id__ds_partitioned__year
-              , subq_0.account_id__ds
-              , subq_0.account_id__ds__week
-              , subq_0.account_id__ds__month
-              , subq_0.account_id__ds__quarter
-              , subq_0.account_id__ds__year
-              , subq_0.account_id
-              , subq_0.account_month
-              , subq_0.account_id__account_month
-              , subq_0.txn_count
-            FROM (
-              -- Read Elements From Data Source 'account_month_txns'
-              SELECT
-                account_month_txns_src_10010.txn_count
-                , account_month_txns_src_10010.ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
-                , account_month_txns_src_10010.ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
-                , account_month_txns_src_10010.account_month
-                , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
-                , account_month_txns_src_10010.ds AS account_id__ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
-                , account_month_txns_src_10010.account_month AS account_id__account_month
-                , account_month_txns_src_10010.account_id
-              FROM ***************************.account_month_txns account_month_txns_src_10010
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              account_month_txns_src_10010.txn_count
+              , account_month_txns_src_10010.ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
+              , account_month_txns_src_10010.ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
+              , account_month_txns_src_10010.account_month
+              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
+              , account_month_txns_src_10010.ds AS account_id__ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
+              , account_month_txns_src_10010.account_month AS account_id__account_month
+              , account_month_txns_src_10010.account_id
+            FROM ***************************.account_month_txns account_month_txns_src_10010
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
         SELECT
-          subq_7.ds_partitioned
-          , subq_7.account_id
-          , subq_7.customer_id__customer_name
+          subq_6.ds_partitioned
+          , subq_6.account_id
+          , subq_6.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned AS ds_partitioned
-            , subq_4.ds_partitioned__week AS ds_partitioned__week
-            , subq_4.ds_partitioned__month AS ds_partitioned__month
-            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_4.ds_partitioned__year AS ds_partitioned__year
-            , subq_4.account_id__ds_partitioned AS account_id__ds_partitioned
-            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_6.ds_partitioned AS customer_id__ds_partitioned
-            , subq_6.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_6.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_6.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_6.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_4.account_id AS account_id
-            , subq_4.customer_id AS customer_id
-            , subq_4.account_id__customer_id AS account_id__customer_id
-            , subq_4.extra_dim AS extra_dim
-            , subq_4.account_id__extra_dim AS account_id__extra_dim
-            , subq_6.customer_name AS customer_id__customer_name
-            , subq_6.customer_atomic_weight AS customer_id__customer_atomic_weight
+            subq_3.ds_partitioned AS ds_partitioned
+            , subq_3.ds_partitioned__week AS ds_partitioned__week
+            , subq_3.ds_partitioned__month AS ds_partitioned__month
+            , subq_3.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_3.ds_partitioned__year AS ds_partitioned__year
+            , subq_3.account_id__ds_partitioned AS account_id__ds_partitioned
+            , subq_3.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_3.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_3.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_3.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_5.ds_partitioned AS customer_id__ds_partitioned
+            , subq_5.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_5.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_5.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_5.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_3.account_id AS account_id
+            , subq_3.customer_id AS customer_id
+            , subq_3.account_id__customer_id AS account_id__customer_id
+            , subq_3.extra_dim AS extra_dim
+            , subq_3.account_id__extra_dim AS account_id__extra_dim
+            , subq_5.customer_name AS customer_id__customer_name
+            , subq_5.customer_atomic_weight AS customer_id__customer_atomic_weight
           FROM (
             -- Read Elements From Data Source 'bridge_table'
             SELECT
@@ -170,7 +142,7 @@ FROM (
               , bridge_table_src_10011.customer_id
               , bridge_table_src_10011.customer_id AS account_id__customer_id
             FROM ***************************.bridge_table bridge_table_src_10011
-          ) subq_4
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['customer_name',
@@ -189,21 +161,21 @@ FROM (
             --    'customer_id__ds_partitioned__quarter',
             --    'customer_id__ds_partitioned__year']
             SELECT
-              subq_5.ds_partitioned
-              , subq_5.ds_partitioned__week
-              , subq_5.ds_partitioned__month
-              , subq_5.ds_partitioned__quarter
-              , subq_5.ds_partitioned__year
-              , subq_5.customer_id__ds_partitioned
-              , subq_5.customer_id__ds_partitioned__week
-              , subq_5.customer_id__ds_partitioned__month
-              , subq_5.customer_id__ds_partitioned__quarter
-              , subq_5.customer_id__ds_partitioned__year
-              , subq_5.customer_id
-              , subq_5.customer_name
-              , subq_5.customer_atomic_weight
-              , subq_5.customer_id__customer_name
-              , subq_5.customer_id__customer_atomic_weight
+              subq_4.ds_partitioned
+              , subq_4.ds_partitioned__week
+              , subq_4.ds_partitioned__month
+              , subq_4.ds_partitioned__quarter
+              , subq_4.ds_partitioned__year
+              , subq_4.customer_id__ds_partitioned
+              , subq_4.customer_id__ds_partitioned__week
+              , subq_4.customer_id__ds_partitioned__month
+              , subq_4.customer_id__ds_partitioned__quarter
+              , subq_4.customer_id__ds_partitioned__year
+              , subq_4.customer_id
+              , subq_4.customer_name
+              , subq_4.customer_atomic_weight
+              , subq_4.customer_id__customer_name
+              , subq_4.customer_id__customer_atomic_weight
             FROM (
               -- Read Elements From Data Source 'customer_table'
               SELECT
@@ -223,24 +195,24 @@ FROM (
                 , DATE_TRUNC('year', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__year
                 , customer_table_src_10013.customer_id
               FROM ***************************.customer_table customer_table_src_10013
-            ) subq_5
-          ) subq_6
+            ) subq_4
+          ) subq_5
           ON
             (
-              subq_4.customer_id = subq_6.customer_id
+              subq_3.customer_id = subq_5.customer_id
             ) AND (
-              subq_4.ds_partitioned = subq_6.ds_partitioned
+              subq_3.ds_partitioned = subq_5.ds_partitioned
             )
-        ) subq_7
-      ) subq_8
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_3.account_id = subq_8.account_id
+          subq_2.account_id = subq_7.account_id
         ) AND (
-          subq_3.ds_partitioned = subq_8.ds_partitioned
+          subq_2.ds_partitioned = subq_7.ds_partitioned
         )
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.account_id__customer_id__customer_name
-) subq_11
+    subq_9.account_id__customer_id__customer_name
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,7 +4,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_10010.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10010
 LEFT OUTER JOIN (
@@ -24,12 +24,12 @@ LEFT OUTER JOIN (
     ) AND (
       bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
     )
-) subq_20
+) subq_18
 ON
   (
-    account_month_txns_src_10010.account_id = subq_20.account_id
+    account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_20.ds_partitioned
+    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned
   )
 GROUP BY
-  subq_20.customer_id__customer_name
+  subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0.sql
@@ -1,137 +1,107 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user__home_state
-  , subq_8.identity_verifications
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user__home_state
-    , SUM(subq_7.identity_verifications) AS identity_verifications
+    subq_6.user__home_state
+    , SUM(subq_6.identity_verifications) AS identity_verifications
   FROM (
     -- Pass Only Elements:
     --   ['identity_verifications', 'user__home_state']
     SELECT
-      subq_6.user__home_state
-      , subq_6.identity_verifications
+      subq_5.user__home_state
+      , subq_5.identity_verifications
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_5.ds_partitioned AS user__ds_partitioned
-        , subq_3.user AS user
-        , subq_5.home_state AS user__home_state
-        , subq_3.identity_verifications AS identity_verifications
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_4.ds_partitioned AS user__ds_partitioned
+        , subq_2.user AS user
+        , subq_4.home_state AS user__home_state
+        , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements:
         --   ['identity_verifications', 'user', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.user
-          , subq_2.identity_verifications
+          subq_1.ds_partitioned
+          , subq_1.user
+          , subq_1.identity_verifications
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.verification__ds
-            , subq_1.verification__ds__week
-            , subq_1.verification__ds__month
-            , subq_1.verification__ds__quarter
-            , subq_1.verification__ds__year
-            , subq_1.verification__ds_partitioned
-            , subq_1.verification__ds_partitioned__week
-            , subq_1.verification__ds_partitioned__month
-            , subq_1.verification__ds_partitioned__quarter
-            , subq_1.verification__ds_partitioned__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.verification
-            , subq_1.user
-            , subq_1.verification__user
-            , subq_1.verification_type
-            , subq_1.verification__verification_type
-            , subq_1.identity_verifications
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.verification__ds
+            , subq_0.verification__ds__week
+            , subq_0.verification__ds__month
+            , subq_0.verification__ds__quarter
+            , subq_0.verification__ds__year
+            , subq_0.verification__ds_partitioned
+            , subq_0.verification__ds_partitioned__week
+            , subq_0.verification__ds_partitioned__month
+            , subq_0.verification__ds_partitioned__quarter
+            , subq_0.verification__ds_partitioned__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.verification
+            , subq_0.user
+            , subq_0.verification__user
+            , subq_0.verification_type
+            , subq_0.verification__verification_type
+            , subq_0.identity_verifications
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'id_verifications'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.verification__ds
-              , subq_0.verification__ds__week
-              , subq_0.verification__ds__month
-              , subq_0.verification__ds__quarter
-              , subq_0.verification__ds__year
-              , subq_0.verification__ds_partitioned
-              , subq_0.verification__ds_partitioned__week
-              , subq_0.verification__ds_partitioned__month
-              , subq_0.verification__ds_partitioned__quarter
-              , subq_0.verification__ds_partitioned__year
-              , subq_0.verification
-              , subq_0.user
-              , subq_0.verification__user
-              , subq_0.verification_type
-              , subq_0.verification__verification_type
-              , subq_0.identity_verifications
-            FROM (
-              -- Read Elements From Data Source 'id_verifications'
-              SELECT
-                1 AS identity_verifications
-                , id_verifications_src_10003.ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
-                , id_verifications_src_10003.ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
-                , id_verifications_src_10003.verification_type
-                , id_verifications_src_10003.ds AS verification__ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
-                , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
-                , id_verifications_src_10003.verification_type AS verification__verification_type
-                , id_verifications_src_10003.verification_id AS verification
-                , id_verifications_src_10003.user_id AS user
-                , id_verifications_src_10003.user_id AS verification__user
-              FROM ***************************.fct_id_verifications id_verifications_src_10003
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS identity_verifications
+              , id_verifications_src_10003.ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
+              , id_verifications_src_10003.ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
+              , id_verifications_src_10003.verification_type
+              , id_verifications_src_10003.ds AS verification__ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
+              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
+              , id_verifications_src_10003.verification_type AS verification__verification_type
+              , id_verifications_src_10003.verification_id AS verification
+              , id_verifications_src_10003.user_id AS user
+              , id_verifications_src_10003.user_id AS verification__user
+            FROM ***************************.fct_id_verifications id_verifications_src_10003
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user', 'ds_partitioned', 'home_state']
         SELECT
-          subq_4.ds_partitioned
-          , subq_4.user
-          , subq_4.home_state
+          subq_3.ds_partitioned
+          , subq_3.user
+          , subq_3.home_state
         FROM (
           -- Read Elements From Data Source 'users_ds_source'
           SELECT
@@ -169,16 +139,16 @@ FROM (
             , users_ds_source_src_10007.home_state AS user__home_state
             , users_ds_source_src_10007.user_id AS user
           FROM ***************************.dim_users users_ds_source_src_10007
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user = subq_5.user
+          subq_2.user = subq_4.user
         ) AND (
-          subq_3.ds_partitioned = subq_5.ds_partitioned
+          subq_2.ds_partitioned = subq_4.ds_partitioned
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user__home_state
-) subq_8
+    subq_6.user__home_state
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -5,10 +5,9 @@
 -- Compute Metrics via Expressions
 SELECT
   users_ds_source_src_10007.home_state AS user__home_state
-  , SUM(subq_12.identity_verifications) AS identity_verifications
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['identity_verifications', 'user', 'ds_partitioned']
@@ -17,14 +16,14 @@ FROM (
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.dim_users users_ds_source_src_10007
 ON
   (
-    subq_12.user = users_ds_source_src_10007.user_id
+    subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_12.ds_partitioned = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned = users_ds_source_src_10007.ds_partitioned
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node__plan0.sql
@@ -1,13 +1,37 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.total_account_balance_first_day AS total_account_balance_first_day
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.total_account_balance_first_day
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -19,41 +43,13 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MIN(ds)
-  SELECT
-    MIN(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['total_account_balance_first_day', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.total_account_balance_first_day
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
 ) subq_2
 ON
-  subq_1.ds = subq_2.ds
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node__plan0_optimized.sql
@@ -1,30 +1,42 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.total_account_balance_first_day AS total_account_balance_first_day
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   SELECT
-    ds
+    account_balance
     , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds
+    MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
 ) subq_5
 ON
-  subq_4.ds = subq_5.ds
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -1,15 +1,38 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.user AS user
-  , subq_1.current_account_balance_by_user AS current_account_balance_by_user
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.user
-    , subq_0.current_account_balance_by_user
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MAX(ds)
+  SELECT
+    subq_1.user
+    , MAX(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -21,45 +44,15 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MAX(ds)
-  SELECT
-    subq_2.user
-    , MAX(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['current_account_balance_by_user', 'user', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.user
-      , subq_0.current_account_balance_by_user
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
   GROUP BY
-    subq_2.user
+    subq_1.user
 ) subq_2
 ON
-  (subq_1.ds = subq_2.ds) AND (subq_1.user = subq_2.user)
+  (subq_0.ds = subq_2.ds__complete) AND (subq_0.user = subq_2.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -1,29 +1,39 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.user AS user
-  , subq_4.current_account_balance_by_user AS current_account_balance_by_user
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   SELECT
-    ds
-    , user_id AS user
+    account_balance
+    , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   -- Filter row on MAX(ds)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds
+    , MAX(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
@@ -32,4 +42,4 @@ INNER JOIN (
     user_id
 ) subq_5
 ON
-  (subq_4.ds = subq_5.ds) AND (subq_4.user = subq_5.user)
+  (subq_3.ds = subq_5.ds__complete) AND (subq_3.user = subq_5.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -1,0 +1,57 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
+  FROM (
+    -- Read Elements From Data Source 'accounts_source'
+    SELECT
+      accounts_source_src_10000.account_balance
+      , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+      , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+      , accounts_source_src_10000.ds
+      , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
+      , accounts_source_src_10000.user_id AS user
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_accounts
+    ) accounts_source_src_10000
+  ) subq_1
+  GROUP BY
+    subq_1.ds__week
+) subq_2
+ON
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    account_balance
+    , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_3
+INNER JOIN (
+  -- Read Elements From Data Source 'accounts_source'
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(ds) AS ds__complete
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5
+ON
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0.sql
@@ -1,95 +1,73 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.user_team___team_id
-  , subq_4.user_team___user_id
-  , subq_4.messages
+  subq_3.user_team___team_id
+  , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-    , SUM(subq_3.messages) AS messages
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+    , SUM(subq_2.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team']
     SELECT
-      subq_2.user_team___team_id
-      , subq_2.user_team___user_id
-      , subq_2.messages
+      subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+      , subq_1.messages
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.user_id__ds
-        , subq_1.user_id__ds__week
-        , subq_1.user_id__ds__month
-        , subq_1.user_id__ds__quarter
-        , subq_1.user_id__ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user_id
-        , subq_1.user_team___team_id
-        , subq_1.user_team___user_id
-        , subq_1.user_id__user_team___team_id
-        , subq_1.user_id__user_team___user_id
-        , subq_1.team_id
-        , subq_1.user_id__team_id
-        , subq_1.messages
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.user_id__ds
+        , subq_0.user_id__ds__week
+        , subq_0.user_id__ds__month
+        , subq_0.user_id__ds__quarter
+        , subq_0.user_id__ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user_id
+        , subq_0.user_team___team_id
+        , subq_0.user_team___user_id
+        , subq_0.user_id__user_team___team_id
+        , subq_0.user_id__user_team___user_id
+        , subq_0.team_id
+        , subq_0.user_id__team_id
+        , subq_0.messages
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'messages_source'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user_id__ds
-          , subq_0.user_id__ds__week
-          , subq_0.user_id__ds__month
-          , subq_0.user_id__ds__quarter
-          , subq_0.user_id__ds__year
-          , subq_0.user_id
-          , subq_0.user_team___team_id
-          , subq_0.user_team___user_id
-          , subq_0.user_id__user_team___team_id
-          , subq_0.user_id__user_team___user_id
-          , subq_0.team_id
-          , subq_0.user_id__team_id
-          , subq_0.messages
-        FROM (
-          -- Read Elements From Data Source 'messages_source'
-          SELECT
-            1 AS messages
-            , messages_source_src_10015.ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-            , messages_source_src_10015.team_id
-            , messages_source_src_10015.ds AS user_id__ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-            , messages_source_src_10015.team_id AS user_id__team_id
-            , messages_source_src_10015.user_id
-            , messages_source_src_10015.team_id AS user_team___team_id
-            , messages_source_src_10015.user_id AS user_team___user_id
-            , messages_source_src_10015.team_id AS user_id__user_team___team_id
-            , messages_source_src_10015.user_id AS user_id__user_team___user_id
-          FROM ***************************.fct_messages messages_source_src_10015
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS messages
+          , messages_source_src_10015.ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+          , messages_source_src_10015.team_id
+          , messages_source_src_10015.ds AS user_id__ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+          , messages_source_src_10015.team_id AS user_id__team_id
+          , messages_source_src_10015.user_id
+          , messages_source_src_10015.team_id AS user_team___team_id
+          , messages_source_src_10015.user_id AS user_team___user_id
+          , messages_source_src_10015.team_id AS user_id__user_team___team_id
+          , messages_source_src_10015.user_id AS user_id__user_team___user_id
+        FROM ***************************.fct_messages messages_source_src_10015
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-) subq_4
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -15,7 +14,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_8
+) subq_6
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,118 +1,96 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user_team___team_id
-  , subq_8.user_team___user_id
-  , subq_8.user_team__country
-  , subq_8.messages
+  subq_7.user_team___team_id
+  , subq_7.user_team___user_id
+  , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-    , SUM(subq_7.messages) AS messages
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+    , SUM(subq_6.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team__country', 'user_team']
     SELECT
-      subq_6.user_team___team_id
-      , subq_6.user_team___user_id
-      , subq_6.user_team__country
-      , subq_6.messages
+      subq_5.user_team___team_id
+      , subq_5.user_team___user_id
+      , subq_5.user_team__country
+      , subq_5.messages
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.user_team___team_id AS user_team___team_id
-        , subq_3.user_team___user_id AS user_team___user_id
-        , subq_5.country AS user_team__country
-        , subq_3.messages AS messages
+        subq_2.user_team___team_id AS user_team___team_id
+        , subq_2.user_team___user_id AS user_team___user_id
+        , subq_4.country AS user_team__country
+        , subq_2.messages AS messages
       FROM (
         -- Pass Only Elements:
         --   ['messages', 'user_team', 'user_team']
         SELECT
-          subq_2.user_team___team_id
-          , subq_2.user_team___user_id
-          , subq_2.messages
+          subq_1.user_team___team_id
+          , subq_1.user_team___user_id
+          , subq_1.messages
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.user_id__ds
-            , subq_1.user_id__ds__week
-            , subq_1.user_id__ds__month
-            , subq_1.user_id__ds__quarter
-            , subq_1.user_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.user_id
-            , subq_1.user_team___team_id
-            , subq_1.user_team___user_id
-            , subq_1.user_id__user_team___team_id
-            , subq_1.user_id__user_team___user_id
-            , subq_1.team_id
-            , subq_1.user_id__team_id
-            , subq_1.messages
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user_id__ds
+            , subq_0.user_id__ds__week
+            , subq_0.user_id__ds__month
+            , subq_0.user_id__ds__quarter
+            , subq_0.user_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.user_id
+            , subq_0.user_team___team_id
+            , subq_0.user_team___user_id
+            , subq_0.user_id__user_team___team_id
+            , subq_0.user_id__user_team___user_id
+            , subq_0.team_id
+            , subq_0.user_id__team_id
+            , subq_0.messages
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'messages_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.user_id__ds
-              , subq_0.user_id__ds__week
-              , subq_0.user_id__ds__month
-              , subq_0.user_id__ds__quarter
-              , subq_0.user_id__ds__year
-              , subq_0.user_id
-              , subq_0.user_team___team_id
-              , subq_0.user_team___user_id
-              , subq_0.user_id__user_team___team_id
-              , subq_0.user_id__user_team___user_id
-              , subq_0.team_id
-              , subq_0.user_id__team_id
-              , subq_0.messages
-            FROM (
-              -- Read Elements From Data Source 'messages_source'
-              SELECT
-                1 AS messages
-                , messages_source_src_10015.ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-                , messages_source_src_10015.team_id
-                , messages_source_src_10015.ds AS user_id__ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-                , messages_source_src_10015.team_id AS user_id__team_id
-                , messages_source_src_10015.user_id
-                , messages_source_src_10015.team_id AS user_team___team_id
-                , messages_source_src_10015.user_id AS user_team___user_id
-                , messages_source_src_10015.team_id AS user_id__user_team___team_id
-                , messages_source_src_10015.user_id AS user_id__user_team___user_id
-              FROM ***************************.fct_messages messages_source_src_10015
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS messages
+              , messages_source_src_10015.ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+              , messages_source_src_10015.team_id
+              , messages_source_src_10015.ds AS user_id__ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+              , messages_source_src_10015.team_id AS user_id__team_id
+              , messages_source_src_10015.user_id
+              , messages_source_src_10015.team_id AS user_team___team_id
+              , messages_source_src_10015.user_id AS user_team___user_id
+              , messages_source_src_10015.team_id AS user_id__user_team___team_id
+              , messages_source_src_10015.user_id AS user_id__user_team___user_id
+            FROM ***************************.fct_messages messages_source_src_10015
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user_team', 'country']
         SELECT
-          subq_4.user_team___team_id
-          , subq_4.user_team___user_id
-          , subq_4.country
+          subq_3.user_team___team_id
+          , subq_3.user_team___user_id
+          , subq_3.country
         FROM (
           -- Read Elements From Data Source 'users_source'
           SELECT
@@ -160,18 +138,18 @@ FROM (
             , users_source_src_10017.ident_2 AS user_team__user_composite_ident_2___ident_2
             , users_source_src_10017.id AS user_team__user_composite_ident_2___user_id
           FROM ***************************.fct_users users_source_src_10017
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user_team___team_id = subq_5.user_team___team_id
+          subq_2.user_team___team_id = subq_4.user_team___team_id
         ) AND (
-          subq_3.user_team___user_id = subq_5.user_team___user_id
+          subq_2.user_team___user_id = subq_4.user_team___user_id
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-) subq_8
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,13 +4,12 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user_team___team_id AS user_team___team_id
-  , subq_12.user_team___user_id AS user_team___user_id
+  subq_10.user_team___team_id AS user_team___team_id
+  , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10017.country AS user_team__country
-  , SUM(subq_12.messages) AS messages
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team', 'user_team']
@@ -19,16 +18,16 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.fct_users users_source_src_10017
 ON
   (
-    subq_12.user_team___team_id = users_source_src_10017.team_id
+    subq_10.user_team___team_id = users_source_src_10017.team_id
   ) AND (
-    subq_12.user_team___user_id = users_source_src_10017.id
+    subq_10.user_team___user_id = users_source_src_10017.id
   )
 GROUP BY
-  subq_12.user_team___team_id
-  , subq_12.user_team___user_id
+  subq_10.user_team___team_id
+  , subq_10.user_team___user_id
   , users_source_src_10017.country

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -1,103 +1,81 @@
 -- Order By ['user_team']
 SELECT
-  subq_5.user_team___team_id
-  , subq_5.user_team___user_id
-  , subq_5.messages
+  subq_4.user_team___team_id
+  , subq_4.user_team___user_id
+  , subq_4.messages
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.user_team___team_id
-    , subq_4.user_team___user_id
-    , subq_4.messages
+    subq_3.user_team___team_id
+    , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-      , SUM(subq_3.messages) AS messages
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+      , SUM(subq_2.messages) AS messages
     FROM (
       -- Pass Only Elements:
       --   ['messages', 'user_team']
       SELECT
-        subq_2.user_team___team_id
-        , subq_2.user_team___user_id
-        , subq_2.messages
+        subq_1.user_team___team_id
+        , subq_1.user_team___user_id
+        , subq_1.messages
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.user_id__ds
-          , subq_1.user_id__ds__week
-          , subq_1.user_id__ds__month
-          , subq_1.user_id__ds__quarter
-          , subq_1.user_id__ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user_id
-          , subq_1.user_team___team_id
-          , subq_1.user_team___user_id
-          , subq_1.user_id__user_team___team_id
-          , subq_1.user_id__user_team___user_id
-          , subq_1.team_id
-          , subq_1.user_id__team_id
-          , subq_1.messages
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.user_id__ds
+          , subq_0.user_id__ds__week
+          , subq_0.user_id__ds__month
+          , subq_0.user_id__ds__quarter
+          , subq_0.user_id__ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user_id
+          , subq_0.user_team___team_id
+          , subq_0.user_team___user_id
+          , subq_0.user_id__user_team___team_id
+          , subq_0.user_id__user_team___user_id
+          , subq_0.team_id
+          , subq_0.user_id__team_id
+          , subq_0.messages
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'messages_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user_id__ds
-            , subq_0.user_id__ds__week
-            , subq_0.user_id__ds__month
-            , subq_0.user_id__ds__quarter
-            , subq_0.user_id__ds__year
-            , subq_0.user_id
-            , subq_0.user_team___team_id
-            , subq_0.user_team___user_id
-            , subq_0.user_id__user_team___team_id
-            , subq_0.user_id__user_team___user_id
-            , subq_0.team_id
-            , subq_0.user_id__team_id
-            , subq_0.messages
-          FROM (
-            -- Read Elements From Data Source 'messages_source'
-            SELECT
-              1 AS messages
-              , messages_source_src_10015.ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-              , messages_source_src_10015.team_id
-              , messages_source_src_10015.ds AS user_id__ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-              , messages_source_src_10015.team_id AS user_id__team_id
-              , messages_source_src_10015.user_id
-              , messages_source_src_10015.team_id AS user_team___team_id
-              , messages_source_src_10015.user_id AS user_team___user_id
-              , messages_source_src_10015.team_id AS user_id__user_team___team_id
-              , messages_source_src_10015.user_id AS user_id__user_team___user_id
-            FROM ***************************.fct_messages messages_source_src_10015
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            1 AS messages
+            , messages_source_src_10015.ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+            , messages_source_src_10015.team_id
+            , messages_source_src_10015.ds AS user_id__ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+            , messages_source_src_10015.team_id AS user_id__team_id
+            , messages_source_src_10015.user_id
+            , messages_source_src_10015.team_id AS user_team___team_id
+            , messages_source_src_10015.user_id AS user_team___user_id
+            , messages_source_src_10015.team_id AS user_id__user_team___team_id
+            , messages_source_src_10015.user_id AS user_id__user_team___user_id
+          FROM ***************************.fct_messages messages_source_src_10015
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-  ) subq_4
-) subq_5
-ORDER BY subq_5.user_team___team_id DESC, subq_5.user_team___user_id DESC
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+  ) subq_3
+) subq_4
+ORDER BY subq_4.user_team___team_id DESC, subq_4.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
@@ -7,7 +7,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -16,7 +15,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_9
+) subq_7
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,367 +1,357 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_23.ds
-  , subq_23.listing__country_latest
-  , CAST(subq_23.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_23.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  subq_19.ds
+  , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']
   SELECT
-    subq_22.ds
-    , subq_22.listing__country_latest
-    , subq_22.bookings
-    , subq_22.views
+    subq_18.ds
+    , subq_18.listing__country_latest
+    , subq_18.bookings
+    , subq_18.views
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_10.ds AS ds
-      , subq_10.listing__country_latest AS listing__country_latest
-      , subq_10.bookings AS bookings
-      , subq_21.views AS views
+      subq_8.ds AS ds
+      , subq_8.listing__country_latest AS listing__country_latest
+      , subq_8.bookings AS bookings
+      , subq_17.views AS views
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.ds
-        , subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.ds
+        , subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest', 'ds']
         SELECT
-          subq_8.ds
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.ds
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.ds AS ds
-            , subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.ds AS ds
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'ds', 'listing']
             SELECT
-              subq_2.ds
-              , subq_2.listing
-              , subq_2.bookings
+              subq_1.ds
+              , subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.ds
-        , subq_9.listing__country_latest
-    ) subq_10
+        subq_7.ds
+        , subq_7.listing__country_latest
+    ) subq_8
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_20.ds
-        , subq_20.listing__country_latest
-        , SUM(subq_20.views) AS views
+        subq_16.ds
+        , subq_16.listing__country_latest
+        , SUM(subq_16.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_19.ds
-          , subq_19.listing__country_latest
-          , subq_19.views
+          subq_15.ds
+          , subq_15.listing__country_latest
+          , subq_15.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.ds AS ds
-            , subq_14.listing AS listing
-            , subq_18.country_latest AS listing__country_latest
-            , subq_14.views AS views
+            subq_11.ds AS ds
+            , subq_11.listing AS listing
+            , subq_14.country_latest AS listing__country_latest
+            , subq_11.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_13.ds
-              , subq_13.listing
-              , subq_13.views
+              subq_10.ds
+              , subq_10.listing
+              , subq_10.views
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_9.ds
+                , subq_9.ds__week
+                , subq_9.ds__month
+                , subq_9.ds__quarter
+                , subq_9.ds__year
+                , subq_9.ds_partitioned
+                , subq_9.ds_partitioned__week
+                , subq_9.ds_partitioned__month
+                , subq_9.ds_partitioned__quarter
+                , subq_9.ds_partitioned__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds
+                , subq_9.create_a_cycle_in_the_join_graph__ds__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_9.ds AS metric_time
+                , subq_9.ds__week AS metric_time__week
+                , subq_9.ds__month AS metric_time__month
+                , subq_9.ds__quarter AS metric_time__quarter
+                , subq_9.ds__year AS metric_time__year
+                , subq_9.listing
+                , subq_9.user
+                , subq_9.create_a_cycle_in_the_join_graph
+                , subq_9.create_a_cycle_in_the_join_graph__listing
+                , subq_9.create_a_cycle_in_the_join_graph__user
+                , subq_9.views
+              FROM (
+                -- Read Elements From Data Source 'views_source'
+                SELECT
+                  1 AS views
+                  , views_source_src_10009.ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
+                  , views_source_src_10009.ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
+                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , views_source_src_10009.listing_id AS listing
+                  , views_source_src_10009.user_id AS user
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
+                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
+                FROM (
+                  -- User Defined SQL Query
+                  SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+                ) views_source_src_10009
+              ) subq_9
+            ) subq_10
+          ) subq_11
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_13.listing
+              , subq_13.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
@@ -370,21 +360,21 @@ FROM (
                 , subq_12.ds__month
                 , subq_12.ds__quarter
                 , subq_12.ds__year
-                , subq_12.ds_partitioned
-                , subq_12.ds_partitioned__week
-                , subq_12.ds_partitioned__month
-                , subq_12.ds_partitioned__quarter
-                , subq_12.ds_partitioned__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds
-                , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_12.created_at
+                , subq_12.created_at__week
+                , subq_12.created_at__month
+                , subq_12.created_at__quarter
+                , subq_12.created_at__year
+                , subq_12.listing__ds
+                , subq_12.listing__ds__week
+                , subq_12.listing__ds__month
+                , subq_12.listing__ds__quarter
+                , subq_12.listing__ds__year
+                , subq_12.listing__created_at
+                , subq_12.listing__created_at__week
+                , subq_12.listing__created_at__month
+                , subq_12.listing__created_at__quarter
+                , subq_12.listing__created_at__year
                 , subq_12.ds AS metric_time
                 , subq_12.ds__week AS metric_time__week
                 , subq_12.ds__month AS metric_time__month
@@ -392,222 +382,80 @@ FROM (
                 , subq_12.ds__year AS metric_time__year
                 , subq_12.listing
                 , subq_12.user
-                , subq_12.create_a_cycle_in_the_join_graph
-                , subq_12.create_a_cycle_in_the_join_graph__listing
-                , subq_12.create_a_cycle_in_the_join_graph__user
-                , subq_12.views
+                , subq_12.listing__user
+                , subq_12.country_latest
+                , subq_12.is_lux_latest
+                , subq_12.capacity_latest
+                , subq_12.listing__country_latest
+                , subq_12.listing__is_lux_latest
+                , subq_12.listing__capacity_latest
+                , subq_12.listings
+                , subq_12.largest_listing
+                , subq_12.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_11.ds
-                  , subq_11.ds__week
-                  , subq_11.ds__month
-                  , subq_11.ds__quarter
-                  , subq_11.ds__year
-                  , subq_11.ds_partitioned
-                  , subq_11.ds_partitioned__week
-                  , subq_11.ds_partitioned__month
-                  , subq_11.ds_partitioned__quarter
-                  , subq_11.ds_partitioned__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_11.listing
-                  , subq_11.user
-                  , subq_11.create_a_cycle_in_the_join_graph
-                  , subq_11.create_a_cycle_in_the_join_graph__listing
-                  , subq_11.create_a_cycle_in_the_join_graph__user
-                  , subq_11.views
-                FROM (
-                  -- Read Elements From Data Source 'views_source'
-                  SELECT
-                    1 AS views
-                    , views_source_src_10009.ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
-                    , views_source_src_10009.ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                    , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , views_source_src_10009.listing_id AS listing
-                    , views_source_src_10009.user_id AS user
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                    , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
-                  ) views_source_src_10009
-                ) subq_11
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
               ) subq_12
             ) subq_13
           ) subq_14
-          LEFT OUTER JOIN (
-            -- Pass Only Elements:
-            --   ['listing', 'country_latest']
-            SELECT
-              subq_17.listing
-              , subq_17.country_latest
-            FROM (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_16.ds
-                , subq_16.ds__week
-                , subq_16.ds__month
-                , subq_16.ds__quarter
-                , subq_16.ds__year
-                , subq_16.created_at
-                , subq_16.created_at__week
-                , subq_16.created_at__month
-                , subq_16.created_at__quarter
-                , subq_16.created_at__year
-                , subq_16.listing__ds
-                , subq_16.listing__ds__week
-                , subq_16.listing__ds__month
-                , subq_16.listing__ds__quarter
-                , subq_16.listing__ds__year
-                , subq_16.listing__created_at
-                , subq_16.listing__created_at__week
-                , subq_16.listing__created_at__month
-                , subq_16.listing__created_at__quarter
-                , subq_16.listing__created_at__year
-                , subq_16.ds AS metric_time
-                , subq_16.ds__week AS metric_time__week
-                , subq_16.ds__month AS metric_time__month
-                , subq_16.ds__quarter AS metric_time__quarter
-                , subq_16.ds__year AS metric_time__year
-                , subq_16.listing
-                , subq_16.user
-                , subq_16.listing__user
-                , subq_16.country_latest
-                , subq_16.is_lux_latest
-                , subq_16.capacity_latest
-                , subq_16.listing__country_latest
-                , subq_16.listing__is_lux_latest
-                , subq_16.listing__capacity_latest
-                , subq_16.listings
-                , subq_16.largest_listing
-                , subq_16.smallest_listing
-              FROM (
-                -- Pass Only Additive Measures
-                SELECT
-                  subq_15.ds
-                  , subq_15.ds__week
-                  , subq_15.ds__month
-                  , subq_15.ds__quarter
-                  , subq_15.ds__year
-                  , subq_15.created_at
-                  , subq_15.created_at__week
-                  , subq_15.created_at__month
-                  , subq_15.created_at__quarter
-                  , subq_15.created_at__year
-                  , subq_15.listing__ds
-                  , subq_15.listing__ds__week
-                  , subq_15.listing__ds__month
-                  , subq_15.listing__ds__quarter
-                  , subq_15.listing__ds__year
-                  , subq_15.listing__created_at
-                  , subq_15.listing__created_at__week
-                  , subq_15.listing__created_at__month
-                  , subq_15.listing__created_at__quarter
-                  , subq_15.listing__created_at__year
-                  , subq_15.listing
-                  , subq_15.user
-                  , subq_15.listing__user
-                  , subq_15.country_latest
-                  , subq_15.is_lux_latest
-                  , subq_15.capacity_latest
-                  , subq_15.listing__country_latest
-                  , subq_15.listing__is_lux_latest
-                  , subq_15.listing__capacity_latest
-                  , subq_15.listings
-                  , subq_15.largest_listing
-                  , subq_15.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_15
-              ) subq_16
-            ) subq_17
-          ) subq_18
           ON
-            subq_14.listing = subq_18.listing
-        ) subq_19
-      ) subq_20
+            subq_11.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       GROUP BY
-        subq_20.ds
-        , subq_20.listing__country_latest
-    ) subq_21
+        subq_16.ds
+        , subq_16.listing__country_latest
+    ) subq_17
     ON
       (
         (
-          subq_10.listing__country_latest = subq_21.listing__country_latest
+          subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
-            subq_10.listing__country_latest IS NULL
+            subq_8.listing__country_latest IS NULL
           ) AND (
-            subq_21.listing__country_latest IS NULL
+            subq_17.listing__country_latest IS NULL
           )
         )
       ) AND (
         (
-          subq_10.ds = subq_21.ds
+          subq_8.ds = subq_17.ds
         ) OR (
-          (subq_10.ds IS NULL) AND (subq_21.ds IS NULL)
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
-  ) subq_22
-) subq_23
+  ) subq_18
+) subq_19

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,21 +3,20 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  subq_34.ds AS ds
-  , subq_34.listing__country_latest AS listing__country_latest
-  , CAST(subq_34.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_45.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
+  subq_28.ds AS ds
+  , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_27.ds AS ds
+    subq_22.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_27.bookings) AS bookings
+    , SUM(subq_22.bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds', 'listing']
@@ -29,27 +28,26 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_27
+  ) subq_22
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_27.listing = listings_latest_src_10004.listing_id
+    subq_22.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_27.ds
+    subq_22.ds
     , listings_latest_src_10004.country
-) subq_34
+) subq_28
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_38.ds AS ds
+    subq_31.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_38.views) AS views
+    , SUM(subq_31.views) AS views
   FROM (
     -- Read Elements From Data Source 'views_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['views', 'ds', 'listing']
@@ -61,30 +59,30 @@ INNER JOIN (
       -- User Defined SQL Query
       SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
     ) views_source_src_10009
-  ) subq_38
+  ) subq_31
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_38.listing = listings_latest_src_10004.listing_id
+    subq_31.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_38.ds
+    subq_31.ds
     , listings_latest_src_10004.country
-) subq_45
+) subq_37
 ON
   (
     (
-      subq_34.listing__country_latest = subq_45.listing__country_latest
+      subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
-        subq_34.listing__country_latest IS NULL
+        subq_28.listing__country_latest IS NULL
       ) AND (
-        subq_45.listing__country_latest IS NULL
+        subq_37.listing__country_latest IS NULL
       )
     )
   ) AND (
     (
-      subq_34.ds = subq_45.ds
+      subq_28.ds = subq_37.ds
     ) OR (
-      (subq_34.ds IS NULL) AND (subq_45.ds IS NULL)
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_mtd
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_ds__plan0.sql
@@ -1,56 +1,45 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_4.txn_revenue) AS txn_revenue
+    SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue']
     SELECT
-      subq_2.txn_revenue
+      subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
-) subq_5
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_all_time
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS revenue_all_time
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS trailing_2_months_revenue
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_distinct_values__plan0.sql
@@ -1,329 +1,243 @@
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
-  subq_12.listing__country_latest
+  subq_10.listing__country_latest
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest']
   SELECT
-    subq_11.listing__country_latest
+    subq_9.listing__country_latest
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_10.listing__country_latest
-      , subq_10.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest']
         SELECT
-          subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.listing__country_latest
-    ) subq_10
-  ) subq_11
-) subq_12
-ORDER BY subq_12.listing__country_latest
+        subq_7.listing__country_latest
+    ) subq_8
+  ) subq_9
+) subq_10
+ORDER BY subq_10.listing__country_latest
 LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,334 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.is_instant
-  , subq_12.bookings
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.is_instant
-    , SUM(subq_11.bookings) AS bookings
+    subq_9.is_instant
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'is_instant']
     SELECT
-      subq_10.is_instant
-      , subq_10.bookings
+      subq_8.is_instant
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.is_instant
-        , subq_9.listing__country_latest
-        , subq_9.bookings
+        subq_7.is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'listing__country_latest']
         SELECT
-          subq_8.is_instant
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.is_instant AS is_instant
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.is_instant AS is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.is_instant
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE listing__country_latest = 'us'
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.is_instant
-) subq_12
+    subq_9.is_instant
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -11,12 +11,11 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'listing__country_latest']
   SELECT
-    subq_16.is_instant AS is_instant
+    subq_13.is_instant AS is_instant
     , listings_latest_src_10004.country AS listing__country_latest
-    , subq_16.bookings AS bookings
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'listing']
@@ -28,12 +27,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_16
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_16.listing = listings_latest_src_10004.listing_id
-) subq_22
+    subq_13.listing = listings_latest_src_10004.listing_id
+) subq_18
 WHERE listing__country_latest = 'us'
 GROUP BY
   is_instant

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_limit_rows__plan0.sql
@@ -1,186 +1,136 @@
 -- Order By [] Limit 1
 SELECT
-  subq_5.ds
-  , subq_5.bookings
+  subq_4.ds
+  , subq_4.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.ds
-    , subq_4.bookings
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.ds
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.ds
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'ds']
       SELECT
-        subq_2.ds
-        , subq_2.bookings
+        subq_1.ds
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.ds
-  ) subq_4
-) subq_5
+      subq_2.ds
+  ) subq_3
+) subq_4
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_limit_rows__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
-) subq_9
+) subq_7
 GROUP BY
   ds
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,133 +1,97 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.listing__country_latest
-  , subq_4.listings
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.listing__country_latest
-    , SUM(subq_3.listings) AS listings
+    subq_2.listing__country_latest
+    , SUM(subq_2.listings) AS listings
   FROM (
     -- Pass Only Elements:
     --   ['listings', 'listing__country_latest']
     SELECT
-      subq_2.listing__country_latest
-      , subq_2.listings
+      subq_1.listing__country_latest
+      , subq_1.listings
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.created_at
-        , subq_1.created_at__week
-        , subq_1.created_at__month
-        , subq_1.created_at__quarter
-        , subq_1.created_at__year
-        , subq_1.listing__ds
-        , subq_1.listing__ds__week
-        , subq_1.listing__ds__month
-        , subq_1.listing__ds__quarter
-        , subq_1.listing__ds__year
-        , subq_1.listing__created_at
-        , subq_1.listing__created_at__week
-        , subq_1.listing__created_at__month
-        , subq_1.listing__created_at__quarter
-        , subq_1.listing__created_at__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.listing
-        , subq_1.user
-        , subq_1.listing__user
-        , subq_1.country_latest
-        , subq_1.is_lux_latest
-        , subq_1.capacity_latest
-        , subq_1.listing__country_latest
-        , subq_1.listing__is_lux_latest
-        , subq_1.listing__capacity_latest
-        , subq_1.listings
-        , subq_1.largest_listing
-        , subq_1.smallest_listing
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.created_at
+        , subq_0.created_at__week
+        , subq_0.created_at__month
+        , subq_0.created_at__quarter
+        , subq_0.created_at__year
+        , subq_0.listing__ds
+        , subq_0.listing__ds__week
+        , subq_0.listing__ds__month
+        , subq_0.listing__ds__quarter
+        , subq_0.listing__ds__year
+        , subq_0.listing__created_at
+        , subq_0.listing__created_at__week
+        , subq_0.listing__created_at__month
+        , subq_0.listing__created_at__quarter
+        , subq_0.listing__created_at__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.listing
+        , subq_0.user
+        , subq_0.listing__user
+        , subq_0.country_latest
+        , subq_0.is_lux_latest
+        , subq_0.capacity_latest
+        , subq_0.listing__country_latest
+        , subq_0.listing__is_lux_latest
+        , subq_0.listing__capacity_latest
+        , subq_0.listings
+        , subq_0.largest_listing
+        , subq_0.smallest_listing
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'listings_latest'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.created_at
-          , subq_0.created_at__week
-          , subq_0.created_at__month
-          , subq_0.created_at__quarter
-          , subq_0.created_at__year
-          , subq_0.listing__ds
-          , subq_0.listing__ds__week
-          , subq_0.listing__ds__month
-          , subq_0.listing__ds__quarter
-          , subq_0.listing__ds__year
-          , subq_0.listing__created_at
-          , subq_0.listing__created_at__week
-          , subq_0.listing__created_at__month
-          , subq_0.listing__created_at__quarter
-          , subq_0.listing__created_at__year
-          , subq_0.listing
-          , subq_0.user
-          , subq_0.listing__user
-          , subq_0.country_latest
-          , subq_0.is_lux_latest
-          , subq_0.capacity_latest
-          , subq_0.listing__country_latest
-          , subq_0.listing__is_lux_latest
-          , subq_0.listing__capacity_latest
-          , subq_0.listings
-          , subq_0.largest_listing
-          , subq_0.smallest_listing
-        FROM (
-          -- Read Elements From Data Source 'listings_latest'
-          SELECT
-            1 AS listings
-            , listings_latest_src_10004.capacity AS largest_listing
-            , listings_latest_src_10004.capacity AS smallest_listing
-            , listings_latest_src_10004.created_at AS ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-            , listings_latest_src_10004.created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-            , listings_latest_src_10004.country AS country_latest
-            , listings_latest_src_10004.is_lux AS is_lux_latest
-            , listings_latest_src_10004.capacity AS capacity_latest
-            , listings_latest_src_10004.created_at AS listing__ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-            , listings_latest_src_10004.created_at AS listing__created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-            , listings_latest_src_10004.country AS listing__country_latest
-            , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-            , listings_latest_src_10004.capacity AS listing__capacity_latest
-            , listings_latest_src_10004.listing_id AS listing
-            , listings_latest_src_10004.user_id AS user
-            , listings_latest_src_10004.user_id AS listing__user
-          FROM ***************************.dim_listings_latest listings_latest_src_10004
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS listings
+          , listings_latest_src_10004.capacity AS largest_listing
+          , listings_latest_src_10004.capacity AS smallest_listing
+          , listings_latest_src_10004.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+          , listings_latest_src_10004.created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+          , listings_latest_src_10004.country AS country_latest
+          , listings_latest_src_10004.is_lux AS is_lux_latest
+          , listings_latest_src_10004.capacity AS capacity_latest
+          , listings_latest_src_10004.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+          , listings_latest_src_10004.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+          , listings_latest_src_10004.country AS listing__country_latest
+          , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10004.capacity AS listing__capacity_latest
+          , listings_latest_src_10004.listing_id AS listing
+          , listings_latest_src_10004.user_id AS user
+          , listings_latest_src_10004.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10004
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.listing__country_latest
-) subq_4
+    subq_2.listing__country_latest
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings', 'listing__country_latest']
@@ -13,6 +12,6 @@ FROM (
     country AS listing__country_latest
     , 1 AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_8
+) subq_6
 GROUP BY
   listing__country_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0.sql
@@ -1,540 +1,404 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time
+  subq_16.metric_time
   , average_booking_value * bookings / NULLIF(booking_value, 0) AS lux_booking_value_rate_expr
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_18.metric_time
-    , subq_18.bookings
-    , subq_18.average_booking_value
-    , subq_18.booking_value
+    subq_15.metric_time
+    , subq_15.bookings
+    , subq_15.average_booking_value
+    , subq_15.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_12.metric_time AS metric_time
-      , subq_12.bookings AS bookings
-      , subq_12.average_booking_value AS average_booking_value
-      , subq_17.booking_value AS booking_value
+      subq_10.metric_time AS metric_time
+      , subq_10.bookings AS bookings
+      , subq_10.average_booking_value AS average_booking_value
+      , subq_14.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_11.metric_time
-        , SUM(subq_11.bookings) AS bookings
-        , AVG(subq_11.average_booking_value) AS average_booking_value
+        subq_9.metric_time
+        , SUM(subq_9.bookings) AS bookings
+        , AVG(subq_9.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time']
         SELECT
-          subq_10.metric_time
-          , subq_10.bookings
-          , subq_10.average_booking_value
+          subq_8.metric_time
+          , subq_8.bookings
+          , subq_8.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time
-            , subq_9.listing__is_lux_latest
-            , subq_9.bookings
-            , subq_9.average_booking_value
+            subq_7.metric_time
+            , subq_7.listing__is_lux_latest
+            , subq_7.bookings
+            , subq_7.average_booking_value
           FROM (
             -- Pass Only Elements:
             --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
             SELECT
-              subq_8.metric_time
-              , subq_8.listing__is_lux_latest
-              , subq_8.bookings
-              , subq_8.average_booking_value
+              subq_6.metric_time
+              , subq_6.listing__is_lux_latest
+              , subq_6.bookings
+              , subq_6.average_booking_value
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_3.metric_time AS metric_time
-                , subq_3.listing AS listing
-                , subq_7.is_lux_latest AS listing__is_lux_latest
-                , subq_3.bookings AS bookings
-                , subq_3.average_booking_value AS average_booking_value
+                subq_2.metric_time AS metric_time
+                , subq_2.listing AS listing
+                , subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.bookings AS bookings
+                , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements:
                 --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
                 SELECT
-                  subq_2.metric_time
-                  , subq_2.listing
-                  , subq_2.bookings
-                  , subq_2.average_booking_value
+                  subq_1.metric_time
+                  , subq_1.listing
+                  , subq_1.bookings
+                  , subq_1.average_booking_value
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_1.ds
-                    , subq_1.ds__week
-                    , subq_1.ds__month
-                    , subq_1.ds__quarter
-                    , subq_1.ds__year
-                    , subq_1.ds_partitioned
-                    , subq_1.ds_partitioned__week
-                    , subq_1.ds_partitioned__month
-                    , subq_1.ds_partitioned__quarter
-                    , subq_1.ds_partitioned__year
-                    , subq_1.booking_paid_at
-                    , subq_1.booking_paid_at__week
-                    , subq_1.booking_paid_at__month
-                    , subq_1.booking_paid_at__quarter
-                    , subq_1.booking_paid_at__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , subq_1.ds AS metric_time
-                    , subq_1.ds__week AS metric_time__week
-                    , subq_1.ds__month AS metric_time__month
-                    , subq_1.ds__quarter AS metric_time__quarter
-                    , subq_1.ds__year AS metric_time__year
-                    , subq_1.listing
-                    , subq_1.guest
-                    , subq_1.host
-                    , subq_1.create_a_cycle_in_the_join_graph
-                    , subq_1.create_a_cycle_in_the_join_graph__listing
-                    , subq_1.create_a_cycle_in_the_join_graph__guest
-                    , subq_1.create_a_cycle_in_the_join_graph__host
-                    , subq_1.is_instant
-                    , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                    , subq_1.bookings
-                    , subq_1.instant_bookings
-                    , subq_1.booking_value
-                    , subq_1.max_booking_value
-                    , subq_1.min_booking_value
-                    , subq_1.bookers
-                    , subq_1.average_booking_value
+                    subq_0.ds
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds_partitioned
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.booking_paid_at
+                    , subq_0.booking_paid_at__week
+                    , subq_0.booking_paid_at__month
+                    , subq_0.booking_paid_at__quarter
+                    , subq_0.booking_paid_at__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                    , subq_0.ds AS metric_time
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.create_a_cycle_in_the_join_graph
+                    , subq_0.create_a_cycle_in_the_join_graph__listing
+                    , subq_0.create_a_cycle_in_the_join_graph__guest
+                    , subq_0.create_a_cycle_in_the_join_graph__host
+                    , subq_0.is_instant
+                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'bookings_source'
                     SELECT
-                      subq_0.ds
-                      , subq_0.ds__week
-                      , subq_0.ds__month
-                      , subq_0.ds__quarter
-                      , subq_0.ds__year
-                      , subq_0.ds_partitioned
-                      , subq_0.ds_partitioned__week
-                      , subq_0.ds_partitioned__month
-                      , subq_0.ds_partitioned__quarter
-                      , subq_0.ds_partitioned__year
-                      , subq_0.booking_paid_at
-                      , subq_0.booking_paid_at__week
-                      , subq_0.booking_paid_at__month
-                      , subq_0.booking_paid_at__quarter
-                      , subq_0.booking_paid_at__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                      , subq_0.listing
-                      , subq_0.guest
-                      , subq_0.host
-                      , subq_0.create_a_cycle_in_the_join_graph
-                      , subq_0.create_a_cycle_in_the_join_graph__listing
-                      , subq_0.create_a_cycle_in_the_join_graph__guest
-                      , subq_0.create_a_cycle_in_the_join_graph__host
-                      , subq_0.is_instant
-                      , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                      , subq_0.bookings
-                      , subq_0.instant_bookings
-                      , subq_0.booking_value
-                      , subq_0.max_booking_value
-                      , subq_0.min_booking_value
-                      , subq_0.bookers
-                      , subq_0.average_booking_value
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_10001.booking_value
+                      , bookings_source_src_10001.booking_value AS max_booking_value
+                      , bookings_source_src_10001.booking_value AS min_booking_value
+                      , bookings_source_src_10001.guest_id AS bookers
+                      , bookings_source_src_10001.booking_value AS average_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_payments
+                      , bookings_source_src_10001.is_instant
+                      , bookings_source_src_10001.ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                      , bookings_source_src_10001.ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                      , bookings_source_src_10001.listing_id AS listing
+                      , bookings_source_src_10001.guest_id AS guest
+                      , bookings_source_src_10001.host_id AS host
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM (
-                      -- Read Elements From Data Source 'bookings_source'
-                      SELECT
-                        1 AS bookings
-                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                        , bookings_source_src_10001.booking_value
-                        , bookings_source_src_10001.booking_value AS max_booking_value
-                        , bookings_source_src_10001.booking_value AS min_booking_value
-                        , bookings_source_src_10001.guest_id AS bookers
-                        , bookings_source_src_10001.booking_value AS average_booking_value
-                        , bookings_source_src_10001.booking_value AS booking_payments
-                        , bookings_source_src_10001.is_instant
-                        , bookings_source_src_10001.ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                        , bookings_source_src_10001.ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                        , bookings_source_src_10001.listing_id AS listing
-                        , bookings_source_src_10001.guest_id AS guest
-                        , bookings_source_src_10001.host_id AS host
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                      FROM (
-                        -- User Defined SQL Query
-                        SELECT * FROM ***************************.fct_bookings
-                      ) bookings_source_src_10001
-                    ) subq_0
-                  ) subq_1
-                ) subq_2
-              ) subq_3
+                      -- User Defined SQL Query
+                      SELECT * FROM ***************************.fct_bookings
+                    ) bookings_source_src_10001
+                  ) subq_0
+                ) subq_1
+              ) subq_2
               LEFT OUTER JOIN (
                 -- Pass Only Elements:
                 --   ['listing', 'is_lux_latest']
                 SELECT
-                  subq_6.listing
-                  , subq_6.is_lux_latest
+                  subq_4.listing
+                  , subq_4.is_lux_latest
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_5.ds
-                    , subq_5.ds__week
-                    , subq_5.ds__month
-                    , subq_5.ds__quarter
-                    , subq_5.ds__year
-                    , subq_5.created_at
-                    , subq_5.created_at__week
-                    , subq_5.created_at__month
-                    , subq_5.created_at__quarter
-                    , subq_5.created_at__year
-                    , subq_5.listing__ds
-                    , subq_5.listing__ds__week
-                    , subq_5.listing__ds__month
-                    , subq_5.listing__ds__quarter
-                    , subq_5.listing__ds__year
-                    , subq_5.listing__created_at
-                    , subq_5.listing__created_at__week
-                    , subq_5.listing__created_at__month
-                    , subq_5.listing__created_at__quarter
-                    , subq_5.listing__created_at__year
-                    , subq_5.ds AS metric_time
-                    , subq_5.ds__week AS metric_time__week
-                    , subq_5.ds__month AS metric_time__month
-                    , subq_5.ds__quarter AS metric_time__quarter
-                    , subq_5.ds__year AS metric_time__year
-                    , subq_5.listing
-                    , subq_5.user
-                    , subq_5.listing__user
-                    , subq_5.country_latest
-                    , subq_5.is_lux_latest
-                    , subq_5.capacity_latest
-                    , subq_5.listing__country_latest
-                    , subq_5.listing__is_lux_latest
-                    , subq_5.listing__capacity_latest
-                    , subq_5.listings
-                    , subq_5.largest_listing
-                    , subq_5.smallest_listing
+                    subq_3.ds
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.created_at
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.listing__ds
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__created_at
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.ds AS metric_time
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'listings_latest'
                     SELECT
-                      subq_4.ds
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.created_at
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.listing__ds
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__created_at
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
-                    FROM (
-                      -- Read Elements From Data Source 'listings_latest'
-                      SELECT
-                        1 AS listings
-                        , listings_latest_src_10004.capacity AS largest_listing
-                        , listings_latest_src_10004.capacity AS smallest_listing
-                        , listings_latest_src_10004.created_at AS ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                        , listings_latest_src_10004.created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                        , listings_latest_src_10004.country AS country_latest
-                        , listings_latest_src_10004.is_lux AS is_lux_latest
-                        , listings_latest_src_10004.capacity AS capacity_latest
-                        , listings_latest_src_10004.created_at AS listing__ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                        , listings_latest_src_10004.created_at AS listing__created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                        , listings_latest_src_10004.country AS listing__country_latest
-                        , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                        , listings_latest_src_10004.capacity AS listing__capacity_latest
-                        , listings_latest_src_10004.listing_id AS listing
-                        , listings_latest_src_10004.user_id AS user
-                        , listings_latest_src_10004.user_id AS listing__user
-                      FROM ***************************.dim_listings_latest listings_latest_src_10004
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
-              ) subq_7
+                      1 AS listings
+                      , listings_latest_src_10004.capacity AS largest_listing
+                      , listings_latest_src_10004.capacity AS smallest_listing
+                      , listings_latest_src_10004.created_at AS ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                      , listings_latest_src_10004.created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                      , listings_latest_src_10004.country AS country_latest
+                      , listings_latest_src_10004.is_lux AS is_lux_latest
+                      , listings_latest_src_10004.capacity AS capacity_latest
+                      , listings_latest_src_10004.created_at AS listing__ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                      , listings_latest_src_10004.created_at AS listing__created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                      , listings_latest_src_10004.country AS listing__country_latest
+                      , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_10004.capacity AS listing__capacity_latest
+                      , listings_latest_src_10004.listing_id AS listing
+                      , listings_latest_src_10004.user_id AS user
+                      , listings_latest_src_10004.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_10004
+                  ) subq_3
+                ) subq_4
+              ) subq_5
               ON
-                subq_3.listing = subq_7.listing
-            ) subq_8
-          ) subq_9
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
           WHERE listing__is_lux_latest
-        ) subq_10
-      ) subq_11
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_11.metric_time
-    ) subq_12
+        subq_9.metric_time
+    ) subq_10
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_16.metric_time
-        , SUM(subq_16.booking_value) AS booking_value
+        subq_13.metric_time
+        , SUM(subq_13.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_15.metric_time
-          , subq_15.booking_value
+          subq_12.metric_time
+          , subq_12.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_14.ds
-            , subq_14.ds__week
-            , subq_14.ds__month
-            , subq_14.ds__quarter
-            , subq_14.ds__year
-            , subq_14.ds_partitioned
-            , subq_14.ds_partitioned__week
-            , subq_14.ds_partitioned__month
-            , subq_14.ds_partitioned__quarter
-            , subq_14.ds_partitioned__year
-            , subq_14.booking_paid_at
-            , subq_14.booking_paid_at__week
-            , subq_14.booking_paid_at__month
-            , subq_14.booking_paid_at__quarter
-            , subq_14.booking_paid_at__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds
-            , subq_14.create_a_cycle_in_the_join_graph__ds__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_14.ds AS metric_time
-            , subq_14.ds__week AS metric_time__week
-            , subq_14.ds__month AS metric_time__month
-            , subq_14.ds__quarter AS metric_time__quarter
-            , subq_14.ds__year AS metric_time__year
-            , subq_14.listing
-            , subq_14.guest
-            , subq_14.host
-            , subq_14.create_a_cycle_in_the_join_graph
-            , subq_14.create_a_cycle_in_the_join_graph__listing
-            , subq_14.create_a_cycle_in_the_join_graph__guest
-            , subq_14.create_a_cycle_in_the_join_graph__host
-            , subq_14.is_instant
-            , subq_14.create_a_cycle_in_the_join_graph__is_instant
-            , subq_14.bookings
-            , subq_14.instant_bookings
-            , subq_14.booking_value
-            , subq_14.max_booking_value
-            , subq_14.min_booking_value
-            , subq_14.bookers
-            , subq_14.average_booking_value
+            subq_11.ds
+            , subq_11.ds__week
+            , subq_11.ds__month
+            , subq_11.ds__quarter
+            , subq_11.ds__year
+            , subq_11.ds_partitioned
+            , subq_11.ds_partitioned__week
+            , subq_11.ds_partitioned__month
+            , subq_11.ds_partitioned__quarter
+            , subq_11.ds_partitioned__year
+            , subq_11.booking_paid_at
+            , subq_11.booking_paid_at__week
+            , subq_11.booking_paid_at__month
+            , subq_11.booking_paid_at__quarter
+            , subq_11.booking_paid_at__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds
+            , subq_11.create_a_cycle_in_the_join_graph__ds__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_11.ds AS metric_time
+            , subq_11.ds__week AS metric_time__week
+            , subq_11.ds__month AS metric_time__month
+            , subq_11.ds__quarter AS metric_time__quarter
+            , subq_11.ds__year AS metric_time__year
+            , subq_11.listing
+            , subq_11.guest
+            , subq_11.host
+            , subq_11.create_a_cycle_in_the_join_graph
+            , subq_11.create_a_cycle_in_the_join_graph__listing
+            , subq_11.create_a_cycle_in_the_join_graph__guest
+            , subq_11.create_a_cycle_in_the_join_graph__host
+            , subq_11.is_instant
+            , subq_11.create_a_cycle_in_the_join_graph__is_instant
+            , subq_11.bookings
+            , subq_11.instant_bookings
+            , subq_11.booking_value
+            , subq_11.max_booking_value
+            , subq_11.min_booking_value
+            , subq_11.bookers
+            , subq_11.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_13.ds
-              , subq_13.ds__week
-              , subq_13.ds__month
-              , subq_13.ds__quarter
-              , subq_13.ds__year
-              , subq_13.ds_partitioned
-              , subq_13.ds_partitioned__week
-              , subq_13.ds_partitioned__month
-              , subq_13.ds_partitioned__quarter
-              , subq_13.ds_partitioned__year
-              , subq_13.booking_paid_at
-              , subq_13.booking_paid_at__week
-              , subq_13.booking_paid_at__month
-              , subq_13.booking_paid_at__quarter
-              , subq_13.booking_paid_at__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds
-              , subq_13.create_a_cycle_in_the_join_graph__ds__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_13.listing
-              , subq_13.guest
-              , subq_13.host
-              , subq_13.create_a_cycle_in_the_join_graph
-              , subq_13.create_a_cycle_in_the_join_graph__listing
-              , subq_13.create_a_cycle_in_the_join_graph__guest
-              , subq_13.create_a_cycle_in_the_join_graph__host
-              , subq_13.is_instant
-              , subq_13.create_a_cycle_in_the_join_graph__is_instant
-              , subq_13.bookings
-              , subq_13.instant_bookings
-              , subq_13.booking_value
-              , subq_13.max_booking_value
-              , subq_13.min_booking_value
-              , subq_13.bookers
-              , subq_13.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_13
-          ) subq_14
-        ) subq_15
-      ) subq_16
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_11
+        ) subq_12
+      ) subq_13
       GROUP BY
-        subq_16.metric_time
-    ) subq_17
+        subq_13.metric_time
+    ) subq_14
     ON
       (
         (
-          subq_12.metric_time = subq_17.metric_time
+          subq_10.metric_time = subq_14.metric_time
         ) OR (
-          (subq_12.metric_time IS NULL) AND (subq_17.metric_time IS NULL)
+          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
         )
       )
-  ) subq_18
-) subq_19
+  ) subq_15
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -7,10 +7,10 @@ FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_32.metric_time AS metric_time
-    , subq_32.bookings AS bookings
-    , subq_32.average_booking_value AS average_booking_value
-    , subq_37.booking_value AS booking_value
+    subq_27.metric_time AS metric_time
+    , subq_27.bookings AS bookings
+    , subq_27.average_booking_value AS average_booking_value
+    , subq_31.booking_value AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
@@ -25,13 +25,12 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
       SELECT
-        subq_23.metric_time AS metric_time
+        subq_19.metric_time AS metric_time
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-        , subq_23.bookings AS bookings
-        , subq_23.average_booking_value AS average_booking_value
+        , subq_19.bookings AS bookings
+        , subq_19.average_booking_value AS average_booking_value
       FROM (
         -- Read Elements From Data Source 'bookings_source'
-        -- Pass Only Additive Measures
         -- Metric Time Dimension 'ds'
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
@@ -44,19 +43,18 @@ FROM (
           -- User Defined SQL Query
           SELECT * FROM ***************************.fct_bookings
         ) bookings_source_src_10001
-      ) subq_23
+      ) subq_19
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_10004
       ON
-        subq_23.listing = listings_latest_src_10004.listing_id
-    ) subq_29
+        subq_19.listing = listings_latest_src_10004.listing_id
+    ) subq_24
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time
-  ) subq_32
+  ) subq_27
   INNER JOIN (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'metric_time']
@@ -70,13 +68,13 @@ FROM (
     ) bookings_source_src_10001
     GROUP BY
       ds
-  ) subq_37
+  ) subq_31
   ON
     (
       (
-        subq_32.metric_time = subq_37.metric_time
+        subq_27.metric_time = subq_31.metric_time
       ) OR (
-        (subq_32.metric_time IS NULL) AND (subq_37.metric_time IS NULL)
+        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
       )
     )
-) subq_39
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,393 +1,293 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_11.metric_time
+  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
   SELECT
-    subq_12.metric_time
-    , subq_12.booking_value_with_is_instant_constraint
-    , subq_12.booking_value
+    subq_10.metric_time
+    , subq_10.booking_value_with_is_instant_constraint
+    , subq_10.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_6.metric_time AS metric_time
-      , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_11.booking_value AS booking_value
+      subq_5.metric_time AS metric_time
+      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+      , subq_9.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time
-        , SUM(subq_5.booking_value) AS booking_value_with_is_instant_constraint
+        subq_4.metric_time
+        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_4.metric_time
-          , subq_4.booking_value
+          subq_3.metric_time
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time
-            , subq_3.is_instant
-            , subq_3.booking_value
+            subq_2.metric_time
+            , subq_2.is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements:
             --   ['booking_value', 'is_instant', 'metric_time']
             SELECT
-              subq_2.metric_time
-              , subq_2.is_instant
-              , subq_2.booking_value
+              subq_1.metric_time
+              , subq_1.is_instant
+              , subq_1.booking_value
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time
-    ) subq_6
+        subq_4.metric_time
+    ) subq_5
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_8.metric_time
+        , SUM(subq_8.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_9.metric_time
-          , subq_9.booking_value
+          subq_7.metric_time
+          , subq_7.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds_partitioned
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.booking_paid_at
-            , subq_8.booking_paid_at__week
-            , subq_8.booking_paid_at__month
-            , subq_8.booking_paid_at__quarter
-            , subq_8.booking_paid_at__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds
-            , subq_8.create_a_cycle_in_the_join_graph__ds__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_8.ds AS metric_time
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.create_a_cycle_in_the_join_graph
-            , subq_8.create_a_cycle_in_the_join_graph__listing
-            , subq_8.create_a_cycle_in_the_join_graph__guest
-            , subq_8.create_a_cycle_in_the_join_graph__host
-            , subq_8.is_instant
-            , subq_8.create_a_cycle_in_the_join_graph__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds_partitioned
+            , subq_6.ds_partitioned__week
+            , subq_6.ds_partitioned__month
+            , subq_6.ds_partitioned__quarter
+            , subq_6.ds_partitioned__year
+            , subq_6.booking_paid_at
+            , subq_6.booking_paid_at__week
+            , subq_6.booking_paid_at__month
+            , subq_6.booking_paid_at__quarter
+            , subq_6.booking_paid_at__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds
+            , subq_6.create_a_cycle_in_the_join_graph__ds__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.guest
+            , subq_6.host
+            , subq_6.create_a_cycle_in_the_join_graph
+            , subq_6.create_a_cycle_in_the_join_graph__listing
+            , subq_6.create_a_cycle_in_the_join_graph__guest
+            , subq_6.create_a_cycle_in_the_join_graph__host
+            , subq_6.is_instant
+            , subq_6.create_a_cycle_in_the_join_graph__is_instant
+            , subq_6.bookings
+            , subq_6.instant_bookings
+            , subq_6.booking_value
+            , subq_6.max_booking_value
+            , subq_6.min_booking_value
+            , subq_6.bookers
+            , subq_6.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_7.ds
-              , subq_7.ds__week
-              , subq_7.ds__month
-              , subq_7.ds__quarter
-              , subq_7.ds__year
-              , subq_7.ds_partitioned
-              , subq_7.ds_partitioned__week
-              , subq_7.ds_partitioned__month
-              , subq_7.ds_partitioned__quarter
-              , subq_7.ds_partitioned__year
-              , subq_7.booking_paid_at
-              , subq_7.booking_paid_at__week
-              , subq_7.booking_paid_at__month
-              , subq_7.booking_paid_at__quarter
-              , subq_7.booking_paid_at__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds
-              , subq_7.create_a_cycle_in_the_join_graph__ds__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_7.listing
-              , subq_7.guest
-              , subq_7.host
-              , subq_7.create_a_cycle_in_the_join_graph
-              , subq_7.create_a_cycle_in_the_join_graph__listing
-              , subq_7.create_a_cycle_in_the_join_graph__guest
-              , subq_7.create_a_cycle_in_the_join_graph__host
-              , subq_7.is_instant
-              , subq_7.create_a_cycle_in_the_join_graph__is_instant
-              , subq_7.bookings
-              , subq_7.instant_bookings
-              , subq_7.booking_value
-              , subq_7.max_booking_value
-              , subq_7.min_booking_value
-              , subq_7.bookers
-              , subq_7.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_7
-          ) subq_8
-        ) subq_9
-      ) subq_10
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_6
+        ) subq_7
+      ) subq_8
       GROUP BY
-        subq_10.metric_time
-    ) subq_11
+        subq_8.metric_time
+    ) subq_9
     ON
       (
         (
-          subq_6.metric_time = subq_11.metric_time
+          subq_5.metric_time = subq_9.metric_time
         ) OR (
-          (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
         )
       )
-  ) subq_12
-) subq_13
+  ) subq_10
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,8 +3,8 @@
 --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time AS metric_time
-  , CAST(subq_20.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_25.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_17.metric_time AS metric_time
+  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
@@ -15,7 +15,6 @@ FROM (
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'is_instant', 'metric_time']
@@ -27,14 +26,13 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_17
+  ) subq_14
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_20
+) subq_17
 INNER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
@@ -48,12 +46,12 @@ INNER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     ds
-) subq_25
+) subq_21
 ON
   (
     (
-      subq_20.metric_time = subq_25.metric_time
+      subq_17.metric_time = subq_21.metric_time
     ) OR (
-      (subq_20.metric_time IS NULL) AND (subq_25.metric_time IS NULL)
+      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,195 +1,145 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.metric_time
+  subq_5.metric_time
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.metric_time
-    , SUM(subq_5.bookings) AS delayed_bookings
+    subq_4.metric_time
+    , SUM(subq_4.bookings) AS delayed_bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
     SELECT
-      subq_4.metric_time
-      , subq_4.bookings
+      subq_3.metric_time
+      , subq_3.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_3.metric_time
-        , subq_3.is_instant
-        , subq_3.bookings
+        subq_2.metric_time
+        , subq_2.is_instant
+        , subq_2.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'metric_time']
         SELECT
-          subq_2.metric_time
-          , subq_2.is_instant
-          , subq_2.bookings
+          subq_1.metric_time
+          , subq_1.is_instant
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.booking_paid_at
-            , subq_1.booking_paid_at__week
-            , subq_1.booking_paid_at__month
-            , subq_1.booking_paid_at__quarter
-            , subq_1.booking_paid_at__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds
-            , subq_1.create_a_cycle_in_the_join_graph__ds__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.listing
-            , subq_1.guest
-            , subq_1.host
-            , subq_1.create_a_cycle_in_the_join_graph
-            , subq_1.create_a_cycle_in_the_join_graph__listing
-            , subq_1.create_a_cycle_in_the_join_graph__guest
-            , subq_1.create_a_cycle_in_the_join_graph__host
-            , subq_1.is_instant
-            , subq_1.create_a_cycle_in_the_join_graph__is_instant
-            , subq_1.bookings
-            , subq_1.instant_bookings
-            , subq_1.booking_value
-            , subq_1.max_booking_value
-            , subq_1.min_booking_value
-            , subq_1.bookers
-            , subq_1.average_booking_value
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.booking_paid_at
-              , subq_0.booking_paid_at__week
-              , subq_0.booking_paid_at__month
-              , subq_0.booking_paid_at__quarter
-              , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_0.listing
-              , subq_0.guest
-              , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
-              , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
-              , subq_0.bookings
-              , subq_0.instant_bookings
-              , subq_0.booking_value
-              , subq_0.max_booking_value
-              , subq_0.min_booking_value
-              , subq_0.bookers
-              , subq_0.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
       WHERE NOT is_instant
-    ) subq_4
-  ) subq_5
+    ) subq_3
+  ) subq_4
   GROUP BY
-    subq_5.metric_time
-) subq_6
+    subq_4.metric_time
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , SUM(bookings) AS delayed_bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'metric_time']
@@ -24,8 +23,8 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_10
+  ) subq_8
   WHERE NOT is_instant
   GROUP BY
     metric_time
-) subq_13
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0.sql
@@ -1,156 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.account_id__customer_id__customer_name
-  , subq_11.txn_count
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.account_id__customer_id__customer_name
-    , SUM(subq_10.txn_count) AS txn_count
+    subq_9.account_id__customer_id__customer_name
+    , SUM(subq_9.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements:
     --   ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_9.account_id__customer_id__customer_name
-      , subq_9.txn_count
+      subq_8.account_id__customer_id__customer_name
+      , subq_8.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_8.ds_partitioned AS account_id__ds_partitioned
-        , subq_3.account_id AS account_id
-        , subq_8.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_3.txn_count AS txn_count
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_7.ds_partitioned AS account_id__ds_partitioned
+        , subq_2.account_id AS account_id
+        , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements:
         --   ['txn_count', 'account_id', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.account_id
-          , subq_2.txn_count
+          subq_1.ds_partitioned
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.account_id__ds_partitioned
-            , subq_1.account_id__ds_partitioned__week
-            , subq_1.account_id__ds_partitioned__month
-            , subq_1.account_id__ds_partitioned__quarter
-            , subq_1.account_id__ds_partitioned__year
-            , subq_1.account_id__ds
-            , subq_1.account_id__ds__week
-            , subq_1.account_id__ds__month
-            , subq_1.account_id__ds__quarter
-            , subq_1.account_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.account_id
-            , subq_1.account_month
-            , subq_1.account_id__account_month
-            , subq_1.txn_count
+            subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.account_id__ds_partitioned
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'account_month_txns'
             SELECT
-              subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.account_id__ds_partitioned
-              , subq_0.account_id__ds_partitioned__week
-              , subq_0.account_id__ds_partitioned__month
-              , subq_0.account_id__ds_partitioned__quarter
-              , subq_0.account_id__ds_partitioned__year
-              , subq_0.account_id__ds
-              , subq_0.account_id__ds__week
-              , subq_0.account_id__ds__month
-              , subq_0.account_id__ds__quarter
-              , subq_0.account_id__ds__year
-              , subq_0.account_id
-              , subq_0.account_month
-              , subq_0.account_id__account_month
-              , subq_0.txn_count
-            FROM (
-              -- Read Elements From Data Source 'account_month_txns'
-              SELECT
-                account_month_txns_src_10010.txn_count
-                , account_month_txns_src_10010.ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
-                , account_month_txns_src_10010.ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
-                , account_month_txns_src_10010.account_month
-                , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
-                , account_month_txns_src_10010.ds AS account_id__ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
-                , account_month_txns_src_10010.account_month AS account_id__account_month
-                , account_month_txns_src_10010.account_id
-              FROM ***************************.account_month_txns account_month_txns_src_10010
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              account_month_txns_src_10010.txn_count
+              , account_month_txns_src_10010.ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
+              , account_month_txns_src_10010.ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
+              , account_month_txns_src_10010.account_month
+              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
+              , account_month_txns_src_10010.ds AS account_id__ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
+              , account_month_txns_src_10010.account_month AS account_id__account_month
+              , account_month_txns_src_10010.account_id
+            FROM ***************************.account_month_txns account_month_txns_src_10010
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
         SELECT
-          subq_7.ds_partitioned
-          , subq_7.account_id
-          , subq_7.customer_id__customer_name
+          subq_6.ds_partitioned
+          , subq_6.account_id
+          , subq_6.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned AS ds_partitioned
-            , subq_4.ds_partitioned__week AS ds_partitioned__week
-            , subq_4.ds_partitioned__month AS ds_partitioned__month
-            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_4.ds_partitioned__year AS ds_partitioned__year
-            , subq_4.account_id__ds_partitioned AS account_id__ds_partitioned
-            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_6.ds_partitioned AS customer_id__ds_partitioned
-            , subq_6.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_6.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_6.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_6.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_4.account_id AS account_id
-            , subq_4.customer_id AS customer_id
-            , subq_4.account_id__customer_id AS account_id__customer_id
-            , subq_4.extra_dim AS extra_dim
-            , subq_4.account_id__extra_dim AS account_id__extra_dim
-            , subq_6.customer_name AS customer_id__customer_name
-            , subq_6.customer_atomic_weight AS customer_id__customer_atomic_weight
+            subq_3.ds_partitioned AS ds_partitioned
+            , subq_3.ds_partitioned__week AS ds_partitioned__week
+            , subq_3.ds_partitioned__month AS ds_partitioned__month
+            , subq_3.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_3.ds_partitioned__year AS ds_partitioned__year
+            , subq_3.account_id__ds_partitioned AS account_id__ds_partitioned
+            , subq_3.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_3.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_3.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_3.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_5.ds_partitioned AS customer_id__ds_partitioned
+            , subq_5.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_5.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_5.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_5.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_3.account_id AS account_id
+            , subq_3.customer_id AS customer_id
+            , subq_3.account_id__customer_id AS account_id__customer_id
+            , subq_3.extra_dim AS extra_dim
+            , subq_3.account_id__extra_dim AS account_id__extra_dim
+            , subq_5.customer_name AS customer_id__customer_name
+            , subq_5.customer_atomic_weight AS customer_id__customer_atomic_weight
           FROM (
             -- Read Elements From Data Source 'bridge_table'
             SELECT
@@ -170,7 +142,7 @@ FROM (
               , bridge_table_src_10011.customer_id
               , bridge_table_src_10011.customer_id AS account_id__customer_id
             FROM ***************************.bridge_table bridge_table_src_10011
-          ) subq_4
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['customer_name',
@@ -189,21 +161,21 @@ FROM (
             --    'customer_id__ds_partitioned__quarter',
             --    'customer_id__ds_partitioned__year']
             SELECT
-              subq_5.ds_partitioned
-              , subq_5.ds_partitioned__week
-              , subq_5.ds_partitioned__month
-              , subq_5.ds_partitioned__quarter
-              , subq_5.ds_partitioned__year
-              , subq_5.customer_id__ds_partitioned
-              , subq_5.customer_id__ds_partitioned__week
-              , subq_5.customer_id__ds_partitioned__month
-              , subq_5.customer_id__ds_partitioned__quarter
-              , subq_5.customer_id__ds_partitioned__year
-              , subq_5.customer_id
-              , subq_5.customer_name
-              , subq_5.customer_atomic_weight
-              , subq_5.customer_id__customer_name
-              , subq_5.customer_id__customer_atomic_weight
+              subq_4.ds_partitioned
+              , subq_4.ds_partitioned__week
+              , subq_4.ds_partitioned__month
+              , subq_4.ds_partitioned__quarter
+              , subq_4.ds_partitioned__year
+              , subq_4.customer_id__ds_partitioned
+              , subq_4.customer_id__ds_partitioned__week
+              , subq_4.customer_id__ds_partitioned__month
+              , subq_4.customer_id__ds_partitioned__quarter
+              , subq_4.customer_id__ds_partitioned__year
+              , subq_4.customer_id
+              , subq_4.customer_name
+              , subq_4.customer_atomic_weight
+              , subq_4.customer_id__customer_name
+              , subq_4.customer_id__customer_atomic_weight
             FROM (
               -- Read Elements From Data Source 'customer_table'
               SELECT
@@ -223,24 +195,24 @@ FROM (
                 , DATE_TRUNC('year', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__year
                 , customer_table_src_10013.customer_id
               FROM ***************************.customer_table customer_table_src_10013
-            ) subq_5
-          ) subq_6
+            ) subq_4
+          ) subq_5
           ON
             (
-              subq_4.customer_id = subq_6.customer_id
+              subq_3.customer_id = subq_5.customer_id
             ) AND (
-              subq_4.ds_partitioned = subq_6.ds_partitioned
+              subq_3.ds_partitioned = subq_5.ds_partitioned
             )
-        ) subq_7
-      ) subq_8
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_3.account_id = subq_8.account_id
+          subq_2.account_id = subq_7.account_id
         ) AND (
-          subq_3.ds_partitioned = subq_8.ds_partitioned
+          subq_2.ds_partitioned = subq_7.ds_partitioned
         )
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.account_id__customer_id__customer_name
-) subq_11
+    subq_9.account_id__customer_id__customer_name
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,7 +4,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_10010.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10010
 LEFT OUTER JOIN (
@@ -24,12 +24,12 @@ LEFT OUTER JOIN (
     ) AND (
       bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
     )
-) subq_20
+) subq_18
 ON
   (
-    account_month_txns_src_10010.account_id = subq_20.account_id
+    account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_20.ds_partitioned
+    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned
   )
 GROUP BY
-  subq_20.customer_id__customer_name
+  subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0.sql
@@ -1,137 +1,107 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user__home_state
-  , subq_8.identity_verifications
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user__home_state
-    , SUM(subq_7.identity_verifications) AS identity_verifications
+    subq_6.user__home_state
+    , SUM(subq_6.identity_verifications) AS identity_verifications
   FROM (
     -- Pass Only Elements:
     --   ['identity_verifications', 'user__home_state']
     SELECT
-      subq_6.user__home_state
-      , subq_6.identity_verifications
+      subq_5.user__home_state
+      , subq_5.identity_verifications
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_5.ds_partitioned AS user__ds_partitioned
-        , subq_3.user AS user
-        , subq_5.home_state AS user__home_state
-        , subq_3.identity_verifications AS identity_verifications
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_4.ds_partitioned AS user__ds_partitioned
+        , subq_2.user AS user
+        , subq_4.home_state AS user__home_state
+        , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements:
         --   ['identity_verifications', 'user', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.user
-          , subq_2.identity_verifications
+          subq_1.ds_partitioned
+          , subq_1.user
+          , subq_1.identity_verifications
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.verification__ds
-            , subq_1.verification__ds__week
-            , subq_1.verification__ds__month
-            , subq_1.verification__ds__quarter
-            , subq_1.verification__ds__year
-            , subq_1.verification__ds_partitioned
-            , subq_1.verification__ds_partitioned__week
-            , subq_1.verification__ds_partitioned__month
-            , subq_1.verification__ds_partitioned__quarter
-            , subq_1.verification__ds_partitioned__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.verification
-            , subq_1.user
-            , subq_1.verification__user
-            , subq_1.verification_type
-            , subq_1.verification__verification_type
-            , subq_1.identity_verifications
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.verification__ds
+            , subq_0.verification__ds__week
+            , subq_0.verification__ds__month
+            , subq_0.verification__ds__quarter
+            , subq_0.verification__ds__year
+            , subq_0.verification__ds_partitioned
+            , subq_0.verification__ds_partitioned__week
+            , subq_0.verification__ds_partitioned__month
+            , subq_0.verification__ds_partitioned__quarter
+            , subq_0.verification__ds_partitioned__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.verification
+            , subq_0.user
+            , subq_0.verification__user
+            , subq_0.verification_type
+            , subq_0.verification__verification_type
+            , subq_0.identity_verifications
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'id_verifications'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.verification__ds
-              , subq_0.verification__ds__week
-              , subq_0.verification__ds__month
-              , subq_0.verification__ds__quarter
-              , subq_0.verification__ds__year
-              , subq_0.verification__ds_partitioned
-              , subq_0.verification__ds_partitioned__week
-              , subq_0.verification__ds_partitioned__month
-              , subq_0.verification__ds_partitioned__quarter
-              , subq_0.verification__ds_partitioned__year
-              , subq_0.verification
-              , subq_0.user
-              , subq_0.verification__user
-              , subq_0.verification_type
-              , subq_0.verification__verification_type
-              , subq_0.identity_verifications
-            FROM (
-              -- Read Elements From Data Source 'id_verifications'
-              SELECT
-                1 AS identity_verifications
-                , id_verifications_src_10003.ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
-                , id_verifications_src_10003.ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
-                , id_verifications_src_10003.verification_type
-                , id_verifications_src_10003.ds AS verification__ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
-                , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
-                , id_verifications_src_10003.verification_type AS verification__verification_type
-                , id_verifications_src_10003.verification_id AS verification
-                , id_verifications_src_10003.user_id AS user
-                , id_verifications_src_10003.user_id AS verification__user
-              FROM ***************************.fct_id_verifications id_verifications_src_10003
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS identity_verifications
+              , id_verifications_src_10003.ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
+              , id_verifications_src_10003.ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
+              , id_verifications_src_10003.verification_type
+              , id_verifications_src_10003.ds AS verification__ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
+              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
+              , id_verifications_src_10003.verification_type AS verification__verification_type
+              , id_verifications_src_10003.verification_id AS verification
+              , id_verifications_src_10003.user_id AS user
+              , id_verifications_src_10003.user_id AS verification__user
+            FROM ***************************.fct_id_verifications id_verifications_src_10003
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user', 'ds_partitioned', 'home_state']
         SELECT
-          subq_4.ds_partitioned
-          , subq_4.user
-          , subq_4.home_state
+          subq_3.ds_partitioned
+          , subq_3.user
+          , subq_3.home_state
         FROM (
           -- Read Elements From Data Source 'users_ds_source'
           SELECT
@@ -169,16 +139,16 @@ FROM (
             , users_ds_source_src_10007.home_state AS user__home_state
             , users_ds_source_src_10007.user_id AS user
           FROM ***************************.dim_users users_ds_source_src_10007
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user = subq_5.user
+          subq_2.user = subq_4.user
         ) AND (
-          subq_3.ds_partitioned = subq_5.ds_partitioned
+          subq_2.ds_partitioned = subq_4.ds_partitioned
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user__home_state
-) subq_8
+    subq_6.user__home_state
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -5,10 +5,9 @@
 -- Compute Metrics via Expressions
 SELECT
   users_ds_source_src_10007.home_state AS user__home_state
-  , SUM(subq_12.identity_verifications) AS identity_verifications
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['identity_verifications', 'user', 'ds_partitioned']
@@ -17,14 +16,14 @@ FROM (
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.dim_users users_ds_source_src_10007
 ON
   (
-    subq_12.user = users_ds_source_src_10007.user_id
+    subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_12.ds_partitioned = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned = users_ds_source_src_10007.ds_partitioned
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node__plan0.sql
@@ -1,13 +1,37 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.total_account_balance_first_day AS total_account_balance_first_day
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.total_account_balance_first_day
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -19,41 +43,13 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MIN(ds)
-  SELECT
-    MIN(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['total_account_balance_first_day', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.total_account_balance_first_day
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
 ) subq_2
 ON
-  subq_1.ds = subq_2.ds
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node__plan0_optimized.sql
@@ -1,30 +1,42 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.total_account_balance_first_day AS total_account_balance_first_day
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   SELECT
-    ds
+    account_balance
     , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds
+    MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
 ) subq_5
 ON
-  subq_4.ds = subq_5.ds
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -1,15 +1,38 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.user AS user
-  , subq_1.current_account_balance_by_user AS current_account_balance_by_user
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.user
-    , subq_0.current_account_balance_by_user
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MAX(ds)
+  SELECT
+    subq_1.user
+    , MAX(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -21,45 +44,15 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MAX(ds)
-  SELECT
-    subq_2.user
-    , MAX(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['current_account_balance_by_user', 'user', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.user
-      , subq_0.current_account_balance_by_user
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
   GROUP BY
-    subq_2.user
+    subq_1.user
 ) subq_2
 ON
-  (subq_1.ds = subq_2.ds) AND (subq_1.user = subq_2.user)
+  (subq_0.ds = subq_2.ds__complete) AND (subq_0.user = subq_2.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -1,29 +1,39 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.user AS user
-  , subq_4.current_account_balance_by_user AS current_account_balance_by_user
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   SELECT
-    ds
-    , user_id AS user
+    account_balance
+    , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   -- Filter row on MAX(ds)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds
+    , MAX(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
@@ -32,4 +42,4 @@ INNER JOIN (
     user_id
 ) subq_5
 ON
-  (subq_4.ds = subq_5.ds) AND (subq_4.user = subq_5.user)
+  (subq_3.ds = subq_5.ds__complete) AND (subq_3.user = subq_5.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -1,0 +1,57 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
+  FROM (
+    -- Read Elements From Data Source 'accounts_source'
+    SELECT
+      accounts_source_src_10000.account_balance
+      , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+      , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+      , accounts_source_src_10000.ds
+      , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
+      , accounts_source_src_10000.user_id AS user
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_accounts
+    ) accounts_source_src_10000
+  ) subq_1
+  GROUP BY
+    subq_1.ds__week
+) subq_2
+ON
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    account_balance
+    , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_3
+INNER JOIN (
+  -- Read Elements From Data Source 'accounts_source'
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(ds) AS ds__complete
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5
+ON
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0.sql
@@ -1,95 +1,73 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.user_team___team_id
-  , subq_4.user_team___user_id
-  , subq_4.messages
+  subq_3.user_team___team_id
+  , subq_3.user_team___user_id
+  , subq_3.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-    , SUM(subq_3.messages) AS messages
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+    , SUM(subq_2.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team']
     SELECT
-      subq_2.user_team___team_id
-      , subq_2.user_team___user_id
-      , subq_2.messages
+      subq_1.user_team___team_id
+      , subq_1.user_team___user_id
+      , subq_1.messages
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.user_id__ds
-        , subq_1.user_id__ds__week
-        , subq_1.user_id__ds__month
-        , subq_1.user_id__ds__quarter
-        , subq_1.user_id__ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user_id
-        , subq_1.user_team___team_id
-        , subq_1.user_team___user_id
-        , subq_1.user_id__user_team___team_id
-        , subq_1.user_id__user_team___user_id
-        , subq_1.team_id
-        , subq_1.user_id__team_id
-        , subq_1.messages
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.user_id__ds
+        , subq_0.user_id__ds__week
+        , subq_0.user_id__ds__month
+        , subq_0.user_id__ds__quarter
+        , subq_0.user_id__ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user_id
+        , subq_0.user_team___team_id
+        , subq_0.user_team___user_id
+        , subq_0.user_id__user_team___team_id
+        , subq_0.user_id__user_team___user_id
+        , subq_0.team_id
+        , subq_0.user_id__team_id
+        , subq_0.messages
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'messages_source'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user_id__ds
-          , subq_0.user_id__ds__week
-          , subq_0.user_id__ds__month
-          , subq_0.user_id__ds__quarter
-          , subq_0.user_id__ds__year
-          , subq_0.user_id
-          , subq_0.user_team___team_id
-          , subq_0.user_team___user_id
-          , subq_0.user_id__user_team___team_id
-          , subq_0.user_id__user_team___user_id
-          , subq_0.team_id
-          , subq_0.user_id__team_id
-          , subq_0.messages
-        FROM (
-          -- Read Elements From Data Source 'messages_source'
-          SELECT
-            1 AS messages
-            , messages_source_src_10015.ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-            , messages_source_src_10015.team_id
-            , messages_source_src_10015.ds AS user_id__ds
-            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-            , messages_source_src_10015.team_id AS user_id__team_id
-            , messages_source_src_10015.user_id
-            , messages_source_src_10015.team_id AS user_team___team_id
-            , messages_source_src_10015.user_id AS user_team___user_id
-            , messages_source_src_10015.team_id AS user_id__user_team___team_id
-            , messages_source_src_10015.user_id AS user_id__user_team___user_id
-          FROM ***************************.fct_messages messages_source_src_10015
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS messages
+          , messages_source_src_10015.ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+          , messages_source_src_10015.team_id
+          , messages_source_src_10015.ds AS user_id__ds
+          , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+          , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+          , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+          , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+          , messages_source_src_10015.team_id AS user_id__team_id
+          , messages_source_src_10015.user_id
+          , messages_source_src_10015.team_id AS user_team___team_id
+          , messages_source_src_10015.user_id AS user_team___user_id
+          , messages_source_src_10015.team_id AS user_id__user_team___team_id
+          , messages_source_src_10015.user_id AS user_id__user_team___user_id
+        FROM ***************************.fct_messages messages_source_src_10015
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.user_team___team_id
-    , subq_3.user_team___user_id
-) subq_4
+    subq_2.user_team___team_id
+    , subq_2.user_team___user_id
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -15,7 +14,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_8
+) subq_6
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0.sql
@@ -1,118 +1,96 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user_team___team_id
-  , subq_8.user_team___user_id
-  , subq_8.user_team__country
-  , subq_8.messages
+  subq_7.user_team___team_id
+  , subq_7.user_team___user_id
+  , subq_7.user_team__country
+  , subq_7.messages
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-    , SUM(subq_7.messages) AS messages
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+    , SUM(subq_6.messages) AS messages
   FROM (
     -- Pass Only Elements:
     --   ['messages', 'user_team__country', 'user_team']
     SELECT
-      subq_6.user_team___team_id
-      , subq_6.user_team___user_id
-      , subq_6.user_team__country
-      , subq_6.messages
+      subq_5.user_team___team_id
+      , subq_5.user_team___user_id
+      , subq_5.user_team__country
+      , subq_5.messages
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.user_team___team_id AS user_team___team_id
-        , subq_3.user_team___user_id AS user_team___user_id
-        , subq_5.country AS user_team__country
-        , subq_3.messages AS messages
+        subq_2.user_team___team_id AS user_team___team_id
+        , subq_2.user_team___user_id AS user_team___user_id
+        , subq_4.country AS user_team__country
+        , subq_2.messages AS messages
       FROM (
         -- Pass Only Elements:
         --   ['messages', 'user_team', 'user_team']
         SELECT
-          subq_2.user_team___team_id
-          , subq_2.user_team___user_id
-          , subq_2.messages
+          subq_1.user_team___team_id
+          , subq_1.user_team___user_id
+          , subq_1.messages
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.user_id__ds
-            , subq_1.user_id__ds__week
-            , subq_1.user_id__ds__month
-            , subq_1.user_id__ds__quarter
-            , subq_1.user_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.user_id
-            , subq_1.user_team___team_id
-            , subq_1.user_team___user_id
-            , subq_1.user_id__user_team___team_id
-            , subq_1.user_id__user_team___user_id
-            , subq_1.team_id
-            , subq_1.user_id__team_id
-            , subq_1.messages
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.user_id__ds
+            , subq_0.user_id__ds__week
+            , subq_0.user_id__ds__month
+            , subq_0.user_id__ds__quarter
+            , subq_0.user_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.user_id
+            , subq_0.user_team___team_id
+            , subq_0.user_team___user_id
+            , subq_0.user_id__user_team___team_id
+            , subq_0.user_id__user_team___user_id
+            , subq_0.team_id
+            , subq_0.user_id__team_id
+            , subq_0.messages
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'messages_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.user_id__ds
-              , subq_0.user_id__ds__week
-              , subq_0.user_id__ds__month
-              , subq_0.user_id__ds__quarter
-              , subq_0.user_id__ds__year
-              , subq_0.user_id
-              , subq_0.user_team___team_id
-              , subq_0.user_team___user_id
-              , subq_0.user_id__user_team___team_id
-              , subq_0.user_id__user_team___user_id
-              , subq_0.team_id
-              , subq_0.user_id__team_id
-              , subq_0.messages
-            FROM (
-              -- Read Elements From Data Source 'messages_source'
-              SELECT
-                1 AS messages
-                , messages_source_src_10015.ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-                , messages_source_src_10015.team_id
-                , messages_source_src_10015.ds AS user_id__ds
-                , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-                , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-                , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-                , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-                , messages_source_src_10015.team_id AS user_id__team_id
-                , messages_source_src_10015.user_id
-                , messages_source_src_10015.team_id AS user_team___team_id
-                , messages_source_src_10015.user_id AS user_team___user_id
-                , messages_source_src_10015.team_id AS user_id__user_team___team_id
-                , messages_source_src_10015.user_id AS user_id__user_team___user_id
-              FROM ***************************.fct_messages messages_source_src_10015
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS messages
+              , messages_source_src_10015.ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+              , messages_source_src_10015.team_id
+              , messages_source_src_10015.ds AS user_id__ds
+              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+              , messages_source_src_10015.team_id AS user_id__team_id
+              , messages_source_src_10015.user_id
+              , messages_source_src_10015.team_id AS user_team___team_id
+              , messages_source_src_10015.user_id AS user_team___user_id
+              , messages_source_src_10015.team_id AS user_id__user_team___team_id
+              , messages_source_src_10015.user_id AS user_id__user_team___user_id
+            FROM ***************************.fct_messages messages_source_src_10015
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user_team', 'country']
         SELECT
-          subq_4.user_team___team_id
-          , subq_4.user_team___user_id
-          , subq_4.country
+          subq_3.user_team___team_id
+          , subq_3.user_team___user_id
+          , subq_3.country
         FROM (
           -- Read Elements From Data Source 'users_source'
           SELECT
@@ -160,18 +138,18 @@ FROM (
             , users_source_src_10017.ident_2 AS user_team__user_composite_ident_2___ident_2
             , users_source_src_10017.id AS user_team__user_composite_ident_2___user_id
           FROM ***************************.fct_users users_source_src_10017
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user_team___team_id = subq_5.user_team___team_id
+          subq_2.user_team___team_id = subq_4.user_team___team_id
         ) AND (
-          subq_3.user_team___user_id = subq_5.user_team___user_id
+          subq_2.user_team___user_id = subq_4.user_team___user_id
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user_team___team_id
-    , subq_7.user_team___user_id
-    , subq_7.user_team__country
-) subq_8
+    subq_6.user_team___team_id
+    , subq_6.user_team___user_id
+    , subq_6.user_team__country
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_join__plan0_optimized.sql
@@ -4,13 +4,12 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.user_team___team_id AS user_team___team_id
-  , subq_12.user_team___user_id AS user_team___user_id
+  subq_10.user_team___team_id AS user_team___team_id
+  , subq_10.user_team___user_id AS user_team___user_id
   , users_source_src_10017.country AS user_team__country
-  , SUM(subq_12.messages) AS messages
+  , SUM(subq_10.messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team', 'user_team']
@@ -19,16 +18,16 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.fct_users users_source_src_10017
 ON
   (
-    subq_12.user_team___team_id = users_source_src_10017.team_id
+    subq_10.user_team___team_id = users_source_src_10017.team_id
   ) AND (
-    subq_12.user_team___user_id = users_source_src_10017.id
+    subq_10.user_team___user_id = users_source_src_10017.id
   )
 GROUP BY
-  subq_12.user_team___team_id
-  , subq_12.user_team___user_id
+  subq_10.user_team___team_id
+  , subq_10.user_team___user_id
   , users_source_src_10017.country

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -1,103 +1,81 @@
 -- Order By ['user_team']
 SELECT
-  subq_5.user_team___team_id
-  , subq_5.user_team___user_id
-  , subq_5.messages
+  subq_4.user_team___team_id
+  , subq_4.user_team___user_id
+  , subq_4.messages
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.user_team___team_id
-    , subq_4.user_team___user_id
-    , subq_4.messages
+    subq_3.user_team___team_id
+    , subq_3.user_team___user_id
+    , subq_3.messages
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-      , SUM(subq_3.messages) AS messages
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+      , SUM(subq_2.messages) AS messages
     FROM (
       -- Pass Only Elements:
       --   ['messages', 'user_team']
       SELECT
-        subq_2.user_team___team_id
-        , subq_2.user_team___user_id
-        , subq_2.messages
+        subq_1.user_team___team_id
+        , subq_1.user_team___user_id
+        , subq_1.messages
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.user_id__ds
-          , subq_1.user_id__ds__week
-          , subq_1.user_id__ds__month
-          , subq_1.user_id__ds__quarter
-          , subq_1.user_id__ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user_id
-          , subq_1.user_team___team_id
-          , subq_1.user_team___user_id
-          , subq_1.user_id__user_team___team_id
-          , subq_1.user_id__user_team___user_id
-          , subq_1.team_id
-          , subq_1.user_id__team_id
-          , subq_1.messages
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.user_id__ds
+          , subq_0.user_id__ds__week
+          , subq_0.user_id__ds__month
+          , subq_0.user_id__ds__quarter
+          , subq_0.user_id__ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user_id
+          , subq_0.user_team___team_id
+          , subq_0.user_team___user_id
+          , subq_0.user_id__user_team___team_id
+          , subq_0.user_id__user_team___user_id
+          , subq_0.team_id
+          , subq_0.user_id__team_id
+          , subq_0.messages
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'messages_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user_id__ds
-            , subq_0.user_id__ds__week
-            , subq_0.user_id__ds__month
-            , subq_0.user_id__ds__quarter
-            , subq_0.user_id__ds__year
-            , subq_0.user_id
-            , subq_0.user_team___team_id
-            , subq_0.user_team___user_id
-            , subq_0.user_id__user_team___team_id
-            , subq_0.user_id__user_team___user_id
-            , subq_0.team_id
-            , subq_0.user_id__team_id
-            , subq_0.messages
-          FROM (
-            -- Read Elements From Data Source 'messages_source'
-            SELECT
-              1 AS messages
-              , messages_source_src_10015.ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
-              , messages_source_src_10015.team_id
-              , messages_source_src_10015.ds AS user_id__ds
-              , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
-              , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
-              , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
-              , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
-              , messages_source_src_10015.team_id AS user_id__team_id
-              , messages_source_src_10015.user_id
-              , messages_source_src_10015.team_id AS user_team___team_id
-              , messages_source_src_10015.user_id AS user_team___user_id
-              , messages_source_src_10015.team_id AS user_id__user_team___team_id
-              , messages_source_src_10015.user_id AS user_id__user_team___user_id
-            FROM ***************************.fct_messages messages_source_src_10015
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            1 AS messages
+            , messages_source_src_10015.ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS ds__year
+            , messages_source_src_10015.team_id
+            , messages_source_src_10015.ds AS user_id__ds
+            , DATE_TRUNC('week', messages_source_src_10015.ds) AS user_id__ds__week
+            , DATE_TRUNC('month', messages_source_src_10015.ds) AS user_id__ds__month
+            , DATE_TRUNC('quarter', messages_source_src_10015.ds) AS user_id__ds__quarter
+            , DATE_TRUNC('year', messages_source_src_10015.ds) AS user_id__ds__year
+            , messages_source_src_10015.team_id AS user_id__team_id
+            , messages_source_src_10015.user_id
+            , messages_source_src_10015.team_id AS user_team___team_id
+            , messages_source_src_10015.user_id AS user_team___user_id
+            , messages_source_src_10015.team_id AS user_id__user_team___team_id
+            , messages_source_src_10015.user_id AS user_id__user_team___user_id
+          FROM ***************************.fct_messages messages_source_src_10015
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.user_team___team_id
-      , subq_3.user_team___user_id
-  ) subq_4
-) subq_5
-ORDER BY subq_5.user_team___team_id DESC, subq_5.user_team___user_id DESC
+      subq_2.user_team___team_id
+      , subq_2.user_team___user_id
+  ) subq_3
+) subq_4
+ORDER BY subq_4.user_team___team_id DESC, subq_4.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_composite_identifier_with_order_by__plan0_optimized.sql
@@ -7,7 +7,6 @@ SELECT
   , SUM(messages) AS messages
 FROM (
   -- Read Elements From Data Source 'messages_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['messages', 'user_team']
@@ -16,7 +15,7 @@ FROM (
     , user_id AS user_team___user_id
     , 1 AS messages
   FROM ***************************.fct_messages messages_source_src_10015
-) subq_9
+) subq_7
 GROUP BY
   user_team___team_id
   , user_team___user_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -1,367 +1,357 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_23.ds
-  , subq_23.listing__country_latest
-  , CAST(subq_23.bookings AS DOUBLE) / CAST(NULLIF(subq_23.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_19.ds
+  , subq_19.listing__country_latest
+  , CAST(subq_19.bookings AS DOUBLE) / CAST(NULLIF(subq_19.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest', 'ds', 'bookings', 'views']
   SELECT
-    subq_22.ds
-    , subq_22.listing__country_latest
-    , subq_22.bookings
-    , subq_22.views
+    subq_18.ds
+    , subq_18.listing__country_latest
+    , subq_18.bookings
+    , subq_18.views
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_10.ds AS ds
-      , subq_10.listing__country_latest AS listing__country_latest
-      , subq_10.bookings AS bookings
-      , subq_21.views AS views
+      subq_8.ds AS ds
+      , subq_8.listing__country_latest AS listing__country_latest
+      , subq_8.bookings AS bookings
+      , subq_17.views AS views
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.ds
-        , subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.ds
+        , subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest', 'ds']
         SELECT
-          subq_8.ds
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.ds
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.ds AS ds
-            , subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.ds AS ds
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'ds', 'listing']
             SELECT
-              subq_2.ds
-              , subq_2.listing
-              , subq_2.bookings
+              subq_1.ds
+              , subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.ds
-        , subq_9.listing__country_latest
-    ) subq_10
+        subq_7.ds
+        , subq_7.listing__country_latest
+    ) subq_8
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_20.ds
-        , subq_20.listing__country_latest
-        , SUM(subq_20.views) AS views
+        subq_16.ds
+        , subq_16.listing__country_latest
+        , SUM(subq_16.views) AS views
       FROM (
         -- Pass Only Elements:
         --   ['views', 'listing__country_latest', 'ds']
         SELECT
-          subq_19.ds
-          , subq_19.listing__country_latest
-          , subq_19.views
+          subq_15.ds
+          , subq_15.listing__country_latest
+          , subq_15.views
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_14.ds AS ds
-            , subq_14.listing AS listing
-            , subq_18.country_latest AS listing__country_latest
-            , subq_14.views AS views
+            subq_11.ds AS ds
+            , subq_11.listing AS listing
+            , subq_14.country_latest AS listing__country_latest
+            , subq_11.views AS views
           FROM (
             -- Pass Only Elements:
             --   ['views', 'ds', 'listing']
             SELECT
-              subq_13.ds
-              , subq_13.listing
-              , subq_13.views
+              subq_10.ds
+              , subq_10.listing
+              , subq_10.views
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_9.ds
+                , subq_9.ds__week
+                , subq_9.ds__month
+                , subq_9.ds__quarter
+                , subq_9.ds__year
+                , subq_9.ds_partitioned
+                , subq_9.ds_partitioned__week
+                , subq_9.ds_partitioned__month
+                , subq_9.ds_partitioned__quarter
+                , subq_9.ds_partitioned__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds
+                , subq_9.create_a_cycle_in_the_join_graph__ds__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds__year
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_9.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_9.ds AS metric_time
+                , subq_9.ds__week AS metric_time__week
+                , subq_9.ds__month AS metric_time__month
+                , subq_9.ds__quarter AS metric_time__quarter
+                , subq_9.ds__year AS metric_time__year
+                , subq_9.listing
+                , subq_9.user
+                , subq_9.create_a_cycle_in_the_join_graph
+                , subq_9.create_a_cycle_in_the_join_graph__listing
+                , subq_9.create_a_cycle_in_the_join_graph__user
+                , subq_9.views
+              FROM (
+                -- Read Elements From Data Source 'views_source'
+                SELECT
+                  1 AS views
+                  , views_source_src_10009.ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
+                  , views_source_src_10009.ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
+                  , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , views_source_src_10009.listing_id AS listing
+                  , views_source_src_10009.user_id AS user
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
+                  , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
+                FROM (
+                  -- User Defined SQL Query
+                  SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
+                ) views_source_src_10009
+              ) subq_9
+            ) subq_10
+          ) subq_11
+          LEFT OUTER JOIN (
+            -- Pass Only Elements:
+            --   ['listing', 'country_latest']
+            SELECT
+              subq_13.listing
+              , subq_13.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
@@ -370,21 +360,21 @@ FROM (
                 , subq_12.ds__month
                 , subq_12.ds__quarter
                 , subq_12.ds__year
-                , subq_12.ds_partitioned
-                , subq_12.ds_partitioned__week
-                , subq_12.ds_partitioned__month
-                , subq_12.ds_partitioned__quarter
-                , subq_12.ds_partitioned__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds
-                , subq_12.create_a_cycle_in_the_join_graph__ds__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds__year
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_12.created_at
+                , subq_12.created_at__week
+                , subq_12.created_at__month
+                , subq_12.created_at__quarter
+                , subq_12.created_at__year
+                , subq_12.listing__ds
+                , subq_12.listing__ds__week
+                , subq_12.listing__ds__month
+                , subq_12.listing__ds__quarter
+                , subq_12.listing__ds__year
+                , subq_12.listing__created_at
+                , subq_12.listing__created_at__week
+                , subq_12.listing__created_at__month
+                , subq_12.listing__created_at__quarter
+                , subq_12.listing__created_at__year
                 , subq_12.ds AS metric_time
                 , subq_12.ds__week AS metric_time__week
                 , subq_12.ds__month AS metric_time__month
@@ -392,222 +382,80 @@ FROM (
                 , subq_12.ds__year AS metric_time__year
                 , subq_12.listing
                 , subq_12.user
-                , subq_12.create_a_cycle_in_the_join_graph
-                , subq_12.create_a_cycle_in_the_join_graph__listing
-                , subq_12.create_a_cycle_in_the_join_graph__user
-                , subq_12.views
+                , subq_12.listing__user
+                , subq_12.country_latest
+                , subq_12.is_lux_latest
+                , subq_12.capacity_latest
+                , subq_12.listing__country_latest
+                , subq_12.listing__is_lux_latest
+                , subq_12.listing__capacity_latest
+                , subq_12.listings
+                , subq_12.largest_listing
+                , subq_12.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_11.ds
-                  , subq_11.ds__week
-                  , subq_11.ds__month
-                  , subq_11.ds__quarter
-                  , subq_11.ds__year
-                  , subq_11.ds_partitioned
-                  , subq_11.ds_partitioned__week
-                  , subq_11.ds_partitioned__month
-                  , subq_11.ds_partitioned__quarter
-                  , subq_11.ds_partitioned__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_11.listing
-                  , subq_11.user
-                  , subq_11.create_a_cycle_in_the_join_graph
-                  , subq_11.create_a_cycle_in_the_join_graph__listing
-                  , subq_11.create_a_cycle_in_the_join_graph__user
-                  , subq_11.views
-                FROM (
-                  -- Read Elements From Data Source 'views_source'
-                  SELECT
-                    1 AS views
-                    , views_source_src_10009.ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS ds__year
-                    , views_source_src_10009.ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS ds_partitioned__year
-                    , views_source_src_10009.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , views_source_src_10009.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', views_source_src_10009.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , views_source_src_10009.listing_id AS listing
-                    , views_source_src_10009.user_id AS user
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph
-                    , views_source_src_10009.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , views_source_src_10009.user_id AS create_a_cycle_in_the_join_graph__user
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
-                  ) views_source_src_10009
-                ) subq_11
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
               ) subq_12
             ) subq_13
           ) subq_14
-          LEFT OUTER JOIN (
-            -- Pass Only Elements:
-            --   ['listing', 'country_latest']
-            SELECT
-              subq_17.listing
-              , subq_17.country_latest
-            FROM (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_16.ds
-                , subq_16.ds__week
-                , subq_16.ds__month
-                , subq_16.ds__quarter
-                , subq_16.ds__year
-                , subq_16.created_at
-                , subq_16.created_at__week
-                , subq_16.created_at__month
-                , subq_16.created_at__quarter
-                , subq_16.created_at__year
-                , subq_16.listing__ds
-                , subq_16.listing__ds__week
-                , subq_16.listing__ds__month
-                , subq_16.listing__ds__quarter
-                , subq_16.listing__ds__year
-                , subq_16.listing__created_at
-                , subq_16.listing__created_at__week
-                , subq_16.listing__created_at__month
-                , subq_16.listing__created_at__quarter
-                , subq_16.listing__created_at__year
-                , subq_16.ds AS metric_time
-                , subq_16.ds__week AS metric_time__week
-                , subq_16.ds__month AS metric_time__month
-                , subq_16.ds__quarter AS metric_time__quarter
-                , subq_16.ds__year AS metric_time__year
-                , subq_16.listing
-                , subq_16.user
-                , subq_16.listing__user
-                , subq_16.country_latest
-                , subq_16.is_lux_latest
-                , subq_16.capacity_latest
-                , subq_16.listing__country_latest
-                , subq_16.listing__is_lux_latest
-                , subq_16.listing__capacity_latest
-                , subq_16.listings
-                , subq_16.largest_listing
-                , subq_16.smallest_listing
-              FROM (
-                -- Pass Only Additive Measures
-                SELECT
-                  subq_15.ds
-                  , subq_15.ds__week
-                  , subq_15.ds__month
-                  , subq_15.ds__quarter
-                  , subq_15.ds__year
-                  , subq_15.created_at
-                  , subq_15.created_at__week
-                  , subq_15.created_at__month
-                  , subq_15.created_at__quarter
-                  , subq_15.created_at__year
-                  , subq_15.listing__ds
-                  , subq_15.listing__ds__week
-                  , subq_15.listing__ds__month
-                  , subq_15.listing__ds__quarter
-                  , subq_15.listing__ds__year
-                  , subq_15.listing__created_at
-                  , subq_15.listing__created_at__week
-                  , subq_15.listing__created_at__month
-                  , subq_15.listing__created_at__quarter
-                  , subq_15.listing__created_at__year
-                  , subq_15.listing
-                  , subq_15.user
-                  , subq_15.listing__user
-                  , subq_15.country_latest
-                  , subq_15.is_lux_latest
-                  , subq_15.capacity_latest
-                  , subq_15.listing__country_latest
-                  , subq_15.listing__is_lux_latest
-                  , subq_15.listing__capacity_latest
-                  , subq_15.listings
-                  , subq_15.largest_listing
-                  , subq_15.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_15
-              ) subq_16
-            ) subq_17
-          ) subq_18
           ON
-            subq_14.listing = subq_18.listing
-        ) subq_19
-      ) subq_20
+            subq_11.listing = subq_14.listing
+        ) subq_15
+      ) subq_16
       GROUP BY
-        subq_20.ds
-        , subq_20.listing__country_latest
-    ) subq_21
+        subq_16.ds
+        , subq_16.listing__country_latest
+    ) subq_17
     ON
       (
         (
-          subq_10.listing__country_latest = subq_21.listing__country_latest
+          subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
-            subq_10.listing__country_latest IS NULL
+            subq_8.listing__country_latest IS NULL
           ) AND (
-            subq_21.listing__country_latest IS NULL
+            subq_17.listing__country_latest IS NULL
           )
         )
       ) AND (
         (
-          subq_10.ds = subq_21.ds
+          subq_8.ds = subq_17.ds
         ) OR (
-          (subq_10.ds IS NULL) AND (subq_21.ds IS NULL)
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
-  ) subq_22
-) subq_23
+  ) subq_18
+) subq_19

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -3,21 +3,20 @@
 --   ['listing__country_latest', 'ds', 'bookings', 'views']
 -- Compute Metrics via Expressions
 SELECT
-  subq_34.ds AS ds
-  , subq_34.listing__country_latest AS listing__country_latest
-  , CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_45.views, 0) AS DOUBLE) AS bookings_per_view
+  subq_28.ds AS ds
+  , subq_28.listing__country_latest AS listing__country_latest
+  , CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_37.views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['bookings', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_27.ds AS ds
+    subq_22.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_27.bookings) AS bookings
+    , SUM(subq_22.bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds', 'listing']
@@ -29,27 +28,26 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_27
+  ) subq_22
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_27.listing = listings_latest_src_10004.listing_id
+    subq_22.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_27.ds
+    subq_22.ds
     , listings_latest_src_10004.country
-) subq_34
+) subq_28
 INNER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements:
   --   ['views', 'listing__country_latest', 'ds']
   -- Aggregate Measures
   SELECT
-    subq_38.ds AS ds
+    subq_31.ds AS ds
     , listings_latest_src_10004.country AS listing__country_latest
-    , SUM(subq_38.views) AS views
+    , SUM(subq_31.views) AS views
   FROM (
     -- Read Elements From Data Source 'views_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['views', 'ds', 'listing']
@@ -61,30 +59,30 @@ INNER JOIN (
       -- User Defined SQL Query
       SELECT user_id, listing_id, ds, ds_partitioned FROM ***************************.fct_views
     ) views_source_src_10009
-  ) subq_38
+  ) subq_31
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_38.listing = listings_latest_src_10004.listing_id
+    subq_31.listing = listings_latest_src_10004.listing_id
   GROUP BY
-    subq_38.ds
+    subq_31.ds
     , listings_latest_src_10004.country
-) subq_45
+) subq_37
 ON
   (
     (
-      subq_34.listing__country_latest = subq_45.listing__country_latest
+      subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
-        subq_34.listing__country_latest IS NULL
+        subq_28.listing__country_latest IS NULL
       ) AND (
-        subq_45.listing__country_latest IS NULL
+        subq_37.listing__country_latest IS NULL
       )
     )
   ) AND (
     (
-      subq_34.ds = subq_45.ds
+      subq_28.ds = subq_37.ds
     ) OR (
-      (subq_34.ds IS NULL) AND (subq_45.ds IS NULL)
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.ds__month
+  , subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_mtd
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_mtd
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_grain_to_date__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_ds__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_ds__plan0.sql
@@ -1,56 +1,45 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.txn_revenue AS trailing_2_months_revenue
+  subq_4.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    SUM(subq_4.txn_revenue) AS txn_revenue
+    SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue']
     SELECT
-      subq_2.txn_revenue
+      subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
-) subq_5
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -1,61 +1,50 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_5.ds__month
-  , subq_5.txn_revenue AS revenue_all_time
+  subq_4.ds__month
+  , subq_4.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_4.ds__month
-    , SUM(subq_4.txn_revenue) AS txn_revenue
+    subq_3.ds__month
+    , SUM(subq_3.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_1.ds__month
+      , subq_1.txn_revenue
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.user
-        , subq_1.txn_revenue
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.user
+        , subq_0.txn_revenue
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'revenue'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.user
-          , subq_0.txn_revenue
+          revenue_src_10006.revenue AS txn_revenue
+          , revenue_src_10006.created_at AS ds
+          , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+          , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+          , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+          , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+          , revenue_src_10006.user_id AS user
         FROM (
-          -- Read Elements From Data Source 'revenue'
-          SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , revenue_src_10006.created_at AS ds
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , revenue_src_10006.user_id AS user
-          FROM (
-            -- User Defined SQL Query
-            SELECT * FROM ***************************.fct_revenue
-          ) revenue_src_10006
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_4
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_revenue
+        ) revenue_src_10006
+      ) subq_0
+    ) subq_1
+  ) subq_3
   GROUP BY
-    subq_4.ds__month
-) subq_5
+    subq_3.ds__month
+) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements:
 --   ['txn_revenue', 'ds__month']

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS revenue_all_time
+  subq_5.ds__month
+  , subq_5.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2000-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,78 +1,67 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.ds__month
-  , subq_6.txn_revenue AS trailing_2_months_revenue
+  subq_5.ds__month
+  , subq_5.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.ds__month
-    , SUM(subq_5.txn_revenue) AS txn_revenue
+    subq_4.ds__month
+    , SUM(subq_4.txn_revenue) AS txn_revenue
   FROM (
     -- Pass Only Elements:
     --   ['txn_revenue', 'ds__month']
     SELECT
-      subq_3.ds__month
-      , subq_3.txn_revenue
+      subq_2.ds__month
+      , subq_2.txn_revenue
     FROM (
       -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
       SELECT
-        subq_2.ds
-        , subq_2.ds__week
-        , subq_2.ds__month
-        , subq_2.ds__quarter
-        , subq_2.ds__year
-        , subq_2.metric_time
-        , subq_2.metric_time__week
-        , subq_2.metric_time__month
-        , subq_2.metric_time__quarter
-        , subq_2.metric_time__year
-        , subq_2.user
-        , subq_2.txn_revenue
+        subq_1.ds
+        , subq_1.ds__week
+        , subq_1.ds__month
+        , subq_1.ds__quarter
+        , subq_1.ds__year
+        , subq_1.metric_time
+        , subq_1.metric_time__week
+        , subq_1.metric_time__month
+        , subq_1.metric_time__quarter
+        , subq_1.metric_time__year
+        , subq_1.user
+        , subq_1.txn_revenue
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.user
-          , subq_1.txn_revenue
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.user
+          , subq_0.txn_revenue
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'revenue'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.user
-            , subq_0.txn_revenue
+            revenue_src_10006.revenue AS txn_revenue
+            , revenue_src_10006.created_at AS ds
+            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+            , revenue_src_10006.user_id AS user
           FROM (
-            -- Read Elements From Data Source 'revenue'
-            SELECT
-              revenue_src_10006.revenue AS txn_revenue
-              , revenue_src_10006.created_at AS ds
-              , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-              , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-              , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-              , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-              , revenue_src_10006.user_id AS user
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_revenue
-            ) revenue_src_10006
-          ) subq_0
-        ) subq_1
-      ) subq_2
-      WHERE subq_2.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-    ) subq_3
-  ) subq_5
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_revenue
+          ) revenue_src_10006
+        ) subq_0
+      ) subq_1
+      WHERE subq_1.metric_time BETWEEN CAST('2019-12-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+    ) subq_2
+  ) subq_4
   GROUP BY
-    subq_5.ds__month
-) subq_6
+    subq_4.ds__month
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,5 +1,4 @@
 -- Read Elements From Data Source 'revenue'
--- Pass Only Additive Measures
 -- Metric Time Dimension 'ds'
 -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
 -- Pass Only Elements:

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_distinct_values__plan0.sql
@@ -1,329 +1,243 @@
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
-  subq_12.listing__country_latest
+  subq_10.listing__country_latest
 FROM (
   -- Pass Only Elements:
   --   ['listing__country_latest']
   SELECT
-    subq_11.listing__country_latest
+    subq_9.listing__country_latest
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_10.listing__country_latest
-      , subq_10.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_9.listing__country_latest
-        , SUM(subq_9.bookings) AS bookings
+        subq_7.listing__country_latest
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'listing__country_latest']
         SELECT
-          subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_9.listing__country_latest
-    ) subq_10
-  ) subq_11
-) subq_12
-ORDER BY subq_12.listing__country_latest
+        subq_7.listing__country_latest
+    ) subq_8
+  ) subq_9
+) subq_10
+ORDER BY subq_10.listing__country_latest
 LIMIT 100

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -1,334 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.is_instant
-  , subq_12.bookings
+  subq_10.is_instant
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_11.is_instant
-    , SUM(subq_11.bookings) AS bookings
+    subq_9.is_instant
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'is_instant']
     SELECT
-      subq_10.is_instant
-      , subq_10.bookings
+      subq_8.is_instant
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_9.is_instant
-        , subq_9.listing__country_latest
-        , subq_9.bookings
+        subq_7.is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'listing__country_latest']
         SELECT
-          subq_8.is_instant
-          , subq_8.listing__country_latest
-          , subq_8.bookings
+          subq_6.is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.is_instant AS is_instant
-            , subq_7.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.is_instant AS is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.is_instant
-              , subq_2.bookings
+              subq_1.listing
+              , subq_1.is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['listing', 'country_latest']
             SELECT
-              subq_6.listing
-              , subq_6.country_latest
+              subq_4.listing
+              , subq_4.country_latest
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_5.ds
-                , subq_5.ds__week
-                , subq_5.ds__month
-                , subq_5.ds__quarter
-                , subq_5.ds__year
-                , subq_5.created_at
-                , subq_5.created_at__week
-                , subq_5.created_at__month
-                , subq_5.created_at__quarter
-                , subq_5.created_at__year
-                , subq_5.listing__ds
-                , subq_5.listing__ds__week
-                , subq_5.listing__ds__month
-                , subq_5.listing__ds__quarter
-                , subq_5.listing__ds__year
-                , subq_5.listing__created_at
-                , subq_5.listing__created_at__week
-                , subq_5.listing__created_at__month
-                , subq_5.listing__created_at__quarter
-                , subq_5.listing__created_at__year
-                , subq_5.ds AS metric_time
-                , subq_5.ds__week AS metric_time__week
-                , subq_5.ds__month AS metric_time__month
-                , subq_5.ds__quarter AS metric_time__quarter
-                , subq_5.ds__year AS metric_time__year
-                , subq_5.listing
-                , subq_5.user
-                , subq_5.listing__user
-                , subq_5.country_latest
-                , subq_5.is_lux_latest
-                , subq_5.capacity_latest
-                , subq_5.listing__country_latest
-                , subq_5.listing__is_lux_latest
-                , subq_5.listing__capacity_latest
-                , subq_5.listings
-                , subq_5.largest_listing
-                , subq_5.smallest_listing
+                subq_3.ds
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.created_at
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.listing__ds
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__created_at
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.ds AS metric_time
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'listings_latest'
                 SELECT
-                  subq_4.ds
-                  , subq_4.ds__week
-                  , subq_4.ds__month
-                  , subq_4.ds__quarter
-                  , subq_4.ds__year
-                  , subq_4.created_at
-                  , subq_4.created_at__week
-                  , subq_4.created_at__month
-                  , subq_4.created_at__quarter
-                  , subq_4.created_at__year
-                  , subq_4.listing__ds
-                  , subq_4.listing__ds__week
-                  , subq_4.listing__ds__month
-                  , subq_4.listing__ds__quarter
-                  , subq_4.listing__ds__year
-                  , subq_4.listing__created_at
-                  , subq_4.listing__created_at__week
-                  , subq_4.listing__created_at__month
-                  , subq_4.listing__created_at__quarter
-                  , subq_4.listing__created_at__year
-                  , subq_4.listing
-                  , subq_4.user
-                  , subq_4.listing__user
-                  , subq_4.country_latest
-                  , subq_4.is_lux_latest
-                  , subq_4.capacity_latest
-                  , subq_4.listing__country_latest
-                  , subq_4.listing__is_lux_latest
-                  , subq_4.listing__capacity_latest
-                  , subq_4.listings
-                  , subq_4.largest_listing
-                  , subq_4.smallest_listing
-                FROM (
-                  -- Read Elements From Data Source 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_10004.capacity AS largest_listing
-                    , listings_latest_src_10004.capacity AS smallest_listing
-                    , listings_latest_src_10004.created_at AS ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                    , listings_latest_src_10004.created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                    , listings_latest_src_10004.country AS country_latest
-                    , listings_latest_src_10004.is_lux AS is_lux_latest
-                    , listings_latest_src_10004.capacity AS capacity_latest
-                    , listings_latest_src_10004.created_at AS listing__ds
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                    , listings_latest_src_10004.created_at AS listing__created_at
-                    , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                    , listings_latest_src_10004.country AS listing__country_latest
-                    , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_10004.capacity AS listing__capacity_latest
-                    , listings_latest_src_10004.listing_id AS listing
-                    , listings_latest_src_10004.user_id AS user
-                    , listings_latest_src_10004.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_10004
-                ) subq_4
-              ) subq_5
-            ) subq_6
-          ) subq_7
+                  1 AS listings
+                  , listings_latest_src_10004.capacity AS largest_listing
+                  , listings_latest_src_10004.capacity AS smallest_listing
+                  , listings_latest_src_10004.created_at AS ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                  , listings_latest_src_10004.created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                  , listings_latest_src_10004.country AS country_latest
+                  , listings_latest_src_10004.is_lux AS is_lux_latest
+                  , listings_latest_src_10004.capacity AS capacity_latest
+                  , listings_latest_src_10004.created_at AS listing__ds
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                  , listings_latest_src_10004.created_at AS listing__created_at
+                  , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                  , listings_latest_src_10004.country AS listing__country_latest
+                  , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_10004.capacity AS listing__capacity_latest
+                  , listings_latest_src_10004.listing_id AS listing
+                  , listings_latest_src_10004.user_id AS user
+                  , listings_latest_src_10004.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_10004
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_7.listing
-        ) subq_8
-      ) subq_9
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE listing__country_latest = 'us'
-    ) subq_10
-  ) subq_11
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_11.is_instant
-) subq_12
+    subq_9.is_instant
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_filter_with_where_constraint_on_join_dim__plan0_optimized.sql
@@ -11,12 +11,11 @@ FROM (
   -- Pass Only Elements:
   --   ['bookings', 'is_instant', 'listing__country_latest']
   SELECT
-    subq_16.is_instant AS is_instant
+    subq_13.is_instant AS is_instant
     , listings_latest_src_10004.country AS listing__country_latest
-    , subq_16.bookings AS bookings
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'listing']
@@ -28,12 +27,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_16
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_10004
   ON
-    subq_16.listing = listings_latest_src_10004.listing_id
-) subq_22
+    subq_13.listing = listings_latest_src_10004.listing_id
+) subq_18
 WHERE listing__country_latest = 'us'
 GROUP BY
   is_instant

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_limit_rows__plan0.sql
@@ -1,186 +1,136 @@
 -- Order By [] Limit 1
 SELECT
-  subq_5.ds
-  , subq_5.bookings
+  subq_4.ds
+  , subq_4.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.ds
-    , subq_4.bookings
+    subq_3.ds
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.ds
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.ds
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'ds']
       SELECT
-        subq_2.ds
-        , subq_2.bookings
+        subq_1.ds
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.ds
-  ) subq_4
-) subq_5
+      subq_2.ds
+  ) subq_3
+) subq_4
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_limit_rows__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_limit_rows__plan0_optimized.sql
@@ -6,7 +6,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
-) subq_9
+) subq_7
 GROUP BY
   ds
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -1,133 +1,97 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.listing__country_latest
-  , subq_4.listings
+  subq_3.listing__country_latest
+  , subq_3.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.listing__country_latest
-    , SUM(subq_3.listings) AS listings
+    subq_2.listing__country_latest
+    , SUM(subq_2.listings) AS listings
   FROM (
     -- Pass Only Elements:
     --   ['listings', 'listing__country_latest']
     SELECT
-      subq_2.listing__country_latest
-      , subq_2.listings
+      subq_1.listing__country_latest
+      , subq_1.listings
     FROM (
       -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.ds
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.created_at
-        , subq_1.created_at__week
-        , subq_1.created_at__month
-        , subq_1.created_at__quarter
-        , subq_1.created_at__year
-        , subq_1.listing__ds
-        , subq_1.listing__ds__week
-        , subq_1.listing__ds__month
-        , subq_1.listing__ds__quarter
-        , subq_1.listing__ds__year
-        , subq_1.listing__created_at
-        , subq_1.listing__created_at__week
-        , subq_1.listing__created_at__month
-        , subq_1.listing__created_at__quarter
-        , subq_1.listing__created_at__year
-        , subq_1.ds AS metric_time
-        , subq_1.ds__week AS metric_time__week
-        , subq_1.ds__month AS metric_time__month
-        , subq_1.ds__quarter AS metric_time__quarter
-        , subq_1.ds__year AS metric_time__year
-        , subq_1.listing
-        , subq_1.user
-        , subq_1.listing__user
-        , subq_1.country_latest
-        , subq_1.is_lux_latest
-        , subq_1.capacity_latest
-        , subq_1.listing__country_latest
-        , subq_1.listing__is_lux_latest
-        , subq_1.listing__capacity_latest
-        , subq_1.listings
-        , subq_1.largest_listing
-        , subq_1.smallest_listing
+        subq_0.ds
+        , subq_0.ds__week
+        , subq_0.ds__month
+        , subq_0.ds__quarter
+        , subq_0.ds__year
+        , subq_0.created_at
+        , subq_0.created_at__week
+        , subq_0.created_at__month
+        , subq_0.created_at__quarter
+        , subq_0.created_at__year
+        , subq_0.listing__ds
+        , subq_0.listing__ds__week
+        , subq_0.listing__ds__month
+        , subq_0.listing__ds__quarter
+        , subq_0.listing__ds__year
+        , subq_0.listing__created_at
+        , subq_0.listing__created_at__week
+        , subq_0.listing__created_at__month
+        , subq_0.listing__created_at__quarter
+        , subq_0.listing__created_at__year
+        , subq_0.ds AS metric_time
+        , subq_0.ds__week AS metric_time__week
+        , subq_0.ds__month AS metric_time__month
+        , subq_0.ds__quarter AS metric_time__quarter
+        , subq_0.ds__year AS metric_time__year
+        , subq_0.listing
+        , subq_0.user
+        , subq_0.listing__user
+        , subq_0.country_latest
+        , subq_0.is_lux_latest
+        , subq_0.capacity_latest
+        , subq_0.listing__country_latest
+        , subq_0.listing__is_lux_latest
+        , subq_0.listing__capacity_latest
+        , subq_0.listings
+        , subq_0.largest_listing
+        , subq_0.smallest_listing
       FROM (
-        -- Pass Only Additive Measures
+        -- Read Elements From Data Source 'listings_latest'
         SELECT
-          subq_0.ds
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.created_at
-          , subq_0.created_at__week
-          , subq_0.created_at__month
-          , subq_0.created_at__quarter
-          , subq_0.created_at__year
-          , subq_0.listing__ds
-          , subq_0.listing__ds__week
-          , subq_0.listing__ds__month
-          , subq_0.listing__ds__quarter
-          , subq_0.listing__ds__year
-          , subq_0.listing__created_at
-          , subq_0.listing__created_at__week
-          , subq_0.listing__created_at__month
-          , subq_0.listing__created_at__quarter
-          , subq_0.listing__created_at__year
-          , subq_0.listing
-          , subq_0.user
-          , subq_0.listing__user
-          , subq_0.country_latest
-          , subq_0.is_lux_latest
-          , subq_0.capacity_latest
-          , subq_0.listing__country_latest
-          , subq_0.listing__is_lux_latest
-          , subq_0.listing__capacity_latest
-          , subq_0.listings
-          , subq_0.largest_listing
-          , subq_0.smallest_listing
-        FROM (
-          -- Read Elements From Data Source 'listings_latest'
-          SELECT
-            1 AS listings
-            , listings_latest_src_10004.capacity AS largest_listing
-            , listings_latest_src_10004.capacity AS smallest_listing
-            , listings_latest_src_10004.created_at AS ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-            , listings_latest_src_10004.created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-            , listings_latest_src_10004.country AS country_latest
-            , listings_latest_src_10004.is_lux AS is_lux_latest
-            , listings_latest_src_10004.capacity AS capacity_latest
-            , listings_latest_src_10004.created_at AS listing__ds
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-            , listings_latest_src_10004.created_at AS listing__created_at
-            , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-            , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-            , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-            , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-            , listings_latest_src_10004.country AS listing__country_latest
-            , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-            , listings_latest_src_10004.capacity AS listing__capacity_latest
-            , listings_latest_src_10004.listing_id AS listing
-            , listings_latest_src_10004.user_id AS user
-            , listings_latest_src_10004.user_id AS listing__user
-          FROM ***************************.dim_listings_latest listings_latest_src_10004
-        ) subq_0
-      ) subq_1
-    ) subq_2
-  ) subq_3
+          1 AS listings
+          , listings_latest_src_10004.capacity AS largest_listing
+          , listings_latest_src_10004.capacity AS smallest_listing
+          , listings_latest_src_10004.created_at AS ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+          , listings_latest_src_10004.created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+          , listings_latest_src_10004.country AS country_latest
+          , listings_latest_src_10004.is_lux AS is_lux_latest
+          , listings_latest_src_10004.capacity AS capacity_latest
+          , listings_latest_src_10004.created_at AS listing__ds
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+          , listings_latest_src_10004.created_at AS listing__created_at
+          , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+          , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+          , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+          , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+          , listings_latest_src_10004.country AS listing__country_latest
+          , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+          , listings_latest_src_10004.capacity AS listing__capacity_latest
+          , listings_latest_src_10004.listing_id AS listing
+          , listings_latest_src_10004.user_id AS user
+          , listings_latest_src_10004.user_id AS listing__user
+        FROM ***************************.dim_listings_latest listings_latest_src_10004
+      ) subq_0
+    ) subq_1
+  ) subq_2
   GROUP BY
-    subq_3.listing__country_latest
-) subq_4
+    subq_2.listing__country_latest
+) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_local_dimension_using_local_identifier__plan0_optimized.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(listings) AS listings
 FROM (
   -- Read Elements From Data Source 'listings_latest'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['listings', 'listing__country_latest']
@@ -13,6 +12,6 @@ FROM (
     country AS listing__country_latest
     , 1 AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_10004
-) subq_8
+) subq_6
 GROUP BY
   listing__country_latest

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0.sql
@@ -1,540 +1,404 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_19.metric_time
+  subq_16.metric_time
   , average_booking_value * bookings / NULLIF(booking_value, 0) AS lux_booking_value_rate_expr
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_18.metric_time
-    , subq_18.bookings
-    , subq_18.average_booking_value
-    , subq_18.booking_value
+    subq_15.metric_time
+    , subq_15.bookings
+    , subq_15.average_booking_value
+    , subq_15.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_12.metric_time AS metric_time
-      , subq_12.bookings AS bookings
-      , subq_12.average_booking_value AS average_booking_value
-      , subq_17.booking_value AS booking_value
+      subq_10.metric_time AS metric_time
+      , subq_10.bookings AS bookings
+      , subq_10.average_booking_value AS average_booking_value
+      , subq_14.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_11.metric_time
-        , SUM(subq_11.bookings) AS bookings
-        , AVG(subq_11.average_booking_value) AS average_booking_value
+        subq_9.metric_time
+        , SUM(subq_9.bookings) AS bookings
+        , AVG(subq_9.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time']
         SELECT
-          subq_10.metric_time
-          , subq_10.bookings
-          , subq_10.average_booking_value
+          subq_8.metric_time
+          , subq_8.bookings
+          , subq_8.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time
-            , subq_9.listing__is_lux_latest
-            , subq_9.bookings
-            , subq_9.average_booking_value
+            subq_7.metric_time
+            , subq_7.listing__is_lux_latest
+            , subq_7.bookings
+            , subq_7.average_booking_value
           FROM (
             -- Pass Only Elements:
             --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
             SELECT
-              subq_8.metric_time
-              , subq_8.listing__is_lux_latest
-              , subq_8.bookings
-              , subq_8.average_booking_value
+              subq_6.metric_time
+              , subq_6.listing__is_lux_latest
+              , subq_6.bookings
+              , subq_6.average_booking_value
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_3.metric_time AS metric_time
-                , subq_3.listing AS listing
-                , subq_7.is_lux_latest AS listing__is_lux_latest
-                , subq_3.bookings AS bookings
-                , subq_3.average_booking_value AS average_booking_value
+                subq_2.metric_time AS metric_time
+                , subq_2.listing AS listing
+                , subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.bookings AS bookings
+                , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements:
                 --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
                 SELECT
-                  subq_2.metric_time
-                  , subq_2.listing
-                  , subq_2.bookings
-                  , subq_2.average_booking_value
+                  subq_1.metric_time
+                  , subq_1.listing
+                  , subq_1.bookings
+                  , subq_1.average_booking_value
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_1.ds
-                    , subq_1.ds__week
-                    , subq_1.ds__month
-                    , subq_1.ds__quarter
-                    , subq_1.ds__year
-                    , subq_1.ds_partitioned
-                    , subq_1.ds_partitioned__week
-                    , subq_1.ds_partitioned__month
-                    , subq_1.ds_partitioned__quarter
-                    , subq_1.ds_partitioned__year
-                    , subq_1.booking_paid_at
-                    , subq_1.booking_paid_at__week
-                    , subq_1.booking_paid_at__month
-                    , subq_1.booking_paid_at__quarter
-                    , subq_1.booking_paid_at__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , subq_1.ds AS metric_time
-                    , subq_1.ds__week AS metric_time__week
-                    , subq_1.ds__month AS metric_time__month
-                    , subq_1.ds__quarter AS metric_time__quarter
-                    , subq_1.ds__year AS metric_time__year
-                    , subq_1.listing
-                    , subq_1.guest
-                    , subq_1.host
-                    , subq_1.create_a_cycle_in_the_join_graph
-                    , subq_1.create_a_cycle_in_the_join_graph__listing
-                    , subq_1.create_a_cycle_in_the_join_graph__guest
-                    , subq_1.create_a_cycle_in_the_join_graph__host
-                    , subq_1.is_instant
-                    , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                    , subq_1.bookings
-                    , subq_1.instant_bookings
-                    , subq_1.booking_value
-                    , subq_1.max_booking_value
-                    , subq_1.min_booking_value
-                    , subq_1.bookers
-                    , subq_1.average_booking_value
+                    subq_0.ds
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds_partitioned
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.booking_paid_at
+                    , subq_0.booking_paid_at__week
+                    , subq_0.booking_paid_at__month
+                    , subq_0.booking_paid_at__quarter
+                    , subq_0.booking_paid_at__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                    , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                    , subq_0.ds AS metric_time
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.create_a_cycle_in_the_join_graph
+                    , subq_0.create_a_cycle_in_the_join_graph__listing
+                    , subq_0.create_a_cycle_in_the_join_graph__guest
+                    , subq_0.create_a_cycle_in_the_join_graph__host
+                    , subq_0.is_instant
+                    , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'bookings_source'
                     SELECT
-                      subq_0.ds
-                      , subq_0.ds__week
-                      , subq_0.ds__month
-                      , subq_0.ds__quarter
-                      , subq_0.ds__year
-                      , subq_0.ds_partitioned
-                      , subq_0.ds_partitioned__week
-                      , subq_0.ds_partitioned__month
-                      , subq_0.ds_partitioned__quarter
-                      , subq_0.ds_partitioned__year
-                      , subq_0.booking_paid_at
-                      , subq_0.booking_paid_at__week
-                      , subq_0.booking_paid_at__month
-                      , subq_0.booking_paid_at__quarter
-                      , subq_0.booking_paid_at__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                      , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                      , subq_0.listing
-                      , subq_0.guest
-                      , subq_0.host
-                      , subq_0.create_a_cycle_in_the_join_graph
-                      , subq_0.create_a_cycle_in_the_join_graph__listing
-                      , subq_0.create_a_cycle_in_the_join_graph__guest
-                      , subq_0.create_a_cycle_in_the_join_graph__host
-                      , subq_0.is_instant
-                      , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                      , subq_0.bookings
-                      , subq_0.instant_bookings
-                      , subq_0.booking_value
-                      , subq_0.max_booking_value
-                      , subq_0.min_booking_value
-                      , subq_0.bookers
-                      , subq_0.average_booking_value
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_10001.booking_value
+                      , bookings_source_src_10001.booking_value AS max_booking_value
+                      , bookings_source_src_10001.booking_value AS min_booking_value
+                      , bookings_source_src_10001.guest_id AS bookers
+                      , bookings_source_src_10001.booking_value AS average_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_payments
+                      , bookings_source_src_10001.is_instant
+                      , bookings_source_src_10001.ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                      , bookings_source_src_10001.ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                      , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                      , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                      , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                      , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                      , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                      , bookings_source_src_10001.listing_id AS listing
+                      , bookings_source_src_10001.guest_id AS guest
+                      , bookings_source_src_10001.host_id AS host
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                      , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                      , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                      , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                     FROM (
-                      -- Read Elements From Data Source 'bookings_source'
-                      SELECT
-                        1 AS bookings
-                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                        , bookings_source_src_10001.booking_value
-                        , bookings_source_src_10001.booking_value AS max_booking_value
-                        , bookings_source_src_10001.booking_value AS min_booking_value
-                        , bookings_source_src_10001.guest_id AS bookers
-                        , bookings_source_src_10001.booking_value AS average_booking_value
-                        , bookings_source_src_10001.booking_value AS booking_payments
-                        , bookings_source_src_10001.is_instant
-                        , bookings_source_src_10001.ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                        , bookings_source_src_10001.ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                        , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                        , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                        , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                        , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                        , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                        , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                        , bookings_source_src_10001.listing_id AS listing
-                        , bookings_source_src_10001.guest_id AS guest
-                        , bookings_source_src_10001.host_id AS host
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                        , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                        , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                        , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                      FROM (
-                        -- User Defined SQL Query
-                        SELECT * FROM ***************************.fct_bookings
-                      ) bookings_source_src_10001
-                    ) subq_0
-                  ) subq_1
-                ) subq_2
-              ) subq_3
+                      -- User Defined SQL Query
+                      SELECT * FROM ***************************.fct_bookings
+                    ) bookings_source_src_10001
+                  ) subq_0
+                ) subq_1
+              ) subq_2
               LEFT OUTER JOIN (
                 -- Pass Only Elements:
                 --   ['listing', 'is_lux_latest']
                 SELECT
-                  subq_6.listing
-                  , subq_6.is_lux_latest
+                  subq_4.listing
+                  , subq_4.is_lux_latest
                 FROM (
                   -- Metric Time Dimension 'ds'
                   SELECT
-                    subq_5.ds
-                    , subq_5.ds__week
-                    , subq_5.ds__month
-                    , subq_5.ds__quarter
-                    , subq_5.ds__year
-                    , subq_5.created_at
-                    , subq_5.created_at__week
-                    , subq_5.created_at__month
-                    , subq_5.created_at__quarter
-                    , subq_5.created_at__year
-                    , subq_5.listing__ds
-                    , subq_5.listing__ds__week
-                    , subq_5.listing__ds__month
-                    , subq_5.listing__ds__quarter
-                    , subq_5.listing__ds__year
-                    , subq_5.listing__created_at
-                    , subq_5.listing__created_at__week
-                    , subq_5.listing__created_at__month
-                    , subq_5.listing__created_at__quarter
-                    , subq_5.listing__created_at__year
-                    , subq_5.ds AS metric_time
-                    , subq_5.ds__week AS metric_time__week
-                    , subq_5.ds__month AS metric_time__month
-                    , subq_5.ds__quarter AS metric_time__quarter
-                    , subq_5.ds__year AS metric_time__year
-                    , subq_5.listing
-                    , subq_5.user
-                    , subq_5.listing__user
-                    , subq_5.country_latest
-                    , subq_5.is_lux_latest
-                    , subq_5.capacity_latest
-                    , subq_5.listing__country_latest
-                    , subq_5.listing__is_lux_latest
-                    , subq_5.listing__capacity_latest
-                    , subq_5.listings
-                    , subq_5.largest_listing
-                    , subq_5.smallest_listing
+                    subq_3.ds
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.created_at
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.listing__ds
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__created_at
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.ds AS metric_time
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
                   FROM (
-                    -- Pass Only Additive Measures
+                    -- Read Elements From Data Source 'listings_latest'
                     SELECT
-                      subq_4.ds
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.created_at
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.listing__ds
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__created_at
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
-                    FROM (
-                      -- Read Elements From Data Source 'listings_latest'
-                      SELECT
-                        1 AS listings
-                        , listings_latest_src_10004.capacity AS largest_listing
-                        , listings_latest_src_10004.capacity AS smallest_listing
-                        , listings_latest_src_10004.created_at AS ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
-                        , listings_latest_src_10004.created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
-                        , listings_latest_src_10004.country AS country_latest
-                        , listings_latest_src_10004.is_lux AS is_lux_latest
-                        , listings_latest_src_10004.capacity AS capacity_latest
-                        , listings_latest_src_10004.created_at AS listing__ds
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
-                        , listings_latest_src_10004.created_at AS listing__created_at
-                        , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
-                        , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
-                        , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
-                        , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
-                        , listings_latest_src_10004.country AS listing__country_latest
-                        , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-                        , listings_latest_src_10004.capacity AS listing__capacity_latest
-                        , listings_latest_src_10004.listing_id AS listing
-                        , listings_latest_src_10004.user_id AS user
-                        , listings_latest_src_10004.user_id AS listing__user
-                      FROM ***************************.dim_listings_latest listings_latest_src_10004
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
-              ) subq_7
+                      1 AS listings
+                      , listings_latest_src_10004.capacity AS largest_listing
+                      , listings_latest_src_10004.capacity AS smallest_listing
+                      , listings_latest_src_10004.created_at AS ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS ds__year
+                      , listings_latest_src_10004.created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS created_at__year
+                      , listings_latest_src_10004.country AS country_latest
+                      , listings_latest_src_10004.is_lux AS is_lux_latest
+                      , listings_latest_src_10004.capacity AS capacity_latest
+                      , listings_latest_src_10004.created_at AS listing__ds
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__ds__year
+                      , listings_latest_src_10004.created_at AS listing__created_at
+                      , DATE_TRUNC('week', listings_latest_src_10004.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_10004.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_10004.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_10004.created_at) AS listing__created_at__year
+                      , listings_latest_src_10004.country AS listing__country_latest
+                      , listings_latest_src_10004.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_10004.capacity AS listing__capacity_latest
+                      , listings_latest_src_10004.listing_id AS listing
+                      , listings_latest_src_10004.user_id AS user
+                      , listings_latest_src_10004.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_10004
+                  ) subq_3
+                ) subq_4
+              ) subq_5
               ON
-                subq_3.listing = subq_7.listing
-            ) subq_8
-          ) subq_9
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
           WHERE listing__is_lux_latest
-        ) subq_10
-      ) subq_11
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_11.metric_time
-    ) subq_12
+        subq_9.metric_time
+    ) subq_10
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_16.metric_time
-        , SUM(subq_16.booking_value) AS booking_value
+        subq_13.metric_time
+        , SUM(subq_13.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_15.metric_time
-          , subq_15.booking_value
+          subq_12.metric_time
+          , subq_12.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_14.ds
-            , subq_14.ds__week
-            , subq_14.ds__month
-            , subq_14.ds__quarter
-            , subq_14.ds__year
-            , subq_14.ds_partitioned
-            , subq_14.ds_partitioned__week
-            , subq_14.ds_partitioned__month
-            , subq_14.ds_partitioned__quarter
-            , subq_14.ds_partitioned__year
-            , subq_14.booking_paid_at
-            , subq_14.booking_paid_at__week
-            , subq_14.booking_paid_at__month
-            , subq_14.booking_paid_at__quarter
-            , subq_14.booking_paid_at__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds
-            , subq_14.create_a_cycle_in_the_join_graph__ds__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds__year
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_14.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_14.ds AS metric_time
-            , subq_14.ds__week AS metric_time__week
-            , subq_14.ds__month AS metric_time__month
-            , subq_14.ds__quarter AS metric_time__quarter
-            , subq_14.ds__year AS metric_time__year
-            , subq_14.listing
-            , subq_14.guest
-            , subq_14.host
-            , subq_14.create_a_cycle_in_the_join_graph
-            , subq_14.create_a_cycle_in_the_join_graph__listing
-            , subq_14.create_a_cycle_in_the_join_graph__guest
-            , subq_14.create_a_cycle_in_the_join_graph__host
-            , subq_14.is_instant
-            , subq_14.create_a_cycle_in_the_join_graph__is_instant
-            , subq_14.bookings
-            , subq_14.instant_bookings
-            , subq_14.booking_value
-            , subq_14.max_booking_value
-            , subq_14.min_booking_value
-            , subq_14.bookers
-            , subq_14.average_booking_value
+            subq_11.ds
+            , subq_11.ds__week
+            , subq_11.ds__month
+            , subq_11.ds__quarter
+            , subq_11.ds__year
+            , subq_11.ds_partitioned
+            , subq_11.ds_partitioned__week
+            , subq_11.ds_partitioned__month
+            , subq_11.ds_partitioned__quarter
+            , subq_11.ds_partitioned__year
+            , subq_11.booking_paid_at
+            , subq_11.booking_paid_at__week
+            , subq_11.booking_paid_at__month
+            , subq_11.booking_paid_at__quarter
+            , subq_11.booking_paid_at__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds
+            , subq_11.create_a_cycle_in_the_join_graph__ds__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds__year
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_11.ds AS metric_time
+            , subq_11.ds__week AS metric_time__week
+            , subq_11.ds__month AS metric_time__month
+            , subq_11.ds__quarter AS metric_time__quarter
+            , subq_11.ds__year AS metric_time__year
+            , subq_11.listing
+            , subq_11.guest
+            , subq_11.host
+            , subq_11.create_a_cycle_in_the_join_graph
+            , subq_11.create_a_cycle_in_the_join_graph__listing
+            , subq_11.create_a_cycle_in_the_join_graph__guest
+            , subq_11.create_a_cycle_in_the_join_graph__host
+            , subq_11.is_instant
+            , subq_11.create_a_cycle_in_the_join_graph__is_instant
+            , subq_11.bookings
+            , subq_11.instant_bookings
+            , subq_11.booking_value
+            , subq_11.max_booking_value
+            , subq_11.min_booking_value
+            , subq_11.bookers
+            , subq_11.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_13.ds
-              , subq_13.ds__week
-              , subq_13.ds__month
-              , subq_13.ds__quarter
-              , subq_13.ds__year
-              , subq_13.ds_partitioned
-              , subq_13.ds_partitioned__week
-              , subq_13.ds_partitioned__month
-              , subq_13.ds_partitioned__quarter
-              , subq_13.ds_partitioned__year
-              , subq_13.booking_paid_at
-              , subq_13.booking_paid_at__week
-              , subq_13.booking_paid_at__month
-              , subq_13.booking_paid_at__quarter
-              , subq_13.booking_paid_at__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds
-              , subq_13.create_a_cycle_in_the_join_graph__ds__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds__year
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_13.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_13.listing
-              , subq_13.guest
-              , subq_13.host
-              , subq_13.create_a_cycle_in_the_join_graph
-              , subq_13.create_a_cycle_in_the_join_graph__listing
-              , subq_13.create_a_cycle_in_the_join_graph__guest
-              , subq_13.create_a_cycle_in_the_join_graph__host
-              , subq_13.is_instant
-              , subq_13.create_a_cycle_in_the_join_graph__is_instant
-              , subq_13.bookings
-              , subq_13.instant_bookings
-              , subq_13.booking_value
-              , subq_13.max_booking_value
-              , subq_13.min_booking_value
-              , subq_13.bookers
-              , subq_13.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_13
-          ) subq_14
-        ) subq_15
-      ) subq_16
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_11
+        ) subq_12
+      ) subq_13
       GROUP BY
-        subq_16.metric_time
-    ) subq_17
+        subq_13.metric_time
+    ) subq_14
     ON
       (
         (
-          subq_12.metric_time = subq_17.metric_time
+          subq_10.metric_time = subq_14.metric_time
         ) OR (
-          (subq_12.metric_time IS NULL) AND (subq_17.metric_time IS NULL)
+          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
         )
       )
-  ) subq_18
-) subq_19
+  ) subq_15
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -7,10 +7,10 @@ FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'average_booking_value', 'bookings', 'booking_value']
   SELECT
-    subq_32.metric_time AS metric_time
-    , subq_32.bookings AS bookings
-    , subq_32.average_booking_value AS average_booking_value
-    , subq_37.booking_value AS booking_value
+    subq_27.metric_time AS metric_time
+    , subq_27.bookings AS bookings
+    , subq_27.average_booking_value AS average_booking_value
+    , subq_31.booking_value AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements:
@@ -25,13 +25,12 @@ FROM (
       -- Pass Only Elements:
       --   ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']
       SELECT
-        subq_23.metric_time AS metric_time
+        subq_19.metric_time AS metric_time
         , listings_latest_src_10004.is_lux AS listing__is_lux_latest
-        , subq_23.bookings AS bookings
-        , subq_23.average_booking_value AS average_booking_value
+        , subq_19.bookings AS bookings
+        , subq_19.average_booking_value AS average_booking_value
       FROM (
         -- Read Elements From Data Source 'bookings_source'
-        -- Pass Only Additive Measures
         -- Metric Time Dimension 'ds'
         -- Pass Only Elements:
         --   ['average_booking_value', 'bookings', 'metric_time', 'listing']
@@ -44,19 +43,18 @@ FROM (
           -- User Defined SQL Query
           SELECT * FROM ***************************.fct_bookings
         ) bookings_source_src_10001
-      ) subq_23
+      ) subq_19
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_10004
       ON
-        subq_23.listing = listings_latest_src_10004.listing_id
-    ) subq_29
+        subq_19.listing = listings_latest_src_10004.listing_id
+    ) subq_24
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time
-  ) subq_32
+  ) subq_27
   INNER JOIN (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'metric_time']
@@ -70,13 +68,13 @@ FROM (
     ) bookings_source_src_10001
     GROUP BY
       ds
-  ) subq_37
+  ) subq_31
   ON
     (
       (
-        subq_32.metric_time = subq_37.metric_time
+        subq_27.metric_time = subq_31.metric_time
       ) OR (
-        (subq_32.metric_time IS NULL) AND (subq_37.metric_time IS NULL)
+        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
       )
     )
-) subq_39
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,393 +1,293 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_11.metric_time
+  , CAST(subq_11.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_11.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Pass Only Elements:
   --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
   SELECT
-    subq_12.metric_time
-    , subq_12.booking_value_with_is_instant_constraint
-    , subq_12.booking_value
+    subq_10.metric_time
+    , subq_10.booking_value_with_is_instant_constraint
+    , subq_10.booking_value
   FROM (
     -- Join Aggregated Measures with Standard Outputs
     SELECT
-      subq_6.metric_time AS metric_time
-      , subq_6.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
-      , subq_11.booking_value AS booking_value
+      subq_5.metric_time AS metric_time
+      , subq_5.booking_value_with_is_instant_constraint AS booking_value_with_is_instant_constraint
+      , subq_9.booking_value AS booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time
-        , SUM(subq_5.booking_value) AS booking_value_with_is_instant_constraint
+        subq_4.metric_time
+        , SUM(subq_4.booking_value) AS booking_value_with_is_instant_constraint
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_4.metric_time
-          , subq_4.booking_value
+          subq_3.metric_time
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time
-            , subq_3.is_instant
-            , subq_3.booking_value
+            subq_2.metric_time
+            , subq_2.is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements:
             --   ['booking_value', 'is_instant', 'metric_time']
             SELECT
-              subq_2.metric_time
-              , subq_2.is_instant
-              , subq_2.booking_value
+              subq_1.metric_time
+              , subq_1.is_instant
+              , subq_1.booking_value
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds_partitioned
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.booking_paid_at
-                , subq_1.booking_paid_at__week
-                , subq_1.booking_paid_at__month
-                , subq_1.booking_paid_at__quarter
-                , subq_1.booking_paid_at__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds
-                , subq_1.create_a_cycle_in_the_join_graph__ds__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds__year
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_1.ds AS metric_time
-                , subq_1.ds__week AS metric_time__week
-                , subq_1.ds__month AS metric_time__month
-                , subq_1.ds__quarter AS metric_time__quarter
-                , subq_1.ds__year AS metric_time__year
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.create_a_cycle_in_the_join_graph
-                , subq_1.create_a_cycle_in_the_join_graph__listing
-                , subq_1.create_a_cycle_in_the_join_graph__guest
-                , subq_1.create_a_cycle_in_the_join_graph__host
-                , subq_1.is_instant
-                , subq_1.create_a_cycle_in_the_join_graph__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
+                subq_0.ds
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds_partitioned
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.booking_paid_at
+                , subq_0.booking_paid_at__week
+                , subq_0.booking_paid_at__month
+                , subq_0.booking_paid_at__quarter
+                , subq_0.booking_paid_at__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds
+                , subq_0.create_a_cycle_in_the_join_graph__ds__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds__year
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_0.ds AS metric_time
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.create_a_cycle_in_the_join_graph
+                , subq_0.create_a_cycle_in_the_join_graph__listing
+                , subq_0.create_a_cycle_in_the_join_graph__guest
+                , subq_0.create_a_cycle_in_the_join_graph__host
+                , subq_0.is_instant
+                , subq_0.create_a_cycle_in_the_join_graph__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
               FROM (
-                -- Pass Only Additive Measures
+                -- Read Elements From Data Source 'bookings_source'
                 SELECT
-                  subq_0.ds
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds_partitioned
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.booking_paid_at
-                  , subq_0.booking_paid_at__week
-                  , subq_0.booking_paid_at__month
-                  , subq_0.booking_paid_at__quarter
-                  , subq_0.booking_paid_at__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds__year
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                  , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.create_a_cycle_in_the_join_graph
-                  , subq_0.create_a_cycle_in_the_join_graph__listing
-                  , subq_0.create_a_cycle_in_the_join_graph__guest
-                  , subq_0.create_a_cycle_in_the_join_graph__host
-                  , subq_0.is_instant
-                  , subq_0.create_a_cycle_in_the_join_graph__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , bookings_source_src_10001.is_instant
+                  , bookings_source_src_10001.ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , bookings_source_src_10001.ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                  , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                  , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                  , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                  , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                  , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                  , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                  , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                  , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
                 FROM (
-                  -- Read Elements From Data Source 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , bookings_source_src_10001.is_instant
-                    , bookings_source_src_10001.ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , bookings_source_src_10001.ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                    , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                    , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                    , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                    , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                    , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                    , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                    , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                    , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-                  FROM (
-                    -- User Defined SQL Query
-                    SELECT * FROM ***************************.fct_bookings
-                  ) bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-            ) subq_2
-          ) subq_3
+                  -- User Defined SQL Query
+                  SELECT * FROM ***************************.fct_bookings
+                ) bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time
-    ) subq_6
+        subq_4.metric_time
+    ) subq_5
     INNER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_8.metric_time
+        , SUM(subq_8.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements:
         --   ['booking_value', 'metric_time']
         SELECT
-          subq_9.metric_time
-          , subq_9.booking_value
+          subq_7.metric_time
+          , subq_7.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds_partitioned
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.booking_paid_at
-            , subq_8.booking_paid_at__week
-            , subq_8.booking_paid_at__month
-            , subq_8.booking_paid_at__quarter
-            , subq_8.booking_paid_at__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds
-            , subq_8.create_a_cycle_in_the_join_graph__ds__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds__year
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_8.ds AS metric_time
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.create_a_cycle_in_the_join_graph
-            , subq_8.create_a_cycle_in_the_join_graph__listing
-            , subq_8.create_a_cycle_in_the_join_graph__guest
-            , subq_8.create_a_cycle_in_the_join_graph__host
-            , subq_8.is_instant
-            , subq_8.create_a_cycle_in_the_join_graph__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.ds_partitioned
+            , subq_6.ds_partitioned__week
+            , subq_6.ds_partitioned__month
+            , subq_6.ds_partitioned__quarter
+            , subq_6.ds_partitioned__year
+            , subq_6.booking_paid_at
+            , subq_6.booking_paid_at__week
+            , subq_6.booking_paid_at__month
+            , subq_6.booking_paid_at__quarter
+            , subq_6.booking_paid_at__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds
+            , subq_6.create_a_cycle_in_the_join_graph__ds__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds__year
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.guest
+            , subq_6.host
+            , subq_6.create_a_cycle_in_the_join_graph
+            , subq_6.create_a_cycle_in_the_join_graph__listing
+            , subq_6.create_a_cycle_in_the_join_graph__guest
+            , subq_6.create_a_cycle_in_the_join_graph__host
+            , subq_6.is_instant
+            , subq_6.create_a_cycle_in_the_join_graph__is_instant
+            , subq_6.bookings
+            , subq_6.instant_bookings
+            , subq_6.booking_value
+            , subq_6.max_booking_value
+            , subq_6.min_booking_value
+            , subq_6.bookers
+            , subq_6.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_7.ds
-              , subq_7.ds__week
-              , subq_7.ds__month
-              , subq_7.ds__quarter
-              , subq_7.ds__year
-              , subq_7.ds_partitioned
-              , subq_7.ds_partitioned__week
-              , subq_7.ds_partitioned__month
-              , subq_7.ds_partitioned__quarter
-              , subq_7.ds_partitioned__year
-              , subq_7.booking_paid_at
-              , subq_7.booking_paid_at__week
-              , subq_7.booking_paid_at__month
-              , subq_7.booking_paid_at__quarter
-              , subq_7.booking_paid_at__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds
-              , subq_7.create_a_cycle_in_the_join_graph__ds__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds__year
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_7.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_7.listing
-              , subq_7.guest
-              , subq_7.host
-              , subq_7.create_a_cycle_in_the_join_graph
-              , subq_7.create_a_cycle_in_the_join_graph__listing
-              , subq_7.create_a_cycle_in_the_join_graph__guest
-              , subq_7.create_a_cycle_in_the_join_graph__host
-              , subq_7.is_instant
-              , subq_7.create_a_cycle_in_the_join_graph__is_instant
-              , subq_7.bookings
-              , subq_7.instant_bookings
-              , subq_7.booking_value
-              , subq_7.max_booking_value
-              , subq_7.min_booking_value
-              , subq_7.bookers
-              , subq_7.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_7
-          ) subq_8
-        ) subq_9
-      ) subq_10
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_6
+        ) subq_7
+      ) subq_8
       GROUP BY
-        subq_10.metric_time
-    ) subq_11
+        subq_8.metric_time
+    ) subq_9
     ON
       (
         (
-          subq_6.metric_time = subq_11.metric_time
+          subq_5.metric_time = subq_9.metric_time
         ) OR (
-          (subq_6.metric_time IS NULL) AND (subq_11.metric_time IS NULL)
+          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
         )
       )
-  ) subq_12
-) subq_13
+  ) subq_10
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,8 +3,8 @@
 --   ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time AS metric_time
-  , CAST(subq_20.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_25.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_17.metric_time AS metric_time
+  , CAST(subq_17.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_21.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements:
@@ -15,7 +15,6 @@ FROM (
     , SUM(booking_value) AS booking_value_with_is_instant_constraint
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['booking_value', 'is_instant', 'metric_time']
@@ -27,14 +26,13 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_17
+  ) subq_14
   WHERE is_instant
   GROUP BY
     metric_time
-) subq_20
+) subq_17
 INNER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['booking_value', 'metric_time']
@@ -48,12 +46,12 @@ INNER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     ds
-) subq_25
+) subq_21
 ON
   (
     (
-      subq_20.metric_time = subq_25.metric_time
+      subq_17.metric_time = subq_21.metric_time
     ) OR (
-      (subq_20.metric_time IS NULL) AND (subq_25.metric_time IS NULL)
+      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,195 +1,145 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_6.metric_time
+  subq_5.metric_time
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_5.metric_time
-    , SUM(subq_5.bookings) AS delayed_bookings
+    subq_4.metric_time
+    , SUM(subq_4.bookings) AS delayed_bookings
   FROM (
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
     SELECT
-      subq_4.metric_time
-      , subq_4.bookings
+      subq_3.metric_time
+      , subq_3.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_3.metric_time
-        , subq_3.is_instant
-        , subq_3.bookings
+        subq_2.metric_time
+        , subq_2.is_instant
+        , subq_2.bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'is_instant', 'metric_time']
         SELECT
-          subq_2.metric_time
-          , subq_2.is_instant
-          , subq_2.bookings
+          subq_1.metric_time
+          , subq_1.is_instant
+          , subq_1.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.booking_paid_at
-            , subq_1.booking_paid_at__week
-            , subq_1.booking_paid_at__month
-            , subq_1.booking_paid_at__quarter
-            , subq_1.booking_paid_at__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds
-            , subq_1.create_a_cycle_in_the_join_graph__ds__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds__year
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.listing
-            , subq_1.guest
-            , subq_1.host
-            , subq_1.create_a_cycle_in_the_join_graph
-            , subq_1.create_a_cycle_in_the_join_graph__listing
-            , subq_1.create_a_cycle_in_the_join_graph__guest
-            , subq_1.create_a_cycle_in_the_join_graph__host
-            , subq_1.is_instant
-            , subq_1.create_a_cycle_in_the_join_graph__is_instant
-            , subq_1.bookings
-            , subq_1.instant_bookings
-            , subq_1.booking_value
-            , subq_1.max_booking_value
-            , subq_1.min_booking_value
-            , subq_1.bookers
-            , subq_1.average_booking_value
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'bookings_source'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.booking_paid_at
-              , subq_0.booking_paid_at__week
-              , subq_0.booking_paid_at__month
-              , subq_0.booking_paid_at__quarter
-              , subq_0.booking_paid_at__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds
-              , subq_0.create_a_cycle_in_the_join_graph__ds__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds__year
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , subq_0.listing
-              , subq_0.guest
-              , subq_0.host
-              , subq_0.create_a_cycle_in_the_join_graph
-              , subq_0.create_a_cycle_in_the_join_graph__listing
-              , subq_0.create_a_cycle_in_the_join_graph__guest
-              , subq_0.create_a_cycle_in_the_join_graph__host
-              , subq_0.is_instant
-              , subq_0.create_a_cycle_in_the_join_graph__is_instant
-              , subq_0.bookings
-              , subq_0.instant_bookings
-              , subq_0.booking_value
-              , subq_0.max_booking_value
-              , subq_0.min_booking_value
-              , subq_0.bookers
-              , subq_0.average_booking_value
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
             FROM (
-              -- Read Elements From Data Source 'bookings_source'
-              SELECT
-                1 AS bookings
-                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                , bookings_source_src_10001.booking_value
-                , bookings_source_src_10001.booking_value AS max_booking_value
-                , bookings_source_src_10001.booking_value AS min_booking_value
-                , bookings_source_src_10001.guest_id AS bookers
-                , bookings_source_src_10001.booking_value AS average_booking_value
-                , bookings_source_src_10001.booking_value AS booking_payments
-                , bookings_source_src_10001.is_instant
-                , bookings_source_src_10001.ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                , bookings_source_src_10001.ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , bookings_source_src_10001.listing_id AS listing
-                , bookings_source_src_10001.guest_id AS guest
-                , bookings_source_src_10001.host_id AS host
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-              FROM (
-                -- User Defined SQL Query
-                SELECT * FROM ***************************.fct_bookings
-              ) bookings_source_src_10001
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
       WHERE NOT is_instant
-    ) subq_4
-  ) subq_5
+    ) subq_3
+  ) subq_4
   GROUP BY
-    subq_5.metric_time
-) subq_6
+    subq_4.metric_time
+) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , SUM(bookings) AS delayed_bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'is_instant', 'metric_time']
@@ -24,8 +23,8 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_10
+  ) subq_8
   WHERE NOT is_instant
   GROUP BY
     metric_time
-) subq_13
+) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0.sql
@@ -1,156 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.account_id__customer_id__customer_name
-  , subq_11.txn_count
+  subq_10.account_id__customer_id__customer_name
+  , subq_10.txn_count
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.account_id__customer_id__customer_name
-    , SUM(subq_10.txn_count) AS txn_count
+    subq_9.account_id__customer_id__customer_name
+    , SUM(subq_9.txn_count) AS txn_count
   FROM (
     -- Pass Only Elements:
     --   ['txn_count', 'account_id__customer_id__customer_name']
     SELECT
-      subq_9.account_id__customer_id__customer_name
-      , subq_9.txn_count
+      subq_8.account_id__customer_id__customer_name
+      , subq_8.txn_count
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_8.ds_partitioned AS account_id__ds_partitioned
-        , subq_3.account_id AS account_id
-        , subq_8.customer_id__customer_name AS account_id__customer_id__customer_name
-        , subq_3.txn_count AS txn_count
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_7.ds_partitioned AS account_id__ds_partitioned
+        , subq_2.account_id AS account_id
+        , subq_7.customer_id__customer_name AS account_id__customer_id__customer_name
+        , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements:
         --   ['txn_count', 'account_id', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.account_id
-          , subq_2.txn_count
+          subq_1.ds_partitioned
+          , subq_1.account_id
+          , subq_1.txn_count
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.account_id__ds_partitioned
-            , subq_1.account_id__ds_partitioned__week
-            , subq_1.account_id__ds_partitioned__month
-            , subq_1.account_id__ds_partitioned__quarter
-            , subq_1.account_id__ds_partitioned__year
-            , subq_1.account_id__ds
-            , subq_1.account_id__ds__week
-            , subq_1.account_id__ds__month
-            , subq_1.account_id__ds__quarter
-            , subq_1.account_id__ds__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.account_id
-            , subq_1.account_month
-            , subq_1.account_id__account_month
-            , subq_1.txn_count
+            subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.account_id__ds_partitioned
+            , subq_0.account_id__ds_partitioned__week
+            , subq_0.account_id__ds_partitioned__month
+            , subq_0.account_id__ds_partitioned__quarter
+            , subq_0.account_id__ds_partitioned__year
+            , subq_0.account_id__ds
+            , subq_0.account_id__ds__week
+            , subq_0.account_id__ds__month
+            , subq_0.account_id__ds__quarter
+            , subq_0.account_id__ds__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.account_id
+            , subq_0.account_month
+            , subq_0.account_id__account_month
+            , subq_0.txn_count
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'account_month_txns'
             SELECT
-              subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.account_id__ds_partitioned
-              , subq_0.account_id__ds_partitioned__week
-              , subq_0.account_id__ds_partitioned__month
-              , subq_0.account_id__ds_partitioned__quarter
-              , subq_0.account_id__ds_partitioned__year
-              , subq_0.account_id__ds
-              , subq_0.account_id__ds__week
-              , subq_0.account_id__ds__month
-              , subq_0.account_id__ds__quarter
-              , subq_0.account_id__ds__year
-              , subq_0.account_id
-              , subq_0.account_month
-              , subq_0.account_id__account_month
-              , subq_0.txn_count
-            FROM (
-              -- Read Elements From Data Source 'account_month_txns'
-              SELECT
-                account_month_txns_src_10010.txn_count
-                , account_month_txns_src_10010.ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
-                , account_month_txns_src_10010.ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
-                , account_month_txns_src_10010.account_month
-                , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
-                , account_month_txns_src_10010.ds AS account_id__ds
-                , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
-                , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
-                , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
-                , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
-                , account_month_txns_src_10010.account_month AS account_id__account_month
-                , account_month_txns_src_10010.account_id
-              FROM ***************************.account_month_txns account_month_txns_src_10010
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              account_month_txns_src_10010.txn_count
+              , account_month_txns_src_10010.ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS ds_partitioned__year
+              , account_month_txns_src_10010.ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS ds__year
+              , account_month_txns_src_10010.account_month
+              , account_month_txns_src_10010.ds_partitioned AS account_id__ds_partitioned
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds_partitioned) AS account_id__ds_partitioned__year
+              , account_month_txns_src_10010.ds AS account_id__ds
+              , DATE_TRUNC('week', account_month_txns_src_10010.ds) AS account_id__ds__week
+              , DATE_TRUNC('month', account_month_txns_src_10010.ds) AS account_id__ds__month
+              , DATE_TRUNC('quarter', account_month_txns_src_10010.ds) AS account_id__ds__quarter
+              , DATE_TRUNC('year', account_month_txns_src_10010.ds) AS account_id__ds__year
+              , account_month_txns_src_10010.account_month AS account_id__account_month
+              , account_month_txns_src_10010.account_id
+            FROM ***************************.account_month_txns account_month_txns_src_10010
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['account_id', 'ds_partitioned', 'customer_id__customer_name']
         SELECT
-          subq_7.ds_partitioned
-          , subq_7.account_id
-          , subq_7.customer_id__customer_name
+          subq_6.ds_partitioned
+          , subq_6.account_id
+          , subq_6.customer_id__customer_name
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned AS ds_partitioned
-            , subq_4.ds_partitioned__week AS ds_partitioned__week
-            , subq_4.ds_partitioned__month AS ds_partitioned__month
-            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_4.ds_partitioned__year AS ds_partitioned__year
-            , subq_4.account_id__ds_partitioned AS account_id__ds_partitioned
-            , subq_4.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
-            , subq_4.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
-            , subq_4.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
-            , subq_4.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
-            , subq_6.ds_partitioned AS customer_id__ds_partitioned
-            , subq_6.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_6.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_6.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_6.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_4.account_id AS account_id
-            , subq_4.customer_id AS customer_id
-            , subq_4.account_id__customer_id AS account_id__customer_id
-            , subq_4.extra_dim AS extra_dim
-            , subq_4.account_id__extra_dim AS account_id__extra_dim
-            , subq_6.customer_name AS customer_id__customer_name
-            , subq_6.customer_atomic_weight AS customer_id__customer_atomic_weight
+            subq_3.ds_partitioned AS ds_partitioned
+            , subq_3.ds_partitioned__week AS ds_partitioned__week
+            , subq_3.ds_partitioned__month AS ds_partitioned__month
+            , subq_3.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_3.ds_partitioned__year AS ds_partitioned__year
+            , subq_3.account_id__ds_partitioned AS account_id__ds_partitioned
+            , subq_3.account_id__ds_partitioned__week AS account_id__ds_partitioned__week
+            , subq_3.account_id__ds_partitioned__month AS account_id__ds_partitioned__month
+            , subq_3.account_id__ds_partitioned__quarter AS account_id__ds_partitioned__quarter
+            , subq_3.account_id__ds_partitioned__year AS account_id__ds_partitioned__year
+            , subq_5.ds_partitioned AS customer_id__ds_partitioned
+            , subq_5.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_5.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_5.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_5.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_3.account_id AS account_id
+            , subq_3.customer_id AS customer_id
+            , subq_3.account_id__customer_id AS account_id__customer_id
+            , subq_3.extra_dim AS extra_dim
+            , subq_3.account_id__extra_dim AS account_id__extra_dim
+            , subq_5.customer_name AS customer_id__customer_name
+            , subq_5.customer_atomic_weight AS customer_id__customer_atomic_weight
           FROM (
             -- Read Elements From Data Source 'bridge_table'
             SELECT
@@ -170,7 +142,7 @@ FROM (
               , bridge_table_src_10011.customer_id
               , bridge_table_src_10011.customer_id AS account_id__customer_id
             FROM ***************************.bridge_table bridge_table_src_10011
-          ) subq_4
+          ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
             --   ['customer_name',
@@ -189,21 +161,21 @@ FROM (
             --    'customer_id__ds_partitioned__quarter',
             --    'customer_id__ds_partitioned__year']
             SELECT
-              subq_5.ds_partitioned
-              , subq_5.ds_partitioned__week
-              , subq_5.ds_partitioned__month
-              , subq_5.ds_partitioned__quarter
-              , subq_5.ds_partitioned__year
-              , subq_5.customer_id__ds_partitioned
-              , subq_5.customer_id__ds_partitioned__week
-              , subq_5.customer_id__ds_partitioned__month
-              , subq_5.customer_id__ds_partitioned__quarter
-              , subq_5.customer_id__ds_partitioned__year
-              , subq_5.customer_id
-              , subq_5.customer_name
-              , subq_5.customer_atomic_weight
-              , subq_5.customer_id__customer_name
-              , subq_5.customer_id__customer_atomic_weight
+              subq_4.ds_partitioned
+              , subq_4.ds_partitioned__week
+              , subq_4.ds_partitioned__month
+              , subq_4.ds_partitioned__quarter
+              , subq_4.ds_partitioned__year
+              , subq_4.customer_id__ds_partitioned
+              , subq_4.customer_id__ds_partitioned__week
+              , subq_4.customer_id__ds_partitioned__month
+              , subq_4.customer_id__ds_partitioned__quarter
+              , subq_4.customer_id__ds_partitioned__year
+              , subq_4.customer_id
+              , subq_4.customer_name
+              , subq_4.customer_atomic_weight
+              , subq_4.customer_id__customer_name
+              , subq_4.customer_id__customer_atomic_weight
             FROM (
               -- Read Elements From Data Source 'customer_table'
               SELECT
@@ -223,24 +195,24 @@ FROM (
                 , DATE_TRUNC('year', customer_table_src_10013.ds_partitioned) AS customer_id__ds_partitioned__year
                 , customer_table_src_10013.customer_id
               FROM ***************************.customer_table customer_table_src_10013
-            ) subq_5
-          ) subq_6
+            ) subq_4
+          ) subq_5
           ON
             (
-              subq_4.customer_id = subq_6.customer_id
+              subq_3.customer_id = subq_5.customer_id
             ) AND (
-              subq_4.ds_partitioned = subq_6.ds_partitioned
+              subq_3.ds_partitioned = subq_5.ds_partitioned
             )
-        ) subq_7
-      ) subq_8
+        ) subq_6
+      ) subq_7
       ON
         (
-          subq_3.account_id = subq_8.account_id
+          subq_2.account_id = subq_7.account_id
         ) AND (
-          subq_3.ds_partitioned = subq_8.ds_partitioned
+          subq_2.ds_partitioned = subq_7.ds_partitioned
         )
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.account_id__customer_id__customer_name
-) subq_11
+    subq_9.account_id__customer_id__customer_name
+) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multihop_node__plan0_optimized.sql
@@ -4,7 +4,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_18.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_10010.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_10010
 LEFT OUTER JOIN (
@@ -24,12 +24,12 @@ LEFT OUTER JOIN (
     ) AND (
       bridge_table_src_10011.ds_partitioned = customer_table_src_10013.ds_partitioned
     )
-) subq_20
+) subq_18
 ON
   (
-    account_month_txns_src_10010.account_id = subq_20.account_id
+    account_month_txns_src_10010.account_id = subq_18.account_id
   ) AND (
-    account_month_txns_src_10010.ds_partitioned = subq_20.ds_partitioned
+    account_month_txns_src_10010.ds_partitioned = subq_18.ds_partitioned
   )
 GROUP BY
-  subq_20.customer_id__customer_name
+  subq_18.customer_id__customer_name

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0.sql
@@ -1,137 +1,107 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_8.user__home_state
-  , subq_8.identity_verifications
+  subq_7.user__home_state
+  , subq_7.identity_verifications
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_7.user__home_state
-    , SUM(subq_7.identity_verifications) AS identity_verifications
+    subq_6.user__home_state
+    , SUM(subq_6.identity_verifications) AS identity_verifications
   FROM (
     -- Pass Only Elements:
     --   ['identity_verifications', 'user__home_state']
     SELECT
-      subq_6.user__home_state
-      , subq_6.identity_verifications
+      subq_5.user__home_state
+      , subq_5.identity_verifications
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_3.ds_partitioned AS ds_partitioned
-        , subq_5.ds_partitioned AS user__ds_partitioned
-        , subq_3.user AS user
-        , subq_5.home_state AS user__home_state
-        , subq_3.identity_verifications AS identity_verifications
+        subq_2.ds_partitioned AS ds_partitioned
+        , subq_4.ds_partitioned AS user__ds_partitioned
+        , subq_2.user AS user
+        , subq_4.home_state AS user__home_state
+        , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements:
         --   ['identity_verifications', 'user', 'ds_partitioned']
         SELECT
-          subq_2.ds_partitioned
-          , subq_2.user
-          , subq_2.identity_verifications
+          subq_1.ds_partitioned
+          , subq_1.user
+          , subq_1.identity_verifications
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_1.ds
-            , subq_1.ds__week
-            , subq_1.ds__month
-            , subq_1.ds__quarter
-            , subq_1.ds__year
-            , subq_1.ds_partitioned
-            , subq_1.ds_partitioned__week
-            , subq_1.ds_partitioned__month
-            , subq_1.ds_partitioned__quarter
-            , subq_1.ds_partitioned__year
-            , subq_1.verification__ds
-            , subq_1.verification__ds__week
-            , subq_1.verification__ds__month
-            , subq_1.verification__ds__quarter
-            , subq_1.verification__ds__year
-            , subq_1.verification__ds_partitioned
-            , subq_1.verification__ds_partitioned__week
-            , subq_1.verification__ds_partitioned__month
-            , subq_1.verification__ds_partitioned__quarter
-            , subq_1.verification__ds_partitioned__year
-            , subq_1.ds AS metric_time
-            , subq_1.ds__week AS metric_time__week
-            , subq_1.ds__month AS metric_time__month
-            , subq_1.ds__quarter AS metric_time__quarter
-            , subq_1.ds__year AS metric_time__year
-            , subq_1.verification
-            , subq_1.user
-            , subq_1.verification__user
-            , subq_1.verification_type
-            , subq_1.verification__verification_type
-            , subq_1.identity_verifications
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.verification__ds
+            , subq_0.verification__ds__week
+            , subq_0.verification__ds__month
+            , subq_0.verification__ds__quarter
+            , subq_0.verification__ds__year
+            , subq_0.verification__ds_partitioned
+            , subq_0.verification__ds_partitioned__week
+            , subq_0.verification__ds_partitioned__month
+            , subq_0.verification__ds_partitioned__quarter
+            , subq_0.verification__ds_partitioned__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.verification
+            , subq_0.user
+            , subq_0.verification__user
+            , subq_0.verification_type
+            , subq_0.verification__verification_type
+            , subq_0.identity_verifications
           FROM (
-            -- Pass Only Additive Measures
+            -- Read Elements From Data Source 'id_verifications'
             SELECT
-              subq_0.ds
-              , subq_0.ds__week
-              , subq_0.ds__month
-              , subq_0.ds__quarter
-              , subq_0.ds__year
-              , subq_0.ds_partitioned
-              , subq_0.ds_partitioned__week
-              , subq_0.ds_partitioned__month
-              , subq_0.ds_partitioned__quarter
-              , subq_0.ds_partitioned__year
-              , subq_0.verification__ds
-              , subq_0.verification__ds__week
-              , subq_0.verification__ds__month
-              , subq_0.verification__ds__quarter
-              , subq_0.verification__ds__year
-              , subq_0.verification__ds_partitioned
-              , subq_0.verification__ds_partitioned__week
-              , subq_0.verification__ds_partitioned__month
-              , subq_0.verification__ds_partitioned__quarter
-              , subq_0.verification__ds_partitioned__year
-              , subq_0.verification
-              , subq_0.user
-              , subq_0.verification__user
-              , subq_0.verification_type
-              , subq_0.verification__verification_type
-              , subq_0.identity_verifications
-            FROM (
-              -- Read Elements From Data Source 'id_verifications'
-              SELECT
-                1 AS identity_verifications
-                , id_verifications_src_10003.ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
-                , id_verifications_src_10003.ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
-                , id_verifications_src_10003.verification_type
-                , id_verifications_src_10003.ds AS verification__ds
-                , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
-                , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
-                , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
-                , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
-                , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
-                , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
-                , id_verifications_src_10003.verification_type AS verification__verification_type
-                , id_verifications_src_10003.verification_id AS verification
-                , id_verifications_src_10003.user_id AS user
-                , id_verifications_src_10003.user_id AS verification__user
-              FROM ***************************.fct_id_verifications id_verifications_src_10003
-            ) subq_0
-          ) subq_1
-        ) subq_2
-      ) subq_3
+              1 AS identity_verifications
+              , id_verifications_src_10003.ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS ds__year
+              , id_verifications_src_10003.ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS ds_partitioned__year
+              , id_verifications_src_10003.verification_type
+              , id_verifications_src_10003.ds AS verification__ds
+              , DATE_TRUNC('week', id_verifications_src_10003.ds) AS verification__ds__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds) AS verification__ds__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds) AS verification__ds__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds) AS verification__ds__year
+              , id_verifications_src_10003.ds_partitioned AS verification__ds_partitioned
+              , DATE_TRUNC('week', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__week
+              , DATE_TRUNC('month', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__month
+              , DATE_TRUNC('quarter', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__quarter
+              , DATE_TRUNC('year', id_verifications_src_10003.ds_partitioned) AS verification__ds_partitioned__year
+              , id_verifications_src_10003.verification_type AS verification__verification_type
+              , id_verifications_src_10003.verification_id AS verification
+              , id_verifications_src_10003.user_id AS user
+              , id_verifications_src_10003.user_id AS verification__user
+            FROM ***************************.fct_id_verifications id_verifications_src_10003
+          ) subq_0
+        ) subq_1
+      ) subq_2
       LEFT OUTER JOIN (
         -- Pass Only Elements:
         --   ['user', 'ds_partitioned', 'home_state']
         SELECT
-          subq_4.ds_partitioned
-          , subq_4.user
-          , subq_4.home_state
+          subq_3.ds_partitioned
+          , subq_3.user
+          , subq_3.home_state
         FROM (
           -- Read Elements From Data Source 'users_ds_source'
           SELECT
@@ -169,16 +139,16 @@ FROM (
             , users_ds_source_src_10007.home_state AS user__home_state
             , users_ds_source_src_10007.user_id AS user
           FROM ***************************.dim_users users_ds_source_src_10007
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       ON
         (
-          subq_3.user = subq_5.user
+          subq_2.user = subq_4.user
         ) AND (
-          subq_3.ds_partitioned = subq_5.ds_partitioned
+          subq_2.ds_partitioned = subq_4.ds_partitioned
         )
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   GROUP BY
-    subq_7.user__home_state
-) subq_8
+    subq_6.user__home_state
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_partitioned_join__plan0_optimized.sql
@@ -5,10 +5,9 @@
 -- Compute Metrics via Expressions
 SELECT
   users_ds_source_src_10007.home_state AS user__home_state
-  , SUM(subq_12.identity_verifications) AS identity_verifications
+  , SUM(subq_10.identity_verifications) AS identity_verifications
 FROM (
   -- Read Elements From Data Source 'id_verifications'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['identity_verifications', 'user', 'ds_partitioned']
@@ -17,14 +16,14 @@ FROM (
     , user_id AS user
     , 1 AS identity_verifications
   FROM ***************************.fct_id_verifications id_verifications_src_10003
-) subq_12
+) subq_10
 LEFT OUTER JOIN
   ***************************.dim_users users_ds_source_src_10007
 ON
   (
-    subq_12.user = users_ds_source_src_10007.user_id
+    subq_10.user = users_ds_source_src_10007.user_id
   ) AND (
-    subq_12.ds_partitioned = users_ds_source_src_10007.ds_partitioned
+    subq_10.ds_partitioned = users_ds_source_src_10007.ds_partitioned
   )
 GROUP BY
   users_ds_source_src_10007.home_state

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node__plan0.sql
@@ -1,13 +1,37 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.total_account_balance_first_day AS total_account_balance_first_day
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.total_account_balance_first_day
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -19,41 +43,13 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MIN(ds)
-  SELECT
-    MIN(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['total_account_balance_first_day', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.total_account_balance_first_day
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
 ) subq_2
 ON
-  subq_1.ds = subq_2.ds
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node__plan0_optimized.sql
@@ -1,30 +1,42 @@
--- Join on MIN(ds) and []
+-- Join on MIN(ds) and [] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.total_account_balance_first_day AS total_account_balance_first_day
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   SELECT
-    ds
+    account_balance
     , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['total_account_balance_first_day', 'ds']
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds
+    MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
 ) subq_5
 ON
-  subq_4.ds = subq_5.ds
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -1,15 +1,38 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_1.ds AS ds
-  , subq_1.user AS user
-  , subq_1.current_account_balance_by_user AS current_account_balance_by_user
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
+  -- Read Elements From Data Source 'accounts_source'
   SELECT
-    subq_0.ds
-    , subq_0.user
-    , subq_0.current_account_balance_by_user
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MAX(ds)
+  SELECT
+    subq_1.user
+    , MAX(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT
@@ -21,45 +44,15 @@ FROM (
       , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
       , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
       , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
       , accounts_source_src_10000.user_id AS user
     FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_accounts
     ) accounts_source_src_10000
-  ) subq_0
-) subq_1
-INNER JOIN (
-  -- Filter row on MAX(ds)
-  SELECT
-    subq_2.user
-    , MAX(subq_2.ds) AS ds
-  FROM (
-    -- Pass Only Elements:
-    --   ['current_account_balance_by_user', 'user', 'ds']
-    SELECT
-      subq_0.ds
-      , subq_0.user
-      , subq_0.current_account_balance_by_user
-    FROM (
-      -- Read Elements From Data Source 'accounts_source'
-      SELECT
-        accounts_source_src_10000.account_balance
-        , accounts_source_src_10000.account_balance AS total_account_balance_first_day
-        , accounts_source_src_10000.account_balance AS current_account_balance_by_user
-        , accounts_source_src_10000.ds
-        , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
-        , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
-        , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
-        , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
-        , accounts_source_src_10000.user_id AS user
-      FROM (
-        -- User Defined SQL Query
-        SELECT * FROM ***************************.fct_accounts
-      ) accounts_source_src_10000
-    ) subq_0
-  ) subq_2
+  ) subq_1
   GROUP BY
-    subq_2.user
+    subq_1.user
 ) subq_2
 ON
-  (subq_1.ds = subq_2.ds) AND (subq_1.user = subq_2.user)
+  (subq_0.ds = subq_2.ds__complete) AND (subq_0.user = subq_2.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -1,29 +1,39 @@
--- Join on MAX(ds) and ['user']
+-- Join on MAX(ds) and ['user'] grouping by None
 SELECT
-  subq_4.ds AS ds
-  , subq_4.user AS user
-  , subq_4.current_account_balance_by_user AS current_account_balance_by_user
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
 FROM (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   SELECT
-    ds
-    , user_id AS user
+    account_balance
+    , account_balance AS total_account_balance_first_day
     , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
-) subq_4
+) subq_3
 INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
-  -- Pass Only Elements:
-  --   ['current_account_balance_by_user', 'user', 'ds']
   -- Filter row on MAX(ds)
   SELECT
     user_id AS user
-    , MAX(ds) AS ds
+    , MAX(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
@@ -32,4 +42,4 @@ INNER JOIN (
     user_id
 ) subq_5
 ON
-  (subq_4.ds = subq_5.ds) AND (subq_4.user = subq_5.user)
+  (subq_3.ds = subq_5.ds__complete) AND (subq_3.user = subq_5.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -1,0 +1,57 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_0.ds AS ds
+  , subq_0.ds__week AS ds__week
+  , subq_0.ds__month AS ds__month
+  , subq_0.ds__quarter AS ds__quarter
+  , subq_0.ds__year AS ds__year
+  , subq_0.user AS user
+  , subq_0.account_type AS account_type
+  , subq_0.account_balance AS account_balance
+  , subq_0.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_0.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    accounts_source_src_10000.account_balance
+    , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+    , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+    , accounts_source_src_10000.ds
+    , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+    , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+    , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+    , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+    , accounts_source_src_10000.account_type
+    , accounts_source_src_10000.user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_0
+INNER JOIN (
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(subq_1.ds) AS ds__complete
+  FROM (
+    -- Read Elements From Data Source 'accounts_source'
+    SELECT
+      accounts_source_src_10000.account_balance
+      , accounts_source_src_10000.account_balance AS total_account_balance_first_day
+      , accounts_source_src_10000.account_balance AS current_account_balance_by_user
+      , accounts_source_src_10000.ds
+      , DATE_TRUNC('week', accounts_source_src_10000.ds) AS ds__week
+      , DATE_TRUNC('month', accounts_source_src_10000.ds) AS ds__month
+      , DATE_TRUNC('quarter', accounts_source_src_10000.ds) AS ds__quarter
+      , DATE_TRUNC('year', accounts_source_src_10000.ds) AS ds__year
+      , accounts_source_src_10000.account_type
+      , accounts_source_src_10000.user_id AS user
+    FROM (
+      -- User Defined SQL Query
+      SELECT * FROM ***************************.fct_accounts
+    ) accounts_source_src_10000
+  ) subq_1
+  GROUP BY
+    subq_1.ds__week
+) subq_2
+ON
+  subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Join on MIN(ds) and [] grouping by ds
+SELECT
+  subq_3.ds AS ds
+  , subq_3.ds__week AS ds__week
+  , subq_3.ds__month AS ds__month
+  , subq_3.ds__quarter AS ds__quarter
+  , subq_3.ds__year AS ds__year
+  , subq_3.user AS user
+  , subq_3.account_type AS account_type
+  , subq_3.account_balance AS account_balance
+  , subq_3.total_account_balance_first_day AS total_account_balance_first_day
+  , subq_3.current_account_balance_by_user AS current_account_balance_by_user
+FROM (
+  -- Read Elements From Data Source 'accounts_source'
+  SELECT
+    account_balance
+    , account_balance AS total_account_balance_first_day
+    , account_balance AS current_account_balance_by_user
+    , ds
+    , DATE_TRUNC('week', ds) AS ds__week
+    , DATE_TRUNC('month', ds) AS ds__month
+    , DATE_TRUNC('quarter', ds) AS ds__quarter
+    , DATE_TRUNC('year', ds) AS ds__year
+    , account_type
+    , user_id AS user
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+) subq_3
+INNER JOIN (
+  -- Read Elements From Data Source 'accounts_source'
+  -- Filter row on MIN(ds)
+  SELECT
+    MIN(ds) AS ds__complete
+  FROM (
+    -- User Defined SQL Query
+    SELECT * FROM ***************************.fct_accounts
+  ) accounts_source_src_10000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5
+ON
+  subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier__plan0.xml
@@ -1,322 +1,244 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_6 -->
+        <!-- node_id = ss_4 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_88),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
         <!--    'column_alias': 'user_team___team_id'}                -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_89),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
         <!--    'column_alias': 'user_team___user_id'}                -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_90),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
         <!--    'column_alias': 'messages'}                           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_5 -->
+            <!-- node_id = ss_3 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
             <!--    'column_alias': 'user_team___team_id'}                -->
             <!-- col1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_87),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
             <!--    'column_alias': 'user_team___user_id'}                -->
             <!-- col2 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
             <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'messages'}                                      -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- group_by0 =                                              -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
             <!--    'column_alias': 'user_team___team_id'}                -->
             <!-- group_by1 =                                              -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_87),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
             <!--    'column_alias': 'user_team___user_id'}                -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                  -->
                 <!--   Pass Only Elements:          -->
                 <!--     ['messages', 'user_team']  -->
-                <!-- node_id = ss_4 -->
+                <!-- node_id = ss_2 -->
                 <!-- col0 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_83),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
                 <!--    'column_alias': 'user_team___team_id'}                -->
                 <!-- col1 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_84),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
                 <!--    'column_alias': 'user_team___user_id'}                -->
                 <!-- col2 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_82),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
                 <!--    'column_alias': 'messages'}                           -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Metric Time Dimension 'ds' -->
-                    <!-- node_id = ss_3 -->
+                    <!-- node_id = ss_1 -->
                     <!-- col0 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
                     <!--    'column_alias': 'ds'}                                 -->
                     <!-- col1 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
                     <!--    'column_alias': 'ds__week'}                           -->
                     <!-- col2 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_64),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
                     <!--    'column_alias': 'ds__month'}                          -->
                     <!-- col3 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
                     <!--    'column_alias': 'ds__quarter'}                        -->
                     <!-- col4 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_66),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
                     <!--    'column_alias': 'ds__year'}                           -->
                     <!-- col5 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_67),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
                     <!--    'column_alias': 'user_id__ds'}                        -->
                     <!-- col6 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_68),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
                     <!--    'column_alias': 'user_id__ds__week'}                  -->
                     <!-- col7 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
                     <!--    'column_alias': 'user_id__ds__month'}                 -->
                     <!-- col8 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
                     <!--    'column_alias': 'user_id__ds__quarter'}               -->
                     <!-- col9 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
                     <!--    'column_alias': 'user_id__ds__year'}                  -->
                     <!-- col10 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_72),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
                     <!--    'column_alias': 'metric_time'}                        -->
                     <!-- col11 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_73),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
                     <!--    'column_alias': 'metric_time__week'}                  -->
                     <!-- col12 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_74),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
                     <!--    'column_alias': 'metric_time__month'}                 -->
                     <!-- col13 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_75),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
                     <!--    'column_alias': 'metric_time__quarter'}               -->
                     <!-- col14 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_76),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),  -->
                     <!--    'column_alias': 'metric_time__year'}                  -->
                     <!-- col15 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_77),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                     <!--    'column_alias': 'user_id'}                            -->
                     <!-- col16 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_78),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                     <!--    'column_alias': 'user_team___team_id'}                -->
                     <!-- col17 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_79),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
                     <!--    'column_alias': 'user_team___user_id'}                -->
                     <!-- col18 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_80),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
                     <!--    'column_alias': 'user_id__user_team___team_id'}       -->
                     <!-- col19 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_81),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
                     <!--    'column_alias': 'user_id__user_team___user_id'}       -->
                     <!-- col20 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_60),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
                     <!--    'column_alias': 'team_id'}                            -->
                     <!-- col21 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
                     <!--    'column_alias': 'user_id__team_id'}                   -->
                     <!-- col22 =                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
                     <!--    'column_alias': 'messages'}                           -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10015) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
-                        <!-- description = Pass Only Additive Measures -->
-                        <!-- node_id = ss_2 -->
-                        <!-- col0 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
-                        <!--    'column_alias': 'ds'}                                 -->
-                        <!-- col1 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
-                        <!--    'column_alias': 'ds__week'}                           -->
-                        <!-- col2 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
-                        <!--    'column_alias': 'ds__month'}                          -->
-                        <!-- col3 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
-                        <!--    'column_alias': 'ds__quarter'}                        -->
-                        <!-- col4 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
-                        <!--    'column_alias': 'ds__year'}                           -->
-                        <!-- col5 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
-                        <!--    'column_alias': 'user_id__ds'}                        -->
-                        <!-- col6 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
-                        <!--    'column_alias': 'user_id__ds__week'}                  -->
-                        <!-- col7 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
-                        <!--    'column_alias': 'user_id__ds__month'}                 -->
-                        <!-- col8 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
-                        <!--    'column_alias': 'user_id__ds__quarter'}               -->
-                        <!-- col9 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-                        <!--    'column_alias': 'user_id__ds__year'}                  -->
-                        <!-- col10 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
-                        <!--    'column_alias': 'user_id'}                            -->
-                        <!-- col11 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),  -->
-                        <!--    'column_alias': 'user_team___team_id'}                -->
-                        <!-- col12 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),  -->
-                        <!--    'column_alias': 'user_team___user_id'}                -->
-                        <!-- col13 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
-                        <!--    'column_alias': 'user_id__user_team___team_id'}       -->
-                        <!-- col14 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
-                        <!--    'column_alias': 'user_id__user_team___user_id'}       -->
-                        <!-- col15 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
-                        <!--    'column_alias': 'team_id'}                            -->
-                        <!-- col16 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
-                        <!--    'column_alias': 'user_id__team_id'}                   -->
-                        <!-- col17 =                                                  -->
-                        <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
-                        <!--    'column_alias': 'messages'}                           -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10015) -->
+                        <!-- description = Read Elements From Data Source 'messages_source' -->
+                        <!-- node_id = ss_10015 -->
+                        <!-- col0 =                                                         -->
+                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                        <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
+                        <!--    'column_alias': 'messages'}                                 -->
+                        <!-- col1 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10263),  -->
+                        <!--    'column_alias': 'ds'}                                    -->
+                        <!-- col2 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
+                        <!--    'column_alias': 'ds__week'}                        -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                        <!--    'column_alias': 'ds__month'}                       -->
+                        <!-- col4 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
+                        <!--    'column_alias': 'ds__quarter'}                     -->
+                        <!-- col5 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
+                        <!--    'column_alias': 'ds__year'}                        -->
+                        <!-- col6 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
+                        <!--    'column_alias': 'team_id'}                               -->
+                        <!-- col7 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10269),  -->
+                        <!--    'column_alias': 'user_id__ds'}                           -->
+                        <!-- col8 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                        <!--    'column_alias': 'user_id__ds__week'}               -->
+                        <!-- col9 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                        <!--    'column_alias': 'user_id__ds__month'}              -->
+                        <!-- col10 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                        <!--    'column_alias': 'user_id__ds__quarter'}            -->
+                        <!-- col11 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                        <!--    'column_alias': 'user_id__ds__year'}               -->
+                        <!-- col12 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10274),  -->
+                        <!--    'column_alias': 'user_id__team_id'}                      -->
+                        <!-- col13 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10275),  -->
+                        <!--    'column_alias': 'user_id'}                               -->
+                        <!-- col14 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
+                        <!--    'column_alias': 'user_team___team_id'}                   -->
+                        <!-- col15 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
+                        <!--    'column_alias': 'user_team___user_id'}                   -->
+                        <!-- col16 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
+                        <!--    'column_alias': 'user_id__user_team___team_id'}          -->
+                        <!-- col17 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10279),  -->
+                        <!--    'column_alias': 'user_id__user_team___user_id'}          -->
+                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
                         <!-- where = None -->
-                        <SqlSelectStatementNode>
-                            <!-- description = Read Elements From Data Source 'messages_source' -->
-                            <!-- node_id = ss_10015 -->
-                            <!-- col0 =                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
-                            <!--    'column_alias': 'messages'}                                 -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10262),  -->
-                            <!--    'column_alias': 'ds'}                                    -->
-                            <!-- col2 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
-                            <!--    'column_alias': 'ds__week'}                        -->
-                            <!-- col3 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
-                            <!--    'column_alias': 'ds__month'}                       -->
-                            <!-- col4 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
-                            <!--    'column_alias': 'ds__quarter'}                     -->
-                            <!-- col5 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
-                            <!--    'column_alias': 'ds__year'}                        -->
-                            <!-- col6 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10267),  -->
-                            <!--    'column_alias': 'team_id'}                               -->
-                            <!-- col7 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
-                            <!--    'column_alias': 'user_id__ds'}                           -->
-                            <!-- col8 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
-                            <!--    'column_alias': 'user_id__ds__week'}               -->
-                            <!-- col9 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
-                            <!--    'column_alias': 'user_id__ds__month'}              -->
-                            <!-- col10 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
-                            <!--    'column_alias': 'user_id__ds__quarter'}            -->
-                            <!-- col11 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
-                            <!--    'column_alias': 'user_id__ds__year'}               -->
-                            <!-- col12 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10273),  -->
-                            <!--    'column_alias': 'user_id__team_id'}                      -->
-                            <!-- col13 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10274),  -->
-                            <!--    'column_alias': 'user_id'}                               -->
-                            <!-- col14 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10275),  -->
-                            <!--    'column_alias': 'user_team___team_id'}                   -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
-                            <!--    'column_alias': 'user_team___user_id'}                   -->
-                            <!-- col16 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
-                            <!--    'column_alias': 'user_id__user_team___team_id'}          -->
-                            <!-- col17 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
-                            <!--    'column_alias': 'user_id__user_team___user_id'}          -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
-                            <!-- where = None -->
-                            <SqlTableFromClauseNode>
-                                <!-- description = Read from ***************************.fct_messages -->
-                                <!-- node_id = tfc_10011 -->
-                                <!-- table_id = ***************************.fct_messages -->
-                            </SqlTableFromClauseNode>
-                        </SqlSelectStatementNode>
+                        <SqlTableFromClauseNode>
+                            <!-- description = Read from ***************************.fct_messages -->
+                            <!-- node_id = tfc_10011 -->
+                            <!-- table_id = ***************************.fct_messages -->
+                        </SqlTableFromClauseNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_join__plan0.xml
@@ -1,105 +1,105 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_9 -->
-        <!-- col0 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_105),  -->
-        <!--    'column_alias': 'user_team___team_id'}                 -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_106),  -->
-        <!--    'column_alias': 'user_team___user_id'}                 -->
-        <!-- col2 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_104),  -->
-        <!--    'column_alias': 'user_team__country'}                  -->
-        <!-- col3 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_107),  -->
-        <!--    'column_alias': 'messages'}                            -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+        <!-- node_id = ss_7 -->
+        <!-- col0 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+        <!--    'column_alias': 'user_team___team_id'}                -->
+        <!-- col1 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+        <!--    'column_alias': 'user_team___user_id'}                -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_68),  -->
+        <!--    'column_alias': 'user_team__country'}                 -->
+        <!-- col3 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+        <!--    'column_alias': 'messages'}                           -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_8 -->
-            <!-- col0 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_102),  -->
-            <!--    'column_alias': 'user_team___team_id'}                 -->
-            <!-- col1 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_103),  -->
-            <!--    'column_alias': 'user_team___user_id'}                 -->
-            <!-- col2 =                                                    -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_101),  -->
-            <!--    'column_alias': 'user_team__country'}                  -->
+            <!-- node_id = ss_6 -->
+            <!-- col0 =                                                   -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_66),  -->
+            <!--    'column_alias': 'user_team___team_id'}                -->
+            <!-- col1 =                                                   -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_67),  -->
+            <!--    'column_alias': 'user_team___user_id'}                -->
+            <!-- col2 =                                                   -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+            <!--    'column_alias': 'user_team__country'}                 -->
             <!-- col3 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
             <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'messages'}                                      -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
-            <!-- group_by0 =                                               -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_102),  -->
-            <!--    'column_alias': 'user_team___team_id'}                 -->
-            <!-- group_by1 =                                               -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_103),  -->
-            <!--    'column_alias': 'user_team___user_id'}                 -->
-            <!-- group_by2 =                                               -->
-            <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_101),  -->
-            <!--    'column_alias': 'user_team__country'}                  -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+            <!-- group_by0 =                                              -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_66),  -->
+            <!--    'column_alias': 'user_team___team_id'}                -->
+            <!-- group_by1 =                                              -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_67),  -->
+            <!--    'column_alias': 'user_team___user_id'}                -->
+            <!-- group_by2 =                                              -->
+            <!--   {'class': 'SqlSelectColumn',                           -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+            <!--    'column_alias': 'user_team__country'}                 -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                                        -->
                 <!--   Pass Only Elements:                                -->
                 <!--     ['messages', 'user_team__country', 'user_team']  -->
-                <!-- node_id = ss_7 -->
+                <!-- node_id = ss_5 -->
                 <!-- col0 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_98),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
                 <!--    'column_alias': 'user_team___team_id'}                -->
                 <!-- col1 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_99),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
                 <!--    'column_alias': 'user_team___user_id'}                -->
                 <!-- col2 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_97),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
                 <!--    'column_alias': 'user_team__country'}                 -->
                 <!-- col3 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_96),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_60),  -->
                 <!--    'column_alias': 'messages'}                           -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Join Standard Outputs -->
-                    <!-- node_id = ss_6 -->
+                    <!-- node_id = ss_4 -->
                     <!-- col0 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_93),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
                     <!--    'column_alias': 'user_team___team_id'}                -->
                     <!-- col1 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_94),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
                     <!--    'column_alias': 'user_team___user_id'}                -->
                     <!-- col2 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_95),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
                     <!--    'column_alias': 'user_team__country'}                 -->
                     <!-- col3 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_92),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),  -->
                     <!--    'column_alias': 'messages'}                           -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- join_0 =                                                  -->
                     <!--   {'class': 'SqlJoinDescription',                         -->
-                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_5),  -->
-                    <!--    'right_source_alias': 'subq_5',                        -->
+                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_3),  -->
+                    <!--    'right_source_alias': 'subq_4',                        -->
                     <!--    'on_condition': SqlLogicalExpression(node_id=lo_0),    -->
                     <!--    'join_type': SqlJoinType.LEFT_OUTER}                   -->
                     <!-- where = None -->
@@ -107,278 +107,200 @@
                         <!-- description =                               -->
                         <!--   Pass Only Elements:                       -->
                         <!--     ['messages', 'user_team', 'user_team']  -->
-                        <!-- node_id = ss_4 -->
+                        <!-- node_id = ss_2 -->
                         <!-- col0 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_83),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
                         <!--    'column_alias': 'user_team___team_id'}                -->
                         <!-- col1 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_84),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
                         <!--    'column_alias': 'user_team___user_id'}                -->
                         <!-- col2 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_82),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
                         <!--    'column_alias': 'messages'}                           -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_3 -->
+                            <!-- node_id = ss_1 -->
                             <!-- col0 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
                             <!--    'column_alias': 'ds'}                                 -->
                             <!-- col1 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
                             <!--    'column_alias': 'ds__week'}                           -->
                             <!-- col2 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_64),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
                             <!--    'column_alias': 'ds__month'}                          -->
                             <!-- col3 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
                             <!--    'column_alias': 'ds__quarter'}                        -->
                             <!-- col4 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_66),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
                             <!--    'column_alias': 'ds__year'}                           -->
                             <!-- col5 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_67),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
                             <!--    'column_alias': 'user_id__ds'}                        -->
                             <!-- col6 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_68),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
                             <!--    'column_alias': 'user_id__ds__week'}                  -->
                             <!-- col7 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
                             <!--    'column_alias': 'user_id__ds__month'}                 -->
                             <!-- col8 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
                             <!--    'column_alias': 'user_id__ds__quarter'}               -->
                             <!-- col9 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
                             <!--    'column_alias': 'user_id__ds__year'}                  -->
                             <!-- col10 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_72),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
                             <!--    'column_alias': 'metric_time'}                        -->
                             <!-- col11 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_73),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
                             <!--    'column_alias': 'metric_time__week'}                  -->
                             <!-- col12 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_74),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
                             <!--    'column_alias': 'metric_time__month'}                 -->
                             <!-- col13 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_75),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
                             <!--    'column_alias': 'metric_time__quarter'}               -->
                             <!-- col14 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_76),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),  -->
                             <!--    'column_alias': 'metric_time__year'}                  -->
                             <!-- col15 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_77),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                             <!--    'column_alias': 'user_id'}                            -->
                             <!-- col16 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_78),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                             <!--    'column_alias': 'user_team___team_id'}                -->
                             <!-- col17 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_79),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
                             <!--    'column_alias': 'user_team___user_id'}                -->
                             <!-- col18 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_80),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
                             <!--    'column_alias': 'user_id__user_team___team_id'}       -->
                             <!-- col19 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_81),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
                             <!--    'column_alias': 'user_id__user_team___user_id'}       -->
                             <!-- col20 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_60),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
                             <!--    'column_alias': 'team_id'}                            -->
                             <!-- col21 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
                             <!--    'column_alias': 'user_id__team_id'}                   -->
                             <!-- col22 =                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
                             <!--    'column_alias': 'messages'}                           -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10015) -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = ss_2 -->
-                                <!-- col0 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
-                                <!--    'column_alias': 'ds'}                                 -->
-                                <!-- col1 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
-                                <!--    'column_alias': 'ds__week'}                           -->
-                                <!-- col2 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
-                                <!--    'column_alias': 'ds__month'}                          -->
-                                <!-- col3 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
-                                <!--    'column_alias': 'ds__quarter'}                        -->
-                                <!-- col4 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
-                                <!--    'column_alias': 'ds__year'}                           -->
-                                <!-- col5 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
-                                <!--    'column_alias': 'user_id__ds'}                        -->
-                                <!-- col6 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
-                                <!--    'column_alias': 'user_id__ds__week'}                  -->
-                                <!-- col7 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
-                                <!--    'column_alias': 'user_id__ds__month'}                 -->
-                                <!-- col8 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
-                                <!--    'column_alias': 'user_id__ds__quarter'}               -->
-                                <!-- col9 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-                                <!--    'column_alias': 'user_id__ds__year'}                  -->
-                                <!-- col10 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
-                                <!--    'column_alias': 'user_id'}                            -->
-                                <!-- col11 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),  -->
-                                <!--    'column_alias': 'user_team___team_id'}                -->
-                                <!-- col12 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),  -->
-                                <!--    'column_alias': 'user_team___user_id'}                -->
-                                <!-- col13 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
-                                <!--    'column_alias': 'user_id__user_team___team_id'}       -->
-                                <!-- col14 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
-                                <!--    'column_alias': 'user_id__user_team___user_id'}       -->
-                                <!-- col15 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
-                                <!--    'column_alias': 'team_id'}                            -->
-                                <!-- col16 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
-                                <!--    'column_alias': 'user_id__team_id'}                   -->
-                                <!-- col17 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
-                                <!--    'column_alias': 'messages'}                           -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10015) -->
+                                <!-- description = Read Elements From Data Source 'messages_source' -->
+                                <!-- node_id = ss_10015 -->
+                                <!-- col0 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
+                                <!--    'column_alias': 'messages'}                                 -->
+                                <!-- col1 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10263),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col2 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col3 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col4 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col5 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
+                                <!--    'column_alias': 'team_id'}                               -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10269),  -->
+                                <!--    'column_alias': 'user_id__ds'}                           -->
+                                <!-- col8 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                                <!--    'column_alias': 'user_id__ds__week'}               -->
+                                <!-- col9 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                                <!--    'column_alias': 'user_id__ds__month'}              -->
+                                <!-- col10 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                                <!--    'column_alias': 'user_id__ds__quarter'}            -->
+                                <!-- col11 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                                <!--    'column_alias': 'user_id__ds__year'}               -->
+                                <!-- col12 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10274),  -->
+                                <!--    'column_alias': 'user_id__team_id'}                      -->
+                                <!-- col13 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10275),  -->
+                                <!--    'column_alias': 'user_id'}                               -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
+                                <!--    'column_alias': 'user_team___team_id'}                   -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
+                                <!--    'column_alias': 'user_team___user_id'}                   -->
+                                <!-- col16 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
+                                <!--    'column_alias': 'user_id__user_team___team_id'}          -->
+                                <!-- col17 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10279),  -->
+                                <!--    'column_alias': 'user_id__user_team___user_id'}          -->
+                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
                                 <!-- where = None -->
-                                <SqlSelectStatementNode>
-                                    <!-- description = Read Elements From Data Source 'messages_source' -->
-                                    <!-- node_id = ss_10015 -->
-                                    <!-- col0 =                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
-                                    <!--    'column_alias': 'messages'}                                 -->
-                                    <!-- col1 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10262),  -->
-                                    <!--    'column_alias': 'ds'}                                    -->
-                                    <!-- col2 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
-                                    <!--    'column_alias': 'ds__week'}                        -->
-                                    <!-- col3 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
-                                    <!--    'column_alias': 'ds__month'}                       -->
-                                    <!-- col4 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
-                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                    <!-- col5 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
-                                    <!--    'column_alias': 'ds__year'}                        -->
-                                    <!-- col6 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10267),  -->
-                                    <!--    'column_alias': 'team_id'}                               -->
-                                    <!-- col7 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
-                                    <!--    'column_alias': 'user_id__ds'}                           -->
-                                    <!-- col8 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
-                                    <!--    'column_alias': 'user_id__ds__week'}               -->
-                                    <!-- col9 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
-                                    <!--    'column_alias': 'user_id__ds__month'}              -->
-                                    <!-- col10 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
-                                    <!--    'column_alias': 'user_id__ds__quarter'}            -->
-                                    <!-- col11 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
-                                    <!--    'column_alias': 'user_id__ds__year'}               -->
-                                    <!-- col12 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10273),  -->
-                                    <!--    'column_alias': 'user_id__team_id'}                      -->
-                                    <!-- col13 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10274),  -->
-                                    <!--    'column_alias': 'user_id'}                               -->
-                                    <!-- col14 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10275),  -->
-                                    <!--    'column_alias': 'user_team___team_id'}                   -->
-                                    <!-- col15 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
-                                    <!--    'column_alias': 'user_team___user_id'}                   -->
-                                    <!-- col16 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
-                                    <!--    'column_alias': 'user_id__user_team___team_id'}          -->
-                                    <!-- col17 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
-                                    <!--    'column_alias': 'user_id__user_team___user_id'}          -->
-                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
-                                    <!-- where = None -->
-                                    <SqlTableFromClauseNode>
-                                        <!-- description = Read from ***************************.fct_messages -->
-                                        <!-- node_id = tfc_10011 -->
-                                        <!-- table_id = ***************************.fct_messages -->
-                                    </SqlTableFromClauseNode>
-                                </SqlSelectStatementNode>
+                                <SqlTableFromClauseNode>
+                                    <!-- description = Read from ***************************.fct_messages -->
+                                    <!-- node_id = tfc_10011 -->
+                                    <!-- table_id = ***************************.fct_messages -->
+                                </SqlTableFromClauseNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
@@ -386,18 +308,18 @@
                         <!-- description =                 -->
                         <!--   Pass Only Elements:         -->
                         <!--     ['user_team', 'country']  -->
-                        <!-- node_id = ss_5 -->
+                        <!-- node_id = ss_3 -->
                         <!-- col0 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
                         <!--    'column_alias': 'user_team___team_id'}                -->
                         <!-- col1 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_87),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
                         <!--    'column_alias': 'user_team___user_id'}                -->
                         <!-- col2 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_85),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
                         <!--    'column_alias': 'country'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10017) -->
                         <!-- where = None -->
@@ -406,7 +328,7 @@
                             <!-- node_id = ss_10017 -->
                             <!-- col0 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10288),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10289),  -->
                             <!--    'column_alias': 'ds'}                                    -->
                             <!-- col1 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -426,15 +348,15 @@
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col5 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10293),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10294),  -->
                             <!--    'column_alias': 'team_id'}                               -->
                             <!-- col6 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10294),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10295),  -->
                             <!--    'column_alias': 'country'}                               -->
                             <!-- col7 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10295),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10296),  -->
                             <!--    'column_alias': 'user_id__ds'}                           -->
                             <!-- col8 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -454,15 +376,15 @@
                             <!--    'column_alias': 'user_id__ds__year'}               -->
                             <!-- col12 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10300),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10301),  -->
                             <!--    'column_alias': 'user_id__team_id'}                      -->
                             <!-- col13 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10301),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10302),  -->
                             <!--    'column_alias': 'user_id__country'}                      -->
                             <!-- col14 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10302),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10303),  -->
                             <!--    'column_alias': 'user_composite_ident_2__ds'}            -->
                             <!-- col15 =                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                          -->
@@ -482,15 +404,15 @@
                             <!--    'column_alias': 'user_composite_ident_2__ds__year'}  -->
                             <!-- col19 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10307),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10308),  -->
                             <!--    'column_alias': 'user_composite_ident_2__team_id'}       -->
                             <!-- col20 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10308),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10309),  -->
                             <!--    'column_alias': 'user_composite_ident_2__country'}       -->
                             <!-- col21 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10309),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10310),  -->
                             <!--    'column_alias': 'user_team__ds'}                         -->
                             <!-- col22 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -510,71 +432,71 @@
                             <!--    'column_alias': 'user_team__ds__year'}             -->
                             <!-- col26 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10314),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10315),  -->
                             <!--    'column_alias': 'user_team__team_id'}                    -->
                             <!-- col27 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10315),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10316),  -->
                             <!--    'column_alias': 'user_team__country'}                    -->
                             <!-- col28 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10316),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10317),  -->
                             <!--    'column_alias': 'user_id'}                               -->
                             <!-- col29 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10317),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10318),  -->
                             <!--    'column_alias': 'user_composite_ident_2___ident_2'}      -->
                             <!-- col30 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10318),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10319),  -->
                             <!--    'column_alias': 'user_composite_ident_2___user_id'}      -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10319),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10320),  -->
                             <!--    'column_alias': 'user_team___team_id'}                   -->
                             <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10320),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10321),  -->
                             <!--    'column_alias': 'user_team___user_id'}                   -->
                             <!-- col33 =                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10321),       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10322),       -->
                             <!--    'column_alias': 'user_id__user_composite_ident_2___ident_2'}  -->
                             <!-- col34 =                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10322),       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10323),       -->
                             <!--    'column_alias': 'user_id__user_composite_ident_2___user_id'}  -->
                             <!-- col35 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10323),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10324),  -->
                             <!--    'column_alias': 'user_id__user_team___team_id'}          -->
                             <!-- col36 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10324),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10325),  -->
                             <!--    'column_alias': 'user_id__user_team___user_id'}          -->
                             <!-- col37 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10325),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10326),  -->
                             <!--    'column_alias': 'user_composite_ident_2__user_id'}       -->
                             <!-- col38 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10326),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10327),         -->
                             <!--    'column_alias': 'user_composite_ident_2__user_team___team_id'}  -->
                             <!-- col39 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10327),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10328),         -->
                             <!--    'column_alias': 'user_composite_ident_2__user_team___user_id'}  -->
                             <!-- col40 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10328),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10329),  -->
                             <!--    'column_alias': 'user_team__user_id'}                    -->
                             <!-- col41 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10329),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10330),         -->
                             <!--    'column_alias': 'user_team__user_composite_ident_2___ident_2'}  -->
                             <!-- col42 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10330),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10331),         -->
                             <!--    'column_alias': 'user_team__user_composite_ident_2___user_id'}  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10013) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_order_by__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_composite_identifier_with_order_by__plan0.xml
@@ -1,347 +1,269 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Order By ['user_team'] -->
-        <!-- node_id = ss_7 -->
+        <!-- node_id = ss_5 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_94),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
         <!--    'column_alias': 'user_team___team_id'}                -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_95),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
         <!--    'column_alias': 'user_team___user_id'}                -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_93),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
         <!--    'column_alias': 'messages'}                           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- where = None -->
         <!-- order_by0 =                                              -->
         <!--   {'class': 'SqlOrderByDescription',                     -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_91),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),  -->
         <!--    'desc': True}                                         -->
         <!-- order_by1 =                                              -->
         <!--   {'class': 'SqlOrderByDescription',                     -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_92),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),  -->
         <!--    'desc': True}                                         -->
         <SqlSelectStatementNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = ss_6 -->
+            <!-- node_id = ss_4 -->
             <!-- col0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_88),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
             <!--    'column_alias': 'user_team___team_id'}                -->
             <!-- col1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_89),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
             <!--    'column_alias': 'user_team___user_id'}                -->
             <!-- col2 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_90),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
             <!--    'column_alias': 'messages'}                           -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Aggregate Measures -->
-                <!-- node_id = ss_5 -->
+                <!-- node_id = ss_3 -->
                 <!-- col0 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
                 <!--    'column_alias': 'user_team___team_id'}                -->
                 <!-- col1 =                                                   -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_87),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
                 <!--    'column_alias': 'user_team___user_id'}                -->
                 <!-- col2 =                                                              -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
                 <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                 <!--    'column_alias': 'messages'}                                      -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
                 <!--    'column_alias': 'user_team___team_id'}                -->
                 <!-- group_by1 =                                              -->
                 <!--   {'class': 'SqlSelectColumn',                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_87),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
                 <!--    'column_alias': 'user_team___user_id'}                -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description =                  -->
                     <!--   Pass Only Elements:          -->
                     <!--     ['messages', 'user_team']  -->
-                    <!-- node_id = ss_4 -->
+                    <!-- node_id = ss_2 -->
                     <!-- col0 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_83),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
                     <!--    'column_alias': 'user_team___team_id'}                -->
                     <!-- col1 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_84),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
                     <!--    'column_alias': 'user_team___user_id'}                -->
                     <!-- col2 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_82),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
                     <!--    'column_alias': 'messages'}                           -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = ss_3 -->
+                        <!-- node_id = ss_1 -->
                         <!-- col0 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_62),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_26),  -->
                         <!--    'column_alias': 'ds'}                                 -->
                         <!-- col1 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_63),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_27),  -->
                         <!--    'column_alias': 'ds__week'}                           -->
                         <!-- col2 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_64),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_28),  -->
                         <!--    'column_alias': 'ds__month'}                          -->
                         <!-- col3 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_65),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_29),  -->
                         <!--    'column_alias': 'ds__quarter'}                        -->
                         <!-- col4 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_66),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_30),  -->
                         <!--    'column_alias': 'ds__year'}                           -->
                         <!-- col5 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_67),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_31),  -->
                         <!--    'column_alias': 'user_id__ds'}                        -->
                         <!-- col6 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_68),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_32),  -->
                         <!--    'column_alias': 'user_id__ds__week'}                  -->
                         <!-- col7 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_69),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_33),  -->
                         <!--    'column_alias': 'user_id__ds__month'}                 -->
                         <!-- col8 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_34),  -->
                         <!--    'column_alias': 'user_id__ds__quarter'}               -->
                         <!-- col9 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_35),  -->
                         <!--    'column_alias': 'user_id__ds__year'}                  -->
                         <!-- col10 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_72),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_36),  -->
                         <!--    'column_alias': 'metric_time'}                        -->
                         <!-- col11 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_73),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_37),  -->
                         <!--    'column_alias': 'metric_time__week'}                  -->
                         <!-- col12 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_74),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_38),  -->
                         <!--    'column_alias': 'metric_time__month'}                 -->
                         <!-- col13 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_75),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_39),  -->
                         <!--    'column_alias': 'metric_time__quarter'}               -->
                         <!-- col14 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_76),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_40),  -->
                         <!--    'column_alias': 'metric_time__year'}                  -->
                         <!-- col15 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_77),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
                         <!--    'column_alias': 'user_id'}                            -->
                         <!-- col16 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_78),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
                         <!--    'column_alias': 'user_team___team_id'}                -->
                         <!-- col17 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_79),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
                         <!--    'column_alias': 'user_team___user_id'}                -->
                         <!-- col18 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_80),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
                         <!--    'column_alias': 'user_id__user_team___team_id'}       -->
                         <!-- col19 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_81),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
                         <!--    'column_alias': 'user_id__user_team___user_id'}       -->
                         <!-- col20 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_60),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_24),  -->
                         <!--    'column_alias': 'team_id'}                            -->
                         <!-- col21 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_61),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_25),  -->
                         <!--    'column_alias': 'user_id__team_id'}                   -->
                         <!-- col22 =                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_59),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_23),  -->
                         <!--    'column_alias': 'messages'}                           -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10015) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = ss_2 -->
-                            <!-- col0 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_44),  -->
-                            <!--    'column_alias': 'ds'}                                 -->
-                            <!-- col1 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_45),  -->
-                            <!--    'column_alias': 'ds__week'}                           -->
-                            <!-- col2 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_46),  -->
-                            <!--    'column_alias': 'ds__month'}                          -->
-                            <!-- col3 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_47),  -->
-                            <!--    'column_alias': 'ds__quarter'}                        -->
-                            <!-- col4 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_48),  -->
-                            <!--    'column_alias': 'ds__year'}                           -->
-                            <!-- col5 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_49),  -->
-                            <!--    'column_alias': 'user_id__ds'}                        -->
-                            <!-- col6 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_50),  -->
-                            <!--    'column_alias': 'user_id__ds__week'}                  -->
-                            <!-- col7 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_51),  -->
-                            <!--    'column_alias': 'user_id__ds__month'}                 -->
-                            <!-- col8 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_52),  -->
-                            <!--    'column_alias': 'user_id__ds__quarter'}               -->
-                            <!-- col9 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_53),  -->
-                            <!--    'column_alias': 'user_id__ds__year'}                  -->
-                            <!-- col10 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_54),  -->
-                            <!--    'column_alias': 'user_id'}                            -->
-                            <!-- col11 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_55),  -->
-                            <!--    'column_alias': 'user_team___team_id'}                -->
-                            <!-- col12 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_56),  -->
-                            <!--    'column_alias': 'user_team___user_id'}                -->
-                            <!-- col13 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_57),  -->
-                            <!--    'column_alias': 'user_id__user_team___team_id'}       -->
-                            <!-- col14 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_58),  -->
-                            <!--    'column_alias': 'user_id__user_team___user_id'}       -->
-                            <!-- col15 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_42),  -->
-                            <!--    'column_alias': 'team_id'}                            -->
-                            <!-- col16 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_43),  -->
-                            <!--    'column_alias': 'user_id__team_id'}                   -->
-                            <!-- col17 =                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_41),  -->
-                            <!--    'column_alias': 'messages'}                           -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10015) -->
+                            <!-- description = Read Elements From Data Source 'messages_source' -->
+                            <!-- node_id = ss_10015 -->
+                            <!-- col0 =                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
+                            <!--    'column_alias': 'messages'}                                 -->
+                            <!-- col1 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10263),  -->
+                            <!--    'column_alias': 'ds'}                                    -->
+                            <!-- col2 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
+                            <!--    'column_alias': 'ds__week'}                        -->
+                            <!-- col3 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
+                            <!--    'column_alias': 'ds__month'}                       -->
+                            <!-- col4 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
+                            <!--    'column_alias': 'ds__quarter'}                     -->
+                            <!-- col5 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
+                            <!--    'column_alias': 'ds__year'}                        -->
+                            <!-- col6 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
+                            <!--    'column_alias': 'team_id'}                               -->
+                            <!-- col7 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10269),  -->
+                            <!--    'column_alias': 'user_id__ds'}                           -->
+                            <!-- col8 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
+                            <!--    'column_alias': 'user_id__ds__week'}               -->
+                            <!-- col9 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
+                            <!--    'column_alias': 'user_id__ds__month'}              -->
+                            <!-- col10 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
+                            <!--    'column_alias': 'user_id__ds__quarter'}            -->
+                            <!-- col11 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
+                            <!--    'column_alias': 'user_id__ds__year'}               -->
+                            <!-- col12 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10274),  -->
+                            <!--    'column_alias': 'user_id__team_id'}                      -->
+                            <!-- col13 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10275),  -->
+                            <!--    'column_alias': 'user_id'}                               -->
+                            <!-- col14 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
+                            <!--    'column_alias': 'user_team___team_id'}                   -->
+                            <!-- col15 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
+                            <!--    'column_alias': 'user_team___user_id'}                   -->
+                            <!-- col16 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
+                            <!--    'column_alias': 'user_id__user_team___team_id'}          -->
+                            <!-- col17 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10279),  -->
+                            <!--    'column_alias': 'user_id__user_team___user_id'}          -->
+                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
                             <!-- where = None -->
-                            <SqlSelectStatementNode>
-                                <!-- description = Read Elements From Data Source 'messages_source' -->
-                                <!-- node_id = ss_10015 -->
-                                <!-- col0 =                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10005 sql_expr=1),  -->
-                                <!--    'column_alias': 'messages'}                                 -->
-                                <!-- col1 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10262),  -->
-                                <!--    'column_alias': 'ds'}                                    -->
-                                <!-- col2 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10144),  -->
-                                <!--    'column_alias': 'ds__week'}                        -->
-                                <!-- col3 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10145),  -->
-                                <!--    'column_alias': 'ds__month'}                       -->
-                                <!-- col4 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10146),  -->
-                                <!--    'column_alias': 'ds__quarter'}                     -->
-                                <!-- col5 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10147),  -->
-                                <!--    'column_alias': 'ds__year'}                        -->
-                                <!-- col6 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10267),  -->
-                                <!--    'column_alias': 'team_id'}                               -->
-                                <!-- col7 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10268),  -->
-                                <!--    'column_alias': 'user_id__ds'}                           -->
-                                <!-- col8 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10148),  -->
-                                <!--    'column_alias': 'user_id__ds__week'}               -->
-                                <!-- col9 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10149),  -->
-                                <!--    'column_alias': 'user_id__ds__month'}              -->
-                                <!-- col10 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10150),  -->
-                                <!--    'column_alias': 'user_id__ds__quarter'}            -->
-                                <!-- col11 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10151),  -->
-                                <!--    'column_alias': 'user_id__ds__year'}               -->
-                                <!-- col12 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10273),  -->
-                                <!--    'column_alias': 'user_id__team_id'}                      -->
-                                <!-- col13 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10274),  -->
-                                <!--    'column_alias': 'user_id'}                               -->
-                                <!-- col14 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10275),  -->
-                                <!--    'column_alias': 'user_team___team_id'}                   -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10276),  -->
-                                <!--    'column_alias': 'user_team___user_id'}                   -->
-                                <!-- col16 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10277),  -->
-                                <!--    'column_alias': 'user_id__user_team___team_id'}          -->
-                                <!-- col17 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10278),  -->
-                                <!--    'column_alias': 'user_id__user_team___user_id'}          -->
-                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10011) -->
-                                <!-- where = None -->
-                                <SqlTableFromClauseNode>
-                                    <!-- description = Read from ***************************.fct_messages -->
-                                    <!-- node_id = tfc_10011 -->
-                                    <!-- table_id = ***************************.fct_messages -->
-                                </SqlTableFromClauseNode>
-                            </SqlSelectStatementNode>
+                            <SqlTableFromClauseNode>
+                                <!-- description = Read from ***************************.fct_messages -->
+                                <!-- node_id = tfc_10011 -->
+                                <!-- table_id = ***************************.fct_messages -->
+                            </SqlTableFromClauseNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -92,35 +92,35 @@
                         <!--    'column_alias': 'instant_bookings'}                                                              -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                         <!--    'column_alias': 'booking_value'}                         -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                         <!--    'column_alias': 'max_booking_value'}                     -->
                         <!-- col4 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                         <!--    'column_alias': 'min_booking_value'}                     -->
                         <!-- col5 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                         <!--    'column_alias': 'bookers'}                               -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                         <!--    'column_alias': 'average_booking_value'}                 -->
                         <!-- col7 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                         <!--    'column_alias': 'booking_payments'}                      -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
                         <!-- col9 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -140,7 +140,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                         <!--    'column_alias': 'ds_partitioned'}                        -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -160,7 +160,7 @@
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col19 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                         <!--    'column_alias': 'booking_paid_at'}                       -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -180,11 +180,11 @@
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
                         <!-- col24 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col25 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col26 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -204,7 +204,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col30 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col31 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -224,7 +224,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col35 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col36 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -244,31 +244,31 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col40 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col41 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                         <!--    'column_alias': 'guest'}                                 -->
                         <!-- col42 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                         <!--    'column_alias': 'host'}                                  -->
                         <!-- col43 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                         <!-- col44 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col45 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col46 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
@@ -302,15 +302,15 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -330,7 +330,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -350,19 +350,19 @@
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -382,7 +382,7 @@
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -402,27 +402,27 @@
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.xml
@@ -1,757 +1,567 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_42 -->
+        <!-- node_id = ss_23 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_803),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_425),  -->
         <!--    'column_alias': 'ds'}                                  -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_802),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_424),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
         <!-- col2 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
         <!--    'column_alias': 'bookings_per_view'}                  -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_41) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description =                                               -->
             <!--   Pass Only Elements:                                       -->
             <!--     ['listing__country_latest', 'ds', 'bookings', 'views']  -->
-            <!-- node_id = ss_41 -->
+            <!-- node_id = ss_22 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_801),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_423),  -->
             <!--    'column_alias': 'ds'}                                  -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_800),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_422),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_798),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_420),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_799),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_421),  -->
             <!--    'column_alias': 'views'}                               -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_40) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Join Aggregated Measures with Standard Outputs -->
-                <!-- node_id = ss_40 -->
+                <!-- node_id = ss_21 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_796),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_418),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_795),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_417),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_794),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_416),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- col3 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_797),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_419),  -->
                 <!--    'column_alias': 'views'}                               -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_30) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- join_0 =                                                   -->
                 <!--   {'class': 'SqlJoinDescription',                          -->
-                <!--    'right_source': SqlSelectStatementNode(node_id=ss_39),  -->
-                <!--    'right_source_alias': 'subq_21',                        -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_5),     -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),  -->
+                <!--    'right_source_alias': 'subq_17',                        -->
+                <!--    'on_condition': SqlLogicalExpression(node_id=lo_4),     -->
                 <!--    'join_type': SqlJoinType.INNER}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_30 -->
+                    <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                     <!--    'column_alias': 'bookings'}                                      -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- group_by1 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                                      -->
                         <!--   Pass Only Elements:                              -->
                         <!--     ['bookings', 'listing__country_latest', 'ds']  -->
-                        <!-- node_id = ss_29 -->
+                        <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_643),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_641),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                         <!--    'column_alias': 'bookings'}                            -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Join Standard Outputs -->
-                            <!-- node_id = ss_28 -->
+                            <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_638),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_639),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_640),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_637),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                             <!--    'column_alias': 'bookings'}                            -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
-                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_27),   -->
-                            <!--    'right_source_alias': 'subq_7',                          -->
-                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_3),  -->
+                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_10),   -->
+                            <!--    'right_source_alias': 'subq_5',                          -->
+                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER}                     -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description =                      -->
                                 <!--   Pass Only Elements:              -->
                                 <!--     ['bookings', 'ds', 'listing']  -->
-                                <!-- node_id = ss_24 -->
+                                <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_23 -->
+                                    <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
                                     <!-- col15 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                     <!-- col16 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                     <!-- col17 =                                                            -->
                                     <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                     <!-- col18 =                                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                     <!-- col19 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                     <!-- col20 =                                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                     <!-- col21 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                     <!-- col22 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                     <!-- col23 =                                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                     <!-- col24 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                     <!-- col25 =                                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                                     <!-- col26 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                                     <!-- col27 =                                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                                     <!-- col28 =                                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                                     <!-- col29 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                                     <!--    'column_alias': 'guest'}                               -->
                                     <!-- col37 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                                     <!--    'column_alias': 'host'}                                -->
                                     <!-- col38 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                     <!-- col39 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                     <!-- col40 =                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                                     <!-- col41 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- col42 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'is_instant'}                          -->
                                     <!-- col43 =                                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                                     <!-- col44 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'bookings'}                            -->
                                     <!-- col45 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'instant_bookings'}                    -->
                                     <!-- col46 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'booking_value'}                       -->
                                     <!-- col47 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'max_booking_value'}                   -->
                                     <!-- col48 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'min_booking_value'}                   -->
                                     <!-- col49 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col50 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_22 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                        <!--    'column_alias': 'ds_partitioned'}                      -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                        <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                        <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                        <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                        <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                                        <!--    'column_alias': 'booking_paid_at'}                     -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                                        <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                                        <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                        <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                        <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col16 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col17 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col18 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col19 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col20 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col21 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col22 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col23 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col24 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col25 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col26 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col27 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col28 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col29 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                                        <!--    'column_alias': 'guest'}                               -->
-                                        <!-- col32 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                                        <!--    'column_alias': 'host'}                                -->
-                                        <!-- col33 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                        <!-- col34 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col35 =                                                        -->
+                                        <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                        <!-- node_id = ss_10001 -->
+                                        <!-- col0 =                                                         -->
                                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col36 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                        <!-- col37 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                        <!--    'column_alias': 'is_instant'}                          -->
-                                        <!-- col38 =                                                             -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                        <!--    'column_alias': 'bookings'}                                 -->
+                                        <!-- col1 =                                                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                        <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                        <!--    'column_alias': 'booking_value'}                         -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                        <!--    'column_alias': 'max_booking_value'}                     -->
+                                        <!-- col4 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                        <!--    'column_alias': 'min_booking_value'}                     -->
+                                        <!-- col5 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                        <!--    'column_alias': 'bookers'}                               -->
+                                        <!-- col6 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                        <!--    'column_alias': 'average_booking_value'}                 -->
+                                        <!-- col7 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                        <!--    'column_alias': 'booking_payments'}                      -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                        <!--    'column_alias': 'is_instant'}                            -->
+                                        <!-- col9 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col13 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                        <!--    'column_alias': 'ds_partitioned'}                        -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                        <!-- col16 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                        <!-- col19 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                        <!--    'column_alias': 'booking_paid_at'}                       -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                        <!-- col21 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                        <!-- col24 =                                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                        <!-- col39 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                        <!--    'column_alias': 'bookings'}                            -->
-                                        <!-- col40 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                        <!--    'column_alias': 'instant_bookings'}                    -->
-                                        <!-- col41 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                        <!--    'column_alias': 'booking_value'}                       -->
-                                        <!-- col42 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                        <!--    'column_alias': 'max_booking_value'}                   -->
-                                        <!-- col43 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                        <!--    'column_alias': 'min_booking_value'}                   -->
-                                        <!-- col44 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                        <!--    'column_alias': 'bookers'}                             -->
-                                        <!-- col45 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                        <!--    'column_alias': 'average_booking_value'}               -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                        <!-- col25 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                        <!-- col26 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                        <!-- col27 =                                                            -->
+                                        <!--   {'class': 'SqlSelectColumn',                                     -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                        <!-- col28 =                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                       -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                        <!-- col29 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                        <!-- col30 =                                                                 -->
+                                        <!--   {'class': 'SqlSelectColumn',                                          -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                        <!-- col31 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                        <!-- col32 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                        <!-- col33 =                                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                        <!-- col34 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                        <!-- col35 =                                                                  -->
+                                        <!--   {'class': 'SqlSelectColumn',                                           -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                        <!-- col36 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                        <!-- col37 =                                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                        <!-- col38 =                                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                        <!-- col39 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                        <!-- col40 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col41 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                        <!--    'column_alias': 'guest'}                                 -->
+                                        <!-- col42 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                        <!--    'column_alias': 'host'}                                  -->
+                                        <!-- col43 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                        <!-- col44 =                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                   -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                        <!-- col45 =                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                        <!-- col46 =                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                            <!-- node_id = ss_10001 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                            <!--    'column_alias': 'bookings'}                                 -->
-                                            <!-- col1 =                                                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                            <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                            <!--    'column_alias': 'booking_value'}                         -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                            <!--    'column_alias': 'max_booking_value'}                     -->
-                                            <!-- col4 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                            <!--    'column_alias': 'min_booking_value'}                     -->
-                                            <!-- col5 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                            <!--    'column_alias': 'bookers'}                               -->
-                                            <!-- col6 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                            <!--    'column_alias': 'average_booking_value'}                 -->
-                                            <!-- col7 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                            <!--    'column_alias': 'booking_payments'}                      -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                            <!--    'column_alias': 'is_instant'}                            -->
-                                            <!-- col9 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col13 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                            <!--    'column_alias': 'ds_partitioned'}                        -->
-                                            <!-- col15 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                            <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                            <!-- col16 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                            <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                            <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                            <!-- col19 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                            <!--    'column_alias': 'booking_paid_at'}                       -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                            <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                            <!-- col21 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                            <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                            <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                            <!-- col24 =                                                             -->
-                                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                            <!-- col25 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col26 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col27 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col28 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col29 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col30 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col31 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col32 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col33 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col34 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col35 =                                                                  -->
-                                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                            <!-- col36 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                            <!-- col37 =                                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                            <!-- col38 =                                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                            <!-- col39 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                            <!-- col40 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col41 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                            <!--    'column_alias': 'guest'}                                 -->
-                                            <!-- col42 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                            <!--    'column_alias': 'host'}                                  -->
-                                            <!-- col43 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                            <!-- col44 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col45 =                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                            <!-- col46 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                            <!-- where = None -->
-                                            <SqlSelectQueryFromClauseNode>
-                                                <!-- description = Read From a Select Query -->
-                                                <!-- node_id = tfc_10001 -->
-                                            </SqlSelectQueryFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlSelectQueryFromClauseNode>
+                                            <!-- description = Read From a Select Query -->
+                                            <!-- node_id = tfc_10001 -->
+                                        </SqlSelectQueryFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -759,442 +569,308 @@
                                 <!-- description =                      -->
                                 <!--   Pass Only Elements:              -->
                                 <!--     ['listing', 'country_latest']  -->
-                                <!-- node_id = ss_27 -->
+                                <!-- node_id = ss_10 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_634),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_633),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_26 -->
+                                    <!-- node_id = ss_9 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_612),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_614),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_615),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_616),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_617),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_618),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_619),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_620),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_621),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_622),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_623),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_624),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_625),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_626),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_627),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_628),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_629),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_630),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_631),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_632),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_25 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_573),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
-                                        <!--    'column_alias': 'created_at'}                          -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),  -->
-                                        <!--    'column_alias': 'created_at__week'}                    -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
-                                        <!--    'column_alias': 'created_at__month'}                   -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
-                                        <!--    'column_alias': 'created_at__quarter'}                 -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
-                                        <!--    'column_alias': 'created_at__year'}                    -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
-                                        <!--    'column_alias': 'listing__ds'}                         -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
-                                        <!--    'column_alias': 'listing__ds__week'}                   -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),  -->
-                                        <!--    'column_alias': 'listing__ds__month'}                  -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),  -->
-                                        <!--    'column_alias': 'listing__ds__quarter'}                -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),  -->
-                                        <!--    'column_alias': 'listing__ds__year'}                   -->
-                                        <!-- col15 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),  -->
-                                        <!--    'column_alias': 'listing__created_at'}                 -->
-                                        <!-- col16 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
-                                        <!--    'column_alias': 'listing__created_at__week'}           -->
-                                        <!-- col17 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
-                                        <!--    'column_alias': 'listing__created_at__month'}          -->
-                                        <!-- col18 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),  -->
-                                        <!--    'column_alias': 'listing__created_at__quarter'}        -->
-                                        <!-- col19 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),  -->
-                                        <!--    'column_alias': 'listing__created_at__year'}           -->
-                                        <!-- col20 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col21 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),  -->
-                                        <!--    'column_alias': 'user'}                                -->
-                                        <!-- col22 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),  -->
-                                        <!--    'column_alias': 'listing__user'}                       -->
-                                        <!-- col23 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
-                                        <!--    'column_alias': 'country_latest'}                      -->
-                                        <!-- col24 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
-                                        <!--    'column_alias': 'is_lux_latest'}                       -->
-                                        <!-- col25 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_569),  -->
-                                        <!--    'column_alias': 'capacity_latest'}                     -->
-                                        <!-- col26 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
-                                        <!--    'column_alias': 'listing__country_latest'}             -->
-                                        <!-- col27 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
-                                        <!--    'column_alias': 'listing__is_lux_latest'}              -->
-                                        <!-- col28 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
-                                        <!--    'column_alias': 'listing__capacity_latest'}            -->
-                                        <!-- col29 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
-                                        <!--    'column_alias': 'listings'}                            -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
-                                        <!--    'column_alias': 'largest_listing'}                     -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
-                                        <!--    'column_alias': 'smallest_listing'}                    -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
+                                        <!-- description = Read Elements From Data Source 'listings_latest' -->
+                                        <!-- node_id = ss_10004 -->
+                                        <!-- col0 =                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
+                                        <!--    'column_alias': 'listings'}                                 -->
+                                        <!-- col1 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                                        <!--    'column_alias': 'largest_listing'}                       -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                                        <!--    'column_alias': 'smallest_listing'}                      -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col4 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col5 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col6 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col7 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'column_alias': 'created_at'}                            -->
+                                        <!-- col9 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'column_alias': 'created_at__week'}                -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'column_alias': 'created_at__month'}               -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'column_alias': 'created_at__quarter'}             -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'column_alias': 'created_at__year'}                -->
+                                        <!-- col13 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'column_alias': 'country_latest'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                                        <!--    'column_alias': 'is_lux_latest'}                         -->
+                                        <!-- col15 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                                        <!--    'column_alias': 'capacity_latest'}                       -->
+                                        <!-- col16 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
+                                        <!--    'column_alias': 'listing__ds'}                           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'column_alias': 'listing__ds__week'}               -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'column_alias': 'listing__ds__month'}              -->
+                                        <!-- col19 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'column_alias': 'listing__ds__quarter'}            -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'column_alias': 'listing__ds__year'}               -->
+                                        <!-- col21 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'column_alias': 'listing__created_at'}                   -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'column_alias': 'listing__created_at__week'}       -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'column_alias': 'listing__created_at__month'}      -->
+                                        <!-- col24 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'column_alias': 'listing__created_at__quarter'}    -->
+                                        <!-- col25 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'column_alias': 'listing__created_at__year'}       -->
+                                        <!-- col26 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'column_alias': 'listing__country_latest'}               -->
+                                        <!-- col27 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                                        <!--    'column_alias': 'listing__is_lux_latest'}                -->
+                                        <!-- col28 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                                        <!--    'column_alias': 'listing__capacity_latest'}              -->
+                                        <!-- col29 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                                        <!--    'column_alias': 'user'}                                  -->
+                                        <!-- col31 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'column_alias': 'listing__user'}                         -->
+                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'listings_latest' -->
-                                            <!-- node_id = ss_10004 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
-                                            <!--    'column_alias': 'listings'}                                 -->
-                                            <!-- col1 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
-                                            <!--    'column_alias': 'largest_listing'}                       -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                                            <!--    'column_alias': 'smallest_listing'}                      -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col4 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col5 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col6 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col7 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
-                                            <!--    'column_alias': 'created_at'}                            -->
-                                            <!-- col9 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
-                                            <!--    'column_alias': 'created_at__week'}                -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
-                                            <!--    'column_alias': 'created_at__month'}               -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
-                                            <!--    'column_alias': 'created_at__quarter'}             -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
-                                            <!--    'column_alias': 'created_at__year'}                -->
-                                            <!-- col13 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
-                                            <!--    'column_alias': 'country_latest'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                                            <!--    'column_alias': 'is_lux_latest'}                         -->
-                                            <!-- col15 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                                            <!--    'column_alias': 'capacity_latest'}                       -->
-                                            <!-- col16 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
-                                            <!--    'column_alias': 'listing__ds'}                           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
-                                            <!--    'column_alias': 'listing__ds__week'}               -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
-                                            <!--    'column_alias': 'listing__ds__month'}              -->
-                                            <!-- col19 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
-                                            <!--    'column_alias': 'listing__ds__quarter'}            -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
-                                            <!--    'column_alias': 'listing__ds__year'}               -->
-                                            <!-- col21 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                                            <!--    'column_alias': 'listing__created_at'}                   -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
-                                            <!--    'column_alias': 'listing__created_at__week'}       -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
-                                            <!--    'column_alias': 'listing__created_at__month'}      -->
-                                            <!-- col24 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
-                                            <!--    'column_alias': 'listing__created_at__quarter'}    -->
-                                            <!-- col25 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
-                                            <!--    'column_alias': 'listing__created_at__year'}       -->
-                                            <!-- col26 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
-                                            <!--    'column_alias': 'listing__country_latest'}               -->
-                                            <!-- col27 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
-                                            <!--    'column_alias': 'listing__is_lux_latest'}                -->
-                                            <!-- col28 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
-                                            <!--    'column_alias': 'listing__capacity_latest'}              -->
-                                            <!-- col29 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col30 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
-                                            <!--    'column_alias': 'user'}                                  -->
-                                            <!-- col31 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
-                                            <!--    'column_alias': 'listing__user'}                         -->
-                                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
-                                            <!-- where = None -->
-                                            <SqlTableFromClauseNode>
-                                                <!-- description = Read from ***************************.dim_listings_latest -->
-                                                <!-- node_id = tfc_10002 -->
-                                                <!-- table_id = ***************************.dim_listings_latest -->
-                                            </SqlTableFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlTableFromClauseNode>
+                                            <!-- description = Read from ***************************.dim_listings_latest -->
+                                            <!-- node_id = tfc_10002 -->
+                                            <!-- table_id = ***************************.dim_listings_latest -->
+                                        </SqlTableFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1203,446 +879,336 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_39 -->
+                    <!-- node_id = ss_20 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_789),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_788),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_3, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
                     <!--    'column_alias': 'views'}                                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_38) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_789),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_411),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- group_by1 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_788),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_410),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                                   -->
                         <!--   Pass Only Elements:                           -->
                         <!--     ['views', 'listing__country_latest', 'ds']  -->
-                        <!-- node_id = ss_38 -->
+                        <!-- node_id = ss_19 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_786),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_408),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_785),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_407),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_784),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_406),  -->
                         <!--    'column_alias': 'views'}                               -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_37) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Join Standard Outputs -->
-                            <!-- node_id = ss_37 -->
+                            <!-- node_id = ss_18 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_781),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_403),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_782),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_404),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_783),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_405),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_780),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
                             <!--    'column_alias': 'views'}                               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_33) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
-                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_36),   -->
-                            <!--    'right_source_alias': 'subq_18',                         -->
-                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_4),  -->
+                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_17),   -->
+                            <!--    'right_source_alias': 'subq_14',                         -->
+                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1),  -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER}                     -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description =                   -->
                                 <!--   Pass Only Elements:           -->
                                 <!--     ['views', 'ds', 'listing']  -->
-                                <!-- node_id = ss_33 -->
+                                <!-- node_id = ss_15 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_705),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
                                 <!--    'column_alias': 'ds'}                                  -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_706),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_704),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
                                 <!--    'column_alias': 'views'}                               -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_32) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_32 -->
+                                    <!-- node_id = ss_14 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_674),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_675),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_676),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_677),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_678),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_679),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_680),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_681),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_682),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_683),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_684),    -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),    -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                     <!-- col11 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_685),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                     <!-- col12 =                                                            -->
                                     <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_686),           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),           -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                     <!-- col13 =                                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_687),             -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),             -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                     <!-- col14 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_688),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                     <!-- col15 =                                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_689),                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),                -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                     <!-- col16 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_690),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                     <!-- col17 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_691),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                     <!-- col18 =                                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_692),                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),                         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                     <!-- col19 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_693),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_694),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_695),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_696),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_697),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_698),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_699),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_700),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_701),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                     <!-- col28 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_702),         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                     <!-- col29 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_703),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__user'}  -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_673),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                                     <!--    'column_alias': 'views'}                               -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_31) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10009) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_31 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_648),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_649),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_650),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_651),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_652),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_653),  -->
-                                        <!--    'column_alias': 'ds_partitioned'}                      -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_654),  -->
-                                        <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_655),  -->
-                                        <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_656),  -->
-                                        <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_657),  -->
-                                        <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                        <!-- col10 =                                                     -->
+                                        <!-- description = Read Elements From Data Source 'views_source' -->
+                                        <!-- node_id = ss_10009 -->
+                                        <!-- col0 =                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10004 sql_expr=1),  -->
+                                        <!--    'column_alias': 'views'}                                    -->
+                                        <!-- col1 =                                                      -->
                                         <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_658),    -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10174),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col2 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10096),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col3 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10097),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col4 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10098),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col5 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10099),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col6 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10179),  -->
+                                        <!--    'column_alias': 'ds_partitioned'}                        -->
+                                        <!-- col7 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10100),  -->
+                                        <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                        <!-- col8 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10101),  -->
+                                        <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                        <!-- col9 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10102),  -->
+                                        <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10103),  -->
+                                        <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                        <!-- col11 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10184),  -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col11 =                                                           -->
+                                        <!-- col12 =                                                           -->
                                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_659),          -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10104),              -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col12 =                                                            -->
+                                        <!-- col13 =                                                            -->
                                         <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_660),           -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10105),               -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col13 =                                                              -->
+                                        <!-- col14 =                                                              -->
                                         <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_661),             -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10106),                 -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col14 =                                                           -->
+                                        <!-- col15 =                                                           -->
                                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_662),          -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10107),              -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col15 =                                                                 -->
+                                        <!-- col16 =                                                                 -->
                                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_663),                -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10189),              -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col16 =                                                                       -->
+                                        <!-- col17 =                                                                       -->
                                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_664),                      -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10108),                          -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col17 =                                                                        -->
+                                        <!-- col18 =                                                                        -->
                                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_665),                       -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10109),                           -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col18 =                                                                          -->
+                                        <!-- col19 =                                                                          -->
                                         <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_666),                         -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10110),                             -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col19 =                                                                       -->
+                                        <!-- col20 =                                                                       -->
                                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_667),                      -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10111),                          -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col20 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_668),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col21 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_669),  -->
-                                        <!--    'column_alias': 'user'}                                -->
-                                        <!-- col22 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_670),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                        <!-- col23 =                                                          -->
+                                        <!-- col21 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10194),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col22 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10195),  -->
+                                        <!--    'column_alias': 'user'}                                  -->
+                                        <!-- col23 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10196),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                        <!-- col24 =                                                          -->
                                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_671),         -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10197),       -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col24 =                                                       -->
+                                        <!-- col25 =                                                       -->
                                         <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_672),      -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10198),    -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__user'}  -->
-                                        <!-- col25 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_647),  -->
-                                        <!--    'column_alias': 'views'}                               -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10009) -->
+                                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10003) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'views_source' -->
-                                            <!-- node_id = ss_10009 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10004 sql_expr=1),  -->
-                                            <!--    'column_alias': 'views'}                                    -->
-                                            <!-- col1 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10173),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col2 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10096),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col3 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10097),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col4 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10098),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col5 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10099),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col6 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10178),  -->
-                                            <!--    'column_alias': 'ds_partitioned'}                        -->
-                                            <!-- col7 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10100),  -->
-                                            <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                            <!-- col8 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10101),  -->
-                                            <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                            <!-- col9 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10102),  -->
-                                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10103),  -->
-                                            <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                            <!-- col11 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10183),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col12 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10104),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col13 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10105),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col14 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10106),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col15 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10107),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col16 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10188),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col17 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10108),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col18 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10109),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col19 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10110),                             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col20 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10111),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col21 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10193),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col22 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10194),  -->
-                                            <!--    'column_alias': 'user'}                                  -->
-                                            <!-- col23 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10195),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                            <!-- col24 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10196),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col25 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10197),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__user'}  -->
-                                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10003) -->
-                                            <!-- where = None -->
-                                            <SqlSelectQueryFromClauseNode>
-                                                <!-- description = Read From a Select Query -->
-                                                <!-- node_id = tfc_10003 -->
-                                            </SqlSelectQueryFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlSelectQueryFromClauseNode>
+                                            <!-- description = Read From a Select Query -->
+                                            <!-- node_id = tfc_10003 -->
+                                        </SqlSelectQueryFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1650,442 +1216,308 @@
                                 <!-- description =                      -->
                                 <!--   Pass Only Elements:              -->
                                 <!--     ['listing', 'country_latest']  -->
-                                <!-- node_id = ss_36 -->
+                                <!-- node_id = ss_17 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_777),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_776),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_35) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_35 -->
+                                    <!-- node_id = ss_16 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_748),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_751),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_752),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_753),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_754),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_755),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_756),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_757),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_758),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_759),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_760),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_761),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_762),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_763),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_764),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_765),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_766),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_767),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_768),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_390),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_769),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_770),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_392),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_771),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_393),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_772),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_773),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_774),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_775),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_742),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_743),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_744),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_745),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_746),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_747),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_739),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_740),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_741),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_34) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_34 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_716),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_717),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_718),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_719),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_720),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_721),  -->
-                                        <!--    'column_alias': 'created_at'}                          -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_722),  -->
-                                        <!--    'column_alias': 'created_at__week'}                    -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_723),  -->
-                                        <!--    'column_alias': 'created_at__month'}                   -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_724),  -->
-                                        <!--    'column_alias': 'created_at__quarter'}                 -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_725),  -->
-                                        <!--    'column_alias': 'created_at__year'}                    -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_726),  -->
-                                        <!--    'column_alias': 'listing__ds'}                         -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_727),  -->
-                                        <!--    'column_alias': 'listing__ds__week'}                   -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_728),  -->
-                                        <!--    'column_alias': 'listing__ds__month'}                  -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_729),  -->
-                                        <!--    'column_alias': 'listing__ds__quarter'}                -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_730),  -->
-                                        <!--    'column_alias': 'listing__ds__year'}                   -->
-                                        <!-- col15 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_731),  -->
-                                        <!--    'column_alias': 'listing__created_at'}                 -->
-                                        <!-- col16 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_732),  -->
-                                        <!--    'column_alias': 'listing__created_at__week'}           -->
-                                        <!-- col17 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_733),  -->
-                                        <!--    'column_alias': 'listing__created_at__month'}          -->
-                                        <!-- col18 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_734),  -->
-                                        <!--    'column_alias': 'listing__created_at__quarter'}        -->
-                                        <!-- col19 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_735),  -->
-                                        <!--    'column_alias': 'listing__created_at__year'}           -->
-                                        <!-- col20 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_736),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col21 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_737),  -->
-                                        <!--    'column_alias': 'user'}                                -->
-                                        <!-- col22 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_738),  -->
-                                        <!--    'column_alias': 'listing__user'}                       -->
-                                        <!-- col23 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_710),  -->
-                                        <!--    'column_alias': 'country_latest'}                      -->
-                                        <!-- col24 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_711),  -->
-                                        <!--    'column_alias': 'is_lux_latest'}                       -->
-                                        <!-- col25 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_712),  -->
-                                        <!--    'column_alias': 'capacity_latest'}                     -->
-                                        <!-- col26 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_713),  -->
-                                        <!--    'column_alias': 'listing__country_latest'}             -->
-                                        <!-- col27 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_714),  -->
-                                        <!--    'column_alias': 'listing__is_lux_latest'}              -->
-                                        <!-- col28 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_715),  -->
-                                        <!--    'column_alias': 'listing__capacity_latest'}            -->
-                                        <!-- col29 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_707),  -->
-                                        <!--    'column_alias': 'listings'}                            -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_708),  -->
-                                        <!--    'column_alias': 'largest_listing'}                     -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_709),  -->
-                                        <!--    'column_alias': 'smallest_listing'}                    -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
+                                        <!-- description = Read Elements From Data Source 'listings_latest' -->
+                                        <!-- node_id = ss_10004 -->
+                                        <!-- col0 =                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
+                                        <!--    'column_alias': 'listings'}                                 -->
+                                        <!-- col1 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                                        <!--    'column_alias': 'largest_listing'}                       -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                                        <!--    'column_alias': 'smallest_listing'}                      -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col4 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col5 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col6 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col7 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'column_alias': 'created_at'}                            -->
+                                        <!-- col9 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'column_alias': 'created_at__week'}                -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'column_alias': 'created_at__month'}               -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'column_alias': 'created_at__quarter'}             -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'column_alias': 'created_at__year'}                -->
+                                        <!-- col13 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'column_alias': 'country_latest'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                                        <!--    'column_alias': 'is_lux_latest'}                         -->
+                                        <!-- col15 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                                        <!--    'column_alias': 'capacity_latest'}                       -->
+                                        <!-- col16 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
+                                        <!--    'column_alias': 'listing__ds'}                           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'column_alias': 'listing__ds__week'}               -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'column_alias': 'listing__ds__month'}              -->
+                                        <!-- col19 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'column_alias': 'listing__ds__quarter'}            -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'column_alias': 'listing__ds__year'}               -->
+                                        <!-- col21 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'column_alias': 'listing__created_at'}                   -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'column_alias': 'listing__created_at__week'}       -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'column_alias': 'listing__created_at__month'}      -->
+                                        <!-- col24 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'column_alias': 'listing__created_at__quarter'}    -->
+                                        <!-- col25 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'column_alias': 'listing__created_at__year'}       -->
+                                        <!-- col26 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'column_alias': 'listing__country_latest'}               -->
+                                        <!-- col27 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                                        <!--    'column_alias': 'listing__is_lux_latest'}                -->
+                                        <!-- col28 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                                        <!--    'column_alias': 'listing__capacity_latest'}              -->
+                                        <!-- col29 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                                        <!--    'column_alias': 'user'}                                  -->
+                                        <!-- col31 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'column_alias': 'listing__user'}                         -->
+                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'listings_latest' -->
-                                            <!-- node_id = ss_10004 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
-                                            <!--    'column_alias': 'listings'}                                 -->
-                                            <!-- col1 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
-                                            <!--    'column_alias': 'largest_listing'}                       -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                                            <!--    'column_alias': 'smallest_listing'}                      -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col4 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col5 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col6 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col7 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
-                                            <!--    'column_alias': 'created_at'}                            -->
-                                            <!-- col9 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
-                                            <!--    'column_alias': 'created_at__week'}                -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
-                                            <!--    'column_alias': 'created_at__month'}               -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
-                                            <!--    'column_alias': 'created_at__quarter'}             -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
-                                            <!--    'column_alias': 'created_at__year'}                -->
-                                            <!-- col13 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
-                                            <!--    'column_alias': 'country_latest'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                                            <!--    'column_alias': 'is_lux_latest'}                         -->
-                                            <!-- col15 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                                            <!--    'column_alias': 'capacity_latest'}                       -->
-                                            <!-- col16 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
-                                            <!--    'column_alias': 'listing__ds'}                           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
-                                            <!--    'column_alias': 'listing__ds__week'}               -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
-                                            <!--    'column_alias': 'listing__ds__month'}              -->
-                                            <!-- col19 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
-                                            <!--    'column_alias': 'listing__ds__quarter'}            -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
-                                            <!--    'column_alias': 'listing__ds__year'}               -->
-                                            <!-- col21 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                                            <!--    'column_alias': 'listing__created_at'}                   -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
-                                            <!--    'column_alias': 'listing__created_at__week'}       -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
-                                            <!--    'column_alias': 'listing__created_at__month'}      -->
-                                            <!-- col24 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
-                                            <!--    'column_alias': 'listing__created_at__quarter'}    -->
-                                            <!-- col25 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
-                                            <!--    'column_alias': 'listing__created_at__year'}       -->
-                                            <!-- col26 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
-                                            <!--    'column_alias': 'listing__country_latest'}               -->
-                                            <!-- col27 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
-                                            <!--    'column_alias': 'listing__is_lux_latest'}                -->
-                                            <!-- col28 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
-                                            <!--    'column_alias': 'listing__capacity_latest'}              -->
-                                            <!-- col29 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col30 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
-                                            <!--    'column_alias': 'user'}                                  -->
-                                            <!-- col31 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
-                                            <!--    'column_alias': 'listing__user'}                         -->
-                                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
-                                            <!-- where = None -->
-                                            <SqlTableFromClauseNode>
-                                                <!-- description = Read from ***************************.dim_listings_latest -->
-                                                <!-- node_id = tfc_10002 -->
-                                                <!-- table_id = ***************************.dim_listings_latest -->
-                                            </SqlTableFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlTableFromClauseNode>
+                                            <!-- description = Read from ***************************.dim_listings_latest -->
+                                            <!-- node_id = tfc_10002 -->
+                                            <!-- table_id = ***************************.dim_listings_latest -->
+                                        </SqlTableFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_data_source__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_data_source__plan0.xml
@@ -104,35 +104,35 @@
                         <!--    'column_alias': 'instant_bookings'}                                                              -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                         <!--    'column_alias': 'booking_value'}                         -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                         <!--    'column_alias': 'max_booking_value'}                     -->
                         <!-- col4 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                         <!--    'column_alias': 'min_booking_value'}                     -->
                         <!-- col5 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                         <!--    'column_alias': 'bookers'}                               -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                         <!--    'column_alias': 'average_booking_value'}                 -->
                         <!-- col7 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                         <!--    'column_alias': 'booking_payments'}                      -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
                         <!-- col9 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -152,7 +152,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                         <!--    'column_alias': 'ds_partitioned'}                        -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -172,7 +172,7 @@
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col19 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                         <!--    'column_alias': 'booking_paid_at'}                       -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -192,11 +192,11 @@
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
                         <!-- col24 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col25 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col26 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -216,7 +216,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col30 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col31 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -236,7 +236,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col35 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col36 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -256,31 +256,31 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col40 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col41 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                         <!--    'column_alias': 'guest'}                                 -->
                         <!-- col42 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                         <!--    'column_alias': 'host'}                                  -->
                         <!-- col43 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                         <!-- col44 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col45 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col46 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
@@ -314,15 +314,15 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -342,7 +342,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -362,19 +362,19 @@
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -394,7 +394,7 @@
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -414,27 +414,27 @@
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -92,35 +92,35 @@
                         <!--    'column_alias': 'instant_bookings'}                                                              -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                         <!--    'column_alias': 'booking_value'}                         -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                         <!--    'column_alias': 'max_booking_value'}                     -->
                         <!-- col4 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                         <!--    'column_alias': 'min_booking_value'}                     -->
                         <!-- col5 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                         <!--    'column_alias': 'bookers'}                               -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                         <!--    'column_alias': 'average_booking_value'}                 -->
                         <!-- col7 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                         <!--    'column_alias': 'booking_payments'}                      -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
                         <!-- col9 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -140,7 +140,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                         <!--    'column_alias': 'ds_partitioned'}                        -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -160,7 +160,7 @@
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col19 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                         <!--    'column_alias': 'booking_paid_at'}                       -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -180,11 +180,11 @@
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
                         <!-- col24 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col25 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col26 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -204,7 +204,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col30 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col31 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -224,7 +224,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col35 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col36 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -244,31 +244,31 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col40 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col41 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                         <!--    'column_alias': 'guest'}                                 -->
                         <!-- col42 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                         <!--    'column_alias': 'host'}                                  -->
                         <!-- col43 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                         <!-- col44 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col45 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col46 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->
@@ -302,15 +302,15 @@
                         <!--    'column_alias': 'listings'}                                 -->
                         <!-- col1 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                         <!--    'column_alias': 'largest_listing'}                       -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
                         <!--    'column_alias': 'smallest_listing'}                      -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col4 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -330,7 +330,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
                         <!--    'column_alias': 'created_at'}                            -->
                         <!-- col9 =                                                -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -350,19 +350,19 @@
                         <!--    'column_alias': 'created_at__year'}                -->
                         <!-- col13 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                         <!--    'column_alias': 'country_latest'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                         <!--    'column_alias': 'is_lux_latest'}                         -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                         <!--    'column_alias': 'capacity_latest'}                       -->
                         <!-- col16 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                         <!--    'column_alias': 'listing__ds'}                           -->
                         <!-- col17 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -382,7 +382,7 @@
                         <!--    'column_alias': 'listing__ds__year'}               -->
                         <!-- col21 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                         <!--    'column_alias': 'listing__created_at'}                   -->
                         <!-- col22 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -402,27 +402,27 @@
                         <!--    'column_alias': 'listing__created_at__year'}       -->
                         <!-- col26 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                         <!--    'column_alias': 'listing__country_latest'}               -->
                         <!-- col27 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                         <!--    'column_alias': 'listing__is_lux_latest'}                -->
                         <!-- col28 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
                         <!--    'column_alias': 'listing__capacity_latest'}              -->
                         <!-- col29 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col30 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
                         <!--    'column_alias': 'user'}                                  -->
                         <!-- col31 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
                         <!--    'column_alias': 'listing__user'}                         -->
                         <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
@@ -62,35 +62,35 @@
                     <!--    'column_alias': 'instant_bookings'}                                                              -->
                     <!-- col2 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                     <!--    'column_alias': 'booking_value'}                         -->
                     <!-- col3 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                     <!--    'column_alias': 'max_booking_value'}                     -->
                     <!-- col4 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                     <!--    'column_alias': 'min_booking_value'}                     -->
                     <!-- col5 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                     <!--    'column_alias': 'bookers'}                               -->
                     <!-- col6 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                     <!--    'column_alias': 'average_booking_value'}                 -->
                     <!-- col7 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                     <!--    'column_alias': 'booking_payments'}                      -->
                     <!-- col8 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                     <!--    'column_alias': 'is_instant'}                            -->
                     <!-- col9 =                                                      -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                     <!--    'column_alias': 'ds'}                                    -->
                     <!-- col10 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -110,7 +110,7 @@
                     <!--    'column_alias': 'ds__year'}                        -->
                     <!-- col14 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                     <!--    'column_alias': 'ds_partitioned'}                        -->
                     <!-- col15 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -130,7 +130,7 @@
                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                     <!-- col19 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                     <!--    'column_alias': 'booking_paid_at'}                       -->
                     <!-- col20 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -150,11 +150,11 @@
                     <!--    'column_alias': 'booking_paid_at__year'}           -->
                     <!-- col24 =                                                             -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                     <!-- col25 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                     <!-- col26 =                                                           -->
                     <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -174,7 +174,7 @@
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                     <!-- col30 =                                                                 -->
                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                     <!-- col31 =                                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -194,7 +194,7 @@
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                     <!-- col35 =                                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                                           -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                     <!-- col36 =                                                                        -->
                     <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -214,31 +214,31 @@
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                     <!-- col40 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                     <!--    'column_alias': 'listing'}                               -->
                     <!-- col41 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                     <!--    'column_alias': 'guest'}                                 -->
                     <!-- col42 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                     <!--    'column_alias': 'host'}                                  -->
                     <!-- col43 =                                                     -->
                     <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                     <!-- col44 =                                                          -->
                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                     <!-- col45 =                                                        -->
                     <!--   {'class': 'SqlSelectColumn',                                 -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                     <!-- col46 =                                                       -->
                     <!--   {'class': 'SqlSelectColumn',                                -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                     <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric__plan0.xml
@@ -1,173 +1,139 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_26 -->
+        <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
         <!--    'column_alias': 'trailing_2_months_revenue'}           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_25 -->
+            <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_revenue'}                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                     -->
                 <!--   Pass Only Elements:             -->
                 <!--     ['txn_revenue', 'ds__month']  -->
-                <!-- node_id = ss_24 -->
+                <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Metric Time Dimension 'ds' -->
-                    <!-- node_id = ss_23 -->
+                    <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
-                        <!-- description = Pass Only Additive Measures -->
-                        <!-- node_id = ss_22 -->
-                        <!-- col0 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                        <!--    'column_alias': 'ds'}                                  -->
-                        <!-- col1 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                        <!--    'column_alias': 'ds__week'}                            -->
-                        <!-- col2 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                        <!--    'column_alias': 'ds__month'}                           -->
-                        <!-- col3 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                        <!--    'column_alias': 'ds__quarter'}                         -->
-                        <!-- col4 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                        <!--    'column_alias': 'ds__year'}                            -->
-                        <!-- col5 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                        <!--    'column_alias': 'user'}                                -->
-                        <!-- col6 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                        <!--    'column_alias': 'txn_revenue'}                         -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
+                        <!-- description = Read Elements From Data Source 'revenue' -->
+                        <!-- node_id = ss_10006 -->
+                        <!-- col0 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'column_alias': 'txn_revenue'}                           -->
+                        <!-- col1 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'column_alias': 'ds'}                                    -->
+                        <!-- col2 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__week'}                        -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'column_alias': 'ds__month'}                       -->
+                        <!-- col4 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'column_alias': 'ds__quarter'}                     -->
+                        <!-- col5 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'column_alias': 'ds__year'}                        -->
+                        <!-- col6 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'column_alias': 'user'}                                  -->
+                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->
-                        <SqlSelectStatementNode>
-                            <!-- description = Read Elements From Data Source 'revenue' -->
-                            <!-- node_id = ss_10006 -->
-                            <!-- col0 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
-                            <!--    'column_alias': 'txn_revenue'}                           -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
-                            <!--    'column_alias': 'ds'}                                    -->
-                            <!-- col2 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
-                            <!--    'column_alias': 'ds__week'}                        -->
-                            <!-- col3 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
-                            <!--    'column_alias': 'ds__month'}                       -->
-                            <!-- col4 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
-                            <!--    'column_alias': 'ds__quarter'}                     -->
-                            <!-- col5 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
-                            <!--    'column_alias': 'ds__year'}                        -->
-                            <!-- col6 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                            <!--    'column_alias': 'user'}                                  -->
-                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
-                            <!-- where = None -->
-                            <SqlSelectQueryFromClauseNode>
-                                <!-- description = Read From a Select Query -->
-                                <!-- node_id = tfc_10002 -->
-                            </SqlSelectQueryFromClauseNode>
-                        </SqlSelectStatementNode>
+                        <SqlSelectQueryFromClauseNode>
+                            <!-- description = Read From a Select Query -->
+                            <!-- node_id = tfc_10002 -->
+                        </SqlSelectQueryFromClauseNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_grain_to_date__plan0.xml
@@ -1,173 +1,139 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_26 -->
+        <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
         <!--    'column_alias': 'revenue_mtd'}                         -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_25 -->
+            <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_revenue'}                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                     -->
                 <!--   Pass Only Elements:             -->
                 <!--     ['txn_revenue', 'ds__month']  -->
-                <!-- node_id = ss_24 -->
+                <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Metric Time Dimension 'ds' -->
-                    <!-- node_id = ss_23 -->
+                    <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
-                        <!-- description = Pass Only Additive Measures -->
-                        <!-- node_id = ss_22 -->
-                        <!-- col0 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                        <!--    'column_alias': 'ds'}                                  -->
-                        <!-- col1 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                        <!--    'column_alias': 'ds__week'}                            -->
-                        <!-- col2 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                        <!--    'column_alias': 'ds__month'}                           -->
-                        <!-- col3 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                        <!--    'column_alias': 'ds__quarter'}                         -->
-                        <!-- col4 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                        <!--    'column_alias': 'ds__year'}                            -->
-                        <!-- col5 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                        <!--    'column_alias': 'user'}                                -->
-                        <!-- col6 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                        <!--    'column_alias': 'txn_revenue'}                         -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
+                        <!-- description = Read Elements From Data Source 'revenue' -->
+                        <!-- node_id = ss_10006 -->
+                        <!-- col0 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'column_alias': 'txn_revenue'}                           -->
+                        <!-- col1 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'column_alias': 'ds'}                                    -->
+                        <!-- col2 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__week'}                        -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'column_alias': 'ds__month'}                       -->
+                        <!-- col4 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'column_alias': 'ds__quarter'}                     -->
+                        <!-- col5 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'column_alias': 'ds__year'}                        -->
+                        <!-- col6 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'column_alias': 'user'}                                  -->
+                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->
-                        <SqlSelectStatementNode>
-                            <!-- description = Read Elements From Data Source 'revenue' -->
-                            <!-- node_id = ss_10006 -->
-                            <!-- col0 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
-                            <!--    'column_alias': 'txn_revenue'}                           -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
-                            <!--    'column_alias': 'ds'}                                    -->
-                            <!-- col2 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
-                            <!--    'column_alias': 'ds__week'}                        -->
-                            <!-- col3 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
-                            <!--    'column_alias': 'ds__month'}                       -->
-                            <!-- col4 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
-                            <!--    'column_alias': 'ds__quarter'}                     -->
-                            <!-- col5 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
-                            <!--    'column_alias': 'ds__year'}                        -->
-                            <!-- col6 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                            <!--    'column_alias': 'user'}                                  -->
-                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
-                            <!-- where = None -->
-                            <SqlSelectQueryFromClauseNode>
-                                <!-- description = Read From a Select Query -->
-                                <!-- node_id = tfc_10002 -->
-                            </SqlSelectQueryFromClauseNode>
-                        </SqlSelectStatementNode>
+                        <SqlSelectQueryFromClauseNode>
+                            <!-- description = Read From a Select Query -->
+                            <!-- node_id = tfc_10002 -->
+                        </SqlSelectQueryFromClauseNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_ds__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_ds__plan0.xml
@@ -1,157 +1,123 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_26 -->
+        <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
         <!--    'column_alias': 'trailing_2_months_revenue'}           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_25 -->
+            <!-- node_id = ss_9 -->
             <!-- col0 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_revenue'}                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =          -->
                 <!--   Pass Only Elements:  -->
                 <!--     ['txn_revenue']    -->
-                <!-- node_id = ss_24 -->
+                <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Metric Time Dimension 'ds' -->
-                    <!-- node_id = ss_23 -->
+                    <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
-                        <!-- description = Pass Only Additive Measures -->
-                        <!-- node_id = ss_22 -->
-                        <!-- col0 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                        <!--    'column_alias': 'ds'}                                  -->
-                        <!-- col1 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                        <!--    'column_alias': 'ds__week'}                            -->
-                        <!-- col2 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                        <!--    'column_alias': 'ds__month'}                           -->
-                        <!-- col3 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                        <!--    'column_alias': 'ds__quarter'}                         -->
-                        <!-- col4 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                        <!--    'column_alias': 'ds__year'}                            -->
-                        <!-- col5 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                        <!--    'column_alias': 'user'}                                -->
-                        <!-- col6 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                        <!--    'column_alias': 'txn_revenue'}                         -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
+                        <!-- description = Read Elements From Data Source 'revenue' -->
+                        <!-- node_id = ss_10006 -->
+                        <!-- col0 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'column_alias': 'txn_revenue'}                           -->
+                        <!-- col1 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'column_alias': 'ds'}                                    -->
+                        <!-- col2 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__week'}                        -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'column_alias': 'ds__month'}                       -->
+                        <!-- col4 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'column_alias': 'ds__quarter'}                     -->
+                        <!-- col5 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'column_alias': 'ds__year'}                        -->
+                        <!-- col6 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'column_alias': 'user'}                                  -->
+                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->
-                        <SqlSelectStatementNode>
-                            <!-- description = Read Elements From Data Source 'revenue' -->
-                            <!-- node_id = ss_10006 -->
-                            <!-- col0 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
-                            <!--    'column_alias': 'txn_revenue'}                           -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
-                            <!--    'column_alias': 'ds'}                                    -->
-                            <!-- col2 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
-                            <!--    'column_alias': 'ds__week'}                        -->
-                            <!-- col3 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
-                            <!--    'column_alias': 'ds__month'}                       -->
-                            <!-- col4 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
-                            <!--    'column_alias': 'ds__quarter'}                     -->
-                            <!-- col5 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
-                            <!--    'column_alias': 'ds__year'}                        -->
-                            <!-- col6 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                            <!--    'column_alias': 'user'}                                  -->
-                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
-                            <!-- where = None -->
-                            <SqlSelectQueryFromClauseNode>
-                                <!-- description = Read From a Select Query -->
-                                <!-- node_id = tfc_10002 -->
-                            </SqlSelectQueryFromClauseNode>
-                        </SqlSelectStatementNode>
+                        <SqlSelectQueryFromClauseNode>
+                            <!-- description = Read From a Select Query -->
+                            <!-- node_id = tfc_10002 -->
+                        </SqlSelectQueryFromClauseNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window__plan0.xml
@@ -1,173 +1,139 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_26 -->
+        <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
         <!--    'column_alias': 'revenue_all_time'}                    -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_25 -->
+            <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_revenue'}                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                     -->
                 <!--   Pass Only Elements:             -->
                 <!--     ['txn_revenue', 'ds__month']  -->
-                <!-- node_id = ss_24 -->
+                <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Metric Time Dimension 'ds' -->
-                    <!-- node_id = ss_23 -->
+                    <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
-                        <!-- description = Pass Only Additive Measures -->
-                        <!-- node_id = ss_22 -->
-                        <!-- col0 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                        <!--    'column_alias': 'ds'}                                  -->
-                        <!-- col1 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                        <!--    'column_alias': 'ds__week'}                            -->
-                        <!-- col2 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                        <!--    'column_alias': 'ds__month'}                           -->
-                        <!-- col3 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                        <!--    'column_alias': 'ds__quarter'}                         -->
-                        <!-- col4 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                        <!--    'column_alias': 'ds__year'}                            -->
-                        <!-- col5 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                        <!--    'column_alias': 'user'}                                -->
-                        <!-- col6 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                        <!--    'column_alias': 'txn_revenue'}                         -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
+                        <!-- description = Read Elements From Data Source 'revenue' -->
+                        <!-- node_id = ss_10006 -->
+                        <!-- col0 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                        <!--    'column_alias': 'txn_revenue'}                           -->
+                        <!-- col1 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                        <!--    'column_alias': 'ds'}                                    -->
+                        <!-- col2 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                        <!--    'column_alias': 'ds__week'}                        -->
+                        <!-- col3 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                        <!--    'column_alias': 'ds__month'}                       -->
+                        <!-- col4 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                        <!--    'column_alias': 'ds__quarter'}                     -->
+                        <!-- col5 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                        <!--    'column_alias': 'ds__year'}                        -->
+                        <!-- col6 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                        <!--    'column_alias': 'user'}                                  -->
+                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->
-                        <SqlSelectStatementNode>
-                            <!-- description = Read Elements From Data Source 'revenue' -->
-                            <!-- node_id = ss_10006 -->
-                            <!-- col0 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
-                            <!--    'column_alias': 'txn_revenue'}                           -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
-                            <!--    'column_alias': 'ds'}                                    -->
-                            <!-- col2 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
-                            <!--    'column_alias': 'ds__week'}                        -->
-                            <!-- col3 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
-                            <!--    'column_alias': 'ds__month'}                       -->
-                            <!-- col4 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
-                            <!--    'column_alias': 'ds__quarter'}                     -->
-                            <!-- col5 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
-                            <!--    'column_alias': 'ds__year'}                        -->
-                            <!-- col6 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                            <!--    'column_alias': 'user'}                                  -->
-                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
-                            <!-- where = None -->
-                            <SqlSelectQueryFromClauseNode>
-                                <!-- description = Read From a Select Query -->
-                                <!-- node_id = tfc_10002 -->
-                            </SqlSelectQueryFromClauseNode>
-                        </SqlSelectStatementNode>
+                        <SqlSelectQueryFromClauseNode>
+                            <!-- description = Read From a Select Query -->
+                            <!-- node_id = tfc_10002 -->
+                        </SqlSelectQueryFromClauseNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_no_window_with_time_constraint__plan0.xml
@@ -1,227 +1,193 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_30 -->
+        <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
         <!--    'column_alias': 'revenue_all_time'}                    -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_29 -->
+            <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_revenue'}                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                     -->
                 <!--   Pass Only Elements:             -->
                 <!--     ['txn_revenue', 'ds__month']  -->
-                <!-- node_id = ss_28 -->
+                <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description =                                                         -->
                     <!--   Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]  -->
-                    <!-- node_id = ss_27 -->
+                    <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = SqlBetweenExpression(node_id=betw_1) -->
                     <SqlSelectStatementNode>
                         <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = ss_26 -->
+                        <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                         <!--    'column_alias': 'txn_revenue'}                         -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = ss_25 -->
-                            <!-- col0 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),  -->
-                            <!--    'column_alias': 'ds'}                                  -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),  -->
-                            <!--    'column_alias': 'ds__week'}                            -->
-                            <!-- col2 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),  -->
-                            <!--    'column_alias': 'ds__month'}                           -->
-                            <!-- col3 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),  -->
-                            <!--    'column_alias': 'ds__quarter'}                         -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),  -->
-                            <!--    'column_alias': 'ds__year'}                            -->
-                            <!-- col5 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),  -->
-                            <!--    'column_alias': 'user'}                                -->
-                            <!-- col6 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),  -->
-                            <!--    'column_alias': 'txn_revenue'}                         -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
+                            <!-- description = Read Elements From Data Source 'revenue' -->
+                            <!-- node_id = ss_10006 -->
+                            <!-- col0 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                            <!--    'column_alias': 'txn_revenue'}                           -->
+                            <!-- col1 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                            <!--    'column_alias': 'ds'}                                    -->
+                            <!-- col2 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                            <!--    'column_alias': 'ds__week'}                        -->
+                            <!-- col3 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                            <!--    'column_alias': 'ds__month'}                       -->
+                            <!-- col4 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                            <!--    'column_alias': 'ds__quarter'}                     -->
+                            <!-- col5 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                            <!--    'column_alias': 'ds__year'}                        -->
+                            <!-- col6 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                            <!--    'column_alias': 'user'}                                  -->
+                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
                             <!-- where = None -->
-                            <SqlSelectStatementNode>
-                                <!-- description = Read Elements From Data Source 'revenue' -->
-                                <!-- node_id = ss_10006 -->
-                                <!-- col0 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
-                                <!--    'column_alias': 'txn_revenue'}                           -->
-                                <!-- col1 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
-                                <!--    'column_alias': 'ds'}                                    -->
-                                <!-- col2 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
-                                <!--    'column_alias': 'ds__week'}                        -->
-                                <!-- col3 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
-                                <!--    'column_alias': 'ds__month'}                       -->
-                                <!-- col4 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
-                                <!--    'column_alias': 'ds__quarter'}                     -->
-                                <!-- col5 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
-                                <!--    'column_alias': 'ds__year'}                        -->
-                                <!-- col6 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                                <!--    'column_alias': 'user'}                                  -->
-                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
-                                <!-- where = None -->
-                                <SqlSelectQueryFromClauseNode>
-                                    <!-- description = Read From a Select Query -->
-                                    <!-- node_id = tfc_10002 -->
-                                </SqlSelectQueryFromClauseNode>
-                            </SqlSelectStatementNode>
+                            <SqlSelectQueryFromClauseNode>
+                                <!-- description = Read From a Select Query -->
+                                <!-- node_id = tfc_10002 -->
+                            </SqlSelectQueryFromClauseNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_cumulative_metric_with_time_constraint__plan0.xml
@@ -1,227 +1,193 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_30 -->
+        <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
         <!--    'column_alias': 'ds__month'}                           -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
         <!--    'column_alias': 'trailing_2_months_revenue'}           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_29 -->
+            <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_revenue'}                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
             <!--    'column_alias': 'ds__month'}                           -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                     -->
                 <!--   Pass Only Elements:             -->
                 <!--     ['txn_revenue', 'ds__month']  -->
-                <!-- node_id = ss_28 -->
+                <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                 <!--    'column_alias': 'ds__month'}                           -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
                 <!--    'column_alias': 'txn_revenue'}                         -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description =                                                         -->
                     <!--   Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]  -->
-                    <!-- node_id = ss_27 -->
+                    <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                     <!--    'column_alias': 'txn_revenue'}                         -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = SqlBetweenExpression(node_id=betw_1) -->
                     <SqlSelectStatementNode>
                         <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = ss_26 -->
+                        <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                         <!--    'column_alias': 'txn_revenue'}                         -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = ss_25 -->
-                            <!-- col0 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),  -->
-                            <!--    'column_alias': 'ds'}                                  -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),  -->
-                            <!--    'column_alias': 'ds__week'}                            -->
-                            <!-- col2 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),  -->
-                            <!--    'column_alias': 'ds__month'}                           -->
-                            <!-- col3 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),  -->
-                            <!--    'column_alias': 'ds__quarter'}                         -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),  -->
-                            <!--    'column_alias': 'ds__year'}                            -->
-                            <!-- col5 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),  -->
-                            <!--    'column_alias': 'user'}                                -->
-                            <!-- col6 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),  -->
-                            <!--    'column_alias': 'txn_revenue'}                         -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10006) -->
+                            <!-- description = Read Elements From Data Source 'revenue' -->
+                            <!-- node_id = ss_10006 -->
+                            <!-- col0 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
+                            <!--    'column_alias': 'txn_revenue'}                           -->
+                            <!-- col1 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10122),  -->
+                            <!--    'column_alias': 'ds'}                                    -->
+                            <!-- col2 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
+                            <!--    'column_alias': 'ds__week'}                        -->
+                            <!-- col3 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
+                            <!--    'column_alias': 'ds__month'}                       -->
+                            <!-- col4 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
+                            <!--    'column_alias': 'ds__quarter'}                     -->
+                            <!-- col5 =                                                -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
+                            <!--    'column_alias': 'ds__year'}                        -->
+                            <!-- col6 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                            <!--    'column_alias': 'user'}                                  -->
+                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
                             <!-- where = None -->
-                            <SqlSelectStatementNode>
-                                <!-- description = Read Elements From Data Source 'revenue' -->
-                                <!-- node_id = ss_10006 -->
-                                <!-- col0 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10120),  -->
-                                <!--    'column_alias': 'txn_revenue'}                           -->
-                                <!-- col1 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10121),  -->
-                                <!--    'column_alias': 'ds'}                                    -->
-                                <!-- col2 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10060),  -->
-                                <!--    'column_alias': 'ds__week'}                        -->
-                                <!-- col3 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10061),  -->
-                                <!--    'column_alias': 'ds__month'}                       -->
-                                <!-- col4 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10062),  -->
-                                <!--    'column_alias': 'ds__quarter'}                     -->
-                                <!-- col5 =                                                -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10063),  -->
-                                <!--    'column_alias': 'ds__year'}                        -->
-                                <!-- col6 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10126),  -->
-                                <!--    'column_alias': 'user'}                                  -->
-                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10002) -->
-                                <!-- where = None -->
-                                <SqlSelectQueryFromClauseNode>
-                                    <!-- description = Read From a Select Query -->
-                                    <!-- node_id = tfc_10002 -->
-                                </SqlSelectQueryFromClauseNode>
-                            </SqlSelectStatementNode>
+                            <SqlSelectQueryFromClauseNode>
+                                <!-- description = Read From a Select Query -->
+                                <!-- node_id = tfc_10002 -->
+                            </SqlSelectQueryFromClauseNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_distinct_values__plan0.xml
@@ -1,707 +1,517 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Order By ['listing__country_latest'] Limit 100 -->
-        <!-- node_id = ss_33 -->
+        <!-- node_id = ss_16 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_647),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_32) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- where = None -->
         <!-- order_by0 =                                               -->
         <!--   {'class': 'SqlOrderByDescription',                      -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
         <!--    'desc': False}                                         -->
         <SqlSelectStatementNode>
             <!-- description =                    -->
             <!--   Pass Only Elements:            -->
             <!--     ['listing__country_latest']  -->
-            <!-- node_id = ss_32 -->
+            <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_31) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->
-                <!-- node_id = ss_31 -->
+                <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_643),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_644),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                 <!--    'column_alias': 'bookings'}                            -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_30) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_30 -->
+                    <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col1 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                     <!--    'column_alias': 'bookings'}                                      -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                                -->
                         <!--   Pass Only Elements:                        -->
                         <!--     ['bookings', 'listing__country_latest']  -->
-                        <!-- node_id = ss_29 -->
+                        <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_640),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_639),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                         <!--    'column_alias': 'bookings'}                            -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Join Standard Outputs -->
-                            <!-- node_id = ss_28 -->
+                            <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_637),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_638),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_636),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
                             <!--    'column_alias': 'bookings'}                            -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
-                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_27),   -->
-                            <!--    'right_source_alias': 'subq_7',                          -->
-                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_3),  -->
+                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_10),   -->
+                            <!--    'right_source_alias': 'subq_5',                          -->
+                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER}                     -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description =                -->
                                 <!--   Pass Only Elements:        -->
                                 <!--     ['bookings', 'listing']  -->
-                                <!-- node_id = ss_24 -->
+                                <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_23 -->
+                                    <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
                                     <!-- col15 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                     <!-- col16 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                     <!-- col17 =                                                            -->
                                     <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                     <!-- col18 =                                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                     <!-- col19 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                     <!-- col20 =                                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                     <!-- col21 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                     <!-- col22 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                     <!-- col23 =                                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                     <!-- col24 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                     <!-- col25 =                                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                                     <!-- col26 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                                     <!-- col27 =                                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                                     <!-- col28 =                                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                                     <!-- col29 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                                     <!--    'column_alias': 'guest'}                               -->
                                     <!-- col37 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                                     <!--    'column_alias': 'host'}                                -->
                                     <!-- col38 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                     <!-- col39 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                     <!-- col40 =                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                                     <!-- col41 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- col42 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'is_instant'}                          -->
                                     <!-- col43 =                                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                                     <!-- col44 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'bookings'}                            -->
                                     <!-- col45 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'instant_bookings'}                    -->
                                     <!-- col46 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'booking_value'}                       -->
                                     <!-- col47 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'max_booking_value'}                   -->
                                     <!-- col48 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'min_booking_value'}                   -->
                                     <!-- col49 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col50 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_22 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                        <!--    'column_alias': 'ds_partitioned'}                      -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                        <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                        <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                        <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                        <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                                        <!--    'column_alias': 'booking_paid_at'}                     -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                                        <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                                        <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                        <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                        <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col16 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col17 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col18 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col19 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col20 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col21 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col22 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col23 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col24 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col25 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col26 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col27 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col28 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col29 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                                        <!--    'column_alias': 'guest'}                               -->
-                                        <!-- col32 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                                        <!--    'column_alias': 'host'}                                -->
-                                        <!-- col33 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                        <!-- col34 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col35 =                                                        -->
+                                        <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                        <!-- node_id = ss_10001 -->
+                                        <!-- col0 =                                                         -->
                                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col36 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                        <!-- col37 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                        <!--    'column_alias': 'is_instant'}                          -->
-                                        <!-- col38 =                                                             -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                        <!--    'column_alias': 'bookings'}                                 -->
+                                        <!-- col1 =                                                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                        <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                        <!--    'column_alias': 'booking_value'}                         -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                        <!--    'column_alias': 'max_booking_value'}                     -->
+                                        <!-- col4 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                        <!--    'column_alias': 'min_booking_value'}                     -->
+                                        <!-- col5 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                        <!--    'column_alias': 'bookers'}                               -->
+                                        <!-- col6 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                        <!--    'column_alias': 'average_booking_value'}                 -->
+                                        <!-- col7 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                        <!--    'column_alias': 'booking_payments'}                      -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                        <!--    'column_alias': 'is_instant'}                            -->
+                                        <!-- col9 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col13 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                        <!--    'column_alias': 'ds_partitioned'}                        -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                        <!-- col16 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                        <!-- col19 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                        <!--    'column_alias': 'booking_paid_at'}                       -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                        <!-- col21 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                        <!-- col24 =                                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                        <!-- col39 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                        <!--    'column_alias': 'bookings'}                            -->
-                                        <!-- col40 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                        <!--    'column_alias': 'instant_bookings'}                    -->
-                                        <!-- col41 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                        <!--    'column_alias': 'booking_value'}                       -->
-                                        <!-- col42 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                        <!--    'column_alias': 'max_booking_value'}                   -->
-                                        <!-- col43 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                        <!--    'column_alias': 'min_booking_value'}                   -->
-                                        <!-- col44 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                        <!--    'column_alias': 'bookers'}                             -->
-                                        <!-- col45 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                        <!--    'column_alias': 'average_booking_value'}               -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                        <!-- col25 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                        <!-- col26 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                        <!-- col27 =                                                            -->
+                                        <!--   {'class': 'SqlSelectColumn',                                     -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                        <!-- col28 =                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                       -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                        <!-- col29 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                        <!-- col30 =                                                                 -->
+                                        <!--   {'class': 'SqlSelectColumn',                                          -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                        <!-- col31 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                        <!-- col32 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                        <!-- col33 =                                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                        <!-- col34 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                        <!-- col35 =                                                                  -->
+                                        <!--   {'class': 'SqlSelectColumn',                                           -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                        <!-- col36 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                        <!-- col37 =                                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                        <!-- col38 =                                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                        <!-- col39 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                        <!-- col40 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col41 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                        <!--    'column_alias': 'guest'}                                 -->
+                                        <!-- col42 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                        <!--    'column_alias': 'host'}                                  -->
+                                        <!-- col43 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                        <!-- col44 =                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                   -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                        <!-- col45 =                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                        <!-- col46 =                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                            <!-- node_id = ss_10001 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                            <!--    'column_alias': 'bookings'}                                 -->
-                                            <!-- col1 =                                                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                            <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                            <!--    'column_alias': 'booking_value'}                         -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                            <!--    'column_alias': 'max_booking_value'}                     -->
-                                            <!-- col4 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                            <!--    'column_alias': 'min_booking_value'}                     -->
-                                            <!-- col5 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                            <!--    'column_alias': 'bookers'}                               -->
-                                            <!-- col6 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                            <!--    'column_alias': 'average_booking_value'}                 -->
-                                            <!-- col7 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                            <!--    'column_alias': 'booking_payments'}                      -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                            <!--    'column_alias': 'is_instant'}                            -->
-                                            <!-- col9 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col13 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                            <!--    'column_alias': 'ds_partitioned'}                        -->
-                                            <!-- col15 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                            <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                            <!-- col16 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                            <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                            <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                            <!-- col19 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                            <!--    'column_alias': 'booking_paid_at'}                       -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                            <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                            <!-- col21 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                            <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                            <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                            <!-- col24 =                                                             -->
-                                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                            <!-- col25 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col26 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col27 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col28 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col29 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col30 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col31 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col32 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col33 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col34 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col35 =                                                                  -->
-                                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                            <!-- col36 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                            <!-- col37 =                                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                            <!-- col38 =                                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                            <!-- col39 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                            <!-- col40 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col41 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                            <!--    'column_alias': 'guest'}                                 -->
-                                            <!-- col42 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                            <!--    'column_alias': 'host'}                                  -->
-                                            <!-- col43 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                            <!-- col44 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col45 =                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                            <!-- col46 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                            <!-- where = None -->
-                                            <SqlSelectQueryFromClauseNode>
-                                                <!-- description = Read From a Select Query -->
-                                                <!-- node_id = tfc_10001 -->
-                                            </SqlSelectQueryFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlSelectQueryFromClauseNode>
+                                            <!-- description = Read From a Select Query -->
+                                            <!-- node_id = tfc_10001 -->
+                                        </SqlSelectQueryFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -709,442 +519,308 @@
                                 <!-- description =                      -->
                                 <!--   Pass Only Elements:              -->
                                 <!--     ['listing', 'country_latest']  -->
-                                <!-- node_id = ss_27 -->
+                                <!-- node_id = ss_10 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_633),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_632),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_26 -->
+                                    <!-- node_id = ss_9 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_612),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_614),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_615),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_616),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_617),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_618),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_619),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_620),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_621),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_622),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_623),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_624),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_625),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_626),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_627),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_628),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_629),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_630),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_631),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_25 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_573),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
-                                        <!--    'column_alias': 'created_at'}                          -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
-                                        <!--    'column_alias': 'created_at__week'}                    -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),  -->
-                                        <!--    'column_alias': 'created_at__month'}                   -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
-                                        <!--    'column_alias': 'created_at__quarter'}                 -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
-                                        <!--    'column_alias': 'created_at__year'}                    -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
-                                        <!--    'column_alias': 'listing__ds'}                         -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
-                                        <!--    'column_alias': 'listing__ds__week'}                   -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
-                                        <!--    'column_alias': 'listing__ds__month'}                  -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),  -->
-                                        <!--    'column_alias': 'listing__ds__quarter'}                -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),  -->
-                                        <!--    'column_alias': 'listing__ds__year'}                   -->
-                                        <!-- col15 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),  -->
-                                        <!--    'column_alias': 'listing__created_at'}                 -->
-                                        <!-- col16 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),  -->
-                                        <!--    'column_alias': 'listing__created_at__week'}           -->
-                                        <!-- col17 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
-                                        <!--    'column_alias': 'listing__created_at__month'}          -->
-                                        <!-- col18 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
-                                        <!--    'column_alias': 'listing__created_at__quarter'}        -->
-                                        <!-- col19 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),  -->
-                                        <!--    'column_alias': 'listing__created_at__year'}           -->
-                                        <!-- col20 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col21 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),  -->
-                                        <!--    'column_alias': 'user'}                                -->
-                                        <!-- col22 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),  -->
-                                        <!--    'column_alias': 'listing__user'}                       -->
-                                        <!-- col23 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
-                                        <!--    'column_alias': 'country_latest'}                      -->
-                                        <!-- col24 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
-                                        <!--    'column_alias': 'is_lux_latest'}                       -->
-                                        <!-- col25 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
-                                        <!--    'column_alias': 'capacity_latest'}                     -->
-                                        <!-- col26 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_569),  -->
-                                        <!--    'column_alias': 'listing__country_latest'}             -->
-                                        <!-- col27 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
-                                        <!--    'column_alias': 'listing__is_lux_latest'}              -->
-                                        <!-- col28 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
-                                        <!--    'column_alias': 'listing__capacity_latest'}            -->
-                                        <!-- col29 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
-                                        <!--    'column_alias': 'listings'}                            -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
-                                        <!--    'column_alias': 'largest_listing'}                     -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
-                                        <!--    'column_alias': 'smallest_listing'}                    -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
+                                        <!-- description = Read Elements From Data Source 'listings_latest' -->
+                                        <!-- node_id = ss_10004 -->
+                                        <!-- col0 =                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
+                                        <!--    'column_alias': 'listings'}                                 -->
+                                        <!-- col1 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                                        <!--    'column_alias': 'largest_listing'}                       -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                                        <!--    'column_alias': 'smallest_listing'}                      -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col4 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col5 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col6 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col7 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'column_alias': 'created_at'}                            -->
+                                        <!-- col9 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'column_alias': 'created_at__week'}                -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'column_alias': 'created_at__month'}               -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'column_alias': 'created_at__quarter'}             -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'column_alias': 'created_at__year'}                -->
+                                        <!-- col13 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'column_alias': 'country_latest'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                                        <!--    'column_alias': 'is_lux_latest'}                         -->
+                                        <!-- col15 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                                        <!--    'column_alias': 'capacity_latest'}                       -->
+                                        <!-- col16 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
+                                        <!--    'column_alias': 'listing__ds'}                           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'column_alias': 'listing__ds__week'}               -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'column_alias': 'listing__ds__month'}              -->
+                                        <!-- col19 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'column_alias': 'listing__ds__quarter'}            -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'column_alias': 'listing__ds__year'}               -->
+                                        <!-- col21 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'column_alias': 'listing__created_at'}                   -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'column_alias': 'listing__created_at__week'}       -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'column_alias': 'listing__created_at__month'}      -->
+                                        <!-- col24 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'column_alias': 'listing__created_at__quarter'}    -->
+                                        <!-- col25 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'column_alias': 'listing__created_at__year'}       -->
+                                        <!-- col26 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'column_alias': 'listing__country_latest'}               -->
+                                        <!-- col27 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                                        <!--    'column_alias': 'listing__is_lux_latest'}                -->
+                                        <!-- col28 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                                        <!--    'column_alias': 'listing__capacity_latest'}              -->
+                                        <!-- col29 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                                        <!--    'column_alias': 'user'}                                  -->
+                                        <!-- col31 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'column_alias': 'listing__user'}                         -->
+                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'listings_latest' -->
-                                            <!-- node_id = ss_10004 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
-                                            <!--    'column_alias': 'listings'}                                 -->
-                                            <!-- col1 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
-                                            <!--    'column_alias': 'largest_listing'}                       -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                                            <!--    'column_alias': 'smallest_listing'}                      -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col4 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col5 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col6 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col7 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
-                                            <!--    'column_alias': 'created_at'}                            -->
-                                            <!-- col9 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
-                                            <!--    'column_alias': 'created_at__week'}                -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
-                                            <!--    'column_alias': 'created_at__month'}               -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
-                                            <!--    'column_alias': 'created_at__quarter'}             -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
-                                            <!--    'column_alias': 'created_at__year'}                -->
-                                            <!-- col13 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
-                                            <!--    'column_alias': 'country_latest'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                                            <!--    'column_alias': 'is_lux_latest'}                         -->
-                                            <!-- col15 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                                            <!--    'column_alias': 'capacity_latest'}                       -->
-                                            <!-- col16 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
-                                            <!--    'column_alias': 'listing__ds'}                           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
-                                            <!--    'column_alias': 'listing__ds__week'}               -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
-                                            <!--    'column_alias': 'listing__ds__month'}              -->
-                                            <!-- col19 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
-                                            <!--    'column_alias': 'listing__ds__quarter'}            -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
-                                            <!--    'column_alias': 'listing__ds__year'}               -->
-                                            <!-- col21 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                                            <!--    'column_alias': 'listing__created_at'}                   -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
-                                            <!--    'column_alias': 'listing__created_at__week'}       -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
-                                            <!--    'column_alias': 'listing__created_at__month'}      -->
-                                            <!-- col24 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
-                                            <!--    'column_alias': 'listing__created_at__quarter'}    -->
-                                            <!-- col25 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
-                                            <!--    'column_alias': 'listing__created_at__year'}       -->
-                                            <!-- col26 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
-                                            <!--    'column_alias': 'listing__country_latest'}               -->
-                                            <!-- col27 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
-                                            <!--    'column_alias': 'listing__is_lux_latest'}                -->
-                                            <!-- col28 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
-                                            <!--    'column_alias': 'listing__capacity_latest'}              -->
-                                            <!-- col29 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col30 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
-                                            <!--    'column_alias': 'user'}                                  -->
-                                            <!-- col31 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
-                                            <!--    'column_alias': 'listing__user'}                         -->
-                                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
-                                            <!-- where = None -->
-                                            <SqlTableFromClauseNode>
-                                                <!-- description = Read from ***************************.dim_listings_latest -->
-                                                <!-- node_id = tfc_10002 -->
-                                                <!-- table_id = ***************************.dim_listings_latest -->
-                                            </SqlTableFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlTableFromClauseNode>
+                                            <!-- description = Read from ***************************.dim_listings_latest -->
+                                            <!-- node_id = tfc_10002 -->
+                                            <!-- table_id = ***************************.dim_listings_latest -->
+                                        </SqlTableFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
@@ -23,35 +23,35 @@
             <!--    'column_alias': 'instant_bookings'}                                                              -->
             <!-- col2 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
             <!--    'column_alias': 'booking_value'}                         -->
             <!-- col3 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
             <!--    'column_alias': 'max_booking_value'}                     -->
             <!-- col4 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
             <!--    'column_alias': 'min_booking_value'}                     -->
             <!-- col5 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
             <!--    'column_alias': 'bookers'}                               -->
             <!-- col6 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
             <!--    'column_alias': 'average_booking_value'}                 -->
             <!-- col7 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
             <!--    'column_alias': 'booking_payments'}                      -->
             <!-- col8 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
             <!--    'column_alias': 'is_instant'}                            -->
             <!-- col9 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
             <!--    'column_alias': 'ds'}                                    -->
             <!-- col10 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -71,7 +71,7 @@
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col14 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
             <!--    'column_alias': 'ds_partitioned'}                        -->
             <!-- col15 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -91,7 +91,7 @@
             <!--    'column_alias': 'ds_partitioned__year'}            -->
             <!-- col19 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
             <!--    'column_alias': 'booking_paid_at'}                       -->
             <!-- col20 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -111,11 +111,11 @@
             <!--    'column_alias': 'booking_paid_at__year'}           -->
             <!-- col24 =                                                             -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
             <!-- col25 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
             <!-- col26 =                                                           -->
             <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -135,7 +135,7 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
             <!-- col30 =                                                                 -->
             <!--   {'class': 'SqlSelectColumn',                                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
             <!-- col31 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -155,7 +155,7 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
             <!-- col35 =                                                                  -->
             <!--   {'class': 'SqlSelectColumn',                                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
             <!-- col36 =                                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -175,31 +175,31 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
             <!-- col40 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
             <!--    'column_alias': 'listing'}                               -->
             <!-- col41 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
             <!--    'column_alias': 'guest'}                                 -->
             <!-- col42 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
             <!--    'column_alias': 'host'}                                  -->
             <!-- col43 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
             <!-- col44 =                                                          -->
             <!--   {'class': 'SqlSelectColumn',                                   -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
             <!-- col45 =                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                 -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
             <!-- col46 =                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
             <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -41,35 +41,35 @@
                 <!--    'column_alias': 'instant_bookings'}                                                              -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                 <!--    'column_alias': 'booking_value'}                         -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                 <!--    'column_alias': 'max_booking_value'}                     -->
                 <!-- col4 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                 <!--    'column_alias': 'min_booking_value'}                     -->
                 <!-- col5 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                 <!--    'column_alias': 'bookers'}                               -->
                 <!-- col6 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                 <!--    'column_alias': 'average_booking_value'}                 -->
                 <!-- col7 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                 <!--    'column_alias': 'booking_payments'}                      -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
                 <!-- col9 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -89,7 +89,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                 <!--    'column_alias': 'ds_partitioned'}                        -->
                 <!-- col15 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -109,7 +109,7 @@
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col19 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                 <!--    'column_alias': 'booking_paid_at'}                       -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -129,11 +129,11 @@
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
                 <!-- col24 =                                                             -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                 <!-- col25 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                 <!-- col26 =                                                           -->
                 <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -153,7 +153,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                 <!-- col30 =                                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                 <!-- col31 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -173,7 +173,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                 <!-- col35 =                                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                 <!-- col36 =                                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -193,31 +193,31 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                 <!-- col40 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col41 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                 <!--    'column_alias': 'guest'}                                 -->
                 <!-- col42 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                 <!--    'column_alias': 'host'}                                  -->
                 <!-- col43 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                 <!-- col44 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                 <!-- col45 =                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                 <!-- col46 =                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_on_join_dim__plan0.xml
@@ -1,728 +1,538 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_33 -->
+        <!-- node_id = ss_16 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_651),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
         <!--    'column_alias': 'is_instant'}                          -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_652),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
         <!--    'column_alias': 'bookings'}                            -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_32) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_32 -->
+            <!-- node_id = ss_15 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_650),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
             <!--    'column_alias': 'is_instant'}                          -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'bookings'}                                      -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_31) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_650),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
             <!--    'column_alias': 'is_instant'}                          -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                   -->
                 <!--   Pass Only Elements:           -->
                 <!--     ['bookings', 'is_instant']  -->
-                <!-- node_id = ss_31 -->
+                <!-- node_id = ss_14 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_648),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                 <!--    'column_alias': 'is_instant'}                          -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_647),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                 <!--    'column_alias': 'bookings'}                            -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_30) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Constrain Output with WHERE -->
-                    <!-- node_id = ss_30 -->
+                    <!-- node_id = ss_13 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                     <!--    'column_alias': 'is_instant'}                          -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_644),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                     <!--    'column_alias': 'bookings'}                            -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                     <!-- where =                                                                       -->
                     <!--   SqlStringExpression(node_id=str_0 sql_expr=listing__country_latest = 'us')  -->
                     <SqlSelectStatementNode>
                         <!-- description =                                              -->
                         <!--   Pass Only Elements:                                      -->
                         <!--     ['bookings', 'is_instant', 'listing__country_latest']  -->
-                        <!-- node_id = ss_29 -->
+                        <!-- node_id = ss_12 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_643),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                         <!--    'column_alias': 'listing__country_latest'}             -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_641),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                         <!--    'column_alias': 'bookings'}                            -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Join Standard Outputs -->
-                            <!-- node_id = ss_28 -->
+                            <!-- node_id = ss_11 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_639),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_638),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_640),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                             <!--    'column_alias': 'listing__country_latest'}             -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_637),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                             <!--    'column_alias': 'bookings'}                            -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
-                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_27),   -->
-                            <!--    'right_source_alias': 'subq_7',                          -->
-                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_3),  -->
+                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_10),   -->
+                            <!--    'right_source_alias': 'subq_5',                          -->
+                            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER}                     -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description =                              -->
                                 <!--   Pass Only Elements:                      -->
                                 <!--     ['bookings', 'is_instant', 'listing']  -->
-                                <!-- node_id = ss_24 -->
+                                <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                                 <!--    'column_alias': 'is_instant'}                          -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_23 -->
+                                    <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
                                     <!-- col15 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                     <!-- col16 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                     <!-- col17 =                                                            -->
                                     <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                     <!-- col18 =                                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                     <!-- col19 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                     <!-- col20 =                                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                     <!-- col21 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                     <!-- col22 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                     <!-- col23 =                                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                     <!-- col24 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                     <!-- col25 =                                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                                     <!-- col26 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                                     <!-- col27 =                                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                                     <!-- col28 =                                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                                     <!-- col29 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                                     <!--    'column_alias': 'guest'}                               -->
                                     <!-- col37 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                                     <!--    'column_alias': 'host'}                                -->
                                     <!-- col38 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                     <!-- col39 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                     <!-- col40 =                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                                     <!-- col41 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- col42 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'is_instant'}                          -->
                                     <!-- col43 =                                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                                     <!-- col44 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'bookings'}                            -->
                                     <!-- col45 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'instant_bookings'}                    -->
                                     <!-- col46 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'booking_value'}                       -->
                                     <!-- col47 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'max_booking_value'}                   -->
                                     <!-- col48 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'min_booking_value'}                   -->
                                     <!-- col49 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col50 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_22 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                        <!--    'column_alias': 'ds_partitioned'}                      -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                        <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                        <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                        <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                        <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                                        <!--    'column_alias': 'booking_paid_at'}                     -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                                        <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                                        <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                        <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                        <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col16 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col17 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col18 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col19 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col20 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col21 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col22 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col23 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col24 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col25 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col26 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col27 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col28 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col29 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                                        <!--    'column_alias': 'guest'}                               -->
-                                        <!-- col32 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                                        <!--    'column_alias': 'host'}                                -->
-                                        <!-- col33 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                        <!-- col34 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col35 =                                                        -->
+                                        <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                        <!-- node_id = ss_10001 -->
+                                        <!-- col0 =                                                         -->
                                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col36 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                        <!-- col37 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                        <!--    'column_alias': 'is_instant'}                          -->
-                                        <!-- col38 =                                                             -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                        <!--    'column_alias': 'bookings'}                                 -->
+                                        <!-- col1 =                                                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                        <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                        <!--    'column_alias': 'booking_value'}                         -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                        <!--    'column_alias': 'max_booking_value'}                     -->
+                                        <!-- col4 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                        <!--    'column_alias': 'min_booking_value'}                     -->
+                                        <!-- col5 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                        <!--    'column_alias': 'bookers'}                               -->
+                                        <!-- col6 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                        <!--    'column_alias': 'average_booking_value'}                 -->
+                                        <!-- col7 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                        <!--    'column_alias': 'booking_payments'}                      -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                        <!--    'column_alias': 'is_instant'}                            -->
+                                        <!-- col9 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col13 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                        <!--    'column_alias': 'ds_partitioned'}                        -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                        <!-- col16 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                        <!-- col19 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                        <!--    'column_alias': 'booking_paid_at'}                       -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                        <!-- col21 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                        <!-- col24 =                                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                        <!-- col39 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                        <!--    'column_alias': 'bookings'}                            -->
-                                        <!-- col40 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                        <!--    'column_alias': 'instant_bookings'}                    -->
-                                        <!-- col41 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                        <!--    'column_alias': 'booking_value'}                       -->
-                                        <!-- col42 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                        <!--    'column_alias': 'max_booking_value'}                   -->
-                                        <!-- col43 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                        <!--    'column_alias': 'min_booking_value'}                   -->
-                                        <!-- col44 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                        <!--    'column_alias': 'bookers'}                             -->
-                                        <!-- col45 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                        <!--    'column_alias': 'average_booking_value'}               -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                        <!-- col25 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                        <!-- col26 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                        <!-- col27 =                                                            -->
+                                        <!--   {'class': 'SqlSelectColumn',                                     -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                        <!-- col28 =                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                       -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                        <!-- col29 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                        <!-- col30 =                                                                 -->
+                                        <!--   {'class': 'SqlSelectColumn',                                          -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                        <!-- col31 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                        <!-- col32 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                        <!-- col33 =                                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                        <!-- col34 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                        <!-- col35 =                                                                  -->
+                                        <!--   {'class': 'SqlSelectColumn',                                           -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                        <!-- col36 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                        <!-- col37 =                                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                        <!-- col38 =                                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                        <!-- col39 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                        <!-- col40 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col41 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                        <!--    'column_alias': 'guest'}                                 -->
+                                        <!-- col42 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                        <!--    'column_alias': 'host'}                                  -->
+                                        <!-- col43 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                        <!-- col44 =                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                   -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                        <!-- col45 =                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                        <!-- col46 =                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                            <!-- node_id = ss_10001 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                            <!--    'column_alias': 'bookings'}                                 -->
-                                            <!-- col1 =                                                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                            <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                            <!--    'column_alias': 'booking_value'}                         -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                            <!--    'column_alias': 'max_booking_value'}                     -->
-                                            <!-- col4 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                            <!--    'column_alias': 'min_booking_value'}                     -->
-                                            <!-- col5 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                            <!--    'column_alias': 'bookers'}                               -->
-                                            <!-- col6 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                            <!--    'column_alias': 'average_booking_value'}                 -->
-                                            <!-- col7 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                            <!--    'column_alias': 'booking_payments'}                      -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                            <!--    'column_alias': 'is_instant'}                            -->
-                                            <!-- col9 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col13 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                            <!--    'column_alias': 'ds_partitioned'}                        -->
-                                            <!-- col15 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                            <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                            <!-- col16 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                            <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                            <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                            <!-- col19 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                            <!--    'column_alias': 'booking_paid_at'}                       -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                            <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                            <!-- col21 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                            <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                            <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                            <!-- col24 =                                                             -->
-                                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                            <!-- col25 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col26 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col27 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col28 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col29 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col30 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col31 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col32 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col33 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col34 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col35 =                                                                  -->
-                                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                            <!-- col36 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                            <!-- col37 =                                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                            <!-- col38 =                                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                            <!-- col39 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                            <!-- col40 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col41 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                            <!--    'column_alias': 'guest'}                                 -->
-                                            <!-- col42 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                            <!--    'column_alias': 'host'}                                  -->
-                                            <!-- col43 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                            <!-- col44 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col45 =                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                            <!-- col46 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                            <!-- where = None -->
-                                            <SqlSelectQueryFromClauseNode>
-                                                <!-- description = Read From a Select Query -->
-                                                <!-- node_id = tfc_10001 -->
-                                            </SqlSelectQueryFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlSelectQueryFromClauseNode>
+                                            <!-- description = Read From a Select Query -->
+                                            <!-- node_id = tfc_10001 -->
+                                        </SqlSelectQueryFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -730,442 +540,308 @@
                                 <!-- description =                      -->
                                 <!--   Pass Only Elements:              -->
                                 <!--     ['listing', 'country_latest']  -->
-                                <!-- node_id = ss_27 -->
+                                <!-- node_id = ss_10 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_634),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                                 <!--    'column_alias': 'listing'}                             -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_633),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                                 <!--    'column_alias': 'country_latest'}                      -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_26 -->
+                                    <!-- node_id = ss_9 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                                     <!--    'column_alias': 'created_at'}                          -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                                     <!--    'column_alias': 'created_at__week'}                    -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_612),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                                     <!--    'column_alias': 'created_at__month'}                   -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                                     <!--    'column_alias': 'created_at__quarter'}                 -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_614),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                                     <!--    'column_alias': 'created_at__year'}                    -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_615),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                                     <!--    'column_alias': 'listing__ds'}                         -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_616),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                                     <!--    'column_alias': 'listing__ds__week'}                   -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_617),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                                     <!--    'column_alias': 'listing__ds__month'}                  -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_618),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_619),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                                     <!--    'column_alias': 'listing__ds__year'}                   -->
                                     <!-- col15 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_620),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                                     <!--    'column_alias': 'listing__created_at'}                 -->
                                     <!-- col16 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_621),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                                     <!--    'column_alias': 'listing__created_at__week'}           -->
                                     <!-- col17 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_622),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                                     <!--    'column_alias': 'listing__created_at__month'}          -->
                                     <!-- col18 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_623),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                     <!-- col19 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_624),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                                     <!--    'column_alias': 'listing__created_at__year'}           -->
                                     <!-- col20 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_625),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col21 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_626),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col22 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_627),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col23 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_628),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col24 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_629),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col25 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_630),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col26 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_631),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                                     <!--    'column_alias': 'user'}                                -->
                                     <!-- col27 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_632),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                                     <!--    'column_alias': 'listing__user'}                       -->
                                     <!-- col28 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                                     <!--    'column_alias': 'country_latest'}                      -->
                                     <!-- col29 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                                     <!--    'column_alias': 'is_lux_latest'}                       -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
                                     <!--    'column_alias': 'capacity_latest'}                     -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                                     <!--    'column_alias': 'listing__country_latest'}             -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                                     <!--    'column_alias': 'listings'}                            -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                                     <!--    'column_alias': 'largest_listing'}                     -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                                     <!--    'column_alias': 'smallest_listing'}                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_25 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_573),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
-                                        <!--    'column_alias': 'created_at'}                          -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),  -->
-                                        <!--    'column_alias': 'created_at__week'}                    -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
-                                        <!--    'column_alias': 'created_at__month'}                   -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
-                                        <!--    'column_alias': 'created_at__quarter'}                 -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
-                                        <!--    'column_alias': 'created_at__year'}                    -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
-                                        <!--    'column_alias': 'listing__ds'}                         -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
-                                        <!--    'column_alias': 'listing__ds__week'}                   -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),  -->
-                                        <!--    'column_alias': 'listing__ds__month'}                  -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),  -->
-                                        <!--    'column_alias': 'listing__ds__quarter'}                -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),  -->
-                                        <!--    'column_alias': 'listing__ds__year'}                   -->
-                                        <!-- col15 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),  -->
-                                        <!--    'column_alias': 'listing__created_at'}                 -->
-                                        <!-- col16 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
-                                        <!--    'column_alias': 'listing__created_at__week'}           -->
-                                        <!-- col17 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
-                                        <!--    'column_alias': 'listing__created_at__month'}          -->
-                                        <!-- col18 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),  -->
-                                        <!--    'column_alias': 'listing__created_at__quarter'}        -->
-                                        <!-- col19 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),  -->
-                                        <!--    'column_alias': 'listing__created_at__year'}           -->
-                                        <!-- col20 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col21 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),  -->
-                                        <!--    'column_alias': 'user'}                                -->
-                                        <!-- col22 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),  -->
-                                        <!--    'column_alias': 'listing__user'}                       -->
-                                        <!-- col23 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
-                                        <!--    'column_alias': 'country_latest'}                      -->
-                                        <!-- col24 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
-                                        <!--    'column_alias': 'is_lux_latest'}                       -->
-                                        <!-- col25 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_569),  -->
-                                        <!--    'column_alias': 'capacity_latest'}                     -->
-                                        <!-- col26 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
-                                        <!--    'column_alias': 'listing__country_latest'}             -->
-                                        <!-- col27 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
-                                        <!--    'column_alias': 'listing__is_lux_latest'}              -->
-                                        <!-- col28 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
-                                        <!--    'column_alias': 'listing__capacity_latest'}            -->
-                                        <!-- col29 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
-                                        <!--    'column_alias': 'listings'}                            -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
-                                        <!--    'column_alias': 'largest_listing'}                     -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
-                                        <!--    'column_alias': 'smallest_listing'}                    -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
+                                        <!-- description = Read Elements From Data Source 'listings_latest' -->
+                                        <!-- node_id = ss_10004 -->
+                                        <!-- col0 =                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
+                                        <!--    'column_alias': 'listings'}                                 -->
+                                        <!-- col1 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                                        <!--    'column_alias': 'largest_listing'}                       -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                                        <!--    'column_alias': 'smallest_listing'}                      -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col4 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col5 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col6 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col7 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                        <!--    'column_alias': 'created_at'}                            -->
+                                        <!-- col9 =                                                -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                        <!--    'column_alias': 'created_at__week'}                -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                        <!--    'column_alias': 'created_at__month'}               -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                        <!--    'column_alias': 'created_at__quarter'}             -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                        <!--    'column_alias': 'created_at__year'}                -->
+                                        <!-- col13 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                        <!--    'column_alias': 'country_latest'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                                        <!--    'column_alias': 'is_lux_latest'}                         -->
+                                        <!-- col15 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                                        <!--    'column_alias': 'capacity_latest'}                       -->
+                                        <!-- col16 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
+                                        <!--    'column_alias': 'listing__ds'}                           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                        <!--    'column_alias': 'listing__ds__week'}               -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                        <!--    'column_alias': 'listing__ds__month'}              -->
+                                        <!-- col19 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                        <!--    'column_alias': 'listing__ds__quarter'}            -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                        <!--    'column_alias': 'listing__ds__year'}               -->
+                                        <!-- col21 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                        <!--    'column_alias': 'listing__created_at'}                   -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                        <!--    'column_alias': 'listing__created_at__week'}       -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                        <!--    'column_alias': 'listing__created_at__month'}      -->
+                                        <!-- col24 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                        <!--    'column_alias': 'listing__created_at__quarter'}    -->
+                                        <!-- col25 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                        <!--    'column_alias': 'listing__created_at__year'}       -->
+                                        <!-- col26 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                        <!--    'column_alias': 'listing__country_latest'}               -->
+                                        <!-- col27 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                                        <!--    'column_alias': 'listing__is_lux_latest'}                -->
+                                        <!-- col28 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                                        <!--    'column_alias': 'listing__capacity_latest'}              -->
+                                        <!-- col29 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col30 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                                        <!--    'column_alias': 'user'}                                  -->
+                                        <!-- col31 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                        <!--    'column_alias': 'listing__user'}                         -->
+                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'listings_latest' -->
-                                            <!-- node_id = ss_10004 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
-                                            <!--    'column_alias': 'listings'}                                 -->
-                                            <!-- col1 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
-                                            <!--    'column_alias': 'largest_listing'}                       -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                                            <!--    'column_alias': 'smallest_listing'}                      -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col4 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col5 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col6 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col7 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
-                                            <!--    'column_alias': 'created_at'}                            -->
-                                            <!-- col9 =                                                -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
-                                            <!--    'column_alias': 'created_at__week'}                -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
-                                            <!--    'column_alias': 'created_at__month'}               -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
-                                            <!--    'column_alias': 'created_at__quarter'}             -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
-                                            <!--    'column_alias': 'created_at__year'}                -->
-                                            <!-- col13 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
-                                            <!--    'column_alias': 'country_latest'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                                            <!--    'column_alias': 'is_lux_latest'}                         -->
-                                            <!-- col15 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                                            <!--    'column_alias': 'capacity_latest'}                       -->
-                                            <!-- col16 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
-                                            <!--    'column_alias': 'listing__ds'}                           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
-                                            <!--    'column_alias': 'listing__ds__week'}               -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
-                                            <!--    'column_alias': 'listing__ds__month'}              -->
-                                            <!-- col19 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
-                                            <!--    'column_alias': 'listing__ds__quarter'}            -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
-                                            <!--    'column_alias': 'listing__ds__year'}               -->
-                                            <!-- col21 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                                            <!--    'column_alias': 'listing__created_at'}                   -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
-                                            <!--    'column_alias': 'listing__created_at__week'}       -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
-                                            <!--    'column_alias': 'listing__created_at__month'}      -->
-                                            <!-- col24 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
-                                            <!--    'column_alias': 'listing__created_at__quarter'}    -->
-                                            <!-- col25 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
-                                            <!--    'column_alias': 'listing__created_at__year'}       -->
-                                            <!-- col26 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
-                                            <!--    'column_alias': 'listing__country_latest'}               -->
-                                            <!-- col27 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
-                                            <!--    'column_alias': 'listing__is_lux_latest'}                -->
-                                            <!-- col28 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
-                                            <!--    'column_alias': 'listing__capacity_latest'}              -->
-                                            <!-- col29 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col30 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
-                                            <!--    'column_alias': 'user'}                                  -->
-                                            <!-- col31 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
-                                            <!--    'column_alias': 'listing__user'}                         -->
-                                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
-                                            <!-- where = None -->
-                                            <SqlTableFromClauseNode>
-                                                <!-- description = Read from ***************************.dim_listings_latest -->
-                                                <!-- node_id = tfc_10002 -->
-                                                <!-- table_id = ***************************.dim_listings_latest -->
-                                            </SqlTableFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlTableFromClauseNode>
+                                            <!-- description = Read from ***************************.dim_listings_latest -->
+                                            <!-- node_id = tfc_10002 -->
+                                            <!-- table_id = ***************************.dim_listings_latest -->
+                                        </SqlTableFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_limit_rows__plan0.xml
@@ -1,658 +1,468 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Order By [] Limit 1 -->
-        <!-- node_id = ss_27 -->
+        <!-- node_id = ss_11 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
         <!--    'column_alias': 'ds'}                                  -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
         <!--    'column_alias': 'bookings'}                            -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = ss_26 -->
+            <!-- node_id = ss_10 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
             <!--    'column_alias': 'ds'}                                  -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
             <!--    'column_alias': 'bookings'}                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Aggregate Measures -->
-                <!-- node_id = ss_25 -->
+                <!-- node_id = ss_9 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- col1 =                                                              -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+                <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                 <!--    'column_alias': 'bookings'}                                      -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                 <!--    'column_alias': 'ds'}                                  -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description =           -->
                     <!--   Pass Only Elements:   -->
                     <!--     ['bookings', 'ds']  -->
-                    <!-- node_id = ss_24 -->
+                    <!-- node_id = ss_8 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                     <!--    'column_alias': 'bookings'}                            -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = ss_23 -->
+                        <!-- node_id = ss_7 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col16 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                         <!-- col17 =                                                            -->
                         <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                         <!-- col18 =                                                              -->
                         <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                         <!-- col19 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col20 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col21 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                         <!-- col22 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                         <!-- col23 =                                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                         <!-- col24 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col25 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col26 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                         <!-- col27 =                                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                         <!-- col28 =                                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                         <!-- col29 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col35 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                         <!--    'column_alias': 'listing'}                             -->
                         <!-- col36 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                         <!--    'column_alias': 'guest'}                               -->
                         <!-- col37 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                         <!--    'column_alias': 'host'}                                -->
                         <!-- col38 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                         <!-- col39 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col40 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col41 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- col42 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col43 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col44 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- col45 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                         <!--    'column_alias': 'instant_bookings'}                    -->
                         <!-- col46 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
                         <!-- col47 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                         <!--    'column_alias': 'max_booking_value'}                   -->
                         <!-- col48 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                         <!--    'column_alias': 'min_booking_value'}                   -->
                         <!-- col49 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                         <!--    'column_alias': 'bookers'}                             -->
                         <!-- col50 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                         <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = ss_22 -->
-                            <!-- col0 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                            <!--    'column_alias': 'ds'}                                  -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                            <!--    'column_alias': 'ds__week'}                            -->
-                            <!-- col2 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                            <!--    'column_alias': 'ds__month'}                           -->
-                            <!-- col3 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                            <!--    'column_alias': 'ds__quarter'}                         -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                            <!--    'column_alias': 'ds__year'}                            -->
-                            <!-- col5 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                            <!--    'column_alias': 'ds_partitioned'}                      -->
-                            <!-- col6 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                            <!--    'column_alias': 'ds_partitioned__week'}                -->
-                            <!-- col7 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                            <!--    'column_alias': 'ds_partitioned__month'}               -->
-                            <!-- col8 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                            <!-- col9 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                            <!--    'column_alias': 'ds_partitioned__year'}                -->
-                            <!-- col10 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                            <!--    'column_alias': 'booking_paid_at'}                     -->
-                            <!-- col11 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                            <!--    'column_alias': 'booking_paid_at__week'}               -->
-                            <!-- col12 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                            <!--    'column_alias': 'booking_paid_at__month'}              -->
-                            <!-- col13 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                            <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                            <!-- col14 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                            <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col30 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col31 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col32 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col33 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col34 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col35 =                                                        -->
+                            <!-- description = Read Elements From Data Source 'bookings_source' -->
+                            <!-- node_id = ss_10001 -->
+                            <!-- col0 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col36 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col38 =                                                             -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                            <!--    'column_alias': 'bookings'}                                 -->
+                            <!-- col1 =                                                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                            <!--    'column_alias': 'instant_bookings'}                                                              -->
+                            <!-- col2 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                            <!--    'column_alias': 'booking_value'}                         -->
+                            <!-- col3 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                            <!--    'column_alias': 'max_booking_value'}                     -->
+                            <!-- col4 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                            <!--    'column_alias': 'min_booking_value'}                     -->
+                            <!-- col5 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                            <!--    'column_alias': 'bookers'}                               -->
+                            <!-- col6 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                            <!--    'column_alias': 'average_booking_value'}                 -->
+                            <!-- col7 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                            <!--    'column_alias': 'booking_payments'}                      -->
+                            <!-- col8 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                            <!--    'column_alias': 'is_instant'}                            -->
+                            <!-- col9 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                            <!--    'column_alias': 'ds'}                                    -->
+                            <!-- col10 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                            <!--    'column_alias': 'ds__week'}                        -->
+                            <!-- col11 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                            <!--    'column_alias': 'ds__month'}                       -->
+                            <!-- col12 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                            <!--    'column_alias': 'ds__quarter'}                     -->
+                            <!-- col13 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                            <!--    'column_alias': 'ds__year'}                        -->
+                            <!-- col14 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                        -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}            -->
+                            <!-- col16 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}           -->
+                            <!-- col17 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                            <!-- col18 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}            -->
+                            <!-- col19 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                            <!--    'column_alias': 'booking_paid_at'}                       -->
+                            <!-- col20 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'column_alias': 'booking_paid_at__week'}           -->
+                            <!-- col21 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'column_alias': 'booking_paid_at__month'}          -->
+                            <!-- col22 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                            <!-- col23 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'booking_paid_at__year'}           -->
+                            <!-- col24 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col39 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col40 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col41 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col43 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                            <!-- col25 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                            <!-- col26 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                            <!-- col27 =                                                            -->
+                            <!--   {'class': 'SqlSelectColumn',                                     -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                            <!-- col28 =                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                       -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                            <!-- col29 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                            <!-- col30 =                                                                 -->
+                            <!--   {'class': 'SqlSelectColumn',                                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                            <!-- col31 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                            <!-- col32 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                            <!-- col33 =                                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                                   -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                            <!-- col34 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                            <!-- col35 =                                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                            <!-- col36 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                            <!-- col37 =                                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                                  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                            <!-- col38 =                                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                            <!-- col39 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col40 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                            <!--    'column_alias': 'listing'}                               -->
+                            <!-- col41 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                            <!--    'column_alias': 'guest'}                                 -->
+                            <!-- col42 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                            <!--    'column_alias': 'host'}                                  -->
+                            <!-- col43 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                            <!-- col44 =                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                            <!-- col45 =                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                            <!-- col46 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
-                            <SqlSelectStatementNode>
-                                <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                <!-- node_id = ss_10001 -->
-                                <!-- col0 =                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                <!--    'column_alias': 'bookings'}                                 -->
-                                <!-- col1 =                                                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                <!-- col2 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                <!--    'column_alias': 'booking_value'}                         -->
-                                <!-- col3 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                <!--    'column_alias': 'max_booking_value'}                     -->
-                                <!-- col4 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                <!--    'column_alias': 'min_booking_value'}                     -->
-                                <!-- col5 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                <!--    'column_alias': 'bookers'}                               -->
-                                <!-- col6 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                <!--    'column_alias': 'average_booking_value'}                 -->
-                                <!-- col7 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                <!--    'column_alias': 'booking_payments'}                      -->
-                                <!-- col8 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col9 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                <!--    'column_alias': 'ds'}                                    -->
-                                <!-- col10 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                <!--    'column_alias': 'ds__week'}                        -->
-                                <!-- col11 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                <!--    'column_alias': 'ds__month'}                       -->
-                                <!-- col12 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                <!--    'column_alias': 'ds__quarter'}                     -->
-                                <!-- col13 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                <!--    'column_alias': 'ds__year'}                        -->
-                                <!-- col14 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                        -->
-                                <!-- col15 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                <!-- col16 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                <!-- col17 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                <!-- col18 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                <!-- col19 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking_paid_at'}                       -->
-                                <!-- col20 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                <!-- col21 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                <!-- col22 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                <!-- col23 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col24 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col25 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col26 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col27 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col28 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col29 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col30 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col31 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col32 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col33 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col34 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col35 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col36 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col37 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col38 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col39 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col40 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col41 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col42 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                <!--    'column_alias': 'host'}                                  -->
-                                <!-- col43 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col44 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col45 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col46 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                <!-- where = None -->
-                                <SqlSelectQueryFromClauseNode>
-                                    <!-- description = Read From a Select Query -->
-                                    <!-- node_id = tfc_10001 -->
-                                </SqlSelectQueryFromClauseNode>
-                            </SqlSelectStatementNode>
+                            <SqlSelectQueryFromClauseNode>
+                                <!-- description = Read From a Select Query -->
+                                <!-- node_id = tfc_10001 -->
+                            </SqlSelectQueryFromClauseNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_identifier__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_local_dimension_using_local_identifier__plan0.xml
@@ -1,474 +1,340 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_26 -->
+        <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
         <!--    'column_alias': 'listing__country_latest'}             -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
         <!--    'column_alias': 'listings'}                            -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_25 -->
+            <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'listings'}                                      -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
             <!--    'column_alias': 'listing__country_latest'}             -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                                -->
                 <!--   Pass Only Elements:                        -->
                 <!--     ['listings', 'listing__country_latest']  -->
-                <!-- node_id = ss_24 -->
+                <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),  -->
                 <!--    'column_alias': 'listing__country_latest'}             -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),  -->
                 <!--    'column_alias': 'listings'}                            -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Metric Time Dimension 'ds' -->
-                    <!-- node_id = ss_23 -->
+                    <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                     <!--    'column_alias': 'ds'}                                  -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                     <!--    'column_alias': 'ds__week'}                            -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                     <!--    'column_alias': 'ds__month'}                           -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                     <!--    'column_alias': 'ds__quarter'}                         -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                     <!--    'column_alias': 'ds__year'}                            -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                     <!--    'column_alias': 'created_at'}                          -->
                     <!-- col6 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                     <!--    'column_alias': 'created_at__week'}                    -->
                     <!-- col7 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                     <!--    'column_alias': 'created_at__month'}                   -->
                     <!-- col8 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                     <!--    'column_alias': 'created_at__quarter'}                 -->
                     <!-- col9 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                     <!--    'column_alias': 'created_at__year'}                    -->
                     <!-- col10 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                     <!--    'column_alias': 'listing__ds'}                         -->
                     <!-- col11 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                     <!--    'column_alias': 'listing__ds__week'}                   -->
                     <!-- col12 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                     <!--    'column_alias': 'listing__ds__month'}                  -->
                     <!-- col13 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                     <!--    'column_alias': 'listing__ds__quarter'}                -->
                     <!-- col14 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                     <!--    'column_alias': 'listing__ds__year'}                   -->
                     <!-- col15 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                     <!--    'column_alias': 'listing__created_at'}                 -->
                     <!-- col16 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                     <!--    'column_alias': 'listing__created_at__week'}           -->
                     <!-- col17 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                     <!--    'column_alias': 'listing__created_at__month'}          -->
                     <!-- col18 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                     <!--    'column_alias': 'listing__created_at__quarter'}        -->
                     <!-- col19 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                     <!--    'column_alias': 'listing__created_at__year'}           -->
                     <!-- col20 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col21 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                     <!--    'column_alias': 'metric_time__week'}                   -->
                     <!-- col22 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                     <!--    'column_alias': 'metric_time__month'}                  -->
                     <!-- col23 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
                     <!--    'column_alias': 'metric_time__quarter'}                -->
                     <!-- col24 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                     <!--    'column_alias': 'metric_time__year'}                   -->
                     <!-- col25 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                     <!--    'column_alias': 'listing'}                             -->
                     <!-- col26 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col27 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                     <!--    'column_alias': 'listing__user'}                       -->
                     <!-- col28 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                     <!--    'column_alias': 'country_latest'}                      -->
                     <!-- col29 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                     <!--    'column_alias': 'is_lux_latest'}                       -->
                     <!-- col30 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                     <!--    'column_alias': 'capacity_latest'}                     -->
                     <!-- col31 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                     <!--    'column_alias': 'listing__country_latest'}             -->
                     <!-- col32 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                     <!-- col33 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                     <!--    'column_alias': 'listing__capacity_latest'}            -->
                     <!-- col34 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                     <!--    'column_alias': 'listings'}                            -->
                     <!-- col35 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                     <!--    'column_alias': 'largest_listing'}                     -->
                     <!-- col36 =                                                   -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                     <!--    'column_alias': 'smallest_listing'}                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
-                        <!-- description = Pass Only Additive Measures -->
-                        <!-- node_id = ss_22 -->
-                        <!-- col0 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                        <!--    'column_alias': 'ds'}                                  -->
-                        <!-- col1 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                        <!--    'column_alias': 'ds__week'}                            -->
-                        <!-- col2 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                        <!--    'column_alias': 'ds__month'}                           -->
-                        <!-- col3 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                        <!--    'column_alias': 'ds__quarter'}                         -->
-                        <!-- col4 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                        <!--    'column_alias': 'ds__year'}                            -->
-                        <!-- col5 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                        <!--    'column_alias': 'created_at'}                          -->
-                        <!-- col6 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                        <!--    'column_alias': 'created_at__week'}                    -->
-                        <!-- col7 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                        <!--    'column_alias': 'created_at__month'}                   -->
-                        <!-- col8 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                        <!--    'column_alias': 'created_at__quarter'}                 -->
-                        <!-- col9 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                        <!--    'column_alias': 'created_at__year'}                    -->
-                        <!-- col10 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                        <!--    'column_alias': 'listing__ds'}                         -->
-                        <!-- col11 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                        <!--    'column_alias': 'listing__ds__week'}                   -->
-                        <!-- col12 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                        <!--    'column_alias': 'listing__ds__month'}                  -->
-                        <!-- col13 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                        <!--    'column_alias': 'listing__ds__quarter'}                -->
-                        <!-- col14 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                        <!--    'column_alias': 'listing__ds__year'}                   -->
-                        <!-- col15 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),  -->
-                        <!--    'column_alias': 'listing__created_at'}                 -->
-                        <!-- col16 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),  -->
-                        <!--    'column_alias': 'listing__created_at__week'}           -->
-                        <!-- col17 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),  -->
-                        <!--    'column_alias': 'listing__created_at__month'}          -->
-                        <!-- col18 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),  -->
-                        <!--    'column_alias': 'listing__created_at__quarter'}        -->
-                        <!-- col19 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),  -->
-                        <!--    'column_alias': 'listing__created_at__year'}           -->
-                        <!-- col20 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),  -->
-                        <!--    'column_alias': 'listing'}                             -->
-                        <!-- col21 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),  -->
-                        <!--    'column_alias': 'user'}                                -->
-                        <!-- col22 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),  -->
-                        <!--    'column_alias': 'listing__user'}                       -->
-                        <!-- col23 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                        <!--    'column_alias': 'country_latest'}                      -->
-                        <!-- col24 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                        <!--    'column_alias': 'is_lux_latest'}                       -->
-                        <!-- col25 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                        <!--    'column_alias': 'capacity_latest'}                     -->
-                        <!-- col26 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                        <!--    'column_alias': 'listing__country_latest'}             -->
-                        <!-- col27 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                        <!--    'column_alias': 'listing__is_lux_latest'}              -->
-                        <!-- col28 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
-                        <!--    'column_alias': 'listing__capacity_latest'}            -->
-                        <!-- col29 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                        <!--    'column_alias': 'listings'}                            -->
-                        <!-- col30 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                        <!--    'column_alias': 'largest_listing'}                     -->
-                        <!-- col31 =                                                   -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                        <!--    'column_alias': 'smallest_listing'}                    -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
+                        <!-- description = Read Elements From Data Source 'listings_latest' -->
+                        <!-- node_id = ss_10004 -->
+                        <!-- col0 =                                                         -->
+                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                        <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
+                        <!--    'column_alias': 'listings'}                                 -->
+                        <!-- col1 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                        <!--    'column_alias': 'largest_listing'}                       -->
+                        <!-- col2 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                        <!--    'column_alias': 'smallest_listing'}                      -->
+                        <!-- col3 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                        <!--    'column_alias': 'ds'}                                    -->
+                        <!-- col4 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                        <!--    'column_alias': 'ds__week'}                        -->
+                        <!-- col5 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                        <!--    'column_alias': 'ds__month'}                       -->
+                        <!-- col6 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                        <!--    'column_alias': 'ds__quarter'}                     -->
+                        <!-- col7 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                        <!--    'column_alias': 'ds__year'}                        -->
+                        <!-- col8 =                                                      -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                        <!--    'column_alias': 'created_at'}                            -->
+                        <!-- col9 =                                                -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                        <!--    'column_alias': 'created_at__week'}                -->
+                        <!-- col10 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                        <!--    'column_alias': 'created_at__month'}               -->
+                        <!-- col11 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                        <!--    'column_alias': 'created_at__quarter'}             -->
+                        <!-- col12 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                        <!--    'column_alias': 'created_at__year'}                -->
+                        <!-- col13 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                        <!--    'column_alias': 'country_latest'}                        -->
+                        <!-- col14 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                        <!--    'column_alias': 'is_lux_latest'}                         -->
+                        <!-- col15 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                        <!--    'column_alias': 'capacity_latest'}                       -->
+                        <!-- col16 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
+                        <!--    'column_alias': 'listing__ds'}                           -->
+                        <!-- col17 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                        <!--    'column_alias': 'listing__ds__week'}               -->
+                        <!-- col18 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                        <!--    'column_alias': 'listing__ds__month'}              -->
+                        <!-- col19 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                        <!--    'column_alias': 'listing__ds__quarter'}            -->
+                        <!-- col20 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                        <!--    'column_alias': 'listing__ds__year'}               -->
+                        <!-- col21 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                        <!--    'column_alias': 'listing__created_at'}                   -->
+                        <!-- col22 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                        <!--    'column_alias': 'listing__created_at__week'}       -->
+                        <!-- col23 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                        <!--    'column_alias': 'listing__created_at__month'}      -->
+                        <!-- col24 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                        <!--    'column_alias': 'listing__created_at__quarter'}    -->
+                        <!-- col25 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                        -->
+                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                        <!--    'column_alias': 'listing__created_at__year'}       -->
+                        <!-- col26 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                        <!--    'column_alias': 'listing__country_latest'}               -->
+                        <!-- col27 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                        <!--    'column_alias': 'listing__is_lux_latest'}                -->
+                        <!-- col28 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                        <!--    'column_alias': 'listing__capacity_latest'}              -->
+                        <!-- col29 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                        <!--    'column_alias': 'listing'}                               -->
+                        <!-- col30 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                        <!--    'column_alias': 'user'}                                  -->
+                        <!-- col31 =                                                     -->
+                        <!--   {'class': 'SqlSelectColumn',                              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                        <!--    'column_alias': 'listing__user'}                         -->
+                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                         <!-- where = None -->
-                        <SqlSelectStatementNode>
-                            <!-- description = Read Elements From Data Source 'listings_latest' -->
-                            <!-- node_id = ss_10004 -->
-                            <!-- col0 =                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
-                            <!--    'column_alias': 'listings'}                                 -->
-                            <!-- col1 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
-                            <!--    'column_alias': 'largest_listing'}                       -->
-                            <!-- col2 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                            <!--    'column_alias': 'smallest_listing'}                      -->
-                            <!-- col3 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                            <!--    'column_alias': 'ds'}                                    -->
-                            <!-- col4 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
-                            <!--    'column_alias': 'ds__week'}                        -->
-                            <!-- col5 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
-                            <!--    'column_alias': 'ds__month'}                       -->
-                            <!-- col6 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
-                            <!--    'column_alias': 'ds__quarter'}                     -->
-                            <!-- col7 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
-                            <!--    'column_alias': 'ds__year'}                        -->
-                            <!-- col8 =                                                      -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
-                            <!--    'column_alias': 'created_at'}                            -->
-                            <!-- col9 =                                                -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
-                            <!--    'column_alias': 'created_at__week'}                -->
-                            <!-- col10 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
-                            <!--    'column_alias': 'created_at__month'}               -->
-                            <!-- col11 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
-                            <!--    'column_alias': 'created_at__quarter'}             -->
-                            <!-- col12 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
-                            <!--    'column_alias': 'created_at__year'}                -->
-                            <!-- col13 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
-                            <!--    'column_alias': 'country_latest'}                        -->
-                            <!-- col14 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                            <!--    'column_alias': 'is_lux_latest'}                         -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                            <!--    'column_alias': 'capacity_latest'}                       -->
-                            <!-- col16 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
-                            <!--    'column_alias': 'listing__ds'}                           -->
-                            <!-- col17 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
-                            <!--    'column_alias': 'listing__ds__week'}               -->
-                            <!-- col18 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
-                            <!--    'column_alias': 'listing__ds__month'}              -->
-                            <!-- col19 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
-                            <!--    'column_alias': 'listing__ds__quarter'}            -->
-                            <!-- col20 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
-                            <!--    'column_alias': 'listing__ds__year'}               -->
-                            <!-- col21 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                            <!--    'column_alias': 'listing__created_at'}                   -->
-                            <!-- col22 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
-                            <!--    'column_alias': 'listing__created_at__week'}       -->
-                            <!-- col23 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
-                            <!--    'column_alias': 'listing__created_at__month'}      -->
-                            <!-- col24 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
-                            <!--    'column_alias': 'listing__created_at__quarter'}    -->
-                            <!-- col25 =                                               -->
-                            <!--   {'class': 'SqlSelectColumn',                        -->
-                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
-                            <!--    'column_alias': 'listing__created_at__year'}       -->
-                            <!-- col26 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
-                            <!--    'column_alias': 'listing__country_latest'}               -->
-                            <!-- col27 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
-                            <!--    'column_alias': 'listing__is_lux_latest'}                -->
-                            <!-- col28 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
-                            <!--    'column_alias': 'listing__capacity_latest'}              -->
-                            <!-- col29 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
-                            <!--    'column_alias': 'listing'}                               -->
-                            <!-- col30 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
-                            <!--    'column_alias': 'user'}                                  -->
-                            <!-- col31 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
-                            <!--    'column_alias': 'listing__user'}                         -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
-                            <!-- where = None -->
-                            <SqlTableFromClauseNode>
-                                <!-- description = Read from ***************************.dim_listings_latest -->
-                                <!-- node_id = tfc_10002 -->
-                                <!-- table_id = ***************************.dim_listings_latest -->
-                            </SqlTableFromClauseNode>
-                        </SqlSelectStatementNode>
+                        <SqlTableFromClauseNode>
+                            <!-- description = Read from ***************************.dim_listings_latest -->
+                            <!-- node_id = tfc_10002 -->
+                            <!-- table_id = ***************************.dim_listings_latest -->
+                        </SqlTableFromClauseNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
@@ -56,35 +56,35 @@
                 <!--    'column_alias': 'instant_bookings'}                                                              -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                 <!--    'column_alias': 'booking_value'}                         -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                 <!--    'column_alias': 'max_booking_value'}                     -->
                 <!-- col4 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                 <!--    'column_alias': 'min_booking_value'}                     -->
                 <!-- col5 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                 <!--    'column_alias': 'bookers'}                               -->
                 <!-- col6 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                 <!--    'column_alias': 'average_booking_value'}                 -->
                 <!-- col7 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                 <!--    'column_alias': 'booking_payments'}                      -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
                 <!-- col9 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -104,7 +104,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                 <!--    'column_alias': 'ds_partitioned'}                        -->
                 <!-- col15 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -124,7 +124,7 @@
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col19 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                 <!--    'column_alias': 'booking_paid_at'}                       -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -144,11 +144,11 @@
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
                 <!-- col24 =                                                             -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                 <!-- col25 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                 <!-- col26 =                                                           -->
                 <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -168,7 +168,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                 <!-- col30 =                                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                 <!-- col31 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -188,7 +188,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                 <!-- col35 =                                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                 <!-- col36 =                                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -208,31 +208,31 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                 <!-- col40 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col41 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                 <!--    'column_alias': 'guest'}                                 -->
                 <!-- col42 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                 <!--    'column_alias': 'host'}                                  -->
                 <!-- col43 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                 <!-- col44 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                 <!-- col45 =                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                 <!-- col46 =                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
@@ -1,802 +1,612 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_39 -->
+        <!-- node_id = ss_21 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_768),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_402),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                                               -->
         <!--   {'class': 'SqlSelectColumn',                                                                                       -->
         <!--    'expr': SqlStringExpression(node_id=str_1 sql_expr=average_booking_value * bookings / NULLIF(booking_value, 0)),  -->
         <!--    'column_alias': 'lux_booking_value_rate_expr'}                                                                    -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_38) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description =                                                              -->
             <!--   Pass Only Elements:                                                      -->
             <!--     ['metric_time', 'average_booking_value', 'bookings', 'booking_value']  -->
-            <!-- node_id = ss_38 -->
+            <!-- node_id = ss_20 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_767),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_401),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_764),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_398),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_765),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_399),  -->
             <!--    'column_alias': 'average_booking_value'}               -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_766),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_400),  -->
             <!--    'column_alias': 'booking_value'}                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_37) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Join Aggregated Measures with Standard Outputs -->
-                <!-- node_id = ss_37 -->
+                <!-- node_id = ss_19 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_762),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_396),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_760),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_394),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_761),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_395),  -->
                 <!--    'column_alias': 'average_booking_value'}               -->
                 <!-- col3 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_763),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_397),  -->
                 <!--    'column_alias': 'booking_value'}                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_32) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- join_0 =                                                   -->
                 <!--   {'class': 'SqlJoinDescription',                          -->
-                <!--    'right_source': SqlSelectStatementNode(node_id=ss_36),  -->
-                <!--    'right_source_alias': 'subq_17',                        -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_3),     -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),  -->
+                <!--    'right_source_alias': 'subq_14',                        -->
+                <!--    'on_condition': SqlLogicalExpression(node_id=lo_2),     -->
                 <!--    'join_type': SqlJoinType.INNER}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_32 -->
+                    <!-- node_id = ss_15 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_656),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                     <!--    'column_alias': 'bookings'}                                      -->
                     <!-- col2 =                                                                  -->
                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_3, sql_function=AVERAGE),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_1, sql_function=AVERAGE),  -->
                     <!--    'column_alias': 'average_booking_value'}                             -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_31) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_656),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                                             -->
                         <!--   Pass Only Elements:                                     -->
                         <!--     ['average_booking_value', 'bookings', 'metric_time']  -->
-                        <!-- node_id = ss_31 -->
+                        <!-- node_id = ss_14 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_653),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_651),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_652),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
                         <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_30) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Constrain Output with WHERE -->
-                            <!-- node_id = ss_30 -->
+                            <!-- node_id = ss_13 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_650),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_649),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_647),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_648),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                             <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                             <!-- where =                                                               -->
                             <!--   SqlStringExpression(node_id=str_0 sql_expr=listing__is_lux_latest)  -->
                             <SqlSelectStatementNode>
                                 <!-- description =                                                                       -->
                                 <!--   Pass Only Elements:                                                               -->
                                 <!--     ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time']  -->
-                                <!-- node_id = ss_29 -->
+                                <!-- node_id = ss_12 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                                 <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_643),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                                 <!--    'column_alias': 'bookings'}                            -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_644),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                                 <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Join Standard Outputs -->
-                                    <!-- node_id = ss_28 -->
+                                    <!-- node_id = ss_11 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_640),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_641),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                                     <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_638),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                                     <!--    'column_alias': 'bookings'}                            -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_639),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                                     <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                     <!-- join_0 =                                                    -->
                                     <!--   {'class': 'SqlJoinDescription',                           -->
-                                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_27),   -->
-                                    <!--    'right_source_alias': 'subq_7',                          -->
-                                    <!--    'on_condition': SqlComparisonExpression(node_id=cmp_3),  -->
+                                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_10),   -->
+                                    <!--    'right_source_alias': 'subq_5',                          -->
+                                    <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
                                     <!--    'join_type': SqlJoinType.LEFT_OUTER}                     -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
                                         <!-- description =                                                        -->
                                         <!--   Pass Only Elements:                                                -->
                                         <!--     ['average_booking_value', 'bookings', 'metric_time', 'listing']  -->
-                                        <!-- node_id = ss_24 -->
+                                        <!-- node_id = ss_8 -->
                                         <!-- col0 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                                         <!--    'column_alias': 'metric_time'}                         -->
                                         <!-- col1 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                                         <!--    'column_alias': 'listing'}                             -->
                                         <!-- col2 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                                         <!--    'column_alias': 'bookings'}                            -->
                                         <!-- col3 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                                         <!--    'column_alias': 'average_booking_value'}               -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                         <!-- where = None -->
                                         <SqlSelectStatementNode>
                                             <!-- description = Metric Time Dimension 'ds' -->
-                                            <!-- node_id = ss_23 -->
+                                            <!-- node_id = ss_7 -->
                                             <!-- col0 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                             <!--    'column_alias': 'ds'}                                  -->
                                             <!-- col1 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                             <!--    'column_alias': 'ds__week'}                            -->
                                             <!-- col2 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                             <!--    'column_alias': 'ds__month'}                           -->
                                             <!-- col3 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                             <!--    'column_alias': 'ds__quarter'}                         -->
                                             <!-- col4 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                             <!--    'column_alias': 'ds__year'}                            -->
                                             <!-- col5 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                             <!--    'column_alias': 'ds_partitioned'}                      -->
                                             <!-- col6 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                                             <!-- col7 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                                             <!-- col8 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                             <!-- col9 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                                             <!-- col10 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                             <!--    'column_alias': 'booking_paid_at'}                     -->
                                             <!-- col11 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                                             <!-- col12 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                                             <!-- col13 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                             <!-- col14 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                             <!--    'column_alias': 'booking_paid_at__year'}               -->
                                             <!-- col15 =                                                     -->
                                             <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                             <!-- col16 =                                                           -->
                                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                             <!-- col17 =                                                            -->
                                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                             <!-- col18 =                                                              -->
                                             <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                             <!-- col19 =                                                           -->
                                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                             <!-- col20 =                                                                 -->
                                             <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                             <!-- col21 =                                                                       -->
                                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                             <!-- col22 =                                                                        -->
                                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                             <!-- col23 =                                                                          -->
                                             <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                             <!-- col24 =                                                                       -->
                                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                             <!-- col25 =                                                                  -->
                                             <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                                             <!-- col26 =                                                                        -->
                                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                                             <!-- col27 =                                                                         -->
                                             <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                                             <!-- col28 =                                                                           -->
                                             <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                                             <!-- col29 =                                                                        -->
                                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                                             <!-- col30 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                                             <!--    'column_alias': 'metric_time'}                         -->
                                             <!-- col31 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                                             <!--    'column_alias': 'metric_time__week'}                   -->
                                             <!-- col32 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                                             <!--    'column_alias': 'metric_time__month'}                  -->
                                             <!-- col33 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                                             <!--    'column_alias': 'metric_time__quarter'}                -->
                                             <!-- col34 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                                             <!--    'column_alias': 'metric_time__year'}                   -->
                                             <!-- col35 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                                             <!--    'column_alias': 'listing'}                             -->
                                             <!-- col36 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                                             <!--    'column_alias': 'guest'}                               -->
                                             <!-- col37 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                                             <!--    'column_alias': 'host'}                                -->
                                             <!-- col38 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                             <!-- col39 =                                                          -->
                                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                             <!-- col40 =                                                        -->
                                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                                             <!-- col41 =                                                       -->
                                             <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                             <!-- col42 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                             <!--    'column_alias': 'is_instant'}                          -->
                                             <!-- col43 =                                                             -->
                                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                                             <!-- col44 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                             <!--    'column_alias': 'bookings'}                            -->
                                             <!-- col45 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                             <!--    'column_alias': 'instant_bookings'}                    -->
                                             <!-- col46 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                             <!--    'column_alias': 'booking_value'}                       -->
                                             <!-- col47 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                             <!--    'column_alias': 'max_booking_value'}                   -->
                                             <!-- col48 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                             <!--    'column_alias': 'min_booking_value'}                   -->
                                             <!-- col49 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                             <!--    'column_alias': 'bookers'}                             -->
                                             <!-- col50 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                             <!--    'column_alias': 'average_booking_value'}               -->
-                                            <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                             <!-- where = None -->
                                             <SqlSelectStatementNode>
-                                                <!-- description = Pass Only Additive Measures -->
-                                                <!-- node_id = ss_22 -->
-                                                <!-- col0 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                                <!--    'column_alias': 'ds'}                                  -->
-                                                <!-- col1 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                                <!--    'column_alias': 'ds__week'}                            -->
-                                                <!-- col2 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                                <!--    'column_alias': 'ds__month'}                           -->
-                                                <!-- col3 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                                <!-- col4 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                                <!--    'column_alias': 'ds__year'}                            -->
-                                                <!-- col5 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                                <!--    'column_alias': 'ds_partitioned'}                      -->
-                                                <!-- col6 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                                <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                                <!-- col7 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                                <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                                <!-- col8 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                                <!-- col9 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                                <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                                <!-- col10 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                                                <!--    'column_alias': 'booking_paid_at'}                     -->
-                                                <!-- col11 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                                                <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                                <!-- col12 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                                                <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                                <!-- col13 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                                <!-- col14 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                                <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                                <!-- col15 =                                                     -->
-                                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                                <!-- col16 =                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                                <!-- col17 =                                                            -->
-                                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                                <!-- col18 =                                                              -->
-                                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                                <!-- col19 =                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                                <!-- col20 =                                                                 -->
-                                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                                <!-- col21 =                                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                                <!-- col22 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                                <!-- col23 =                                                                          -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                                <!-- col24 =                                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                                <!-- col25 =                                                                  -->
-                                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                                <!-- col26 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                                <!-- col27 =                                                                         -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                                <!-- col28 =                                                                           -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                                <!-- col29 =                                                                        -->
-                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                                <!-- col30 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                                                <!--    'column_alias': 'listing'}                             -->
-                                                <!-- col31 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                                                <!--    'column_alias': 'guest'}                               -->
-                                                <!-- col32 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                                                <!--    'column_alias': 'host'}                                -->
-                                                <!-- col33 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                                <!-- col34 =                                                          -->
-                                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                                <!-- col35 =                                                        -->
+                                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                                <!-- node_id = ss_10001 -->
+                                                <!-- col0 =                                                         -->
                                                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                                <!-- col36 =                                                       -->
-                                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                                <!-- col37 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                                <!--    'column_alias': 'is_instant'}                          -->
-                                                <!-- col38 =                                                             -->
+                                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                                <!--    'column_alias': 'bookings'}                                 -->
+                                                <!-- col1 =                                                                                              -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                                <!-- col2 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                                <!--    'column_alias': 'booking_value'}                         -->
+                                                <!-- col3 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                                <!-- col4 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                                <!-- col5 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                                <!--    'column_alias': 'bookers'}                               -->
+                                                <!-- col6 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                                <!-- col7 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                                <!--    'column_alias': 'booking_payments'}                      -->
+                                                <!-- col8 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                                <!--    'column_alias': 'is_instant'}                            -->
+                                                <!-- col9 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                                <!--    'column_alias': 'ds'}                                    -->
+                                                <!-- col10 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                                <!--    'column_alias': 'ds__week'}                        -->
+                                                <!-- col11 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                                <!--    'column_alias': 'ds__month'}                       -->
+                                                <!-- col12 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                                <!-- col13 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                                <!--    'column_alias': 'ds__year'}                        -->
+                                                <!-- col14 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                                <!-- col15 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                                <!-- col16 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                                <!-- col17 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                                <!-- col18 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                                <!-- col19 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                                <!-- col20 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                                <!-- col21 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                                <!-- col22 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                                <!-- col23 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                                <!-- col24 =                                                             -->
                                                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                                <!-- col39 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                                <!--    'column_alias': 'bookings'}                            -->
-                                                <!-- col40 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                                <!-- col41 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                                <!--    'column_alias': 'booking_value'}                       -->
-                                                <!-- col42 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                                <!-- col43 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                                <!-- col44 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                                <!--    'column_alias': 'bookers'}                             -->
-                                                <!-- col45 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                                <!--    'column_alias': 'average_booking_value'}               -->
-                                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                                <!-- col25 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                                <!-- col26 =                                                           -->
+                                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                                <!-- col27 =                                                            -->
+                                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                                <!-- col28 =                                                              -->
+                                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                                <!-- col29 =                                                           -->
+                                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                                <!-- col30 =                                                                 -->
+                                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                                <!-- col31 =                                                                       -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                                <!-- col32 =                                                                        -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                                <!-- col33 =                                                                          -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                                <!-- col34 =                                                                       -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                                <!-- col35 =                                                                  -->
+                                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                                <!-- col36 =                                                                        -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                                <!-- col37 =                                                                         -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                                <!-- col38 =                                                                           -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                                <!-- col39 =                                                                        -->
+                                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                                <!-- col40 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                                <!--    'column_alias': 'listing'}                               -->
+                                                <!-- col41 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                                <!--    'column_alias': 'guest'}                                 -->
+                                                <!-- col42 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                                <!--    'column_alias': 'host'}                                  -->
+                                                <!-- col43 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                                <!-- col44 =                                                          -->
+                                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                                <!-- col45 =                                                        -->
+                                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                                <!-- col46 =                                                       -->
+                                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                                 <!-- where = None -->
-                                                <SqlSelectStatementNode>
-                                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                                    <!-- node_id = ss_10001 -->
-                                                    <!-- col0 =                                                         -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                                    <!--    'column_alias': 'bookings'}                                 -->
-                                                    <!-- col1 =                                                                                              -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                                    <!-- col2 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                                    <!--    'column_alias': 'booking_value'}                         -->
-                                                    <!-- col3 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                                    <!--    'column_alias': 'max_booking_value'}                     -->
-                                                    <!-- col4 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                                    <!--    'column_alias': 'min_booking_value'}                     -->
-                                                    <!-- col5 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                                    <!--    'column_alias': 'bookers'}                               -->
-                                                    <!-- col6 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                                    <!--    'column_alias': 'average_booking_value'}                 -->
-                                                    <!-- col7 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                                    <!--    'column_alias': 'booking_payments'}                      -->
-                                                    <!-- col8 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                                    <!--    'column_alias': 'is_instant'}                            -->
-                                                    <!-- col9 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                                    <!--    'column_alias': 'ds'}                                    -->
-                                                    <!-- col10 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                                    <!--    'column_alias': 'ds__week'}                        -->
-                                                    <!-- col11 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                                    <!--    'column_alias': 'ds__month'}                       -->
-                                                    <!-- col12 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                                    <!-- col13 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                                    <!--    'column_alias': 'ds__year'}                        -->
-                                                    <!-- col14 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                                    <!--    'column_alias': 'ds_partitioned'}                        -->
-                                                    <!-- col15 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                                    <!-- col16 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                                    <!-- col17 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                                    <!-- col18 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                                    <!-- col19 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                                    <!--    'column_alias': 'booking_paid_at'}                       -->
-                                                    <!-- col20 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                                    <!-- col21 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                                    <!-- col22 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                                    <!-- col23 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                                    <!-- col24 =                                                             -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                                    <!-- col25 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                                    <!-- col26 =                                                           -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                                    <!-- col27 =                                                            -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                                    <!-- col28 =                                                              -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                                    <!-- col29 =                                                           -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                                    <!-- col30 =                                                                 -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                                    <!-- col31 =                                                                       -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                                    <!-- col32 =                                                                        -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                                    <!-- col33 =                                                                          -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                                    <!-- col34 =                                                                       -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                                    <!-- col35 =                                                                  -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                                    <!-- col36 =                                                                        -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                                    <!-- col37 =                                                                         -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                                    <!-- col38 =                                                                           -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                                    <!-- col39 =                                                                        -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                                    <!-- col40 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                                    <!--    'column_alias': 'listing'}                               -->
-                                                    <!-- col41 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                                    <!--    'column_alias': 'guest'}                                 -->
-                                                    <!-- col42 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                                    <!--    'column_alias': 'host'}                                  -->
-                                                    <!-- col43 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                                    <!-- col44 =                                                          -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                                    <!-- col45 =                                                        -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                                    <!-- col46 =                                                       -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                                    <!-- where = None -->
-                                                    <SqlSelectQueryFromClauseNode>
-                                                        <!-- description = Read From a Select Query -->
-                                                        <!-- node_id = tfc_10001 -->
-                                                    </SqlSelectQueryFromClauseNode>
-                                                </SqlSelectStatementNode>
+                                                <SqlSelectQueryFromClauseNode>
+                                                    <!-- description = Read From a Select Query -->
+                                                    <!-- node_id = tfc_10001 -->
+                                                </SqlSelectQueryFromClauseNode>
                                             </SqlSelectStatementNode>
                                         </SqlSelectStatementNode>
                                     </SqlSelectStatementNode>
@@ -804,442 +614,308 @@
                                         <!-- description =                     -->
                                         <!--   Pass Only Elements:             -->
                                         <!--     ['listing', 'is_lux_latest']  -->
-                                        <!-- node_id = ss_27 -->
+                                        <!-- node_id = ss_10 -->
                                         <!-- col0 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_635),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
                                         <!--    'column_alias': 'listing'}                             -->
                                         <!-- col1 =                                                    -->
                                         <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_634),  -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                                         <!--    'column_alias': 'is_lux_latest'}                       -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                         <!-- where = None -->
                                         <SqlSelectStatementNode>
                                             <!-- description = Metric Time Dimension 'ds' -->
-                                            <!-- node_id = ss_26 -->
+                                            <!-- node_id = ss_9 -->
                                             <!-- col0 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                                             <!--    'column_alias': 'ds'}                                  -->
                                             <!-- col1 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                                             <!--    'column_alias': 'ds__week'}                            -->
                                             <!-- col2 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                                             <!--    'column_alias': 'ds__month'}                           -->
                                             <!-- col3 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                                             <!--    'column_alias': 'ds__quarter'}                         -->
                                             <!-- col4 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                                             <!--    'column_alias': 'ds__year'}                            -->
                                             <!-- col5 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                                             <!--    'column_alias': 'created_at'}                          -->
                                             <!-- col6 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_612),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                                             <!--    'column_alias': 'created_at__week'}                    -->
                                             <!-- col7 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                                             <!--    'column_alias': 'created_at__month'}                   -->
                                             <!-- col8 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_614),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                                             <!--    'column_alias': 'created_at__quarter'}                 -->
                                             <!-- col9 =                                                    -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_615),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                                             <!--    'column_alias': 'created_at__year'}                    -->
                                             <!-- col10 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_616),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                                             <!--    'column_alias': 'listing__ds'}                         -->
                                             <!-- col11 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_617),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                                             <!--    'column_alias': 'listing__ds__week'}                   -->
                                             <!-- col12 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_618),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                                             <!--    'column_alias': 'listing__ds__month'}                  -->
                                             <!-- col13 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_619),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                                             <!--    'column_alias': 'listing__ds__quarter'}                -->
                                             <!-- col14 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_620),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                                             <!--    'column_alias': 'listing__ds__year'}                   -->
                                             <!-- col15 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_621),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                                             <!--    'column_alias': 'listing__created_at'}                 -->
                                             <!-- col16 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_622),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                                             <!--    'column_alias': 'listing__created_at__week'}           -->
                                             <!-- col17 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_623),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                                             <!--    'column_alias': 'listing__created_at__month'}          -->
                                             <!-- col18 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_624),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                                             <!--    'column_alias': 'listing__created_at__quarter'}        -->
                                             <!-- col19 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_625),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                                             <!--    'column_alias': 'listing__created_at__year'}           -->
                                             <!-- col20 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_626),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                                             <!--    'column_alias': 'metric_time'}                         -->
                                             <!-- col21 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_627),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
                                             <!--    'column_alias': 'metric_time__week'}                   -->
                                             <!-- col22 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_628),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
                                             <!--    'column_alias': 'metric_time__month'}                  -->
                                             <!-- col23 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_629),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
                                             <!--    'column_alias': 'metric_time__quarter'}                -->
                                             <!-- col24 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_630),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
                                             <!--    'column_alias': 'metric_time__year'}                   -->
                                             <!-- col25 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_631),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
                                             <!--    'column_alias': 'listing'}                             -->
                                             <!-- col26 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_632),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                                             <!--    'column_alias': 'user'}                                -->
                                             <!-- col27 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_633),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                                             <!--    'column_alias': 'listing__user'}                       -->
                                             <!-- col28 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                                             <!--    'column_alias': 'country_latest'}                      -->
                                             <!-- col29 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
                                             <!--    'column_alias': 'is_lux_latest'}                       -->
                                             <!-- col30 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                                             <!--    'column_alias': 'capacity_latest'}                     -->
                                             <!-- col31 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                                             <!--    'column_alias': 'listing__country_latest'}             -->
                                             <!-- col32 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                                             <!--    'column_alias': 'listing__is_lux_latest'}              -->
                                             <!-- col33 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                                             <!--    'column_alias': 'listing__capacity_latest'}            -->
                                             <!-- col34 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                                             <!--    'column_alias': 'listings'}                            -->
                                             <!-- col35 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                                             <!--    'column_alias': 'largest_listing'}                     -->
                                             <!-- col36 =                                                   -->
                                             <!--   {'class': 'SqlSelectColumn',                            -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),  -->
+                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                                             <!--    'column_alias': 'smallest_listing'}                    -->
-                                            <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
                                             <!-- where = None -->
                                             <SqlSelectStatementNode>
-                                                <!-- description = Pass Only Additive Measures -->
-                                                <!-- node_id = ss_25 -->
-                                                <!-- col0 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
-                                                <!--    'column_alias': 'ds'}                                  -->
-                                                <!-- col1 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
-                                                <!--    'column_alias': 'ds__week'}                            -->
-                                                <!-- col2 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
-                                                <!--    'column_alias': 'ds__month'}                           -->
-                                                <!-- col3 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
-                                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                                <!-- col4 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
-                                                <!--    'column_alias': 'ds__year'}                            -->
-                                                <!-- col5 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),  -->
-                                                <!--    'column_alias': 'created_at'}                          -->
-                                                <!-- col6 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
-                                                <!--    'column_alias': 'created_at__week'}                    -->
-                                                <!-- col7 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
-                                                <!--    'column_alias': 'created_at__month'}                   -->
-                                                <!-- col8 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
-                                                <!--    'column_alias': 'created_at__quarter'}                 -->
-                                                <!-- col9 =                                                    -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
-                                                <!--    'column_alias': 'created_at__year'}                    -->
-                                                <!-- col10 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
-                                                <!--    'column_alias': 'listing__ds'}                         -->
-                                                <!-- col11 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),  -->
-                                                <!--    'column_alias': 'listing__ds__week'}                   -->
-                                                <!-- col12 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),  -->
-                                                <!--    'column_alias': 'listing__ds__month'}                  -->
-                                                <!-- col13 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),  -->
-                                                <!--    'column_alias': 'listing__ds__quarter'}                -->
-                                                <!-- col14 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),  -->
-                                                <!--    'column_alias': 'listing__ds__year'}                   -->
-                                                <!-- col15 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
-                                                <!--    'column_alias': 'listing__created_at'}                 -->
-                                                <!-- col16 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
-                                                <!--    'column_alias': 'listing__created_at__week'}           -->
-                                                <!-- col17 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),  -->
-                                                <!--    'column_alias': 'listing__created_at__month'}          -->
-                                                <!-- col18 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),  -->
-                                                <!--    'column_alias': 'listing__created_at__quarter'}        -->
-                                                <!-- col19 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),  -->
-                                                <!--    'column_alias': 'listing__created_at__year'}           -->
-                                                <!-- col20 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),  -->
-                                                <!--    'column_alias': 'listing'}                             -->
-                                                <!-- col21 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),  -->
-                                                <!--    'column_alias': 'user'}                                -->
-                                                <!-- col22 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),  -->
-                                                <!--    'column_alias': 'listing__user'}                       -->
-                                                <!-- col23 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
-                                                <!--    'column_alias': 'country_latest'}                      -->
-                                                <!-- col24 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_569),  -->
-                                                <!--    'column_alias': 'is_lux_latest'}                       -->
-                                                <!-- col25 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
-                                                <!--    'column_alias': 'capacity_latest'}                     -->
-                                                <!-- col26 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
-                                                <!--    'column_alias': 'listing__country_latest'}             -->
-                                                <!-- col27 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
-                                                <!--    'column_alias': 'listing__is_lux_latest'}              -->
-                                                <!-- col28 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_573),  -->
-                                                <!--    'column_alias': 'listing__capacity_latest'}            -->
-                                                <!-- col29 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
-                                                <!--    'column_alias': 'listings'}                            -->
-                                                <!-- col30 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
-                                                <!--    'column_alias': 'largest_listing'}                     -->
-                                                <!-- col31 =                                                   -->
-                                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
-                                                <!--    'column_alias': 'smallest_listing'}                    -->
-                                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10004) -->
+                                                <!-- description = Read Elements From Data Source 'listings_latest' -->
+                                                <!-- node_id = ss_10004 -->
+                                                <!-- col0 =                                                         -->
+                                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                                <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
+                                                <!--    'column_alias': 'listings'}                                 -->
+                                                <!-- col1 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                                                <!--    'column_alias': 'largest_listing'}                       -->
+                                                <!-- col2 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                                                <!--    'column_alias': 'smallest_listing'}                      -->
+                                                <!-- col3 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
+                                                <!--    'column_alias': 'ds'}                                    -->
+                                                <!-- col4 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
+                                                <!--    'column_alias': 'ds__week'}                        -->
+                                                <!-- col5 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
+                                                <!--    'column_alias': 'ds__month'}                       -->
+                                                <!-- col6 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
+                                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                                <!-- col7 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
+                                                <!--    'column_alias': 'ds__year'}                        -->
+                                                <!-- col8 =                                                      -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
+                                                <!--    'column_alias': 'created_at'}                            -->
+                                                <!-- col9 =                                                -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
+                                                <!--    'column_alias': 'created_at__week'}                -->
+                                                <!-- col10 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
+                                                <!--    'column_alias': 'created_at__month'}               -->
+                                                <!-- col11 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
+                                                <!--    'column_alias': 'created_at__quarter'}             -->
+                                                <!-- col12 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
+                                                <!--    'column_alias': 'created_at__year'}                -->
+                                                <!-- col13 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                                                <!--    'column_alias': 'country_latest'}                        -->
+                                                <!-- col14 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                                                <!--    'column_alias': 'is_lux_latest'}                         -->
+                                                <!-- col15 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                                                <!--    'column_alias': 'capacity_latest'}                       -->
+                                                <!-- col16 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
+                                                <!--    'column_alias': 'listing__ds'}                           -->
+                                                <!-- col17 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
+                                                <!--    'column_alias': 'listing__ds__week'}               -->
+                                                <!-- col18 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
+                                                <!--    'column_alias': 'listing__ds__month'}              -->
+                                                <!-- col19 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
+                                                <!--    'column_alias': 'listing__ds__quarter'}            -->
+                                                <!-- col20 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
+                                                <!--    'column_alias': 'listing__ds__year'}               -->
+                                                <!-- col21 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
+                                                <!--    'column_alias': 'listing__created_at'}                   -->
+                                                <!-- col22 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
+                                                <!--    'column_alias': 'listing__created_at__week'}       -->
+                                                <!-- col23 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
+                                                <!--    'column_alias': 'listing__created_at__month'}      -->
+                                                <!-- col24 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
+                                                <!--    'column_alias': 'listing__created_at__quarter'}    -->
+                                                <!-- col25 =                                               -->
+                                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
+                                                <!--    'column_alias': 'listing__created_at__year'}       -->
+                                                <!-- col26 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                                                <!--    'column_alias': 'listing__country_latest'}               -->
+                                                <!-- col27 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                                                <!--    'column_alias': 'listing__is_lux_latest'}                -->
+                                                <!-- col28 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                                                <!--    'column_alias': 'listing__capacity_latest'}              -->
+                                                <!-- col29 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                                                <!--    'column_alias': 'listing'}                               -->
+                                                <!-- col30 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                                                <!--    'column_alias': 'user'}                                  -->
+                                                <!-- col31 =                                                     -->
+                                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
+                                                <!--    'column_alias': 'listing__user'}                         -->
+                                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                                                 <!-- where = None -->
-                                                <SqlSelectStatementNode>
-                                                    <!-- description = Read Elements From Data Source 'listings_latest' -->
-                                                    <!-- node_id = ss_10004 -->
-                                                    <!-- col0 =                                                         -->
-                                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                                    <!--    'expr': SqlStringExpression(node_id=str_10003 sql_expr=1),  -->
-                                                    <!--    'column_alias': 'listings'}                                 -->
-                                                    <!-- col1 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
-                                                    <!--    'column_alias': 'largest_listing'}                       -->
-                                                    <!-- col2 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
-                                                    <!--    'column_alias': 'smallest_listing'}                      -->
-                                                    <!-- col3 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
-                                                    <!--    'column_alias': 'ds'}                                    -->
-                                                    <!-- col4 =                                                -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10044),  -->
-                                                    <!--    'column_alias': 'ds__week'}                        -->
-                                                    <!-- col5 =                                                -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10045),  -->
-                                                    <!--    'column_alias': 'ds__month'}                       -->
-                                                    <!-- col6 =                                                -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10046),  -->
-                                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                                    <!-- col7 =                                                -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10047),  -->
-                                                    <!--    'column_alias': 'ds__year'}                        -->
-                                                    <!-- col8 =                                                      -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
-                                                    <!--    'column_alias': 'created_at'}                            -->
-                                                    <!-- col9 =                                                -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10048),  -->
-                                                    <!--    'column_alias': 'created_at__week'}                -->
-                                                    <!-- col10 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10049),  -->
-                                                    <!--    'column_alias': 'created_at__month'}               -->
-                                                    <!-- col11 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10050),  -->
-                                                    <!--    'column_alias': 'created_at__quarter'}             -->
-                                                    <!-- col12 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10051),  -->
-                                                    <!--    'column_alias': 'created_at__year'}                -->
-                                                    <!-- col13 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
-                                                    <!--    'column_alias': 'country_latest'}                        -->
-                                                    <!-- col14 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
-                                                    <!--    'column_alias': 'is_lux_latest'}                         -->
-                                                    <!-- col15 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
-                                                    <!--    'column_alias': 'capacity_latest'}                       -->
-                                                    <!-- col16 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
-                                                    <!--    'column_alias': 'listing__ds'}                           -->
-                                                    <!-- col17 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10052),  -->
-                                                    <!--    'column_alias': 'listing__ds__week'}               -->
-                                                    <!-- col18 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10053),  -->
-                                                    <!--    'column_alias': 'listing__ds__month'}              -->
-                                                    <!-- col19 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10054),  -->
-                                                    <!--    'column_alias': 'listing__ds__quarter'}            -->
-                                                    <!-- col20 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10055),  -->
-                                                    <!--    'column_alias': 'listing__ds__year'}               -->
-                                                    <!-- col21 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
-                                                    <!--    'column_alias': 'listing__created_at'}                   -->
-                                                    <!-- col22 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10056),  -->
-                                                    <!--    'column_alias': 'listing__created_at__week'}       -->
-                                                    <!-- col23 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10057),  -->
-                                                    <!--    'column_alias': 'listing__created_at__month'}      -->
-                                                    <!-- col24 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10058),  -->
-                                                    <!--    'column_alias': 'listing__created_at__quarter'}    -->
-                                                    <!-- col25 =                                               -->
-                                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10059),  -->
-                                                    <!--    'column_alias': 'listing__created_at__year'}       -->
-                                                    <!-- col26 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
-                                                    <!--    'column_alias': 'listing__country_latest'}               -->
-                                                    <!-- col27 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
-                                                    <!--    'column_alias': 'listing__is_lux_latest'}                -->
-                                                    <!-- col28 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
-                                                    <!--    'column_alias': 'listing__capacity_latest'}              -->
-                                                    <!-- col29 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
-                                                    <!--    'column_alias': 'listing'}                               -->
-                                                    <!-- col30 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
-                                                    <!--    'column_alias': 'user'}                                  -->
-                                                    <!-- col31 =                                                     -->
-                                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
-                                                    <!--    'column_alias': 'listing__user'}                         -->
-                                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
-                                                    <!-- where = None -->
-                                                    <SqlTableFromClauseNode>
-                                                        <!-- description = Read from ***************************.dim_listings_latest -->
-                                                        <!-- node_id = tfc_10002 -->
-                                                        <!-- table_id = ***************************.dim_listings_latest -->
-                                                    </SqlTableFromClauseNode>
-                                                </SqlSelectStatementNode>
+                                                <SqlTableFromClauseNode>
+                                                    <!-- description = Read from ***************************.dim_listings_latest -->
+                                                    <!-- node_id = tfc_10002 -->
+                                                    <!-- table_id = ***************************.dim_listings_latest -->
+                                                </SqlTableFromClauseNode>
                                             </SqlSelectStatementNode>
                                         </SqlSelectStatementNode>
                                     </SqlSelectStatementNode>
@@ -1250,632 +926,442 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_36 -->
+                    <!-- node_id = ss_18 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_757),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_4, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
                     <!--    'column_alias': 'booking_value'}                                 -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_35) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_757),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_391),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                         -->
                         <!--   Pass Only Elements:                 -->
                         <!--     ['booking_value', 'metric_time']  -->
-                        <!-- node_id = ss_35 -->
+                        <!-- node_id = ss_17 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_755),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_389),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_754),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_388),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_34) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_34 -->
+                            <!-- node_id = ss_16 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_712),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_713),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_714),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_715),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_716),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_717),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_718),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_719),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_720),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_721),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_355),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_722),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_723),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_724),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_725),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_726),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_360),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
                             <!-- col15 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_727),    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),    -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                             <!-- col16 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_728),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                             <!-- col17 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_729),           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),           -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                             <!-- col18 =                                                              -->
                             <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_730),             -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_364),             -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                             <!-- col19 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_731),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                             <!-- col20 =                                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_732),                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),                -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                             <!-- col21 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_733),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                             <!-- col22 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_734),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_368),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                             <!-- col23 =                                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_735),                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_369),                         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                             <!-- col24 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_736),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                             <!-- col25 =                                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_737),                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_371),                 -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                             <!-- col26 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_738),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_372),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                             <!-- col27 =                                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_739),                        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_373),                        -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                             <!-- col28 =                                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_740),                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_374),                          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                             <!-- col29 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_741),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_375),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_742),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_376),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_743),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_377),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_744),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_378),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_745),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_379),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_746),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_380),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_747),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_381),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_748),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_382),  -->
                             <!--    'column_alias': 'guest'}                               -->
                             <!-- col37 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_749),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_383),  -->
                             <!--    'column_alias': 'host'}                                -->
                             <!-- col38 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_750),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_384),  -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                             <!-- col39 =                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_751),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_385),         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                             <!-- col40 =                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_752),       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_386),       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                             <!-- col41 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_753),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_387),      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- col42 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_710),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col43 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_711),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),            -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                             <!-- col44 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_703),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- col45 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_704),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
                             <!--    'column_alias': 'instant_bookings'}                    -->
                             <!-- col46 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_705),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
                             <!--    'column_alias': 'booking_value'}                       -->
                             <!-- col47 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_706),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
                             <!--    'column_alias': 'max_booking_value'}                   -->
                             <!-- col48 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_707),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
                             <!--    'column_alias': 'min_booking_value'}                   -->
                             <!-- col49 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_708),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                             <!--    'column_alias': 'bookers'}                             -->
                             <!-- col50 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_709),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
                             <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_33) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = ss_33 -->
-                                <!-- col0 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_666),  -->
-                                <!--    'column_alias': 'ds'}                                  -->
-                                <!-- col1 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_667),  -->
-                                <!--    'column_alias': 'ds__week'}                            -->
-                                <!-- col2 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_668),  -->
-                                <!--    'column_alias': 'ds__month'}                           -->
-                                <!-- col3 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_669),  -->
-                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                <!-- col4 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_670),  -->
-                                <!--    'column_alias': 'ds__year'}                            -->
-                                <!-- col5 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_671),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                      -->
-                                <!-- col6 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_672),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                <!-- col7 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_673),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                <!-- col8 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_674),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                <!-- col9 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_675),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                <!-- col10 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_676),  -->
-                                <!--    'column_alias': 'booking_paid_at'}                     -->
-                                <!-- col11 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_677),  -->
-                                <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                <!-- col12 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_678),  -->
-                                <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                <!-- col13 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_679),  -->
-                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                <!-- col14 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_680),  -->
-                                <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_681),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_682),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_683),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_684),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_685),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_686),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_687),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_688),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_689),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_690),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_691),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_692),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_693),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_694),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_695),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col30 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_696),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col31 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_697),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col32 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_698),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col33 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_699),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col34 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_700),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col35 =                                                        -->
+                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                <!-- node_id = ss_10001 -->
+                                <!-- col0 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_701),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col36 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_702),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_664),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col38 =                                                             -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                <!--    'column_alias': 'bookings'}                                 -->
+                                <!-- col1 =                                                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                <!-- col2 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                <!--    'column_alias': 'booking_value'}                         -->
+                                <!-- col3 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                <!-- col4 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                <!-- col5 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                <!--    'column_alias': 'bookers'}                               -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                <!--    'column_alias': 'booking_payments'}                      -->
+                                <!-- col8 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                <!--    'column_alias': 'is_instant'}                            -->
+                                <!-- col9 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col10 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col11 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col12 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col13 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col17 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col19 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                <!-- col20 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                <!-- col22 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                <!-- col23 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                <!-- col24 =                                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_665),            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col39 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_657),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col40 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_658),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col41 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_659),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_660),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col43 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_661),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_662),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_663),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col26 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col27 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col28 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col29 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col30 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col31 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col32 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col33 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col34 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col35 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col36 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col37 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col38 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col39 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col40 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                <!--    'column_alias': 'listing'}                               -->
+                                <!-- col41 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                <!--    'column_alias': 'guest'}                                 -->
+                                <!-- col42 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                <!--    'column_alias': 'host'}                                  -->
+                                <!-- col43 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                <!-- col44 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col45 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col46 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
-                                <SqlSelectStatementNode>
-                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                    <!-- node_id = ss_10001 -->
-                                    <!-- col0 =                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                    <!--    'column_alias': 'bookings'}                                 -->
-                                    <!-- col1 =                                                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                    <!-- col2 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                    <!--    'column_alias': 'booking_value'}                         -->
-                                    <!-- col3 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                     -->
-                                    <!-- col4 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                     -->
-                                    <!-- col5 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                    <!--    'column_alias': 'bookers'}                               -->
-                                    <!-- col6 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                    <!--    'column_alias': 'average_booking_value'}                 -->
-                                    <!-- col7 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                    <!--    'column_alias': 'booking_payments'}                      -->
-                                    <!-- col8 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                    <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col9 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                    <!--    'column_alias': 'ds'}                                    -->
-                                    <!-- col10 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                    <!--    'column_alias': 'ds__week'}                        -->
-                                    <!-- col11 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                    <!--    'column_alias': 'ds__month'}                       -->
-                                    <!-- col12 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                    <!-- col13 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                    <!--    'column_alias': 'ds__year'}                        -->
-                                    <!-- col14 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds_partitioned'}                        -->
-                                    <!-- col15 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                    <!-- col16 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                    <!-- col17 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                    <!-- col18 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                    <!-- col19 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking_paid_at'}                       -->
-                                    <!-- col20 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                    <!-- col21 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                    <!-- col22 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                    <!-- col23 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col24 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col25 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col26 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col27 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col28 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col29 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col30 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col31 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col32 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col33 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col34 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col35 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col36 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col37 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col38 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col39 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col40 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col41 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                    <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col42 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                    <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col43 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col44 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col45 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col46 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                    <!-- where = None -->
-                                    <SqlSelectQueryFromClauseNode>
-                                        <!-- description = Read From a Select Query -->
-                                        <!-- node_id = tfc_10001 -->
-                                    </SqlSelectQueryFromClauseNode>
-                                </SqlSelectStatementNode>
+                                <SqlSelectQueryFromClauseNode>
+                                    <!-- description = Read From a Select Query -->
+                                    <!-- node_id = tfc_10001 -->
+                                </SqlSelectQueryFromClauseNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
@@ -1,723 +1,533 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_34 -->
+        <!-- node_id = ss_17 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_680),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlRatioComputationExpression(node_id=rc_0),  -->
         <!--    'column_alias': 'instant_booking_value_ratio'}        -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_33) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description =                                                                     -->
             <!--   Pass Only Elements:                                                             -->
             <!--     ['metric_time', 'booking_value_with_is_instant_constraint', 'booking_value']  -->
-            <!-- node_id = ss_33 -->
+            <!-- node_id = ss_16 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_679),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                          -->
             <!--   {'class': 'SqlSelectColumn',                                  -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_677),        -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),        -->
             <!--    'column_alias': 'booking_value_with_is_instant_constraint'}  -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_678),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
             <!--    'column_alias': 'booking_value'}                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_32) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Join Aggregated Measures with Standard Outputs -->
-                <!-- node_id = ss_32 -->
+                <!-- node_id = ss_15 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_675),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                  -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_674),        -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),        -->
                 <!--    'column_alias': 'booking_value_with_is_instant_constraint'}  -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_676),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                 <!--    'column_alias': 'booking_value'}                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                 <!-- join_0 =                                                   -->
                 <!--   {'class': 'SqlJoinDescription',                          -->
-                <!--    'right_source': SqlSelectStatementNode(node_id=ss_31),  -->
-                <!--    'right_source_alias': 'subq_11',                        -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_3),     -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
+                <!--    'right_source_alias': 'subq_9',                         -->
+                <!--    'on_condition': SqlLogicalExpression(node_id=lo_2),     -->
                 <!--    'join_type': SqlJoinType.INNER}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_27 -->
+                    <!-- node_id = ss_11 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                     <!--    'column_alias': 'booking_value_with_is_instant_constraint'}      -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                         -->
                         <!--   Pass Only Elements:                 -->
                         <!--     ['booking_value', 'metric_time']  -->
-                        <!-- node_id = ss_26 -->
+                        <!-- node_id = ss_10 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Constrain Output with WHERE -->
-                            <!-- node_id = ss_25 -->
+                            <!-- node_id = ss_9 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                             <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=is_instant) -->
                             <SqlSelectStatementNode>
                                 <!-- description =                                       -->
                                 <!--   Pass Only Elements:                               -->
                                 <!--     ['booking_value', 'is_instant', 'metric_time']  -->
-                                <!-- node_id = ss_24 -->
+                                <!-- node_id = ss_8 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                                 <!--    'column_alias': 'metric_time'}                         -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                                 <!--    'column_alias': 'is_instant'}                          -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                                 <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Metric Time Dimension 'ds' -->
-                                    <!-- node_id = ss_23 -->
+                                    <!-- node_id = ss_7 -->
                                     <!-- col0 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                                     <!--    'column_alias': 'ds'}                                  -->
                                     <!-- col1 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                                     <!--    'column_alias': 'ds__week'}                            -->
                                     <!-- col2 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                                     <!--    'column_alias': 'ds__month'}                           -->
                                     <!-- col3 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                                     <!--    'column_alias': 'ds__quarter'}                         -->
                                     <!-- col4 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                                     <!--    'column_alias': 'ds__year'}                            -->
                                     <!-- col5 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                      -->
                                     <!-- col6 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                                     <!--    'column_alias': 'ds_partitioned__week'}                -->
                                     <!-- col7 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                                     <!--    'column_alias': 'ds_partitioned__month'}               -->
                                     <!-- col8 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                                     <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                     <!-- col9 =                                                    -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                                     <!--    'column_alias': 'ds_partitioned__year'}                -->
                                     <!-- col10 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                                     <!--    'column_alias': 'booking_paid_at'}                     -->
                                     <!-- col11 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                                     <!--    'column_alias': 'booking_paid_at__week'}               -->
                                     <!-- col12 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                                     <!--    'column_alias': 'booking_paid_at__month'}              -->
                                     <!-- col13 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                                     <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                                     <!-- col14 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                                     <!--    'column_alias': 'booking_paid_at__year'}               -->
                                     <!-- col15 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                                     <!-- col16 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                                     <!-- col17 =                                                            -->
                                     <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                                     <!-- col18 =                                                              -->
                                     <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                                     <!-- col19 =                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                                     <!-- col20 =                                                                 -->
                                     <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                                     <!-- col21 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                                     <!-- col22 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                                     <!-- col23 =                                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                                     <!-- col24 =                                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                                     <!-- col25 =                                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                                     <!-- col26 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                                     <!-- col27 =                                                                         -->
                                     <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                                     <!-- col28 =                                                                           -->
                                     <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                                     <!-- col29 =                                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                                     <!-- col30 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                                     <!--    'column_alias': 'metric_time'}                         -->
                                     <!-- col31 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                                     <!--    'column_alias': 'metric_time__week'}                   -->
                                     <!-- col32 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                                     <!--    'column_alias': 'metric_time__month'}                  -->
                                     <!-- col33 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                                     <!--    'column_alias': 'metric_time__quarter'}                -->
                                     <!-- col34 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                                     <!--    'column_alias': 'metric_time__year'}                   -->
                                     <!-- col35 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                                     <!--    'column_alias': 'listing'}                             -->
                                     <!-- col36 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                                     <!--    'column_alias': 'guest'}                               -->
                                     <!-- col37 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                                     <!--    'column_alias': 'host'}                                -->
                                     <!-- col38 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                                     <!-- col39 =                                                          -->
                                     <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                                     <!-- col40 =                                                        -->
                                     <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                                     <!-- col41 =                                                       -->
                                     <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                                     <!-- col42 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                                     <!--    'column_alias': 'is_instant'}                          -->
                                     <!-- col43 =                                                             -->
                                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                                     <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                                     <!-- col44 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                                     <!--    'column_alias': 'bookings'}                            -->
                                     <!-- col45 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                                     <!--    'column_alias': 'instant_bookings'}                    -->
                                     <!-- col46 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                                     <!--    'column_alias': 'booking_value'}                       -->
                                     <!-- col47 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                                     <!--    'column_alias': 'max_booking_value'}                   -->
                                     <!-- col48 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--    'column_alias': 'min_booking_value'}                   -->
                                     <!-- col49 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                                     <!--    'column_alias': 'bookers'}                             -->
                                     <!-- col50 =                                                   -->
                                     <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                                     <!--    'column_alias': 'average_booking_value'}               -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                                     <!-- where = None -->
                                     <SqlSelectStatementNode>
-                                        <!-- description = Pass Only Additive Measures -->
-                                        <!-- node_id = ss_22 -->
-                                        <!-- col0 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                        <!--    'column_alias': 'ds'}                                  -->
-                                        <!-- col1 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                        <!--    'column_alias': 'ds__week'}                            -->
-                                        <!-- col2 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                        <!--    'column_alias': 'ds__month'}                           -->
-                                        <!-- col3 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                        <!--    'column_alias': 'ds__quarter'}                         -->
-                                        <!-- col4 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                        <!--    'column_alias': 'ds__year'}                            -->
-                                        <!-- col5 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                        <!--    'column_alias': 'ds_partitioned'}                      -->
-                                        <!-- col6 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                        <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                        <!-- col7 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                        <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                        <!-- col8 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                        <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                        <!-- col9 =                                                    -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                        <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                        <!-- col10 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                                        <!--    'column_alias': 'booking_paid_at'}                     -->
-                                        <!-- col11 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                                        <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                        <!-- col12 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                                        <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                        <!-- col13 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                        <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                        <!-- col14 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                        <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                        <!-- col15 =                                                     -->
-                                        <!--   {'class': 'SqlSelectColumn',                              -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                        <!-- col16 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                        <!-- col17 =                                                            -->
-                                        <!--   {'class': 'SqlSelectColumn',                                     -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                        <!-- col18 =                                                              -->
-                                        <!--   {'class': 'SqlSelectColumn',                                       -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                        <!-- col19 =                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                        <!-- col20 =                                                                 -->
-                                        <!--   {'class': 'SqlSelectColumn',                                          -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                        <!-- col21 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                        <!-- col22 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                        <!-- col23 =                                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                        <!-- col24 =                                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                        <!-- col25 =                                                                  -->
-                                        <!--   {'class': 'SqlSelectColumn',                                           -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                        <!-- col26 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                        <!-- col27 =                                                                         -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                        <!-- col28 =                                                                           -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                        <!-- col29 =                                                                        -->
-                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                        <!-- col30 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                                        <!--    'column_alias': 'listing'}                             -->
-                                        <!-- col31 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                                        <!--    'column_alias': 'guest'}                               -->
-                                        <!-- col32 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                                        <!--    'column_alias': 'host'}                                -->
-                                        <!-- col33 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                        <!-- col34 =                                                          -->
-                                        <!--   {'class': 'SqlSelectColumn',                                   -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                        <!-- col35 =                                                        -->
+                                        <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                        <!-- node_id = ss_10001 -->
+                                        <!-- col0 =                                                         -->
                                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                        <!-- col36 =                                                       -->
-                                        <!--   {'class': 'SqlSelectColumn',                                -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                        <!-- col37 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                        <!--    'column_alias': 'is_instant'}                          -->
-                                        <!-- col38 =                                                             -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                        <!--    'column_alias': 'bookings'}                                 -->
+                                        <!-- col1 =                                                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                        <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                        <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                        <!-- col2 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                        <!--    'column_alias': 'booking_value'}                         -->
+                                        <!-- col3 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                        <!--    'column_alias': 'max_booking_value'}                     -->
+                                        <!-- col4 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                        <!--    'column_alias': 'min_booking_value'}                     -->
+                                        <!-- col5 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                        <!--    'column_alias': 'bookers'}                               -->
+                                        <!-- col6 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                        <!--    'column_alias': 'average_booking_value'}                 -->
+                                        <!-- col7 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                        <!--    'column_alias': 'booking_payments'}                      -->
+                                        <!-- col8 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                        <!--    'column_alias': 'is_instant'}                            -->
+                                        <!-- col9 =                                                      -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                        <!--    'column_alias': 'ds'}                                    -->
+                                        <!-- col10 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                        <!--    'column_alias': 'ds__week'}                        -->
+                                        <!-- col11 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                        <!--    'column_alias': 'ds__month'}                       -->
+                                        <!-- col12 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                        <!--    'column_alias': 'ds__quarter'}                     -->
+                                        <!-- col13 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                        <!--    'column_alias': 'ds__year'}                        -->
+                                        <!-- col14 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                        <!--    'column_alias': 'ds_partitioned'}                        -->
+                                        <!-- col15 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                        <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                        <!-- col16 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                        <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                        <!-- col17 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                        <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                        <!-- col18 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                        <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                        <!-- col19 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                        <!--    'column_alias': 'booking_paid_at'}                       -->
+                                        <!-- col20 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                        <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                        <!-- col21 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                        <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                        <!-- col22 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                        <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                        <!-- col23 =                                               -->
+                                        <!--   {'class': 'SqlSelectColumn',                        -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                        <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                        <!-- col24 =                                                             -->
                                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                        <!-- col39 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                        <!--    'column_alias': 'bookings'}                            -->
-                                        <!-- col40 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                        <!--    'column_alias': 'instant_bookings'}                    -->
-                                        <!-- col41 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                        <!--    'column_alias': 'booking_value'}                       -->
-                                        <!-- col42 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                        <!--    'column_alias': 'max_booking_value'}                   -->
-                                        <!-- col43 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                        <!--    'column_alias': 'min_booking_value'}                   -->
-                                        <!-- col44 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                        <!--    'column_alias': 'bookers'}                             -->
-                                        <!-- col45 =                                                   -->
-                                        <!--   {'class': 'SqlSelectColumn',                            -->
-                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                        <!--    'column_alias': 'average_booking_value'}               -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                        <!-- col25 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                        <!-- col26 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                        <!-- col27 =                                                            -->
+                                        <!--   {'class': 'SqlSelectColumn',                                     -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                        <!-- col28 =                                                              -->
+                                        <!--   {'class': 'SqlSelectColumn',                                       -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                        <!-- col29 =                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                        <!-- col30 =                                                                 -->
+                                        <!--   {'class': 'SqlSelectColumn',                                          -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                        <!-- col31 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                        <!-- col32 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                        <!-- col33 =                                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                        <!-- col34 =                                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                        <!-- col35 =                                                                  -->
+                                        <!--   {'class': 'SqlSelectColumn',                                           -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                        <!-- col36 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                        <!-- col37 =                                                                         -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                        <!-- col38 =                                                                           -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                        <!-- col39 =                                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                        <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                        <!-- col40 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                        <!--    'column_alias': 'listing'}                               -->
+                                        <!-- col41 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                        <!--    'column_alias': 'guest'}                                 -->
+                                        <!-- col42 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                        <!--    'column_alias': 'host'}                                  -->
+                                        <!-- col43 =                                                     -->
+                                        <!--   {'class': 'SqlSelectColumn',                              -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                        <!-- col44 =                                                          -->
+                                        <!--   {'class': 'SqlSelectColumn',                                   -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                        <!-- col45 =                                                        -->
+                                        <!--   {'class': 'SqlSelectColumn',                                 -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                        <!-- col46 =                                                       -->
+                                        <!--   {'class': 'SqlSelectColumn',                                -->
+                                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                        <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                        <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                         <!-- where = None -->
-                                        <SqlSelectStatementNode>
-                                            <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                            <!-- node_id = ss_10001 -->
-                                            <!-- col0 =                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                            <!--    'column_alias': 'bookings'}                                 -->
-                                            <!-- col1 =                                                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                            <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                            <!-- col2 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                            <!--    'column_alias': 'booking_value'}                         -->
-                                            <!-- col3 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                            <!--    'column_alias': 'max_booking_value'}                     -->
-                                            <!-- col4 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                            <!--    'column_alias': 'min_booking_value'}                     -->
-                                            <!-- col5 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                            <!--    'column_alias': 'bookers'}                               -->
-                                            <!-- col6 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                            <!--    'column_alias': 'average_booking_value'}                 -->
-                                            <!-- col7 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                            <!--    'column_alias': 'booking_payments'}                      -->
-                                            <!-- col8 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                            <!--    'column_alias': 'is_instant'}                            -->
-                                            <!-- col9 =                                                      -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                            <!--    'column_alias': 'ds'}                                    -->
-                                            <!-- col10 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                            <!--    'column_alias': 'ds__week'}                        -->
-                                            <!-- col11 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                            <!--    'column_alias': 'ds__month'}                       -->
-                                            <!-- col12 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                            <!--    'column_alias': 'ds__quarter'}                     -->
-                                            <!-- col13 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                            <!--    'column_alias': 'ds__year'}                        -->
-                                            <!-- col14 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                            <!--    'column_alias': 'ds_partitioned'}                        -->
-                                            <!-- col15 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                            <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                            <!-- col16 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                            <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                            <!-- col17 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                            <!-- col18 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                            <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                            <!-- col19 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                            <!--    'column_alias': 'booking_paid_at'}                       -->
-                                            <!-- col20 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                            <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                            <!-- col21 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                            <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                            <!-- col22 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                            <!-- col23 =                                               -->
-                                            <!--   {'class': 'SqlSelectColumn',                        -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                            <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                            <!-- col24 =                                                             -->
-                                            <!--   {'class': 'SqlSelectColumn',                                      -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                            <!-- col25 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                            <!-- col26 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                            <!-- col27 =                                                            -->
-                                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                            <!-- col28 =                                                              -->
-                                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                            <!-- col29 =                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                            <!-- col30 =                                                                 -->
-                                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                            <!-- col31 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                            <!-- col32 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                            <!-- col33 =                                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                            <!-- col34 =                                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                            <!-- col35 =                                                                  -->
-                                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                            <!-- col36 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                            <!-- col37 =                                                                         -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                            <!-- col38 =                                                                           -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                            <!-- col39 =                                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                            <!-- col40 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                            <!--    'column_alias': 'listing'}                               -->
-                                            <!-- col41 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                            <!--    'column_alias': 'guest'}                                 -->
-                                            <!-- col42 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                            <!--    'column_alias': 'host'}                                  -->
-                                            <!-- col43 =                                                     -->
-                                            <!--   {'class': 'SqlSelectColumn',                              -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                            <!-- col44 =                                                          -->
-                                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                            <!-- col45 =                                                        -->
-                                            <!--   {'class': 'SqlSelectColumn',                                 -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                            <!-- col46 =                                                       -->
-                                            <!--   {'class': 'SqlSelectColumn',                                -->
-                                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                            <!-- where = None -->
-                                            <SqlSelectQueryFromClauseNode>
-                                                <!-- description = Read From a Select Query -->
-                                                <!-- node_id = tfc_10001 -->
-                                            </SqlSelectQueryFromClauseNode>
-                                        </SqlSelectStatementNode>
+                                        <SqlSelectQueryFromClauseNode>
+                                            <!-- description = Read From a Select Query -->
+                                            <!-- node_id = tfc_10001 -->
+                                        </SqlSelectQueryFromClauseNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -726,632 +536,442 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->
-                    <!-- node_id = ss_31 -->
+                    <!-- node_id = ss_14 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_671),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                              -->
                     <!--   {'class': 'SqlSelectColumn',                                      -->
-                    <!--    'expr': SqlFunctionExpression(node_id=fnc_3, sql_function=SUM),  -->
+                    <!--    'expr': SqlFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
                     <!--    'column_alias': 'booking_value'}                                 -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_30) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                     <!-- group_by0 =                                               -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_671),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                         -->
                         <!--   Pass Only Elements:                 -->
                         <!--     ['booking_value', 'metric_time']  -->
-                        <!-- node_id = ss_30 -->
+                        <!-- node_id = ss_13 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_669),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_668),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_29 -->
+                            <!-- node_id = ss_12 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_626),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_627),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_628),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_629),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_630),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_631),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_632),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_633),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_634),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_635),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_636),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_637),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_638),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_639),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_640),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
                             <!-- col15 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_641),    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),    -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                             <!-- col16 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                             <!-- col17 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_643),           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),           -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                             <!-- col18 =                                                              -->
                             <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_644),             -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),             -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                             <!-- col19 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                             <!-- col20 =                                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),                -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                             <!-- col21 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_647),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                             <!-- col22 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_648),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                             <!-- col23 =                                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_649),                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),                         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                             <!-- col24 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_650),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                             <!-- col25 =                                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_651),                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),                 -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                             <!-- col26 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_652),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                             <!-- col27 =                                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_653),                        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),                        -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                             <!-- col28 =                                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_654),                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),                          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                             <!-- col29 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_655),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_656),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_657),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_658),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_659),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_660),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_661),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_662),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
                             <!--    'column_alias': 'guest'}                               -->
                             <!-- col37 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_663),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
                             <!--    'column_alias': 'host'}                                -->
                             <!-- col38 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_664),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),  -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                             <!-- col39 =                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_665),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                             <!-- col40 =                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_666),       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                             <!-- col41 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_667),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- col42 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_624),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col43 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_625),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),            -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                             <!-- col44 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_617),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- col45 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_618),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                             <!--    'column_alias': 'instant_bookings'}                    -->
                             <!-- col46 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_619),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                             <!--    'column_alias': 'booking_value'}                       -->
                             <!-- col47 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_620),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                             <!--    'column_alias': 'max_booking_value'}                   -->
                             <!-- col48 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_621),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                             <!--    'column_alias': 'min_booking_value'}                   -->
                             <!-- col49 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_622),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                             <!--    'column_alias': 'bookers'}                             -->
                             <!-- col50 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_623),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                             <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = ss_28 -->
-                                <!-- col0 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
-                                <!--    'column_alias': 'ds'}                                  -->
-                                <!-- col1 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
-                                <!--    'column_alias': 'ds__week'}                            -->
-                                <!-- col2 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
-                                <!--    'column_alias': 'ds__month'}                           -->
-                                <!-- col3 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
-                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                <!-- col4 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
-                                <!--    'column_alias': 'ds__year'}                            -->
-                                <!-- col5 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                      -->
-                                <!-- col6 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                <!-- col7 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                <!-- col8 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                <!-- col9 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                <!-- col10 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
-                                <!--    'column_alias': 'booking_paid_at'}                     -->
-                                <!-- col11 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),  -->
-                                <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                <!-- col12 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),  -->
-                                <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                <!-- col13 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),  -->
-                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                <!-- col14 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),  -->
-                                <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col30 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col31 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col32 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_612),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col33 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col34 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_614),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col35 =                                                        -->
+                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                <!-- node_id = ss_10001 -->
+                                <!-- col0 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_615),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col36 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_616),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col38 =                                                             -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                <!--    'column_alias': 'bookings'}                                 -->
+                                <!-- col1 =                                                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                <!-- col2 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                <!--    'column_alias': 'booking_value'}                         -->
+                                <!-- col3 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                <!-- col4 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                <!-- col5 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                <!--    'column_alias': 'bookers'}                               -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                <!--    'column_alias': 'booking_payments'}                      -->
+                                <!-- col8 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                <!--    'column_alias': 'is_instant'}                            -->
+                                <!-- col9 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col10 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col11 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col12 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col13 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col17 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col19 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                <!-- col20 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                <!-- col22 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                <!-- col23 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                <!-- col24 =                                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col39 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col40 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col41 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_573),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col43 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col26 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col27 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col28 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col29 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col30 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col31 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col32 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col33 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col34 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col35 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col36 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col37 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col38 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col39 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col40 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                <!--    'column_alias': 'listing'}                               -->
+                                <!-- col41 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                <!--    'column_alias': 'guest'}                                 -->
+                                <!-- col42 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                <!--    'column_alias': 'host'}                                  -->
+                                <!-- col43 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                <!-- col44 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col45 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col46 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
-                                <SqlSelectStatementNode>
-                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                    <!-- node_id = ss_10001 -->
-                                    <!-- col0 =                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                    <!--    'column_alias': 'bookings'}                                 -->
-                                    <!-- col1 =                                                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                    <!-- col2 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                    <!--    'column_alias': 'booking_value'}                         -->
-                                    <!-- col3 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                     -->
-                                    <!-- col4 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                     -->
-                                    <!-- col5 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                    <!--    'column_alias': 'bookers'}                               -->
-                                    <!-- col6 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                    <!--    'column_alias': 'average_booking_value'}                 -->
-                                    <!-- col7 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                    <!--    'column_alias': 'booking_payments'}                      -->
-                                    <!-- col8 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                    <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col9 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                    <!--    'column_alias': 'ds'}                                    -->
-                                    <!-- col10 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                    <!--    'column_alias': 'ds__week'}                        -->
-                                    <!-- col11 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                    <!--    'column_alias': 'ds__month'}                       -->
-                                    <!-- col12 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                    <!-- col13 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                    <!--    'column_alias': 'ds__year'}                        -->
-                                    <!-- col14 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds_partitioned'}                        -->
-                                    <!-- col15 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                    <!-- col16 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                    <!-- col17 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                    <!-- col18 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                    <!-- col19 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking_paid_at'}                       -->
-                                    <!-- col20 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                    <!-- col21 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                    <!-- col22 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                    <!-- col23 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col24 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col25 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col26 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col27 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col28 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col29 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col30 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col31 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col32 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col33 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col34 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col35 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col36 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col37 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col38 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col39 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col40 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col41 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                    <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col42 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                    <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col43 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col44 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col45 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col46 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                    <!-- where = None -->
-                                    <SqlSelectQueryFromClauseNode>
-                                        <!-- description = Read From a Select Query -->
-                                        <!-- node_id = tfc_10001 -->
-                                    </SqlSelectQueryFromClauseNode>
-                                </SqlSelectStatementNode>
+                                <SqlSelectQueryFromClauseNode>
+                                    <!-- description = Read From a Select Query -->
+                                    <!-- node_id = tfc_10001 -->
+                                </SqlSelectQueryFromClauseNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_single_expr_and_alias__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_single_expr_and_alias__plan0.xml
@@ -1,681 +1,491 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_28 -->
+        <!-- node_id = ss_12 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                                -->
         <!--    'expr': SqlStringExpression(node_id=str_1 sql_expr=delayed_bookings * 2),  -->
         <!--    'column_alias': 'double_counted_delayed_bookings'}                         -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_27 -->
+            <!-- node_id = ss_11 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'delayed_bookings'}                              -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                    -->
                 <!--   Pass Only Elements:            -->
                 <!--     ['bookings', 'metric_time']  -->
-                <!-- node_id = ss_26 -->
+                <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                 <!--    'column_alias': 'bookings'}                            -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Constrain Output with WHERE -->
-                    <!-- node_id = ss_25 -->
+                    <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
                     <!--    'column_alias': 'is_instant'}                          -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                     <!--    'column_alias': 'bookings'}                            -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- where = SqlStringExpression(node_id=str_0 sql_expr=NOT is_instant) -->
                     <SqlSelectStatementNode>
                         <!-- description =                                  -->
                         <!--   Pass Only Elements:                          -->
                         <!--     ['bookings', 'is_instant', 'metric_time']  -->
-                        <!-- node_id = ss_24 -->
+                        <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_563),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                         <!--    'column_alias': 'bookings'}                            -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_23 -->
+                            <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                             <!--    'column_alias': 'booking_paid_at'}                     -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                             <!--    'column_alias': 'booking_paid_at__week'}               -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                             <!--    'column_alias': 'booking_paid_at__month'}              -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                             <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                             <!--    'column_alias': 'booking_paid_at__year'}               -->
                             <!-- col15 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                             <!-- col16 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                             <!-- col17 =                                                            -->
                             <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                             <!-- col18 =                                                              -->
                             <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                             <!-- col19 =                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                             <!-- col20 =                                                                 -->
                             <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                             <!-- col21 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                             <!-- col22 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                             <!-- col23 =                                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                             <!-- col24 =                                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                             <!-- col25 =                                                                  -->
                             <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                             <!-- col26 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                             <!-- col27 =                                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                             <!-- col28 =                                                                           -->
                             <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                             <!-- col29 =                                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col31 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col32 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col33 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col34 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col35 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                             <!--    'column_alias': 'listing'}                             -->
                             <!-- col36 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                             <!--    'column_alias': 'guest'}                               -->
                             <!-- col37 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                             <!--    'column_alias': 'host'}                                -->
                             <!-- col38 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                             <!-- col39 =                                                          -->
                             <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                             <!-- col40 =                                                        -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                             <!-- col41 =                                                       -->
                             <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                             <!-- col42 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                             <!--    'column_alias': 'is_instant'}                          -->
                             <!-- col43 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                             <!-- col44 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                             <!--    'column_alias': 'bookings'}                            -->
                             <!-- col45 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                             <!--    'column_alias': 'instant_bookings'}                    -->
                             <!-- col46 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                             <!--    'column_alias': 'booking_value'}                       -->
                             <!-- col47 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                             <!--    'column_alias': 'max_booking_value'}                   -->
                             <!-- col48 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                             <!--    'column_alias': 'min_booking_value'}                   -->
                             <!-- col49 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                             <!--    'column_alias': 'bookers'}                             -->
                             <!-- col50 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                             <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = ss_22 -->
-                                <!-- col0 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                <!--    'column_alias': 'ds'}                                  -->
-                                <!-- col1 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                <!--    'column_alias': 'ds__week'}                            -->
-                                <!-- col2 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                <!--    'column_alias': 'ds__month'}                           -->
-                                <!-- col3 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                <!-- col4 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                <!--    'column_alias': 'ds__year'}                            -->
-                                <!-- col5 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                      -->
-                                <!-- col6 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                <!-- col7 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                <!-- col8 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                <!-- col9 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                <!-- col10 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                                <!--    'column_alias': 'booking_paid_at'}                     -->
-                                <!-- col11 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                                <!--    'column_alias': 'booking_paid_at__week'}               -->
-                                <!-- col12 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                                <!--    'column_alias': 'booking_paid_at__month'}              -->
-                                <!-- col13 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                                <!-- col14 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                <!--    'column_alias': 'booking_paid_at__year'}               -->
-                                <!-- col15 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col16 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col17 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col18 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col19 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col20 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col21 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col22 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col23 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col24 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col25 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col26 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col27 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col28 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col29 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col30 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                                <!--    'column_alias': 'listing'}                             -->
-                                <!-- col31 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                                <!--    'column_alias': 'guest'}                               -->
-                                <!-- col32 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                                <!--    'column_alias': 'host'}                                -->
-                                <!-- col33 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                                <!-- col34 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col35 =                                                        -->
+                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                <!-- node_id = ss_10001 -->
+                                <!-- col0 =                                                         -->
                                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col36 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- col37 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                <!--    'column_alias': 'is_instant'}                          -->
-                                <!-- col38 =                                                             -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                <!--    'column_alias': 'bookings'}                                 -->
+                                <!-- col1 =                                                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                <!-- col2 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                <!--    'column_alias': 'booking_value'}                         -->
+                                <!-- col3 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                <!-- col4 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                <!-- col5 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                <!--    'column_alias': 'bookers'}                               -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                <!--    'column_alias': 'booking_payments'}                      -->
+                                <!-- col8 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                <!--    'column_alias': 'is_instant'}                            -->
+                                <!-- col9 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col10 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col11 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col12 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col13 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col17 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col19 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                <!-- col20 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                <!-- col22 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                <!-- col23 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                <!-- col24 =                                                             -->
                                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col39 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                <!--    'column_alias': 'bookings'}                            -->
-                                <!-- col40 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                <!--    'column_alias': 'instant_bookings'}                    -->
-                                <!-- col41 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                <!--    'column_alias': 'booking_value'}                       -->
-                                <!-- col42 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                <!--    'column_alias': 'max_booking_value'}                   -->
-                                <!-- col43 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                <!--    'column_alias': 'min_booking_value'}                   -->
-                                <!-- col44 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                <!--    'column_alias': 'bookers'}                             -->
-                                <!-- col45 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                <!--    'column_alias': 'average_booking_value'}               -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col26 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col27 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col28 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col29 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col30 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col31 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col32 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col33 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col34 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col35 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col36 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col37 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col38 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col39 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col40 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                                <!--    'column_alias': 'listing'}                               -->
+                                <!-- col41 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                                <!--    'column_alias': 'guest'}                                 -->
+                                <!-- col42 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                                <!--    'column_alias': 'host'}                                  -->
+                                <!-- col43 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                <!-- col44 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col45 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col46 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
-                                <SqlSelectStatementNode>
-                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                    <!-- node_id = ss_10001 -->
-                                    <!-- col0 =                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                    <!--    'column_alias': 'bookings'}                                 -->
-                                    <!-- col1 =                                                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                    <!-- col2 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                    <!--    'column_alias': 'booking_value'}                         -->
-                                    <!-- col3 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                    <!--    'column_alias': 'max_booking_value'}                     -->
-                                    <!-- col4 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                    <!--    'column_alias': 'min_booking_value'}                     -->
-                                    <!-- col5 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                    <!--    'column_alias': 'bookers'}                               -->
-                                    <!-- col6 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                    <!--    'column_alias': 'average_booking_value'}                 -->
-                                    <!-- col7 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                    <!--    'column_alias': 'booking_payments'}                      -->
-                                    <!-- col8 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                    <!--    'column_alias': 'is_instant'}                            -->
-                                    <!-- col9 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                    <!--    'column_alias': 'ds'}                                    -->
-                                    <!-- col10 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                    <!--    'column_alias': 'ds__week'}                        -->
-                                    <!-- col11 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                    <!--    'column_alias': 'ds__month'}                       -->
-                                    <!-- col12 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                    <!-- col13 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                    <!--    'column_alias': 'ds__year'}                        -->
-                                    <!-- col14 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                    <!--    'column_alias': 'ds_partitioned'}                        -->
-                                    <!-- col15 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                    <!-- col16 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                    <!-- col17 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                    <!-- col18 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                    <!-- col19 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                    <!--    'column_alias': 'booking_paid_at'}                       -->
-                                    <!-- col20 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                    <!-- col21 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                    <!-- col22 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                    <!-- col23 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                    <!-- col24 =                                                             -->
-                                    <!--   {'class': 'SqlSelectColumn',                                      -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                    <!-- col25 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                    <!-- col26 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                    <!-- col27 =                                                            -->
-                                    <!--   {'class': 'SqlSelectColumn',                                     -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                    <!-- col28 =                                                              -->
-                                    <!--   {'class': 'SqlSelectColumn',                                       -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                    <!-- col29 =                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                    <!-- col30 =                                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                                          -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                    <!-- col31 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                    <!-- col32 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                    <!-- col33 =                                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                    <!-- col34 =                                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                    <!-- col35 =                                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                                           -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                    <!-- col36 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                    <!-- col37 =                                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                    <!-- col38 =                                                                           -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                    <!-- col39 =                                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                    <!-- col40 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                    <!--    'column_alias': 'listing'}                               -->
-                                    <!-- col41 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                    <!--    'column_alias': 'guest'}                                 -->
-                                    <!-- col42 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                    <!--    'column_alias': 'host'}                                  -->
-                                    <!-- col43 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                    <!-- col44 =                                                          -->
-                                    <!--   {'class': 'SqlSelectColumn',                                   -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                    <!-- col45 =                                                        -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                    <!-- col46 =                                                       -->
-                                    <!--   {'class': 'SqlSelectColumn',                                -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                    <!-- where = None -->
-                                    <SqlSelectQueryFromClauseNode>
-                                        <!-- description = Read From a Select Query -->
-                                        <!-- node_id = tfc_10001 -->
-                                    </SqlSelectQueryFromClauseNode>
-                                </SqlSelectStatementNode>
+                                <SqlSelectQueryFromClauseNode>
+                                    <!-- description = Read From a Select Query -->
+                                    <!-- node_id = tfc_10001 -->
+                                </SqlSelectQueryFromClauseNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
@@ -60,35 +60,35 @@
                 <!--    'column_alias': 'instant_bookings'}                                                              -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                 <!--    'column_alias': 'booking_value'}                         -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                 <!--    'column_alias': 'max_booking_value'}                     -->
                 <!-- col4 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                 <!--    'column_alias': 'min_booking_value'}                     -->
                 <!-- col5 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                 <!--    'column_alias': 'bookers'}                               -->
                 <!-- col6 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                 <!--    'column_alias': 'average_booking_value'}                 -->
                 <!-- col7 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                 <!--    'column_alias': 'booking_payments'}                      -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
                 <!-- col9 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -108,7 +108,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                 <!--    'column_alias': 'ds_partitioned'}                        -->
                 <!-- col15 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -128,7 +128,7 @@
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col19 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                 <!--    'column_alias': 'booking_paid_at'}                       -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -148,11 +148,11 @@
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
                 <!-- col24 =                                                             -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                 <!-- col25 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                 <!-- col26 =                                                           -->
                 <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -172,7 +172,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                 <!-- col30 =                                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                 <!-- col31 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -192,7 +192,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                 <!-- col35 =                                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                 <!-- col36 =                                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -212,31 +212,31 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                 <!-- col40 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col41 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                 <!--    'column_alias': 'guest'}                                 -->
                 <!-- col42 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                 <!--    'column_alias': 'host'}                                  -->
                 <!-- col43 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                 <!-- col44 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                 <!-- col45 =                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                 <!-- col46 =                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->
@@ -270,15 +270,15 @@
                 <!--    'column_alias': 'listings'}                                 -->
                 <!-- col1 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                 <!--    'column_alias': 'largest_listing'}                       -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -298,7 +298,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
                 <!--    'column_alias': 'created_at'}                            -->
                 <!-- col9 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -318,19 +318,19 @@
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col13 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                 <!--    'column_alias': 'country_latest'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                 <!--    'column_alias': 'is_lux_latest'}                         -->
                 <!-- col15 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
                 <!-- col16 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                 <!--    'column_alias': 'listing__ds'}                           -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -350,7 +350,7 @@
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col21 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                 <!--    'column_alias': 'listing__created_at'}                   -->
                 <!-- col22 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -370,27 +370,27 @@
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col26 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                 <!--    'column_alias': 'listing__country_latest'}               -->
                 <!-- col27 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                 <!-- col28 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                 <!-- col29 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col30 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
                 <!--    'column_alias': 'listing__user'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                 <!-- where = None -->
@@ -425,15 +425,15 @@
                 <!--    'column_alias': 'listings'}                                 -->
                 <!-- col1 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                 <!--    'column_alias': 'largest_listing'}                       -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -453,7 +453,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
                 <!--    'column_alias': 'created_at'}                            -->
                 <!-- col9 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -473,19 +473,19 @@
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col13 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                 <!--    'column_alias': 'country_latest'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                 <!--    'column_alias': 'is_lux_latest'}                         -->
                 <!-- col15 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
                 <!-- col16 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                 <!--    'column_alias': 'listing__ds'}                           -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -505,7 +505,7 @@
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col21 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                 <!--    'column_alias': 'listing__created_at'}                   -->
                 <!-- col22 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -525,27 +525,27 @@
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col26 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                 <!--    'column_alias': 'listing__country_latest'}               -->
                 <!-- col27 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                 <!-- col28 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                 <!-- col29 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col30 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
                 <!--    'column_alias': 'listing__user'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multihop_node__plan0.xml
@@ -1,77 +1,77 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_13 -->
+        <!-- node_id = ss_11 -->
         <!-- col0 =                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),      -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_159),      -->
         <!--    'column_alias': 'account_id__customer_id__customer_name'}  -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_160),  -->
         <!--    'column_alias': 'txn_count'}                           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_12 -->
+            <!-- node_id = ss_10 -->
             <!-- col0 =                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),      -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_158),      -->
             <!--    'column_alias': 'account_id__customer_id__customer_name'}  -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
             <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'txn_count'}                                     -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
             <!-- group_by0 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),      -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_158),      -->
             <!--    'column_alias': 'account_id__customer_id__customer_name'}  -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                                                -->
                 <!--   Pass Only Elements:                                        -->
                 <!--     ['txn_count', 'account_id__customer_id__customer_name']  -->
-                <!-- node_id = ss_11 -->
+                <!-- node_id = ss_9 -->
                 <!-- col0 =                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),      -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_156),      -->
                 <!--    'column_alias': 'account_id__customer_id__customer_name'}  -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_155),  -->
                 <!--    'column_alias': 'txn_count'}                           -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Join Standard Outputs -->
-                    <!-- node_id = ss_10 -->
+                    <!-- node_id = ss_8 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_151),  -->
                     <!--    'column_alias': 'ds_partitioned'}                      -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_154),  -->
                     <!--    'column_alias': 'account_id__ds_partitioned'}          -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_152),  -->
                     <!--    'column_alias': 'account_id'}                          -->
                     <!-- col3 =                                                        -->
                     <!--   {'class': 'SqlSelectColumn',                                -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),      -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_153),      -->
                     <!--    'column_alias': 'account_id__customer_id__customer_name'}  -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_150),  -->
                     <!--    'column_alias': 'txn_count'}                           -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                     <!-- join_0 =                                                  -->
                     <!--   {'class': 'SqlJoinDescription',                         -->
-                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_9),  -->
-                    <!--    'right_source_alias': 'subq_8',                        -->
+                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_7),  -->
+                    <!--    'right_source_alias': 'subq_7',                        -->
                     <!--    'on_condition': SqlLogicalExpression(node_id=lo_2),    -->
                     <!--    'join_type': SqlJoinType.LEFT_OUTER}                   -->
                     <!-- where = None -->
@@ -79,350 +79,248 @@
                         <!-- description =                                      -->
                         <!--   Pass Only Elements:                              -->
                         <!--     ['txn_count', 'account_id', 'ds_partitioned']  -->
-                        <!-- node_id = ss_6 -->
+                        <!-- node_id = ss_4 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_148),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_100),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_149),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_101),  -->
                         <!--    'column_alias': 'account_id'}                          -->
-                        <!-- col2 =                                                    -->
-                        <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_147),  -->
-                        <!--    'column_alias': 'txn_count'}                           -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                        <!-- col2 =                                                   -->
+                        <!--   {'class': 'SqlSelectColumn',                           -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_99),  -->
+                        <!--    'column_alias': 'txn_count'}                          -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_5 -->
-                            <!-- col0 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_121),  -->
-                            <!--    'column_alias': 'ds_partitioned'}                      -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_122),  -->
-                            <!--    'column_alias': 'ds_partitioned__week'}                -->
-                            <!-- col2 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_123),  -->
-                            <!--    'column_alias': 'ds_partitioned__month'}               -->
-                            <!-- col3 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_124),  -->
-                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_125),  -->
-                            <!--    'column_alias': 'ds_partitioned__year'}                -->
-                            <!-- col5 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_126),  -->
-                            <!--    'column_alias': 'ds'}                                  -->
-                            <!-- col6 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_127),  -->
-                            <!--    'column_alias': 'ds__week'}                            -->
-                            <!-- col7 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_128),  -->
-                            <!--    'column_alias': 'ds__month'}                           -->
-                            <!-- col8 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_129),  -->
-                            <!--    'column_alias': 'ds__quarter'}                         -->
-                            <!-- col9 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_130),  -->
-                            <!--    'column_alias': 'ds__year'}                            -->
-                            <!-- col10 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_131),  -->
-                            <!--    'column_alias': 'account_id__ds_partitioned'}          -->
-                            <!-- col11 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_132),  -->
-                            <!--    'column_alias': 'account_id__ds_partitioned__week'}    -->
-                            <!-- col12 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_133),  -->
-                            <!--    'column_alias': 'account_id__ds_partitioned__month'}   -->
+                            <!-- node_id = ss_3 -->
+                            <!-- col0 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_73),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                     -->
+                            <!-- col1 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_74),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}               -->
+                            <!-- col2 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_75),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}              -->
+                            <!-- col3 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_76),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}            -->
+                            <!-- col4 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_77),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}               -->
+                            <!-- col5 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_78),  -->
+                            <!--    'column_alias': 'ds'}                                 -->
+                            <!-- col6 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_79),  -->
+                            <!--    'column_alias': 'ds__week'}                           -->
+                            <!-- col7 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_80),  -->
+                            <!--    'column_alias': 'ds__month'}                          -->
+                            <!-- col8 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_81),  -->
+                            <!--    'column_alias': 'ds__quarter'}                        -->
+                            <!-- col9 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_82),  -->
+                            <!--    'column_alias': 'ds__year'}                           -->
+                            <!-- col10 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_83),  -->
+                            <!--    'column_alias': 'account_id__ds_partitioned'}         -->
+                            <!-- col11 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_84),  -->
+                            <!--    'column_alias': 'account_id__ds_partitioned__week'}   -->
+                            <!-- col12 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_85),  -->
+                            <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
                             <!-- col13 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                             -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_134),   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),    -->
                             <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
-                            <!-- col14 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_135),  -->
-                            <!--    'column_alias': 'account_id__ds_partitioned__year'}    -->
-                            <!-- col15 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_136),  -->
-                            <!--    'column_alias': 'account_id__ds'}                      -->
-                            <!-- col16 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_137),  -->
-                            <!--    'column_alias': 'account_id__ds__week'}                -->
-                            <!-- col17 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_138),  -->
-                            <!--    'column_alias': 'account_id__ds__month'}               -->
-                            <!-- col18 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_139),  -->
-                            <!--    'column_alias': 'account_id__ds__quarter'}             -->
-                            <!-- col19 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_140),  -->
-                            <!--    'column_alias': 'account_id__ds__year'}                -->
-                            <!-- col20 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_141),  -->
-                            <!--    'column_alias': 'metric_time'}                         -->
-                            <!-- col21 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_142),  -->
-                            <!--    'column_alias': 'metric_time__week'}                   -->
-                            <!-- col22 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_143),  -->
-                            <!--    'column_alias': 'metric_time__month'}                  -->
-                            <!-- col23 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_144),  -->
-                            <!--    'column_alias': 'metric_time__quarter'}                -->
-                            <!-- col24 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_145),  -->
-                            <!--    'column_alias': 'metric_time__year'}                   -->
-                            <!-- col25 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_146),  -->
-                            <!--    'column_alias': 'account_id'}                          -->
-                            <!-- col26 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_119),  -->
-                            <!--    'column_alias': 'account_month'}                       -->
-                            <!-- col27 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_120),  -->
-                            <!--    'column_alias': 'account_id__account_month'}           -->
-                            <!-- col28 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_118),  -->
-                            <!--    'column_alias': 'txn_count'}                           -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- col14 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_87),  -->
+                            <!--    'column_alias': 'account_id__ds_partitioned__year'}   -->
+                            <!-- col15 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_88),  -->
+                            <!--    'column_alias': 'account_id__ds'}                     -->
+                            <!-- col16 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_89),  -->
+                            <!--    'column_alias': 'account_id__ds__week'}               -->
+                            <!-- col17 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_90),  -->
+                            <!--    'column_alias': 'account_id__ds__month'}              -->
+                            <!-- col18 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_91),  -->
+                            <!--    'column_alias': 'account_id__ds__quarter'}            -->
+                            <!-- col19 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_92),  -->
+                            <!--    'column_alias': 'account_id__ds__year'}               -->
+                            <!-- col20 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_93),  -->
+                            <!--    'column_alias': 'metric_time'}                        -->
+                            <!-- col21 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_94),  -->
+                            <!--    'column_alias': 'metric_time__week'}                  -->
+                            <!-- col22 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_95),  -->
+                            <!--    'column_alias': 'metric_time__month'}                 -->
+                            <!-- col23 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_96),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}               -->
+                            <!-- col24 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_97),  -->
+                            <!--    'column_alias': 'metric_time__year'}                  -->
+                            <!-- col25 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_98),  -->
+                            <!--    'column_alias': 'account_id'}                         -->
+                            <!-- col26 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_71),  -->
+                            <!--    'column_alias': 'account_month'}                      -->
+                            <!-- col27 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_72),  -->
+                            <!--    'column_alias': 'account_id__account_month'}          -->
+                            <!-- col28 =                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_70),  -->
+                            <!--    'column_alias': 'txn_count'}                          -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10010) -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = ss_4 -->
-                                <!-- col0 =                                                   -->
+                                <!-- description = Read Elements From Data Source 'account_month_txns' -->
+                                <!-- node_id = ss_10010 -->
+                                <!-- col0 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10199),  -->
+                                <!--    'column_alias': 'txn_count'}                             -->
+                                <!-- col1 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10200),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col2 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10112),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col3 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10113),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col4 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10114),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col5 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10115),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10205),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col7 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10116),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col8 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10117),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col9 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10118),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col10 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10119),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col11 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10210),  -->
+                                <!--    'column_alias': 'account_month'}                         -->
+                                <!-- col12 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10211),  -->
+                                <!--    'column_alias': 'account_id__ds_partitioned'}            -->
+                                <!-- col13 =                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                          -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10120),    -->
+                                <!--    'column_alias': 'account_id__ds_partitioned__week'}  -->
+                                <!-- col14 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_97),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                     -->
-                                <!-- col1 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_98),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}               -->
-                                <!-- col2 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_99),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}              -->
-                                <!-- col3 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_100),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                <!-- col4 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_101),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                <!-- col5 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_102),  -->
-                                <!--    'column_alias': 'ds'}                                  -->
-                                <!-- col6 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_103),  -->
-                                <!--    'column_alias': 'ds__week'}                            -->
-                                <!-- col7 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_104),  -->
-                                <!--    'column_alias': 'ds__month'}                           -->
-                                <!-- col8 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_105),  -->
-                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                <!-- col9 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_106),  -->
-                                <!--    'column_alias': 'ds__year'}                            -->
-                                <!-- col10 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_107),  -->
-                                <!--    'column_alias': 'account_id__ds_partitioned'}          -->
-                                <!-- col11 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_108),  -->
-                                <!--    'column_alias': 'account_id__ds_partitioned__week'}    -->
-                                <!-- col12 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_109),  -->
-                                <!--    'column_alias': 'account_id__ds_partitioned__month'}   -->
-                                <!-- col13 =                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10121),     -->
+                                <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
+                                <!-- col15 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_110),   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10122),       -->
                                 <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
-                                <!-- col14 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_111),  -->
-                                <!--    'column_alias': 'account_id__ds_partitioned__year'}    -->
-                                <!-- col15 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_112),  -->
-                                <!--    'column_alias': 'account_id__ds'}                      -->
-                                <!-- col16 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_113),  -->
-                                <!--    'column_alias': 'account_id__ds__week'}                -->
-                                <!-- col17 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_114),  -->
-                                <!--    'column_alias': 'account_id__ds__month'}               -->
-                                <!-- col18 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_115),  -->
-                                <!--    'column_alias': 'account_id__ds__quarter'}             -->
-                                <!-- col19 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_116),  -->
-                                <!--    'column_alias': 'account_id__ds__year'}                -->
-                                <!-- col20 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_117),  -->
-                                <!--    'column_alias': 'account_id'}                          -->
-                                <!-- col21 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_95),  -->
-                                <!--    'column_alias': 'account_month'}                      -->
-                                <!-- col22 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_96),  -->
-                                <!--    'column_alias': 'account_id__account_month'}          -->
-                                <!-- col23 =                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_94),  -->
-                                <!--    'column_alias': 'txn_count'}                          -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10010) -->
+                                <!-- col16 =                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                          -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10123),    -->
+                                <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
+                                <!-- col17 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10216),  -->
+                                <!--    'column_alias': 'account_id__ds'}                        -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
+                                <!--    'column_alias': 'account_id__ds__week'}            -->
+                                <!-- col19 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
+                                <!--    'column_alias': 'account_id__ds__month'}           -->
+                                <!-- col20 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
+                                <!--    'column_alias': 'account_id__ds__quarter'}         -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
+                                <!--    'column_alias': 'account_id__ds__year'}            -->
+                                <!-- col22 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10221),  -->
+                                <!--    'column_alias': 'account_id__account_month'}             -->
+                                <!-- col23 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10222),  -->
+                                <!--    'column_alias': 'account_id'}                            -->
+                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
                                 <!-- where = None -->
-                                <SqlSelectStatementNode>
-                                    <!-- description = Read Elements From Data Source 'account_month_txns' -->
-                                    <!-- node_id = ss_10010 -->
-                                    <!-- col0 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10198),  -->
-                                    <!--    'column_alias': 'txn_count'}                             -->
-                                    <!-- col1 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10199),  -->
-                                    <!--    'column_alias': 'ds_partitioned'}                        -->
-                                    <!-- col2 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10112),  -->
-                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                    <!-- col3 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10113),  -->
-                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                    <!-- col4 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10114),  -->
-                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                    <!-- col5 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10115),  -->
-                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                    <!-- col6 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10204),  -->
-                                    <!--    'column_alias': 'ds'}                                    -->
-                                    <!-- col7 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10116),  -->
-                                    <!--    'column_alias': 'ds__week'}                        -->
-                                    <!-- col8 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10117),  -->
-                                    <!--    'column_alias': 'ds__month'}                       -->
-                                    <!-- col9 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10118),  -->
-                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                    <!-- col10 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10119),  -->
-                                    <!--    'column_alias': 'ds__year'}                        -->
-                                    <!-- col11 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10209),  -->
-                                    <!--    'column_alias': 'account_month'}                         -->
-                                    <!-- col12 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10210),  -->
-                                    <!--    'column_alias': 'account_id__ds_partitioned'}            -->
-                                    <!-- col13 =                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10120),    -->
-                                    <!--    'column_alias': 'account_id__ds_partitioned__week'}  -->
-                                    <!-- col14 =                                                  -->
-                                    <!--   {'class': 'SqlSelectColumn',                           -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10121),     -->
-                                    <!--    'column_alias': 'account_id__ds_partitioned__month'}  -->
-                                    <!-- col15 =                                                    -->
-                                    <!--   {'class': 'SqlSelectColumn',                             -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10122),       -->
-                                    <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
-                                    <!-- col16 =                                                 -->
-                                    <!--   {'class': 'SqlSelectColumn',                          -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10123),    -->
-                                    <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
-                                    <!-- col17 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10215),  -->
-                                    <!--    'column_alias': 'account_id__ds'}                        -->
-                                    <!-- col18 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10124),  -->
-                                    <!--    'column_alias': 'account_id__ds__week'}            -->
-                                    <!-- col19 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10125),  -->
-                                    <!--    'column_alias': 'account_id__ds__month'}           -->
-                                    <!-- col20 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10126),  -->
-                                    <!--    'column_alias': 'account_id__ds__quarter'}         -->
-                                    <!-- col21 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10127),  -->
-                                    <!--    'column_alias': 'account_id__ds__year'}            -->
-                                    <!-- col22 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10220),  -->
-                                    <!--    'column_alias': 'account_id__account_month'}             -->
-                                    <!-- col23 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10221),  -->
-                                    <!--    'column_alias': 'account_id'}                            -->
-                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10006) -->
-                                    <!-- where = None -->
-                                    <SqlTableFromClauseNode>
-                                        <!-- description = Read from ***************************.account_month_txns -->
-                                        <!-- node_id = tfc_10006 -->
-                                        <!-- table_id = ***************************.account_month_txns -->
-                                    </SqlTableFromClauseNode>
-                                </SqlSelectStatementNode>
+                                <SqlTableFromClauseNode>
+                                    <!-- description = Read from ***************************.account_month_txns -->
+                                    <!-- node_id = tfc_10006 -->
+                                    <!-- table_id = ***************************.account_month_txns -->
+                                </SqlTableFromClauseNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
@@ -430,117 +328,117 @@
                         <!-- description =                                                       -->
                         <!--   Pass Only Elements:                                               -->
                         <!--     ['account_id', 'ds_partitioned', 'customer_id__customer_name']  -->
-                        <!-- node_id = ss_9 -->
+                        <!-- node_id = ss_7 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_192),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_144),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_193),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_145),  -->
                         <!--    'column_alias': 'account_id'}                          -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_191),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_143),  -->
                         <!--    'column_alias': 'customer_id__customer_name'}          -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Join Standard Outputs -->
-                            <!-- node_id = ss_8 -->
+                            <!-- node_id = ss_6 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_171),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_123),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_172),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_124),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_173),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_125),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_174),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_126),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_127),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_128),  -->
                             <!--    'column_alias': 'account_id__ds_partitioned'}          -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_129),  -->
                             <!--    'column_alias': 'account_id__ds_partitioned__week'}    -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_130),  -->
                             <!--    'column_alias': 'account_id__ds_partitioned__month'}   -->
                             <!-- col8 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                             -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_131),   -->
                             <!--    'column_alias': 'account_id__ds_partitioned__quarter'}  -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_132),  -->
                             <!--    'column_alias': 'account_id__ds_partitioned__year'}    -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_138),  -->
                             <!--    'column_alias': 'customer_id__ds_partitioned'}         -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_139),  -->
                             <!--    'column_alias': 'customer_id__ds_partitioned__week'}   -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_140),  -->
                             <!--    'column_alias': 'customer_id__ds_partitioned__month'}  -->
                             <!-- col13 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_141),    -->
                             <!--    'column_alias': 'customer_id__ds_partitioned__quarter'}  -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_190),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_142),  -->
                             <!--    'column_alias': 'customer_id__ds_partitioned__year'}   -->
                             <!-- col15 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_133),  -->
                             <!--    'column_alias': 'account_id'}                          -->
                             <!-- col16 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_134),  -->
                             <!--    'column_alias': 'customer_id'}                         -->
                             <!-- col17 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_135),  -->
                             <!--    'column_alias': 'account_id__customer_id'}             -->
                             <!-- col18 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_169),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_121),  -->
                             <!--    'column_alias': 'extra_dim'}                           -->
                             <!-- col19 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_170),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_122),  -->
                             <!--    'column_alias': 'account_id__extra_dim'}               -->
                             <!-- col20 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_136),  -->
                             <!--    'column_alias': 'customer_id__customer_name'}          -->
                             <!-- col21 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                             -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_137),   -->
                             <!--    'column_alias': 'customer_id__customer_atomic_weight'}  -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_10011) -->
                             <!-- join_0 =                                                  -->
                             <!--   {'class': 'SqlJoinDescription',                         -->
-                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_7),  -->
-                            <!--    'right_source_alias': 'subq_6',                        -->
+                            <!--    'right_source': SqlSelectStatementNode(node_id=ss_5),  -->
+                            <!--    'right_source_alias': 'subq_5',                        -->
                             <!--    'on_condition': SqlLogicalExpression(node_id=lo_1),    -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER}                   -->
                             <!-- where = None -->
@@ -549,11 +447,11 @@
                                 <!-- node_id = ss_10011 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10222),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10223),  -->
                                 <!--    'column_alias': 'extra_dim'}                             -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10223),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10224),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                        -->
                                 <!-- col2 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -573,11 +471,11 @@
                                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                                 <!-- col6 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10228),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10229),  -->
                                 <!--    'column_alias': 'account_id__extra_dim'}                 -->
                                 <!-- col7 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10229),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10230),  -->
                                 <!--    'column_alias': 'account_id__ds_partitioned'}            -->
                                 <!-- col8 =                                                  -->
                                 <!--   {'class': 'SqlSelectColumn',                          -->
@@ -597,15 +495,15 @@
                                 <!--    'column_alias': 'account_id__ds_partitioned__year'}  -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10234),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10235),  -->
                                 <!--    'column_alias': 'account_id'}                            -->
                                 <!-- col13 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10235),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10236),  -->
                                 <!--    'column_alias': 'customer_id'}                           -->
                                 <!-- col14 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10236),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10237),  -->
                                 <!--    'column_alias': 'account_id__customer_id'}               -->
                                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10007) -->
                                 <!-- where = None -->
@@ -633,66 +531,66 @@
                                 <!--      'customer_id__ds_partitioned__month',    -->
                                 <!--      'customer_id__ds_partitioned__quarter',  -->
                                 <!--      'customer_id__ds_partitioned__year']     -->
-                                <!-- node_id = ss_7 -->
+                                <!-- node_id = ss_5 -->
                                 <!-- col0 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_154),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_106),  -->
                                 <!--    'column_alias': 'ds_partitioned'}                      -->
                                 <!-- col1 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_155),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_107),  -->
                                 <!--    'column_alias': 'ds_partitioned__week'}                -->
                                 <!-- col2 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_156),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_108),  -->
                                 <!--    'column_alias': 'ds_partitioned__month'}               -->
                                 <!-- col3 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_157),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_109),  -->
                                 <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                                 <!-- col4 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_158),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_110),  -->
                                 <!--    'column_alias': 'ds_partitioned__year'}                -->
                                 <!-- col5 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_159),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_111),  -->
                                 <!--    'column_alias': 'customer_id__ds_partitioned'}         -->
                                 <!-- col6 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_160),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_112),  -->
                                 <!--    'column_alias': 'customer_id__ds_partitioned__week'}   -->
                                 <!-- col7 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_161),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_113),  -->
                                 <!--    'column_alias': 'customer_id__ds_partitioned__month'}  -->
                                 <!-- col8 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_162),    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_114),    -->
                                 <!--    'column_alias': 'customer_id__ds_partitioned__quarter'}  -->
                                 <!-- col9 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_163),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_115),  -->
                                 <!--    'column_alias': 'customer_id__ds_partitioned__year'}   -->
                                 <!-- col10 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_164),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_116),  -->
                                 <!--    'column_alias': 'customer_id'}                         -->
                                 <!-- col11 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_150),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_102),  -->
                                 <!--    'column_alias': 'customer_name'}                       -->
                                 <!-- col12 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_151),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_103),  -->
                                 <!--    'column_alias': 'customer_atomic_weight'}              -->
                                 <!-- col13 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_152),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_104),  -->
                                 <!--    'column_alias': 'customer_id__customer_name'}          -->
                                 <!-- col14 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_153),   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_105),   -->
                                 <!--    'column_alias': 'customer_id__customer_atomic_weight'}  -->
                                 <!-- from_source = SqlSelectStatementNode(node_id=ss_10013) -->
                                 <!-- where = None -->
@@ -701,15 +599,15 @@
                                     <!-- node_id = ss_10013 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10244),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10245),  -->
                                     <!--    'column_alias': 'customer_name'}                         -->
                                     <!-- col1 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10245),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10246),  -->
                                     <!--    'column_alias': 'customer_atomic_weight'}                -->
                                     <!-- col2 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10246),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10247),  -->
                                     <!--    'column_alias': 'ds_partitioned'}                        -->
                                     <!-- col3 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -729,15 +627,15 @@
                                     <!--    'column_alias': 'ds_partitioned__year'}            -->
                                     <!-- col7 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10251),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10252),  -->
                                     <!--    'column_alias': 'customer_id__customer_name'}            -->
                                     <!-- col8 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10252),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10253),  -->
                                     <!--    'column_alias': 'customer_id__customer_atomic_weight'}   -->
                                     <!-- col9 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10253),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10254),  -->
                                     <!--    'column_alias': 'customer_id__ds_partitioned'}           -->
                                     <!-- col10 =                                                  -->
                                     <!--   {'class': 'SqlSelectColumn',                           -->
@@ -757,7 +655,7 @@
                                     <!--    'column_alias': 'customer_id__ds_partitioned__year'}  -->
                                     <!-- col14 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10258),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10259),  -->
                                     <!--    'column_alias': 'customer_id'}                           -->
                                     <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10009) -->
                                     <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
@@ -98,35 +98,35 @@
                         <!--    'column_alias': 'instant_bookings'}                                                              -->
                         <!-- col2 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                         <!--    'column_alias': 'booking_value'}                         -->
                         <!-- col3 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                         <!--    'column_alias': 'max_booking_value'}                     -->
                         <!-- col4 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                         <!--    'column_alias': 'min_booking_value'}                     -->
                         <!-- col5 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                         <!--    'column_alias': 'bookers'}                               -->
                         <!-- col6 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                         <!--    'column_alias': 'average_booking_value'}                 -->
                         <!-- col7 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                         <!--    'column_alias': 'booking_payments'}                      -->
                         <!-- col8 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                         <!--    'column_alias': 'is_instant'}                            -->
                         <!-- col9 =                                                      -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                         <!--    'column_alias': 'ds'}                                    -->
                         <!-- col10 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -146,7 +146,7 @@
                         <!--    'column_alias': 'ds__year'}                        -->
                         <!-- col14 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                         <!--    'column_alias': 'ds_partitioned'}                        -->
                         <!-- col15 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -166,7 +166,7 @@
                         <!--    'column_alias': 'ds_partitioned__year'}            -->
                         <!-- col19 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                         <!--    'column_alias': 'booking_paid_at'}                       -->
                         <!-- col20 =                                               -->
                         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -186,11 +186,11 @@
                         <!--    'column_alias': 'booking_paid_at__year'}           -->
                         <!-- col24 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col25 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col26 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -210,7 +210,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col30 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col31 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -230,7 +230,7 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col35 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col36 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -250,31 +250,31 @@
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col40 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                         <!--    'column_alias': 'listing'}                               -->
                         <!-- col41 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                         <!--    'column_alias': 'guest'}                                 -->
                         <!-- col42 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                         <!--    'column_alias': 'host'}                                  -->
                         <!-- col43 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                         <!-- col44 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col45 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col46 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                         <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_partitioned_join__plan0.xml
@@ -1,452 +1,342 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Compute Metrics via Expressions -->
-        <!-- node_id = ss_29 -->
+        <!-- node_id = ss_13 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),  -->
         <!--    'column_alias': 'user__home_state'}                    -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
         <!--    'column_alias': 'identity_verifications'}              -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Aggregate Measures -->
-            <!-- node_id = ss_28 -->
+            <!-- node_id = ss_12 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
             <!--    'column_alias': 'user__home_state'}                    -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
             <!--    'column_alias': 'identity_verifications'}                        -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),  -->
             <!--    'column_alias': 'user__home_state'}                    -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description =                                       -->
                 <!--   Pass Only Elements:                               -->
                 <!--     ['identity_verifications', 'user__home_state']  -->
-                <!-- node_id = ss_27 -->
+                <!-- node_id = ss_11 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                 <!--    'column_alias': 'user__home_state'}                    -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                 <!--    'column_alias': 'identity_verifications'}              -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Join Standard Outputs -->
-                    <!-- node_id = ss_26 -->
+                    <!-- node_id = ss_10 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                     <!--    'column_alias': 'ds_partitioned'}                      -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                     <!--    'column_alias': 'user__ds_partitioned'}                -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                     <!--    'column_alias': 'user'}                                -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                     <!--    'column_alias': 'user__home_state'}                    -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                     <!--    'column_alias': 'identity_verifications'}              -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
-                    <!-- join_0 =                                                   -->
-                    <!--   {'class': 'SqlJoinDescription',                          -->
-                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_25),  -->
-                    <!--    'right_source_alias': 'subq_5',                         -->
-                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_1),     -->
-                    <!--    'join_type': SqlJoinType.LEFT_OUTER}                    -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- join_0 =                                                  -->
+                    <!--   {'class': 'SqlJoinDescription',                         -->
+                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_9),  -->
+                    <!--    'right_source_alias': 'subq_4',                        -->
+                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_0),    -->
+                    <!--    'join_type': SqlJoinType.LEFT_OUTER}                   -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                                             -->
                         <!--   Pass Only Elements:                                     -->
                         <!--     ['identity_verifications', 'user', 'ds_partitioned']  -->
-                        <!-- node_id = ss_24 -->
+                        <!-- node_id = ss_8 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
                         <!--    'column_alias': 'identity_verifications'}              -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
                             <!-- description = Metric Time Dimension 'ds' -->
-                            <!-- node_id = ss_23 -->
+                            <!-- node_id = ss_7 -->
                             <!-- col0 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                             <!--    'column_alias': 'ds'}                                  -->
                             <!-- col1 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                             <!--    'column_alias': 'ds__week'}                            -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                             <!--    'column_alias': 'ds__month'}                           -->
                             <!-- col3 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                             <!--    'column_alias': 'ds__quarter'}                         -->
                             <!-- col4 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                             <!--    'column_alias': 'ds__year'}                            -->
                             <!-- col5 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
                             <!--    'column_alias': 'ds_partitioned'}                      -->
                             <!-- col6 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                             <!--    'column_alias': 'ds_partitioned__week'}                -->
                             <!-- col7 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                             <!--    'column_alias': 'ds_partitioned__month'}               -->
                             <!-- col8 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                             <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                             <!-- col9 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                             <!--    'column_alias': 'ds_partitioned__year'}                -->
                             <!-- col10 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                             <!--    'column_alias': 'verification__ds'}                    -->
                             <!-- col11 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                             <!--    'column_alias': 'verification__ds__week'}              -->
                             <!-- col12 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                             <!--    'column_alias': 'verification__ds__month'}             -->
                             <!-- col13 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                             <!--    'column_alias': 'verification__ds__quarter'}           -->
                             <!-- col14 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                             <!--    'column_alias': 'verification__ds__year'}              -->
                             <!-- col15 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                             <!--    'column_alias': 'verification__ds_partitioned'}        -->
                             <!-- col16 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                             <!--    'column_alias': 'verification__ds_partitioned__week'}  -->
                             <!-- col17 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                             -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),   -->
                             <!--    'column_alias': 'verification__ds_partitioned__month'}  -->
                             <!-- col18 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                               -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),     -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),     -->
                             <!--    'column_alias': 'verification__ds_partitioned__quarter'}  -->
                             <!-- col19 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                             <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
                             <!-- col20 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                             <!--    'column_alias': 'metric_time'}                         -->
                             <!-- col21 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
                             <!--    'column_alias': 'metric_time__week'}                   -->
                             <!-- col22 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
                             <!--    'column_alias': 'metric_time__month'}                  -->
                             <!-- col23 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
                             <!--    'column_alias': 'metric_time__quarter'}                -->
                             <!-- col24 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
                             <!--    'column_alias': 'metric_time__year'}                   -->
                             <!-- col25 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
                             <!--    'column_alias': 'verification'}                        -->
                             <!-- col26 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
                             <!--    'column_alias': 'user'}                                -->
                             <!-- col27 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
                             <!--    'column_alias': 'verification__user'}                  -->
                             <!-- col28 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                             <!--    'column_alias': 'verification_type'}                   -->
                             <!-- col29 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                             <!--    'column_alias': 'verification__verification_type'}     -->
                             <!-- col30 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                             <!--    'column_alias': 'identity_verifications'}              -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10003) -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
-                                <!-- description = Pass Only Additive Measures -->
-                                <!-- node_id = ss_22 -->
-                                <!-- col0 =                                                    -->
+                                <!-- description = Read Elements From Data Source 'id_verifications' -->
+                                <!-- node_id = ss_10003 -->
+                                <!-- col0 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=1),  -->
+                                <!--    'column_alias': 'identity_verifications'}                   -->
+                                <!-- col1 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10062),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col2 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col3 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col4 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col5 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10067),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col7 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col8 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col9 =                                                -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col10 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col11 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
+                                <!--    'column_alias': 'verification_type'}                     -->
+                                <!-- col12 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10073),  -->
+                                <!--    'column_alias': 'verification__ds'}                      -->
+                                <!-- col13 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
+                                <!--    'column_alias': 'verification__ds__week'}          -->
+                                <!-- col14 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
+                                <!--    'column_alias': 'verification__ds__month'}         -->
+                                <!-- col15 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
+                                <!--    'column_alias': 'verification__ds__quarter'}       -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
+                                <!--    'column_alias': 'verification__ds__year'}          -->
+                                <!-- col17 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10078),  -->
+                                <!--    'column_alias': 'verification__ds_partitioned'}          -->
+                                <!-- col18 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                                <!--    'column_alias': 'ds'}                                  -->
-                                <!-- col1 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                                <!--    'column_alias': 'ds__week'}                            -->
-                                <!-- col2 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                                <!--    'column_alias': 'ds__month'}                           -->
-                                <!-- col3 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                                <!--    'column_alias': 'ds__quarter'}                         -->
-                                <!-- col4 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                                <!--    'column_alias': 'ds__year'}                            -->
-                                <!-- col5 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                      -->
-                                <!-- col6 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}                -->
-                                <!-- col7 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}               -->
-                                <!-- col8 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                                <!-- col9 =                                                    -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}                -->
-                                <!-- col10 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                                <!--    'column_alias': 'verification__ds'}                    -->
-                                <!-- col11 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                                <!--    'column_alias': 'verification__ds__week'}              -->
-                                <!-- col12 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                                <!--    'column_alias': 'verification__ds__month'}             -->
-                                <!-- col13 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                                <!--    'column_alias': 'verification__ds__quarter'}           -->
-                                <!-- col14 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                                <!--    'column_alias': 'verification__ds__year'}              -->
-                                <!-- col15 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                                <!--    'column_alias': 'verification__ds_partitioned'}        -->
-                                <!-- col16 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),      -->
                                 <!--    'column_alias': 'verification__ds_partitioned__week'}  -->
-                                <!-- col17 =                                                    -->
+                                <!-- col19 =                                                    -->
                                 <!--   {'class': 'SqlSelectColumn',                             -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),       -->
                                 <!--    'column_alias': 'verification__ds_partitioned__month'}  -->
-                                <!-- col18 =                                                      -->
+                                <!-- col20 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                               -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),         -->
                                 <!--    'column_alias': 'verification__ds_partitioned__quarter'}  -->
-                                <!-- col19 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                                <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
-                                <!-- col20 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                                <!--    'column_alias': 'verification'}                        -->
                                 <!-- col21 =                                                   -->
                                 <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),  -->
-                                <!--    'column_alias': 'user'}                                -->
-                                <!-- col22 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),  -->
-                                <!--    'column_alias': 'verification__user'}                  -->
-                                <!-- col23 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                                <!--    'column_alias': 'verification_type'}                   -->
-                                <!-- col24 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                                <!--    'column_alias': 'verification__verification_type'}     -->
-                                <!-- col25 =                                                   -->
-                                <!--   {'class': 'SqlSelectColumn',                            -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                                <!--    'column_alias': 'identity_verifications'}              -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10003) -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),      -->
+                                <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
+                                <!-- col22 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10083),  -->
+                                <!--    'column_alias': 'verification__verification_type'}       -->
+                                <!-- col23 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
+                                <!--    'column_alias': 'verification'}                          -->
+                                <!-- col24 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
+                                <!--    'column_alias': 'user'}                                  -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                                <!--    'column_alias': 'verification__user'}                    -->
+                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
                                 <!-- where = None -->
-                                <SqlSelectStatementNode>
-                                    <!-- description = Read Elements From Data Source 'id_verifications' -->
-                                    <!-- node_id = ss_10003 -->
-                                    <!-- col0 =                                                         -->
-                                    <!--   {'class': 'SqlSelectColumn',                                 -->
-                                    <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=1),  -->
-                                    <!--    'column_alias': 'identity_verifications'}                   -->
-                                    <!-- col1 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10061),  -->
-                                    <!--    'column_alias': 'ds'}                                    -->
-                                    <!-- col2 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10028),  -->
-                                    <!--    'column_alias': 'ds__week'}                        -->
-                                    <!-- col3 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10029),  -->
-                                    <!--    'column_alias': 'ds__month'}                       -->
-                                    <!-- col4 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10030),  -->
-                                    <!--    'column_alias': 'ds__quarter'}                     -->
-                                    <!-- col5 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10031),  -->
-                                    <!--    'column_alias': 'ds__year'}                        -->
-                                    <!-- col6 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10066),  -->
-                                    <!--    'column_alias': 'ds_partitioned'}                        -->
-                                    <!-- col7 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10032),  -->
-                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                    <!-- col8 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10033),  -->
-                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                    <!-- col9 =                                                -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10034),  -->
-                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                    <!-- col10 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10035),  -->
-                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                    <!-- col11 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10071),  -->
-                                    <!--    'column_alias': 'verification_type'}                     -->
-                                    <!-- col12 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10072),  -->
-                                    <!--    'column_alias': 'verification__ds'}                      -->
-                                    <!-- col13 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10036),  -->
-                                    <!--    'column_alias': 'verification__ds__week'}          -->
-                                    <!-- col14 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10037),  -->
-                                    <!--    'column_alias': 'verification__ds__month'}         -->
-                                    <!-- col15 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10038),  -->
-                                    <!--    'column_alias': 'verification__ds__quarter'}       -->
-                                    <!-- col16 =                                               -->
-                                    <!--   {'class': 'SqlSelectColumn',                        -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10039),  -->
-                                    <!--    'column_alias': 'verification__ds__year'}          -->
-                                    <!-- col17 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10077),  -->
-                                    <!--    'column_alias': 'verification__ds_partitioned'}          -->
-                                    <!-- col18 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10040),      -->
-                                    <!--    'column_alias': 'verification__ds_partitioned__week'}  -->
-                                    <!-- col19 =                                                    -->
-                                    <!--   {'class': 'SqlSelectColumn',                             -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10041),       -->
-                                    <!--    'column_alias': 'verification__ds_partitioned__month'}  -->
-                                    <!-- col20 =                                                      -->
-                                    <!--   {'class': 'SqlSelectColumn',                               -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10042),         -->
-                                    <!--    'column_alias': 'verification__ds_partitioned__quarter'}  -->
-                                    <!-- col21 =                                                   -->
-                                    <!--   {'class': 'SqlSelectColumn',                            -->
-                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10043),      -->
-                                    <!--    'column_alias': 'verification__ds_partitioned__year'}  -->
-                                    <!-- col22 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10082),  -->
-                                    <!--    'column_alias': 'verification__verification_type'}       -->
-                                    <!-- col23 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10083),  -->
-                                    <!--    'column_alias': 'verification'}                          -->
-                                    <!-- col24 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10084),  -->
-                                    <!--    'column_alias': 'user'}                                  -->
-                                    <!-- col25 =                                                     -->
-                                    <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10085),  -->
-                                    <!--    'column_alias': 'verification__user'}                    -->
-                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10001) -->
-                                    <!-- where = None -->
-                                    <SqlTableFromClauseNode>
-                                        <!-- description = Read from ***************************.fct_id_verifications -->
-                                        <!-- node_id = tfc_10001 -->
-                                        <!-- table_id = ***************************.fct_id_verifications -->
-                                    </SqlTableFromClauseNode>
-                                </SqlSelectStatementNode>
+                                <SqlTableFromClauseNode>
+                                    <!-- description = Read from ***************************.fct_id_verifications -->
+                                    <!-- node_id = tfc_10001 -->
+                                    <!-- table_id = ***************************.fct_id_verifications -->
+                                </SqlTableFromClauseNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
@@ -454,18 +344,18 @@
                         <!-- description =                                 -->
                         <!--   Pass Only Elements:                         -->
                         <!--     ['user', 'ds_partitioned', 'home_state']  -->
-                        <!-- node_id = ss_25 -->
+                        <!-- node_id = ss_9 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),  -->
                         <!--    'column_alias': 'user'}                                -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
                         <!--    'column_alias': 'home_state'}                          -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_10007) -->
                         <!-- where = None -->
@@ -474,7 +364,7 @@
                             <!-- node_id = ss_10007 -->
                             <!-- col0 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10127),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10128),  -->
                             <!--    'column_alias': 'ds'}                                    -->
                             <!-- col1 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -494,7 +384,7 @@
                             <!--    'column_alias': 'ds__year'}                        -->
                             <!-- col5 =                                                      -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10132),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10133),  -->
                             <!--    'column_alias': 'created_at'}                            -->
                             <!-- col6 =                                                -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -514,7 +404,7 @@
                             <!--    'column_alias': 'created_at__year'}                -->
                             <!-- col10 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10137),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10138),  -->
                             <!--    'column_alias': 'ds_partitioned'}                        -->
                             <!-- col11 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -534,11 +424,11 @@
                             <!--    'column_alias': 'ds_partitioned__year'}            -->
                             <!-- col15 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10142),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10143),  -->
                             <!--    'column_alias': 'home_state'}                            -->
                             <!-- col16 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10143),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10144),  -->
                             <!--    'column_alias': 'user__ds'}                              -->
                             <!-- col17 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -558,7 +448,7 @@
                             <!--    'column_alias': 'user__ds__year'}                  -->
                             <!-- col21 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10148),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10149),  -->
                             <!--    'column_alias': 'user__created_at'}                      -->
                             <!-- col22 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -578,7 +468,7 @@
                             <!--    'column_alias': 'user__created_at__year'}          -->
                             <!-- col26 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10153),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10154),  -->
                             <!--    'column_alias': 'user__ds_partitioned'}                  -->
                             <!-- col27 =                                               -->
                             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -598,11 +488,11 @@
                             <!--    'column_alias': 'user__ds_partitioned__year'}      -->
                             <!-- col31 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10158),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10159),  -->
                             <!--    'column_alias': 'user__home_state'}                      -->
                             <!-- col32 =                                                     -->
                             <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10159),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10160),  -->
                             <!--    'column_alias': 'user'}                                  -->
                             <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10004) -->
                             <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
@@ -1,36 +1,112 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
-        <!-- description = Join on MIN(ds) and [] -->
-        <!-- node_id = ss_2 -->
+        <!-- description = Join on MIN(ds) and [] grouping by None -->
+        <!-- node_id = ss_1 -->
         <!-- col0 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
         <!--    'column_alias': 'ds'}                                -->
         <!-- col1 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
+        <!--    'column_alias': 'ds__week'}                          -->
+        <!-- col2 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
+        <!--    'column_alias': 'ds__month'}                         -->
+        <!-- col3 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
+        <!--    'column_alias': 'ds__quarter'}                        -->
+        <!-- col4 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),  -->
+        <!--    'column_alias': 'ds__year'}                           -->
+        <!-- col5 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
+        <!--    'column_alias': 'user'}                               -->
+        <!-- col6 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
+        <!--    'column_alias': 'account_type'}                      -->
+        <!-- col7 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_3),  -->
+        <!--    'column_alias': 'account_balance'}                   -->
+        <!-- col8 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
         <!--    'column_alias': 'total_account_balance_first_day'}   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- col9 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
+        <!--    'column_alias': 'current_account_balance_by_user'}   -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
         <!-- join_0 =                                                    -->
         <!--   {'class': 'SqlJoinDescription',                           -->
-        <!--    'right_source': SqlSelectStatementNode(node_id=ss_1),    -->
+        <!--    'right_source': SqlSelectStatementNode(node_id=ss_0),    -->
         <!--    'right_source_alias': 'subq_2',                          -->
         <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
         <!--    'join_type': SqlJoinType.INNER}                          -->
         <!-- where = None -->
         <SqlSelectStatementNode>
-            <!-- description =                                  -->
-            <!--   Pass Only Elements:                          -->
-            <!--     ['total_account_balance_first_day', 'ds']  -->
+            <!-- description = Read Elements From Data Source 'accounts_source' -->
+            <!-- node_id = ss_10000 -->
+            <!-- col0 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10000),  -->
+            <!--    'column_alias': 'account_balance'}                       -->
+            <!-- col1 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10001),  -->
+            <!--    'column_alias': 'total_account_balance_first_day'}       -->
+            <!-- col2 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
+            <!--    'column_alias': 'current_account_balance_by_user'}       -->
+            <!-- col3 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
+            <!--    'column_alias': 'ds'}                                    -->
+            <!-- col4 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+            <!--    'column_alias': 'ds__week'}                        -->
+            <!-- col5 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+            <!--    'column_alias': 'ds__month'}                       -->
+            <!-- col6 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+            <!--    'column_alias': 'ds__quarter'}                     -->
+            <!-- col7 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+            <!--    'column_alias': 'ds__year'}                        -->
+            <!-- col8 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
+            <!--    'column_alias': 'account_type'}                          -->
+            <!-- col9 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+            <!--    'column_alias': 'user'}                                  -->
+            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
+            <!-- where = None -->
+            <SqlSelectQueryFromClauseNode>
+                <!-- description = Read From a Select Query -->
+                <!-- node_id = tfc_10000 -->
+            </SqlSelectQueryFromClauseNode>
+        </SqlSelectStatementNode>
+        <SqlSelectStatementNode>
+            <!-- description = Filter row on MIN(ds) -->
             <!-- node_id = ss_0 -->
-            <!-- col0 =                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
-            <!--    'column_alias': 'ds'}                                -->
-            <!-- col1 =                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
-            <!--    'column_alias': 'total_account_balance_first_day'}   -->
+            <!-- col0 =                                                              -->
+            <!--   {'class': 'SqlSelectColumn',                                      -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=MIN),  -->
+            <!--    'column_alias': 'ds__complete'}                                  -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -71,6 +147,10 @@
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
+                <!--    'column_alias': 'account_type'}                          -->
+                <!-- col9 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
                 <!-- where = None -->
@@ -78,78 +158,6 @@
                     <!-- description = Read From a Select Query -->
                     <!-- node_id = tfc_10000 -->
                 </SqlSelectQueryFromClauseNode>
-            </SqlSelectStatementNode>
-        </SqlSelectStatementNode>
-        <SqlSelectStatementNode>
-            <!-- description = Filter row on MIN(ds) -->
-            <!-- node_id = ss_1 -->
-            <!-- col0 =                                                              -->
-            <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=MIN),  -->
-            <!--    'column_alias': 'ds'}                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
-            <!-- where = None -->
-            <SqlSelectStatementNode>
-                <!-- description =                                  -->
-                <!--   Pass Only Elements:                          -->
-                <!--     ['total_account_balance_first_day', 'ds']  -->
-                <!-- node_id = ss_0 -->
-                <!-- col0 =                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
-                <!--    'column_alias': 'ds'}                                -->
-                <!-- col1 =                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
-                <!--    'column_alias': 'total_account_balance_first_day'}   -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
-                <!-- where = None -->
-                <SqlSelectStatementNode>
-                    <!-- description = Read Elements From Data Source 'accounts_source' -->
-                    <!-- node_id = ss_10000 -->
-                    <!-- col0 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10000),  -->
-                    <!--    'column_alias': 'account_balance'}                       -->
-                    <!-- col1 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10001),  -->
-                    <!--    'column_alias': 'total_account_balance_first_day'}       -->
-                    <!-- col2 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
-                    <!--    'column_alias': 'current_account_balance_by_user'}       -->
-                    <!-- col3 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-                    <!--    'column_alias': 'ds'}                                    -->
-                    <!-- col4 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
-                    <!--    'column_alias': 'ds__week'}                        -->
-                    <!-- col5 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
-                    <!--    'column_alias': 'ds__month'}                       -->
-                    <!-- col6 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
-                    <!--    'column_alias': 'ds__quarter'}                     -->
-                    <!-- col7 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
-                    <!--    'column_alias': 'ds__year'}                        -->
-                    <!-- col8 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
-                    <!--    'column_alias': 'user'}                                  -->
-                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
-                    <!-- where = None -->
-                    <SqlSelectQueryFromClauseNode>
-                        <!-- description = Read From a Select Query -->
-                        <!-- node_id = tfc_10000 -->
-                    </SqlSelectQueryFromClauseNode>
-                </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
@@ -1,7 +1,7 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
-        <!-- description = Join on MAX(ds) and ['user'] -->
-        <!-- node_id = ss_2 -->
+        <!-- description = Join on MAX(ds) and ['user'] grouping by None -->
+        <!-- node_id = ss_1 -->
         <!-- col0 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
@@ -9,37 +9,113 @@
         <!-- col1 =                                                   -->
         <!--   {'class': 'SqlSelectColumn',                           -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),  -->
+        <!--    'column_alias': 'ds__week'}                           -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
+        <!--    'column_alias': 'ds__month'}                          -->
+        <!-- col3 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
+        <!--    'column_alias': 'ds__quarter'}                        -->
+        <!-- col4 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_14),  -->
+        <!--    'column_alias': 'ds__year'}                           -->
+        <!-- col5 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_15),  -->
         <!--    'column_alias': 'user'}                               -->
-        <!-- col2 =                                                  -->
+        <!-- col6 =                                                  -->
         <!--   {'class': 'SqlSelectColumn',                          -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
+        <!--    'column_alias': 'account_type'}                      -->
+        <!-- col7 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
+        <!--    'column_alias': 'account_balance'}                   -->
+        <!-- col8 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
+        <!--    'column_alias': 'total_account_balance_first_day'}   -->
+        <!-- col9 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
         <!--    'column_alias': 'current_account_balance_by_user'}   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
         <!-- join_0 =                                                  -->
         <!--   {'class': 'SqlJoinDescription',                         -->
-        <!--    'right_source': SqlSelectStatementNode(node_id=ss_1),  -->
+        <!--    'right_source': SqlSelectStatementNode(node_id=ss_0),  -->
         <!--    'right_source_alias': 'subq_2',                        -->
         <!--    'on_condition': SqlLogicalExpression(node_id=lo_0),    -->
         <!--    'join_type': SqlJoinType.INNER}                        -->
         <!-- where = None -->
         <SqlSelectStatementNode>
-            <!-- description =                                          -->
-            <!--   Pass Only Elements:                                  -->
-            <!--     ['current_account_balance_by_user', 'user', 'ds']  -->
+            <!-- description = Read Elements From Data Source 'accounts_source' -->
+            <!-- node_id = ss_10000 -->
+            <!-- col0 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10000),  -->
+            <!--    'column_alias': 'account_balance'}                       -->
+            <!-- col1 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10001),  -->
+            <!--    'column_alias': 'total_account_balance_first_day'}       -->
+            <!-- col2 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
+            <!--    'column_alias': 'current_account_balance_by_user'}       -->
+            <!-- col3 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
+            <!--    'column_alias': 'ds'}                                    -->
+            <!-- col4 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+            <!--    'column_alias': 'ds__week'}                        -->
+            <!-- col5 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+            <!--    'column_alias': 'ds__month'}                       -->
+            <!-- col6 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+            <!--    'column_alias': 'ds__quarter'}                     -->
+            <!-- col7 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+            <!--    'column_alias': 'ds__year'}                        -->
+            <!-- col8 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
+            <!--    'column_alias': 'account_type'}                          -->
+            <!-- col9 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+            <!--    'column_alias': 'user'}                                  -->
+            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
+            <!-- where = None -->
+            <SqlSelectQueryFromClauseNode>
+                <!-- description = Read From a Select Query -->
+                <!-- node_id = tfc_10000 -->
+            </SqlSelectQueryFromClauseNode>
+        </SqlSelectStatementNode>
+        <SqlSelectStatementNode>
+            <!-- description = Filter row on MAX(ds) -->
             <!-- node_id = ss_0 -->
             <!-- col0 =                                                  -->
             <!--   {'class': 'SqlSelectColumn',                          -->
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
-            <!--    'column_alias': 'ds'}                                -->
-            <!-- col1 =                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
             <!--    'column_alias': 'user'}                              -->
-            <!-- col2 =                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
-            <!--    'column_alias': 'current_account_balance_by_user'}   -->
+            <!-- col1 =                                                              -->
+            <!--   {'class': 'SqlSelectColumn',                                      -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=MAX),  -->
+            <!--    'column_alias': 'ds__complete'}                                  -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
+            <!-- group_by0 =                                             -->
+            <!--   {'class': 'SqlSelectColumn',                          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
+            <!--    'column_alias': 'user'}                              -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Read Elements From Data Source 'accounts_source' -->
@@ -79,6 +155,10 @@
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
+                <!--    'column_alias': 'account_type'}                          -->
+                <!-- col9 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
                 <!-- where = None -->
@@ -86,90 +166,6 @@
                     <!-- description = Read From a Select Query -->
                     <!-- node_id = tfc_10000 -->
                 </SqlSelectQueryFromClauseNode>
-            </SqlSelectStatementNode>
-        </SqlSelectStatementNode>
-        <SqlSelectStatementNode>
-            <!-- description = Filter row on MAX(ds) -->
-            <!-- node_id = ss_1 -->
-            <!-- col0 =                                                  -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
-            <!--    'column_alias': 'user'}                              -->
-            <!-- col1 =                                                              -->
-            <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=MAX),  -->
-            <!--    'column_alias': 'ds'}                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
-            <!-- group_by0 =                                             -->
-            <!--   {'class': 'SqlSelectColumn',                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
-            <!--    'column_alias': 'user'}                              -->
-            <!-- where = None -->
-            <SqlSelectStatementNode>
-                <!-- description =                                          -->
-                <!--   Pass Only Elements:                                  -->
-                <!--     ['current_account_balance_by_user', 'user', 'ds']  -->
-                <!-- node_id = ss_0 -->
-                <!-- col0 =                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
-                <!--    'column_alias': 'ds'}                                -->
-                <!-- col1 =                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_2),  -->
-                <!--    'column_alias': 'user'}                              -->
-                <!-- col2 =                                                  -->
-                <!--   {'class': 'SqlSelectColumn',                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_0),  -->
-                <!--    'column_alias': 'current_account_balance_by_user'}   -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
-                <!-- where = None -->
-                <SqlSelectStatementNode>
-                    <!-- description = Read Elements From Data Source 'accounts_source' -->
-                    <!-- node_id = ss_10000 -->
-                    <!-- col0 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10000),  -->
-                    <!--    'column_alias': 'account_balance'}                       -->
-                    <!-- col1 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10001),  -->
-                    <!--    'column_alias': 'total_account_balance_first_day'}       -->
-                    <!-- col2 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
-                    <!--    'column_alias': 'current_account_balance_by_user'}       -->
-                    <!-- col3 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
-                    <!--    'column_alias': 'ds'}                                    -->
-                    <!-- col4 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
-                    <!--    'column_alias': 'ds__week'}                        -->
-                    <!-- col5 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
-                    <!--    'column_alias': 'ds__month'}                       -->
-                    <!-- col6 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
-                    <!--    'column_alias': 'ds__quarter'}                     -->
-                    <!-- col7 =                                                -->
-                    <!--   {'class': 'SqlSelectColumn',                        -->
-                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
-                    <!--    'column_alias': 'ds__year'}                        -->
-                    <!-- col8 =                                                      -->
-                    <!--   {'class': 'SqlSelectColumn',                              -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
-                    <!--    'column_alias': 'user'}                                  -->
-                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
-                    <!-- where = None -->
-                    <SqlSelectQueryFromClauseNode>
-                        <!-- description = Read From a Select Query -->
-                        <!-- node_id = tfc_10000 -->
-                    </SqlSelectQueryFromClauseNode>
-                </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -1,0 +1,168 @@
+<SqlQueryPlan>
+    <SqlSelectStatementNode>
+        <!-- description = Join on MIN(ds) and [] grouping by ds -->
+        <!-- node_id = ss_1 -->
+        <!-- col0 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_8),  -->
+        <!--    'column_alias': 'ds'}                                -->
+        <!-- col1 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_9),  -->
+        <!--    'column_alias': 'ds__week'}                          -->
+        <!-- col2 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10),  -->
+        <!--    'column_alias': 'ds__month'}                          -->
+        <!-- col3 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_11),  -->
+        <!--    'column_alias': 'ds__quarter'}                        -->
+        <!-- col4 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_12),  -->
+        <!--    'column_alias': 'ds__year'}                           -->
+        <!-- col5 =                                                   -->
+        <!--   {'class': 'SqlSelectColumn',                           -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_13),  -->
+        <!--    'column_alias': 'user'}                               -->
+        <!-- col6 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_7),  -->
+        <!--    'column_alias': 'account_type'}                      -->
+        <!-- col7 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_4),  -->
+        <!--    'column_alias': 'account_balance'}                   -->
+        <!-- col8 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_5),  -->
+        <!--    'column_alias': 'total_account_balance_first_day'}   -->
+        <!-- col9 =                                                  -->
+        <!--   {'class': 'SqlSelectColumn',                          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_6),  -->
+        <!--    'column_alias': 'current_account_balance_by_user'}   -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
+        <!-- join_0 =                                                    -->
+        <!--   {'class': 'SqlJoinDescription',                           -->
+        <!--    'right_source': SqlSelectStatementNode(node_id=ss_0),    -->
+        <!--    'right_source_alias': 'subq_2',                          -->
+        <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
+        <!--    'join_type': SqlJoinType.INNER}                          -->
+        <!-- where = None -->
+        <SqlSelectStatementNode>
+            <!-- description = Read Elements From Data Source 'accounts_source' -->
+            <!-- node_id = ss_10000 -->
+            <!-- col0 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10000),  -->
+            <!--    'column_alias': 'account_balance'}                       -->
+            <!-- col1 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10001),  -->
+            <!--    'column_alias': 'total_account_balance_first_day'}       -->
+            <!-- col2 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
+            <!--    'column_alias': 'current_account_balance_by_user'}       -->
+            <!-- col3 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
+            <!--    'column_alias': 'ds'}                                    -->
+            <!-- col4 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+            <!--    'column_alias': 'ds__week'}                        -->
+            <!-- col5 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+            <!--    'column_alias': 'ds__month'}                       -->
+            <!-- col6 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+            <!--    'column_alias': 'ds__quarter'}                     -->
+            <!-- col7 =                                                -->
+            <!--   {'class': 'SqlSelectColumn',                        -->
+            <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+            <!--    'column_alias': 'ds__year'}                        -->
+            <!-- col8 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
+            <!--    'column_alias': 'account_type'}                          -->
+            <!-- col9 =                                                      -->
+            <!--   {'class': 'SqlSelectColumn',                              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+            <!--    'column_alias': 'user'}                                  -->
+            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
+            <!-- where = None -->
+            <SqlSelectQueryFromClauseNode>
+                <!-- description = Read From a Select Query -->
+                <!-- node_id = tfc_10000 -->
+            </SqlSelectQueryFromClauseNode>
+        </SqlSelectStatementNode>
+        <SqlSelectStatementNode>
+            <!-- description = Filter row on MIN(ds) -->
+            <!-- node_id = ss_0 -->
+            <!-- col0 =                                                              -->
+            <!--   {'class': 'SqlSelectColumn',                                      -->
+            <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=MIN),  -->
+            <!--    'column_alias': 'ds__complete'}                                  -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_10000) -->
+            <!-- group_by0 =                                             -->
+            <!--   {'class': 'SqlSelectColumn',                          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
+            <!--    'column_alias': 'ds__week'}                          -->
+            <!-- where = None -->
+            <SqlSelectStatementNode>
+                <!-- description = Read Elements From Data Source 'accounts_source' -->
+                <!-- node_id = ss_10000 -->
+                <!-- col0 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10000),  -->
+                <!--    'column_alias': 'account_balance'}                       -->
+                <!-- col1 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10001),  -->
+                <!--    'column_alias': 'total_account_balance_first_day'}       -->
+                <!-- col2 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10002),  -->
+                <!--    'column_alias': 'current_account_balance_by_user'}       -->
+                <!-- col3 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10003),  -->
+                <!--    'column_alias': 'ds'}                                    -->
+                <!-- col4 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10000),  -->
+                <!--    'column_alias': 'ds__week'}                        -->
+                <!-- col5 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10001),  -->
+                <!--    'column_alias': 'ds__month'}                       -->
+                <!-- col6 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10002),  -->
+                <!--    'column_alias': 'ds__quarter'}                     -->
+                <!-- col7 =                                                -->
+                <!--   {'class': 'SqlSelectColumn',                        -->
+                <!--    'expr': SqlDateTruncExpression(node_id=dt_10003),  -->
+                <!--    'column_alias': 'ds__year'}                        -->
+                <!-- col8 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10008),  -->
+                <!--    'column_alias': 'account_type'}                          -->
+                <!-- col9 =                                                      -->
+                <!--   {'class': 'SqlSelectColumn',                              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                <!--    'column_alias': 'user'}                                  -->
+                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10000) -->
+                <!-- where = None -->
+                <SqlSelectQueryFromClauseNode>
+                    <!-- description = Read From a Select Query -->
+                    <!-- node_id = tfc_10000 -->
+                </SqlSelectQueryFromClauseNode>
+            </SqlSelectStatementNode>
+        </SqlSelectStatementNode>
+    </SqlSelectStatementNode>
+</SqlQueryPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
@@ -50,35 +50,35 @@
                 <!--    'column_alias': 'instant_bookings'}                                                              -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
                 <!--    'column_alias': 'booking_value'}                         -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
                 <!--    'column_alias': 'max_booking_value'}                     -->
                 <!-- col4 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
                 <!--    'column_alias': 'min_booking_value'}                     -->
                 <!-- col5 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
                 <!--    'column_alias': 'bookers'}                               -->
                 <!-- col6 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
                 <!--    'column_alias': 'average_booking_value'}                 -->
                 <!-- col7 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
                 <!--    'column_alias': 'booking_payments'}                      -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
                 <!--    'column_alias': 'is_instant'}                            -->
                 <!-- col9 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col10 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -98,7 +98,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
                 <!--    'column_alias': 'ds_partitioned'}                        -->
                 <!-- col15 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -118,7 +118,7 @@
                 <!--    'column_alias': 'ds_partitioned__year'}            -->
                 <!-- col19 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
                 <!--    'column_alias': 'booking_paid_at'}                       -->
                 <!-- col20 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -138,11 +138,11 @@
                 <!--    'column_alias': 'booking_paid_at__year'}           -->
                 <!-- col24 =                                                             -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                 <!-- col25 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                 <!-- col26 =                                                           -->
                 <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -162,7 +162,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                 <!-- col30 =                                                                 -->
                 <!--   {'class': 'SqlSelectColumn',                                          -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                 <!-- col31 =                                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -182,7 +182,7 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                 <!-- col35 =                                                                  -->
                 <!--   {'class': 'SqlSelectColumn',                                           -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                 <!-- col36 =                                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -202,31 +202,31 @@
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                 <!-- col40 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col41 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
                 <!--    'column_alias': 'guest'}                                 -->
                 <!-- col42 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
                 <!--    'column_alias': 'host'}                                  -->
                 <!-- col43 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
                 <!-- col44 =                                                          -->
                 <!--   {'class': 'SqlSelectColumn',                                   -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                 <!-- col45 =                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                 -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                 <!-- col46 =                                                       -->
                 <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
                 <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                 <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                 <!-- where = None -->
@@ -260,15 +260,15 @@
                 <!--    'column_alias': 'listings'}                                 -->
                 <!-- col1 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10086),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
                 <!--    'column_alias': 'largest_listing'}                       -->
                 <!-- col2 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10087),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
                 <!--    'column_alias': 'smallest_listing'}                      -->
                 <!-- col3 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10088),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10089),  -->
                 <!--    'column_alias': 'ds'}                                    -->
                 <!-- col4 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -288,7 +288,7 @@
                 <!--    'column_alias': 'ds__year'}                        -->
                 <!-- col8 =                                                      -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10093),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10094),  -->
                 <!--    'column_alias': 'created_at'}                            -->
                 <!-- col9 =                                                -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -308,19 +308,19 @@
                 <!--    'column_alias': 'created_at__year'}                -->
                 <!-- col13 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10098),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
                 <!--    'column_alias': 'country_latest'}                        -->
                 <!-- col14 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10099),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
                 <!--    'column_alias': 'is_lux_latest'}                         -->
                 <!-- col15 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10100),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
                 <!--    'column_alias': 'capacity_latest'}                       -->
                 <!-- col16 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10101),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10102),  -->
                 <!--    'column_alias': 'listing__ds'}                           -->
                 <!-- col17 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -340,7 +340,7 @@
                 <!--    'column_alias': 'listing__ds__year'}               -->
                 <!-- col21 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10106),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10107),  -->
                 <!--    'column_alias': 'listing__created_at'}                   -->
                 <!-- col22 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -360,27 +360,27 @@
                 <!--    'column_alias': 'listing__created_at__year'}       -->
                 <!-- col26 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10111),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
                 <!--    'column_alias': 'listing__country_latest'}               -->
                 <!-- col27 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10112),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
                 <!--    'column_alias': 'listing__is_lux_latest'}                -->
                 <!-- col28 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10113),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
                 <!--    'column_alias': 'listing__capacity_latest'}              -->
                 <!-- col29 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10114),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
                 <!--    'column_alias': 'listing'}                               -->
                 <!-- col30 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10115),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
                 <!--    'column_alias': 'user'}                                  -->
                 <!-- col31 =                                                     -->
                 <!--   {'class': 'SqlSelectColumn',                              -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10116),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10117),  -->
                 <!--    'column_alias': 'listing__user'}                         -->
                 <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10002) -->
                 <!-- where = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
@@ -12,35 +12,35 @@
         <!--    'column_alias': 'instant_bookings'}                                                              -->
         <!-- col2 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
         <!--    'column_alias': 'booking_value'}                         -->
         <!-- col3 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
         <!--    'column_alias': 'max_booking_value'}                     -->
         <!-- col4 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
         <!--    'column_alias': 'min_booking_value'}                     -->
         <!-- col5 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
         <!--    'column_alias': 'bookers'}                               -->
         <!-- col6 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
         <!--    'column_alias': 'average_booking_value'}                 -->
         <!-- col7 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
         <!--    'column_alias': 'booking_payments'}                      -->
         <!-- col8 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
         <!--    'column_alias': 'is_instant'}                            -->
         <!-- col9 =                                                      -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
         <!--    'column_alias': 'ds'}                                    -->
         <!-- col10 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -60,7 +60,7 @@
         <!--    'column_alias': 'ds__year'}                        -->
         <!-- col14 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
         <!--    'column_alias': 'ds_partitioned'}                        -->
         <!-- col15 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -80,7 +80,7 @@
         <!--    'column_alias': 'ds_partitioned__year'}            -->
         <!-- col19 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
         <!--    'column_alias': 'booking_paid_at'}                       -->
         <!-- col20 =                                               -->
         <!--   {'class': 'SqlSelectColumn',                        -->
@@ -100,11 +100,11 @@
         <!--    'column_alias': 'booking_paid_at__year'}           -->
         <!-- col24 =                                                             -->
         <!--   {'class': 'SqlSelectColumn',                                      -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
         <!-- col25 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
         <!-- col26 =                                                           -->
         <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -124,7 +124,7 @@
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
         <!-- col30 =                                                                 -->
         <!--   {'class': 'SqlSelectColumn',                                          -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
         <!-- col31 =                                                                       -->
         <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -144,7 +144,7 @@
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
         <!-- col35 =                                                                  -->
         <!--   {'class': 'SqlSelectColumn',                                           -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
         <!-- col36 =                                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -164,31 +164,31 @@
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
         <!-- col40 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
         <!--    'column_alias': 'listing'}                               -->
         <!-- col41 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
         <!--    'column_alias': 'guest'}                                 -->
         <!-- col42 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
         <!--    'column_alias': 'host'}                                  -->
         <!-- col43 =                                                     -->
         <!--   {'class': 'SqlSelectColumn',                              -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
         <!-- col44 =                                                          -->
         <!--   {'class': 'SqlSelectColumn',                                   -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
         <!-- col45 =                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                 -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
         <!-- col46 =                                                       -->
         <!--   {'class': 'SqlSelectColumn',                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
         <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
         <!-- where = None -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,357 +1,263 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_10.metric_time, subq_11.metric_time) AS metric_time
-  , subq_10.bookings AS bookings
-  , subq_11.booking_payments AS booking_payments
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
+  , subq_9.booking_payments AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.metric_time
-    , subq_4.bookings
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.metric_time
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.metric_time
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time']
       SELECT
-        subq_2.metric_time
-        , subq_2.bookings
+        subq_1.metric_time
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.metric_time
-  ) subq_4
-) subq_10
+      subq_2.metric_time
+  ) subq_3
+) subq_8
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time
-    , subq_9.booking_payments
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time
-      , SUM(subq_8.booking_payments) AS booking_payments
+      subq_6.metric_time
+      , SUM(subq_6.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_7.metric_time
-        , subq_7.booking_payments
+        subq_5.metric_time
+        , subq_5.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.ds_partitioned
-          , subq_6.ds_partitioned__week
-          , subq_6.ds_partitioned__month
-          , subq_6.ds_partitioned__quarter
-          , subq_6.ds_partitioned__year
-          , subq_6.booking_paid_at
-          , subq_6.booking_paid_at__week
-          , subq_6.booking_paid_at__month
-          , subq_6.booking_paid_at__quarter
-          , subq_6.booking_paid_at__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds
-          , subq_6.create_a_cycle_in_the_join_graph__ds__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_6.booking_paid_at AS metric_time
-          , subq_6.booking_paid_at__week AS metric_time__week
-          , subq_6.booking_paid_at__month AS metric_time__month
-          , subq_6.booking_paid_at__quarter AS metric_time__quarter
-          , subq_6.booking_paid_at__year AS metric_time__year
-          , subq_6.listing
-          , subq_6.guest
-          , subq_6.host
-          , subq_6.create_a_cycle_in_the_join_graph
-          , subq_6.create_a_cycle_in_the_join_graph__listing
-          , subq_6.create_a_cycle_in_the_join_graph__guest
-          , subq_6.create_a_cycle_in_the_join_graph__host
-          , subq_6.is_instant
-          , subq_6.create_a_cycle_in_the_join_graph__is_instant
-          , subq_6.booking_payments
+          subq_4.ds
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds_partitioned
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.booking_paid_at
+          , subq_4.booking_paid_at__week
+          , subq_4.booking_paid_at__month
+          , subq_4.booking_paid_at__quarter
+          , subq_4.booking_paid_at__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds
+          , subq_4.create_a_cycle_in_the_join_graph__ds__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_4.booking_paid_at AS metric_time
+          , subq_4.booking_paid_at__week AS metric_time__week
+          , subq_4.booking_paid_at__month AS metric_time__month
+          , subq_4.booking_paid_at__quarter AS metric_time__quarter
+          , subq_4.booking_paid_at__year AS metric_time__year
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.create_a_cycle_in_the_join_graph
+          , subq_4.create_a_cycle_in_the_join_graph__listing
+          , subq_4.create_a_cycle_in_the_join_graph__guest
+          , subq_4.create_a_cycle_in_the_join_graph__host
+          , subq_4.is_instant
+          , subq_4.create_a_cycle_in_the_join_graph__is_instant
+          , subq_4.booking_payments
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds_partitioned
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.booking_paid_at
-            , subq_5.booking_paid_at__week
-            , subq_5.booking_paid_at__month
-            , subq_5.booking_paid_at__quarter
-            , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_5.listing
-            , subq_5.guest
-            , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
-            , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
-            , subq_5.booking_payments
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_5
-        ) subq_6
-      ) subq_7
-    ) subq_8
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_4
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_8.metric_time
-  ) subq_9
-) subq_11
+      subq_6.metric_time
+  ) subq_7
+) subq_9
 ON
-  subq_10.metric_time = subq_11.metric_time
+  subq_8.metric_time = subq_9.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_22.metric_time, subq_23.metric_time) AS metric_time
-  , subq_22.bookings AS bookings
-  , subq_23.booking_payments AS booking_payments
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
+  , subq_19.booking_payments AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,7 +11,6 @@ FROM (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
@@ -22,13 +21,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_15
+  ) subq_12
   GROUP BY
     metric_time
-) subq_22
+) subq_18
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'booking_paid_at'
   -- Pass Only Elements:
   --   ['booking_payments', 'metric_time']
@@ -43,6 +41,6 @@ FULL OUTER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     metric_time
-) subq_23
+) subq_19
 ON
-  subq_22.metric_time = subq_23.metric_time
+  subq_18.metric_time = subq_19.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,357 +1,263 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_10.metric_time, subq_11.metric_time) AS metric_time
-  , subq_10.bookings AS bookings
-  , subq_11.booking_payments AS booking_payments
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
+  , subq_9.booking_payments AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.metric_time
-    , subq_4.bookings
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.metric_time
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.metric_time
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time']
       SELECT
-        subq_2.metric_time
-        , subq_2.bookings
+        subq_1.metric_time
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.metric_time
-  ) subq_4
-) subq_10
+      subq_2.metric_time
+  ) subq_3
+) subq_8
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time
-    , subq_9.booking_payments
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time
-      , SUM(subq_8.booking_payments) AS booking_payments
+      subq_6.metric_time
+      , SUM(subq_6.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_7.metric_time
-        , subq_7.booking_payments
+        subq_5.metric_time
+        , subq_5.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.ds_partitioned
-          , subq_6.ds_partitioned__week
-          , subq_6.ds_partitioned__month
-          , subq_6.ds_partitioned__quarter
-          , subq_6.ds_partitioned__year
-          , subq_6.booking_paid_at
-          , subq_6.booking_paid_at__week
-          , subq_6.booking_paid_at__month
-          , subq_6.booking_paid_at__quarter
-          , subq_6.booking_paid_at__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds
-          , subq_6.create_a_cycle_in_the_join_graph__ds__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_6.booking_paid_at AS metric_time
-          , subq_6.booking_paid_at__week AS metric_time__week
-          , subq_6.booking_paid_at__month AS metric_time__month
-          , subq_6.booking_paid_at__quarter AS metric_time__quarter
-          , subq_6.booking_paid_at__year AS metric_time__year
-          , subq_6.listing
-          , subq_6.guest
-          , subq_6.host
-          , subq_6.create_a_cycle_in_the_join_graph
-          , subq_6.create_a_cycle_in_the_join_graph__listing
-          , subq_6.create_a_cycle_in_the_join_graph__guest
-          , subq_6.create_a_cycle_in_the_join_graph__host
-          , subq_6.is_instant
-          , subq_6.create_a_cycle_in_the_join_graph__is_instant
-          , subq_6.booking_payments
+          subq_4.ds
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds_partitioned
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.booking_paid_at
+          , subq_4.booking_paid_at__week
+          , subq_4.booking_paid_at__month
+          , subq_4.booking_paid_at__quarter
+          , subq_4.booking_paid_at__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds
+          , subq_4.create_a_cycle_in_the_join_graph__ds__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_4.booking_paid_at AS metric_time
+          , subq_4.booking_paid_at__week AS metric_time__week
+          , subq_4.booking_paid_at__month AS metric_time__month
+          , subq_4.booking_paid_at__quarter AS metric_time__quarter
+          , subq_4.booking_paid_at__year AS metric_time__year
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.create_a_cycle_in_the_join_graph
+          , subq_4.create_a_cycle_in_the_join_graph__listing
+          , subq_4.create_a_cycle_in_the_join_graph__guest
+          , subq_4.create_a_cycle_in_the_join_graph__host
+          , subq_4.is_instant
+          , subq_4.create_a_cycle_in_the_join_graph__is_instant
+          , subq_4.booking_payments
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds_partitioned
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.booking_paid_at
-            , subq_5.booking_paid_at__week
-            , subq_5.booking_paid_at__month
-            , subq_5.booking_paid_at__quarter
-            , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_5.listing
-            , subq_5.guest
-            , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
-            , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
-            , subq_5.booking_payments
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_5
-        ) subq_6
-      ) subq_7
-    ) subq_8
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_4
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_8.metric_time
-  ) subq_9
-) subq_11
+      subq_6.metric_time
+  ) subq_7
+) subq_9
 ON
-  subq_10.metric_time = subq_11.metric_time
+  subq_8.metric_time = subq_9.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_22.metric_time, subq_23.metric_time) AS metric_time
-  , subq_22.bookings AS bookings
-  , subq_23.booking_payments AS booking_payments
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
+  , subq_19.booking_payments AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,7 +11,6 @@ FROM (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
@@ -22,13 +21,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_15
+  ) subq_12
   GROUP BY
     metric_time
-) subq_22
+) subq_18
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'booking_paid_at'
   -- Pass Only Elements:
   --   ['booking_payments', 'metric_time']
@@ -43,6 +41,6 @@ FULL OUTER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     booking_paid_at
-) subq_23
+) subq_19
 ON
-  subq_22.metric_time = subq_23.metric_time
+  subq_18.metric_time = subq_19.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,357 +1,263 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_10.metric_time, subq_11.metric_time) AS metric_time
-  , subq_10.bookings AS bookings
-  , subq_11.booking_payments AS booking_payments
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
+  , subq_9.booking_payments AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.metric_time
-    , subq_4.bookings
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.metric_time
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.metric_time
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time']
       SELECT
-        subq_2.metric_time
-        , subq_2.bookings
+        subq_1.metric_time
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.metric_time
-  ) subq_4
-) subq_10
+      subq_2.metric_time
+  ) subq_3
+) subq_8
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time
-    , subq_9.booking_payments
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time
-      , SUM(subq_8.booking_payments) AS booking_payments
+      subq_6.metric_time
+      , SUM(subq_6.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_7.metric_time
-        , subq_7.booking_payments
+        subq_5.metric_time
+        , subq_5.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.ds_partitioned
-          , subq_6.ds_partitioned__week
-          , subq_6.ds_partitioned__month
-          , subq_6.ds_partitioned__quarter
-          , subq_6.ds_partitioned__year
-          , subq_6.booking_paid_at
-          , subq_6.booking_paid_at__week
-          , subq_6.booking_paid_at__month
-          , subq_6.booking_paid_at__quarter
-          , subq_6.booking_paid_at__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds
-          , subq_6.create_a_cycle_in_the_join_graph__ds__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_6.booking_paid_at AS metric_time
-          , subq_6.booking_paid_at__week AS metric_time__week
-          , subq_6.booking_paid_at__month AS metric_time__month
-          , subq_6.booking_paid_at__quarter AS metric_time__quarter
-          , subq_6.booking_paid_at__year AS metric_time__year
-          , subq_6.listing
-          , subq_6.guest
-          , subq_6.host
-          , subq_6.create_a_cycle_in_the_join_graph
-          , subq_6.create_a_cycle_in_the_join_graph__listing
-          , subq_6.create_a_cycle_in_the_join_graph__guest
-          , subq_6.create_a_cycle_in_the_join_graph__host
-          , subq_6.is_instant
-          , subq_6.create_a_cycle_in_the_join_graph__is_instant
-          , subq_6.booking_payments
+          subq_4.ds
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds_partitioned
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.booking_paid_at
+          , subq_4.booking_paid_at__week
+          , subq_4.booking_paid_at__month
+          , subq_4.booking_paid_at__quarter
+          , subq_4.booking_paid_at__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds
+          , subq_4.create_a_cycle_in_the_join_graph__ds__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_4.booking_paid_at AS metric_time
+          , subq_4.booking_paid_at__week AS metric_time__week
+          , subq_4.booking_paid_at__month AS metric_time__month
+          , subq_4.booking_paid_at__quarter AS metric_time__quarter
+          , subq_4.booking_paid_at__year AS metric_time__year
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.create_a_cycle_in_the_join_graph
+          , subq_4.create_a_cycle_in_the_join_graph__listing
+          , subq_4.create_a_cycle_in_the_join_graph__guest
+          , subq_4.create_a_cycle_in_the_join_graph__host
+          , subq_4.is_instant
+          , subq_4.create_a_cycle_in_the_join_graph__is_instant
+          , subq_4.booking_payments
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds_partitioned
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.booking_paid_at
-            , subq_5.booking_paid_at__week
-            , subq_5.booking_paid_at__month
-            , subq_5.booking_paid_at__quarter
-            , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_5.listing
-            , subq_5.guest
-            , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
-            , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
-            , subq_5.booking_payments
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_5
-        ) subq_6
-      ) subq_7
-    ) subq_8
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_4
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_8.metric_time
-  ) subq_9
-) subq_11
+      subq_6.metric_time
+  ) subq_7
+) subq_9
 ON
-  subq_10.metric_time = subq_11.metric_time
+  subq_8.metric_time = subq_9.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_22.metric_time, subq_23.metric_time) AS metric_time
-  , subq_22.bookings AS bookings
-  , subq_23.booking_payments AS booking_payments
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
+  , subq_19.booking_payments AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,7 +11,6 @@ FROM (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
@@ -22,13 +21,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_15
+  ) subq_12
   GROUP BY
     metric_time
-) subq_22
+) subq_18
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'booking_paid_at'
   -- Pass Only Elements:
   --   ['booking_payments', 'metric_time']
@@ -43,6 +41,6 @@ FULL OUTER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     booking_paid_at
-) subq_23
+) subq_19
 ON
-  subq_22.metric_time = subq_23.metric_time
+  subq_18.metric_time = subq_19.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,357 +1,263 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_10.metric_time, subq_11.metric_time) AS metric_time
-  , subq_10.bookings AS bookings
-  , subq_11.booking_payments AS booking_payments
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
+  , subq_9.booking_payments AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.metric_time
-    , subq_4.bookings
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.metric_time
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.metric_time
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time']
       SELECT
-        subq_2.metric_time
-        , subq_2.bookings
+        subq_1.metric_time
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.metric_time
-  ) subq_4
-) subq_10
+      subq_2.metric_time
+  ) subq_3
+) subq_8
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time
-    , subq_9.booking_payments
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time
-      , SUM(subq_8.booking_payments) AS booking_payments
+      subq_6.metric_time
+      , SUM(subq_6.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_7.metric_time
-        , subq_7.booking_payments
+        subq_5.metric_time
+        , subq_5.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.ds_partitioned
-          , subq_6.ds_partitioned__week
-          , subq_6.ds_partitioned__month
-          , subq_6.ds_partitioned__quarter
-          , subq_6.ds_partitioned__year
-          , subq_6.booking_paid_at
-          , subq_6.booking_paid_at__week
-          , subq_6.booking_paid_at__month
-          , subq_6.booking_paid_at__quarter
-          , subq_6.booking_paid_at__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds
-          , subq_6.create_a_cycle_in_the_join_graph__ds__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_6.booking_paid_at AS metric_time
-          , subq_6.booking_paid_at__week AS metric_time__week
-          , subq_6.booking_paid_at__month AS metric_time__month
-          , subq_6.booking_paid_at__quarter AS metric_time__quarter
-          , subq_6.booking_paid_at__year AS metric_time__year
-          , subq_6.listing
-          , subq_6.guest
-          , subq_6.host
-          , subq_6.create_a_cycle_in_the_join_graph
-          , subq_6.create_a_cycle_in_the_join_graph__listing
-          , subq_6.create_a_cycle_in_the_join_graph__guest
-          , subq_6.create_a_cycle_in_the_join_graph__host
-          , subq_6.is_instant
-          , subq_6.create_a_cycle_in_the_join_graph__is_instant
-          , subq_6.booking_payments
+          subq_4.ds
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds_partitioned
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.booking_paid_at
+          , subq_4.booking_paid_at__week
+          , subq_4.booking_paid_at__month
+          , subq_4.booking_paid_at__quarter
+          , subq_4.booking_paid_at__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds
+          , subq_4.create_a_cycle_in_the_join_graph__ds__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_4.booking_paid_at AS metric_time
+          , subq_4.booking_paid_at__week AS metric_time__week
+          , subq_4.booking_paid_at__month AS metric_time__month
+          , subq_4.booking_paid_at__quarter AS metric_time__quarter
+          , subq_4.booking_paid_at__year AS metric_time__year
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.create_a_cycle_in_the_join_graph
+          , subq_4.create_a_cycle_in_the_join_graph__listing
+          , subq_4.create_a_cycle_in_the_join_graph__guest
+          , subq_4.create_a_cycle_in_the_join_graph__host
+          , subq_4.is_instant
+          , subq_4.create_a_cycle_in_the_join_graph__is_instant
+          , subq_4.booking_payments
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds_partitioned
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.booking_paid_at
-            , subq_5.booking_paid_at__week
-            , subq_5.booking_paid_at__month
-            , subq_5.booking_paid_at__quarter
-            , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_5.listing
-            , subq_5.guest
-            , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
-            , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
-            , subq_5.booking_payments
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_5
-        ) subq_6
-      ) subq_7
-    ) subq_8
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_4
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_8.metric_time
-  ) subq_9
-) subq_11
+      subq_6.metric_time
+  ) subq_7
+) subq_9
 ON
-  subq_10.metric_time = subq_11.metric_time
+  subq_8.metric_time = subq_9.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_22.metric_time, subq_23.metric_time) AS metric_time
-  , subq_22.bookings AS bookings
-  , subq_23.booking_payments AS booking_payments
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
+  , subq_19.booking_payments AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,7 +11,6 @@ FROM (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
@@ -22,13 +21,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_15
+  ) subq_12
   GROUP BY
     metric_time
-) subq_22
+) subq_18
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'booking_paid_at'
   -- Pass Only Elements:
   --   ['booking_payments', 'metric_time']
@@ -43,6 +41,6 @@ FULL OUTER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     booking_paid_at
-) subq_23
+) subq_19
 ON
-  subq_22.metric_time = subq_23.metric_time
+  subq_18.metric_time = subq_19.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,357 +1,263 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_10.metric_time, subq_11.metric_time) AS metric_time
-  , subq_10.bookings AS bookings
-  , subq_11.booking_payments AS booking_payments
+  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
+  , subq_8.bookings AS bookings
+  , subq_9.booking_payments AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_4.metric_time
-    , subq_4.bookings
+    subq_3.metric_time
+    , subq_3.bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_3.metric_time
-      , SUM(subq_3.bookings) AS bookings
+      subq_2.metric_time
+      , SUM(subq_2.bookings) AS bookings
     FROM (
       -- Pass Only Elements:
       --   ['bookings', 'metric_time']
       SELECT
-        subq_2.metric_time
-        , subq_2.bookings
+        subq_1.metric_time
+        , subq_1.bookings
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_1.ds
-          , subq_1.ds__week
-          , subq_1.ds__month
-          , subq_1.ds__quarter
-          , subq_1.ds__year
-          , subq_1.ds_partitioned
-          , subq_1.ds_partitioned__week
-          , subq_1.ds_partitioned__month
-          , subq_1.ds_partitioned__quarter
-          , subq_1.ds_partitioned__year
-          , subq_1.booking_paid_at
-          , subq_1.booking_paid_at__week
-          , subq_1.booking_paid_at__month
-          , subq_1.booking_paid_at__quarter
-          , subq_1.booking_paid_at__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds
-          , subq_1.create_a_cycle_in_the_join_graph__ds__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds__year
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_1.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_1.ds AS metric_time
-          , subq_1.ds__week AS metric_time__week
-          , subq_1.ds__month AS metric_time__month
-          , subq_1.ds__quarter AS metric_time__quarter
-          , subq_1.ds__year AS metric_time__year
-          , subq_1.listing
-          , subq_1.guest
-          , subq_1.host
-          , subq_1.create_a_cycle_in_the_join_graph
-          , subq_1.create_a_cycle_in_the_join_graph__listing
-          , subq_1.create_a_cycle_in_the_join_graph__guest
-          , subq_1.create_a_cycle_in_the_join_graph__host
-          , subq_1.is_instant
-          , subq_1.create_a_cycle_in_the_join_graph__is_instant
-          , subq_1.bookings
-          , subq_1.instant_bookings
-          , subq_1.booking_value
-          , subq_1.max_booking_value
-          , subq_1.min_booking_value
-          , subq_1.bookers
-          , subq_1.average_booking_value
+          subq_0.ds
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds_partitioned
+          , subq_0.ds_partitioned__week
+          , subq_0.ds_partitioned__month
+          , subq_0.ds_partitioned__quarter
+          , subq_0.ds_partitioned__year
+          , subq_0.booking_paid_at
+          , subq_0.booking_paid_at__week
+          , subq_0.booking_paid_at__month
+          , subq_0.booking_paid_at__quarter
+          , subq_0.booking_paid_at__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds
+          , subq_0.create_a_cycle_in_the_join_graph__ds__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds__year
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_0.ds AS metric_time
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.listing
+          , subq_0.guest
+          , subq_0.host
+          , subq_0.create_a_cycle_in_the_join_graph
+          , subq_0.create_a_cycle_in_the_join_graph__listing
+          , subq_0.create_a_cycle_in_the_join_graph__guest
+          , subq_0.create_a_cycle_in_the_join_graph__host
+          , subq_0.is_instant
+          , subq_0.create_a_cycle_in_the_join_graph__is_instant
+          , subq_0.bookings
+          , subq_0.instant_bookings
+          , subq_0.booking_value
+          , subq_0.max_booking_value
+          , subq_0.min_booking_value
+          , subq_0.bookers
+          , subq_0.average_booking_value
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_0.ds
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds_partitioned
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.booking_paid_at
-            , subq_0.booking_paid_at__week
-            , subq_0.booking_paid_at__month
-            , subq_0.booking_paid_at__quarter
-            , subq_0.booking_paid_at__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds
-            , subq_0.create_a_cycle_in_the_join_graph__ds__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds__year
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.create_a_cycle_in_the_join_graph
-            , subq_0.create_a_cycle_in_the_join_graph__listing
-            , subq_0.create_a_cycle_in_the_join_graph__guest
-            , subq_0.create_a_cycle_in_the_join_graph__host
-            , subq_0.is_instant
-            , subq_0.create_a_cycle_in_the_join_graph__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_0
-        ) subq_1
-      ) subq_2
-    ) subq_3
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_0
+      ) subq_1
+    ) subq_2
     GROUP BY
-      subq_3.metric_time
-  ) subq_4
-) subq_10
+      subq_2.metric_time
+  ) subq_3
+) subq_8
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time
-    , subq_9.booking_payments
+    subq_7.metric_time
+    , subq_7.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_8.metric_time
-      , SUM(subq_8.booking_payments) AS booking_payments
+      subq_6.metric_time
+      , SUM(subq_6.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_7.metric_time
-        , subq_7.booking_payments
+        subq_5.metric_time
+        , subq_5.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.ds_partitioned
-          , subq_6.ds_partitioned__week
-          , subq_6.ds_partitioned__month
-          , subq_6.ds_partitioned__quarter
-          , subq_6.ds_partitioned__year
-          , subq_6.booking_paid_at
-          , subq_6.booking_paid_at__week
-          , subq_6.booking_paid_at__month
-          , subq_6.booking_paid_at__quarter
-          , subq_6.booking_paid_at__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds
-          , subq_6.create_a_cycle_in_the_join_graph__ds__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds__year
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_6.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_6.booking_paid_at AS metric_time
-          , subq_6.booking_paid_at__week AS metric_time__week
-          , subq_6.booking_paid_at__month AS metric_time__month
-          , subq_6.booking_paid_at__quarter AS metric_time__quarter
-          , subq_6.booking_paid_at__year AS metric_time__year
-          , subq_6.listing
-          , subq_6.guest
-          , subq_6.host
-          , subq_6.create_a_cycle_in_the_join_graph
-          , subq_6.create_a_cycle_in_the_join_graph__listing
-          , subq_6.create_a_cycle_in_the_join_graph__guest
-          , subq_6.create_a_cycle_in_the_join_graph__host
-          , subq_6.is_instant
-          , subq_6.create_a_cycle_in_the_join_graph__is_instant
-          , subq_6.booking_payments
+          subq_4.ds
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds_partitioned
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.booking_paid_at
+          , subq_4.booking_paid_at__week
+          , subq_4.booking_paid_at__month
+          , subq_4.booking_paid_at__quarter
+          , subq_4.booking_paid_at__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds
+          , subq_4.create_a_cycle_in_the_join_graph__ds__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds__year
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_4.booking_paid_at AS metric_time
+          , subq_4.booking_paid_at__week AS metric_time__week
+          , subq_4.booking_paid_at__month AS metric_time__month
+          , subq_4.booking_paid_at__quarter AS metric_time__quarter
+          , subq_4.booking_paid_at__year AS metric_time__year
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.create_a_cycle_in_the_join_graph
+          , subq_4.create_a_cycle_in_the_join_graph__listing
+          , subq_4.create_a_cycle_in_the_join_graph__guest
+          , subq_4.create_a_cycle_in_the_join_graph__host
+          , subq_4.is_instant
+          , subq_4.create_a_cycle_in_the_join_graph__is_instant
+          , subq_4.booking_payments
         FROM (
-          -- Pass Only Additive Measures
+          -- Read Elements From Data Source 'bookings_source'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.ds_partitioned
-            , subq_5.ds_partitioned__week
-            , subq_5.ds_partitioned__month
-            , subq_5.ds_partitioned__quarter
-            , subq_5.ds_partitioned__year
-            , subq_5.booking_paid_at
-            , subq_5.booking_paid_at__week
-            , subq_5.booking_paid_at__month
-            , subq_5.booking_paid_at__quarter
-            , subq_5.booking_paid_at__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds
-            , subq_5.create_a_cycle_in_the_join_graph__ds__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds__year
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_5.listing
-            , subq_5.guest
-            , subq_5.host
-            , subq_5.create_a_cycle_in_the_join_graph
-            , subq_5.create_a_cycle_in_the_join_graph__listing
-            , subq_5.create_a_cycle_in_the_join_graph__guest
-            , subq_5.create_a_cycle_in_the_join_graph__host
-            , subq_5.is_instant
-            , subq_5.create_a_cycle_in_the_join_graph__is_instant
-            , subq_5.booking_payments
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_10001.booking_value
+            , bookings_source_src_10001.booking_value AS max_booking_value
+            , bookings_source_src_10001.booking_value AS min_booking_value
+            , bookings_source_src_10001.guest_id AS bookers
+            , bookings_source_src_10001.booking_value AS average_booking_value
+            , bookings_source_src_10001.booking_value AS booking_payments
+            , bookings_source_src_10001.is_instant
+            , bookings_source_src_10001.ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+            , bookings_source_src_10001.ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+            , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+            , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+            , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+            , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+            , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+            , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , bookings_source_src_10001.listing_id AS listing
+            , bookings_source_src_10001.guest_id AS guest
+            , bookings_source_src_10001.host_id AS host
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+            , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+            , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+            , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
           FROM (
-            -- Read Elements From Data Source 'bookings_source'
-            SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_10001.booking_value
-              , bookings_source_src_10001.booking_value AS max_booking_value
-              , bookings_source_src_10001.booking_value AS min_booking_value
-              , bookings_source_src_10001.guest_id AS bookers
-              , bookings_source_src_10001.booking_value AS average_booking_value
-              , bookings_source_src_10001.booking_value AS booking_payments
-              , bookings_source_src_10001.is_instant
-              , bookings_source_src_10001.ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-              , bookings_source_src_10001.ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
-              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
-              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
-              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
-              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
-              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
-              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
-              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
-              , bookings_source_src_10001.listing_id AS listing
-              , bookings_source_src_10001.guest_id AS guest
-              , bookings_source_src_10001.host_id AS host
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
-              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
-              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
-              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
-            FROM (
-              -- User Defined SQL Query
-              SELECT * FROM ***************************.fct_bookings
-            ) bookings_source_src_10001
-          ) subq_5
-        ) subq_6
-      ) subq_7
-    ) subq_8
+            -- User Defined SQL Query
+            SELECT * FROM ***************************.fct_bookings
+          ) bookings_source_src_10001
+        ) subq_4
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_8.metric_time
-  ) subq_9
-) subq_11
+      subq_6.metric_time
+  ) subq_7
+) subq_9
 ON
-  subq_10.metric_time = subq_11.metric_time
+  subq_8.metric_time = subq_9.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_22.metric_time, subq_23.metric_time) AS metric_time
-  , subq_22.bookings AS bookings
-  , subq_23.booking_payments AS booking_payments
+  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
+  , subq_18.bookings AS bookings
+  , subq_19.booking_payments AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,7 +11,6 @@ FROM (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'metric_time']
@@ -22,13 +21,12 @@ FROM (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_10001
-  ) subq_15
+  ) subq_12
   GROUP BY
     metric_time
-) subq_22
+) subq_18
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'booking_paid_at'
   -- Pass Only Elements:
   --   ['booking_payments', 'metric_time']
@@ -43,6 +41,6 @@ FULL OUTER JOIN (
   ) bookings_source_src_10001
   GROUP BY
     booking_paid_at
-) subq_23
+) subq_19
 ON
-  subq_22.metric_time = subq_23.metric_time
+  subq_18.metric_time = subq_19.metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
@@ -197,35 +197,35 @@
             <!--    'column_alias': 'instant_bookings'}                                                              -->
             <!-- col2 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
             <!--    'column_alias': 'booking_value'}                         -->
             <!-- col3 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
             <!--    'column_alias': 'max_booking_value'}                     -->
             <!-- col4 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
             <!--    'column_alias': 'min_booking_value'}                     -->
             <!-- col5 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
             <!--    'column_alias': 'bookers'}                               -->
             <!-- col6 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
             <!--    'column_alias': 'average_booking_value'}                 -->
             <!-- col7 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
             <!--    'column_alias': 'booking_payments'}                      -->
             <!-- col8 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
             <!--    'column_alias': 'is_instant'}                            -->
             <!-- col9 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
             <!--    'column_alias': 'ds'}                                    -->
             <!-- col10 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -245,7 +245,7 @@
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col14 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
             <!--    'column_alias': 'ds_partitioned'}                        -->
             <!-- col15 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -265,7 +265,7 @@
             <!--    'column_alias': 'ds_partitioned__year'}            -->
             <!-- col19 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
             <!--    'column_alias': 'booking_paid_at'}                       -->
             <!-- col20 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -285,11 +285,11 @@
             <!--    'column_alias': 'booking_paid_at__year'}           -->
             <!-- col24 =                                                             -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
             <!-- col25 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
             <!-- col26 =                                                           -->
             <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -309,7 +309,7 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
             <!-- col30 =                                                                 -->
             <!--   {'class': 'SqlSelectColumn',                                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
             <!-- col31 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -329,7 +329,7 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
             <!-- col35 =                                                                  -->
             <!--   {'class': 'SqlSelectColumn',                                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
             <!-- col36 =                                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -349,31 +349,31 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
             <!-- col40 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
             <!--    'column_alias': 'listing'}                               -->
             <!-- col41 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
             <!--    'column_alias': 'guest'}                                 -->
             <!-- col42 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
             <!--    'column_alias': 'host'}                                  -->
             <!-- col43 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
             <!-- col44 =                                                          -->
             <!--   {'class': 'SqlSelectColumn',                                   -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
             <!-- col45 =                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                 -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
             <!-- col46 =                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
             <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
             <!-- where = None -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
@@ -221,35 +221,35 @@
             <!--    'column_alias': 'instant_bookings'}                                                              -->
             <!-- col2 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
             <!--    'column_alias': 'booking_value'}                         -->
             <!-- col3 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
             <!--    'column_alias': 'max_booking_value'}                     -->
             <!-- col4 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
             <!--    'column_alias': 'min_booking_value'}                     -->
             <!-- col5 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
             <!--    'column_alias': 'bookers'}                               -->
             <!-- col6 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
             <!--    'column_alias': 'average_booking_value'}                 -->
             <!-- col7 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
             <!--    'column_alias': 'booking_payments'}                      -->
             <!-- col8 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
             <!--    'column_alias': 'is_instant'}                            -->
             <!-- col9 =                                                      -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
             <!--    'column_alias': 'ds'}                                    -->
             <!-- col10 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -269,7 +269,7 @@
             <!--    'column_alias': 'ds__year'}                        -->
             <!-- col14 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
             <!--    'column_alias': 'ds_partitioned'}                        -->
             <!-- col15 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -289,7 +289,7 @@
             <!--    'column_alias': 'ds_partitioned__year'}            -->
             <!-- col19 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
             <!--    'column_alias': 'booking_paid_at'}                       -->
             <!-- col20 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                        -->
@@ -309,11 +309,11 @@
             <!--    'column_alias': 'booking_paid_at__year'}           -->
             <!-- col24 =                                                             -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
             <!-- col25 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
             <!-- col26 =                                                           -->
             <!--   {'class': 'SqlSelectColumn',                                    -->
@@ -333,7 +333,7 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
             <!-- col30 =                                                                 -->
             <!--   {'class': 'SqlSelectColumn',                                          -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
             <!-- col31 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                                -->
@@ -353,7 +353,7 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
             <!-- col35 =                                                                  -->
             <!--   {'class': 'SqlSelectColumn',                                           -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
             <!-- col36 =                                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                                 -->
@@ -373,31 +373,31 @@
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
             <!-- col40 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
             <!--    'column_alias': 'listing'}                               -->
             <!-- col41 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
             <!--    'column_alias': 'guest'}                                 -->
             <!-- col42 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
             <!--    'column_alias': 'host'}                                  -->
             <!-- col43 =                                                     -->
             <!--   {'class': 'SqlSelectColumn',                              -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
             <!-- col44 =                                                          -->
             <!--   {'class': 'SqlSelectColumn',                                   -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
             <!-- col45 =                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                 -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
             <!-- col46 =                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
             <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
             <!-- where = None -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -1,668 +1,478 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = Combine Metrics -->
-        <!-- node_id = ss_32 -->
+        <!-- node_id = ss_15 -->
         <!-- col0 =                                                                   -->
         <!--   {'class': 'SqlSelectColumn',                                           -->
-        <!--    'expr': SqlFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+        <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
         <!--    'column_alias': 'metric_time'}                                        -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_660),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),  -->
         <!--    'column_alias': 'bookings'}                            -->
         <!-- col2 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_661),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),  -->
         <!--    'column_alias': 'booking_payments'}                    -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
         <!-- join_0 =                                                    -->
         <!--   {'class': 'SqlJoinDescription',                           -->
-        <!--    'right_source': SqlSelectStatementNode(node_id=ss_31),   -->
-        <!--    'right_source_alias': 'subq_11',                         -->
-        <!--    'on_condition': SqlComparisonExpression(node_id=cmp_3),  -->
+        <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
+        <!--    'right_source_alias': 'subq_9',                          -->
+        <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
         <!--    'join_type': SqlJoinType.FULL_OUTER}                     -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = ss_26 -->
+            <!-- node_id = ss_10 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_565),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_566),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
             <!--    'column_alias': 'bookings'}                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Aggregate Measures -->
-                <!-- node_id = ss_25 -->
+                <!-- node_id = ss_9 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                              -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlFunctionExpression(node_id=fnc_2, sql_function=SUM),  -->
+                <!--    'expr': SqlFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
                 <!--    'column_alias': 'bookings'}                                      -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_564),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description =                    -->
                     <!--   Pass Only Elements:            -->
                     <!--     ['bookings', 'metric_time']  -->
-                    <!-- node_id = ss_24 -->
+                    <!-- node_id = ss_8 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_562),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_561),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
                     <!--    'column_alias': 'bookings'}                            -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Metric Time Dimension 'ds' -->
-                        <!-- node_id = ss_23 -->
+                        <!-- node_id = ss_7 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_519),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_520),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_521),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_522),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_523),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_524),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_525),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_526),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_527),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_528),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_529),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_530),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_531),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_532),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_533),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_534),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col16 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_535),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                         <!-- col17 =                                                            -->
                         <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_536),           -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),           -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                         <!-- col18 =                                                              -->
                         <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_537),             -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),             -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                         <!-- col19 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_538),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col20 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_539),                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),                -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col21 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_540),                      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),                      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                         <!-- col22 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_541),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                         <!-- col23 =                                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_542),                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),                         -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                         <!-- col24 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_543),                      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),                      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col25 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_544),                 -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),                 -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col26 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_545),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                         <!-- col27 =                                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_546),                        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),                        -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                         <!-- col28 =                                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_547),                          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),                          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                         <!-- col29 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_548),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_549),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_550),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_551),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_552),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_553),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col35 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_554),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),  -->
                         <!--    'column_alias': 'listing'}                             -->
                         <!-- col36 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_555),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),  -->
                         <!--    'column_alias': 'guest'}                               -->
                         <!-- col37 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_556),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),  -->
                         <!--    'column_alias': 'host'}                                -->
                         <!-- col38 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_557),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                         <!-- col39 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_558),         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),         -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col40 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_559),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col41 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_560),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- col42 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_517),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col43 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_518),            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),            -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col44 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_510),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_222),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- col45 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_511),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_223),  -->
                         <!--    'column_alias': 'instant_bookings'}                    -->
                         <!-- col46 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_512),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_224),  -->
                         <!--    'column_alias': 'booking_value'}                       -->
                         <!-- col47 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_513),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_225),  -->
                         <!--    'column_alias': 'max_booking_value'}                   -->
                         <!-- col48 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_514),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_226),  -->
                         <!--    'column_alias': 'min_booking_value'}                   -->
                         <!-- col49 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_515),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_227),  -->
                         <!--    'column_alias': 'bookers'}                             -->
                         <!-- col50 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_516),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
                         <!--    'column_alias': 'average_booking_value'}               -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = ss_22 -->
-                            <!-- col0 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
-                            <!--    'column_alias': 'ds'}                                  -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_474),  -->
-                            <!--    'column_alias': 'ds__week'}                            -->
-                            <!-- col2 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_475),  -->
-                            <!--    'column_alias': 'ds__month'}                           -->
-                            <!-- col3 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_476),  -->
-                            <!--    'column_alias': 'ds__quarter'}                         -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_477),  -->
-                            <!--    'column_alias': 'ds__year'}                            -->
-                            <!-- col5 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_478),  -->
-                            <!--    'column_alias': 'ds_partitioned'}                      -->
-                            <!-- col6 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_479),  -->
-                            <!--    'column_alias': 'ds_partitioned__week'}                -->
-                            <!-- col7 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_480),  -->
-                            <!--    'column_alias': 'ds_partitioned__month'}               -->
-                            <!-- col8 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_481),  -->
-                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                            <!-- col9 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_482),  -->
-                            <!--    'column_alias': 'ds_partitioned__year'}                -->
-                            <!-- col10 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_483),  -->
-                            <!--    'column_alias': 'booking_paid_at'}                     -->
-                            <!-- col11 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_484),  -->
-                            <!--    'column_alias': 'booking_paid_at__week'}               -->
-                            <!-- col12 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_485),  -->
-                            <!--    'column_alias': 'booking_paid_at__month'}              -->
-                            <!-- col13 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_486),  -->
-                            <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                            <!-- col14 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_487),  -->
-                            <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_488),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_489),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_490),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_491),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_492),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_493),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_494),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_495),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_496),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_497),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_498),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_499),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_500),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_501),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_502),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col30 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_503),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col31 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_504),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col32 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_505),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col33 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_506),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col34 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_507),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col35 =                                                        -->
+                            <!-- description = Read Elements From Data Source 'bookings_source' -->
+                            <!-- node_id = ss_10001 -->
+                            <!-- col0 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_508),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col36 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_509),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_471),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col38 =                                                             -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                            <!--    'column_alias': 'bookings'}                                 -->
+                            <!-- col1 =                                                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                            <!--    'column_alias': 'instant_bookings'}                                                              -->
+                            <!-- col2 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                            <!--    'column_alias': 'booking_value'}                         -->
+                            <!-- col3 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                            <!--    'column_alias': 'max_booking_value'}                     -->
+                            <!-- col4 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                            <!--    'column_alias': 'min_booking_value'}                     -->
+                            <!-- col5 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                            <!--    'column_alias': 'bookers'}                               -->
+                            <!-- col6 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                            <!--    'column_alias': 'average_booking_value'}                 -->
+                            <!-- col7 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                            <!--    'column_alias': 'booking_payments'}                      -->
+                            <!-- col8 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                            <!--    'column_alias': 'is_instant'}                            -->
+                            <!-- col9 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                            <!--    'column_alias': 'ds'}                                    -->
+                            <!-- col10 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                            <!--    'column_alias': 'ds__week'}                        -->
+                            <!-- col11 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                            <!--    'column_alias': 'ds__month'}                       -->
+                            <!-- col12 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                            <!--    'column_alias': 'ds__quarter'}                     -->
+                            <!-- col13 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                            <!--    'column_alias': 'ds__year'}                        -->
+                            <!-- col14 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                        -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}            -->
+                            <!-- col16 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}           -->
+                            <!-- col17 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                            <!-- col18 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}            -->
+                            <!-- col19 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                            <!--    'column_alias': 'booking_paid_at'}                       -->
+                            <!-- col20 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'column_alias': 'booking_paid_at__week'}           -->
+                            <!-- col21 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'column_alias': 'booking_paid_at__month'}          -->
+                            <!-- col22 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                            <!-- col23 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'booking_paid_at__year'}           -->
+                            <!-- col24 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col39 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_464),  -->
-                            <!--    'column_alias': 'bookings'}                            -->
-                            <!-- col40 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_465),  -->
-                            <!--    'column_alias': 'instant_bookings'}                    -->
-                            <!-- col41 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
-                            <!--    'column_alias': 'booking_value'}                       -->
-                            <!-- col42 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
-                            <!--    'column_alias': 'max_booking_value'}                   -->
-                            <!-- col43 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
-                            <!--    'column_alias': 'min_booking_value'}                   -->
-                            <!-- col44 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
-                            <!--    'column_alias': 'bookers'}                             -->
-                            <!-- col45 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_470),  -->
-                            <!--    'column_alias': 'average_booking_value'}               -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                            <!-- col25 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                            <!-- col26 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                            <!-- col27 =                                                            -->
+                            <!--   {'class': 'SqlSelectColumn',                                     -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                            <!-- col28 =                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                       -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                            <!-- col29 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                            <!-- col30 =                                                                 -->
+                            <!--   {'class': 'SqlSelectColumn',                                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                            <!-- col31 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                            <!-- col32 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                            <!-- col33 =                                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                                   -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                            <!-- col34 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                            <!-- col35 =                                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                            <!-- col36 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                            <!-- col37 =                                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                                  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                            <!-- col38 =                                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                            <!-- col39 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col40 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                            <!--    'column_alias': 'listing'}                               -->
+                            <!-- col41 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                            <!--    'column_alias': 'guest'}                                 -->
+                            <!-- col42 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                            <!--    'column_alias': 'host'}                                  -->
+                            <!-- col43 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                            <!-- col44 =                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                            <!-- col45 =                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                            <!-- col46 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
-                            <SqlSelectStatementNode>
-                                <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                <!-- node_id = ss_10001 -->
-                                <!-- col0 =                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                <!--    'column_alias': 'bookings'}                                 -->
-                                <!-- col1 =                                                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                <!-- col2 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                <!--    'column_alias': 'booking_value'}                         -->
-                                <!-- col3 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                <!--    'column_alias': 'max_booking_value'}                     -->
-                                <!-- col4 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                <!--    'column_alias': 'min_booking_value'}                     -->
-                                <!-- col5 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                <!--    'column_alias': 'bookers'}                               -->
-                                <!-- col6 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                <!--    'column_alias': 'average_booking_value'}                 -->
-                                <!-- col7 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                <!--    'column_alias': 'booking_payments'}                      -->
-                                <!-- col8 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col9 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                <!--    'column_alias': 'ds'}                                    -->
-                                <!-- col10 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                <!--    'column_alias': 'ds__week'}                        -->
-                                <!-- col11 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                <!--    'column_alias': 'ds__month'}                       -->
-                                <!-- col12 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                <!--    'column_alias': 'ds__quarter'}                     -->
-                                <!-- col13 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                <!--    'column_alias': 'ds__year'}                        -->
-                                <!-- col14 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                        -->
-                                <!-- col15 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                <!-- col16 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                <!-- col17 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                <!-- col18 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                <!-- col19 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking_paid_at'}                       -->
-                                <!-- col20 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                <!-- col21 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                <!-- col22 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                <!-- col23 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col24 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col25 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col26 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col27 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col28 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col29 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col30 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col31 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col32 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col33 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col34 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col35 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col36 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col37 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col38 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col39 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col40 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col41 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col42 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                <!--    'column_alias': 'host'}                                  -->
-                                <!-- col43 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col44 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col45 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col46 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                <!-- where = None -->
-                                <SqlSelectQueryFromClauseNode>
-                                    <!-- description = Read From a Select Query -->
-                                    <!-- node_id = tfc_10001 -->
-                                </SqlSelectQueryFromClauseNode>
-                            </SqlSelectStatementNode>
+                            <SqlSelectQueryFromClauseNode>
+                                <!-- description = Read From a Select Query -->
+                                <!-- node_id = tfc_10001 -->
+                            </SqlSelectQueryFromClauseNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -670,597 +480,431 @@
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = Compute Metrics via Expressions -->
-            <!-- node_id = ss_31 -->
+            <!-- node_id = ss_14 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_656),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_657),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),  -->
             <!--    'column_alias': 'booking_payments'}                    -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_30) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Aggregate Measures -->
-                <!-- node_id = ss_30 -->
+                <!-- node_id = ss_13 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_655),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                              -->
                 <!--   {'class': 'SqlSelectColumn',                                      -->
-                <!--    'expr': SqlFunctionExpression(node_id=fnc_3, sql_function=SUM),  -->
+                <!--    'expr': SqlFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
                 <!--    'column_alias': 'booking_payments'}                              -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_29) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- group_by0 =                                               -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_655),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description =                            -->
                     <!--   Pass Only Elements:                    -->
                     <!--     ['booking_payments', 'metric_time']  -->
-                    <!-- node_id = ss_29 -->
+                    <!-- node_id = ss_12 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_653),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_652),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
                     <!--    'column_alias': 'booking_payments'}                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Metric Time Dimension 'booking_paid_at' -->
-                        <!-- node_id = ss_28 -->
+                        <!-- node_id = ss_11 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_610),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),  -->
                         <!--    'column_alias': 'ds'}                                  -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_611),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),  -->
                         <!--    'column_alias': 'ds__week'}                            -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_612),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),  -->
                         <!--    'column_alias': 'ds__month'}                           -->
                         <!-- col3 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_613),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
                         <!--    'column_alias': 'ds__quarter'}                         -->
                         <!-- col4 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_614),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
                         <!--    'column_alias': 'ds__year'}                            -->
                         <!-- col5 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_615),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_287),  -->
                         <!--    'column_alias': 'ds_partitioned'}                      -->
                         <!-- col6 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_616),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
                         <!--    'column_alias': 'ds_partitioned__week'}                -->
                         <!-- col7 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_617),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
                         <!--    'column_alias': 'ds_partitioned__month'}               -->
                         <!-- col8 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_618),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
                         <!--    'column_alias': 'ds_partitioned__quarter'}             -->
                         <!-- col9 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_619),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
                         <!--    'column_alias': 'ds_partitioned__year'}                -->
                         <!-- col10 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_620),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
                         <!--    'column_alias': 'booking_paid_at'}                     -->
                         <!-- col11 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_621),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
                         <!--    'column_alias': 'booking_paid_at__week'}               -->
                         <!-- col12 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_622),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
                         <!--    'column_alias': 'booking_paid_at__month'}              -->
                         <!-- col13 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_623),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
                         <!--    'column_alias': 'booking_paid_at__quarter'}            -->
                         <!-- col14 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_624),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
                         <!--    'column_alias': 'booking_paid_at__year'}               -->
                         <!-- col15 =                                                     -->
                         <!--   {'class': 'SqlSelectColumn',                              -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_625),    -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),    -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
                         <!-- col16 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_626),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
                         <!-- col17 =                                                            -->
                         <!--   {'class': 'SqlSelectColumn',                                     -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_627),           -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),           -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
                         <!-- col18 =                                                              -->
                         <!--   {'class': 'SqlSelectColumn',                                       -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_628),             -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),             -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
                         <!-- col19 =                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_629),          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
                         <!-- col20 =                                                                 -->
                         <!--   {'class': 'SqlSelectColumn',                                          -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_630),                -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),                -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
                         <!-- col21 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_631),                      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),                      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
                         <!-- col22 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_632),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
                         <!-- col23 =                                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_633),                         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),                         -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
                         <!-- col24 =                                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_634),                      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),                      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
                         <!-- col25 =                                                                  -->
                         <!--   {'class': 'SqlSelectColumn',                                           -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_635),                 -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),                 -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
                         <!-- col26 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_636),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
                         <!-- col27 =                                                                         -->
                         <!--   {'class': 'SqlSelectColumn',                                                  -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_637),                        -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),                        -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
                         <!-- col28 =                                                                           -->
                         <!--   {'class': 'SqlSelectColumn',                                                    -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_638),                          -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),                          -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
                         <!-- col29 =                                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_639),                       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),                       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
                         <!-- col30 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_640),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col31 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_641),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
                         <!--    'column_alias': 'metric_time__week'}                   -->
                         <!-- col32 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_642),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
                         <!--    'column_alias': 'metric_time__month'}                  -->
                         <!-- col33 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_643),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
                         <!--    'column_alias': 'metric_time__quarter'}                -->
                         <!-- col34 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_644),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
                         <!--    'column_alias': 'metric_time__year'}                   -->
                         <!-- col35 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_645),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
                         <!--    'column_alias': 'listing'}                             -->
                         <!-- col36 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_646),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
                         <!--    'column_alias': 'guest'}                               -->
                         <!-- col37 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_647),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
                         <!--    'column_alias': 'host'}                                -->
                         <!-- col38 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_648),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
                         <!-- col39 =                                                          -->
                         <!--   {'class': 'SqlSelectColumn',                                   -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_649),         -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),         -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
                         <!-- col40 =                                                        -->
                         <!--   {'class': 'SqlSelectColumn',                                 -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_650),       -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),       -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
                         <!-- col41 =                                                       -->
                         <!--   {'class': 'SqlSelectColumn',                                -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_651),      -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),      -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
                         <!-- col42 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_608),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
                         <!--    'column_alias': 'is_instant'}                          -->
                         <!-- col43 =                                                             -->
                         <!--   {'class': 'SqlSelectColumn',                                      -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_609),            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),            -->
                         <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
                         <!-- col44 =                                                   -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_607),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
                         <!--    'column_alias': 'booking_payments'}                    -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_27) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
                         <!-- where = None -->
                         <SqlSelectStatementNode>
-                            <!-- description = Pass Only Additive Measures -->
-                            <!-- node_id = ss_27 -->
-                            <!-- col0 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_570),  -->
-                            <!--    'column_alias': 'ds'}                                  -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_571),  -->
-                            <!--    'column_alias': 'ds__week'}                            -->
-                            <!-- col2 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_572),  -->
-                            <!--    'column_alias': 'ds__month'}                           -->
-                            <!-- col3 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_573),  -->
-                            <!--    'column_alias': 'ds__quarter'}                         -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_574),  -->
-                            <!--    'column_alias': 'ds__year'}                            -->
-                            <!-- col5 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_575),  -->
-                            <!--    'column_alias': 'ds_partitioned'}                      -->
-                            <!-- col6 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_576),  -->
-                            <!--    'column_alias': 'ds_partitioned__week'}                -->
-                            <!-- col7 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_577),  -->
-                            <!--    'column_alias': 'ds_partitioned__month'}               -->
-                            <!-- col8 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_578),  -->
-                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
-                            <!-- col9 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_579),  -->
-                            <!--    'column_alias': 'ds_partitioned__year'}                -->
-                            <!-- col10 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_580),  -->
-                            <!--    'column_alias': 'booking_paid_at'}                     -->
-                            <!-- col11 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_581),  -->
-                            <!--    'column_alias': 'booking_paid_at__week'}               -->
-                            <!-- col12 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_582),  -->
-                            <!--    'column_alias': 'booking_paid_at__month'}              -->
-                            <!-- col13 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_583),  -->
-                            <!--    'column_alias': 'booking_paid_at__quarter'}            -->
-                            <!-- col14 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_584),  -->
-                            <!--    'column_alias': 'booking_paid_at__year'}               -->
-                            <!-- col15 =                                                     -->
-                            <!--   {'class': 'SqlSelectColumn',                              -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_585),    -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                            <!-- col16 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_586),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                            <!-- col17 =                                                            -->
-                            <!--   {'class': 'SqlSelectColumn',                                     -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_587),           -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                            <!-- col18 =                                                              -->
-                            <!--   {'class': 'SqlSelectColumn',                                       -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_588),             -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                            <!-- col19 =                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                            <!-- col20 =                                                                 -->
-                            <!--   {'class': 'SqlSelectColumn',                                          -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),                -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                            <!-- col21 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_591),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                            <!-- col22 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_592),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                            <!-- col23 =                                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_593),                         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                            <!-- col24 =                                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_594),                      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                            <!-- col25 =                                                                  -->
-                            <!--   {'class': 'SqlSelectColumn',                                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_595),                 -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                            <!-- col26 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_596),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                            <!-- col27 =                                                                         -->
-                            <!--   {'class': 'SqlSelectColumn',                                                  -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_597),                        -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                            <!-- col28 =                                                                           -->
-                            <!--   {'class': 'SqlSelectColumn',                                                    -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_598),                          -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                            <!-- col29 =                                                                        -->
-                            <!--   {'class': 'SqlSelectColumn',                                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_599),                       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                            <!-- col30 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_600),  -->
-                            <!--    'column_alias': 'listing'}                             -->
-                            <!-- col31 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_601),  -->
-                            <!--    'column_alias': 'guest'}                               -->
-                            <!-- col32 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_602),  -->
-                            <!--    'column_alias': 'host'}                                -->
-                            <!-- col33 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_603),  -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
-                            <!-- col34 =                                                          -->
-                            <!--   {'class': 'SqlSelectColumn',                                   -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_604),         -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                            <!-- col35 =                                                        -->
+                            <!-- description = Read Elements From Data Source 'bookings_source' -->
+                            <!-- node_id = ss_10001 -->
+                            <!-- col0 =                                                         -->
                             <!--   {'class': 'SqlSelectColumn',                                 -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_605),       -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                            <!-- col36 =                                                       -->
-                            <!--   {'class': 'SqlSelectColumn',                                -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_606),      -->
-                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                            <!-- col37 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_568),  -->
-                            <!--    'column_alias': 'is_instant'}                          -->
-                            <!-- col38 =                                                             -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                            <!--    'column_alias': 'bookings'}                                 -->
+                            <!-- col1 =                                                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                            <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                            <!--    'column_alias': 'instant_bookings'}                                                              -->
+                            <!-- col2 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                            <!--    'column_alias': 'booking_value'}                         -->
+                            <!-- col3 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                            <!--    'column_alias': 'max_booking_value'}                     -->
+                            <!-- col4 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                            <!--    'column_alias': 'min_booking_value'}                     -->
+                            <!-- col5 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                            <!--    'column_alias': 'bookers'}                               -->
+                            <!-- col6 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                            <!--    'column_alias': 'average_booking_value'}                 -->
+                            <!-- col7 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                            <!--    'column_alias': 'booking_payments'}                      -->
+                            <!-- col8 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                            <!--    'column_alias': 'is_instant'}                            -->
+                            <!-- col9 =                                                      -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                            <!--    'column_alias': 'ds'}                                    -->
+                            <!-- col10 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                            <!--    'column_alias': 'ds__week'}                        -->
+                            <!-- col11 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                            <!--    'column_alias': 'ds__month'}                       -->
+                            <!-- col12 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                            <!--    'column_alias': 'ds__quarter'}                     -->
+                            <!-- col13 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                            <!--    'column_alias': 'ds__year'}                        -->
+                            <!-- col14 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                        -->
+                            <!-- col15 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}            -->
+                            <!-- col16 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}           -->
+                            <!-- col17 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                            <!-- col18 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}            -->
+                            <!-- col19 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                            <!--    'column_alias': 'booking_paid_at'}                       -->
+                            <!-- col20 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                            <!--    'column_alias': 'booking_paid_at__week'}           -->
+                            <!-- col21 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                            <!--    'column_alias': 'booking_paid_at__month'}          -->
+                            <!-- col22 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                            <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                            <!-- col23 =                                               -->
+                            <!--   {'class': 'SqlSelectColumn',                        -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                            <!--    'column_alias': 'booking_paid_at__year'}           -->
+                            <!-- col24 =                                                             -->
                             <!--   {'class': 'SqlSelectColumn',                                      -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_569),            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),          -->
                             <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                            <!-- col39 =                                                   -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_567),  -->
-                            <!--    'column_alias': 'booking_payments'}                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                            <!-- col25 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10033),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                            <!-- col26 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                            <!-- col27 =                                                            -->
+                            <!--   {'class': 'SqlSelectColumn',                                     -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                            <!-- col28 =                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                       -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                            <!-- col29 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                            <!-- col30 =                                                                 -->
+                            <!--   {'class': 'SqlSelectColumn',                                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                            <!-- col31 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                            <!-- col32 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                            <!-- col33 =                                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                                   -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                            <!-- col34 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                            <!-- col35 =                                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),               -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                            <!-- col36 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                            <!-- col37 =                                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                                  -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                            <!-- col38 =                                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                                    -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                            <!-- col39 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col40 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
+                            <!--    'column_alias': 'listing'}                               -->
+                            <!-- col41 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
+                            <!--    'column_alias': 'guest'}                                 -->
+                            <!-- col42 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
+                            <!--    'column_alias': 'host'}                                  -->
+                            <!-- col43 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                            <!-- col44 =                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                            <!-- col45 =                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),     -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                            <!-- col46 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),    -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                            <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
                             <!-- where = None -->
-                            <SqlSelectStatementNode>
-                                <!-- description = Read Elements From Data Source 'bookings_source' -->
-                                <!-- node_id = ss_10001 -->
-                                <!-- col0 =                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
-                                <!--    'column_alias': 'bookings'}                                 -->
-                                <!-- col1 =                                                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
-                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
-                                <!--    'column_alias': 'instant_bookings'}                                                              -->
-                                <!-- col2 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10009),  -->
-                                <!--    'column_alias': 'booking_value'}                         -->
-                                <!-- col3 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
-                                <!--    'column_alias': 'max_booking_value'}                     -->
-                                <!-- col4 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
-                                <!--    'column_alias': 'min_booking_value'}                     -->
-                                <!-- col5 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
-                                <!--    'column_alias': 'bookers'}                               -->
-                                <!-- col6 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
-                                <!--    'column_alias': 'average_booking_value'}                 -->
-                                <!-- col7 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
-                                <!--    'column_alias': 'booking_payments'}                      -->
-                                <!-- col8 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
-                                <!--    'column_alias': 'is_instant'}                            -->
-                                <!-- col9 =                                                      -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
-                                <!--    'column_alias': 'ds'}                                    -->
-                                <!-- col10 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
-                                <!--    'column_alias': 'ds__week'}                        -->
-                                <!-- col11 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
-                                <!--    'column_alias': 'ds__month'}                       -->
-                                <!-- col12 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
-                                <!--    'column_alias': 'ds__quarter'}                     -->
-                                <!-- col13 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
-                                <!--    'column_alias': 'ds__year'}                        -->
-                                <!-- col14 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
-                                <!--    'column_alias': 'ds_partitioned'}                        -->
-                                <!-- col15 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
-                                <!--    'column_alias': 'ds_partitioned__week'}            -->
-                                <!-- col16 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
-                                <!--    'column_alias': 'ds_partitioned__month'}           -->
-                                <!-- col17 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
-                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
-                                <!-- col18 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
-                                <!--    'column_alias': 'ds_partitioned__year'}            -->
-                                <!-- col19 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10026),  -->
-                                <!--    'column_alias': 'booking_paid_at'}                       -->
-                                <!-- col20 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
-                                <!--    'column_alias': 'booking_paid_at__week'}           -->
-                                <!-- col21 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
-                                <!--    'column_alias': 'booking_paid_at__month'}          -->
-                                <!-- col22 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
-                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
-                                <!-- col23 =                                               -->
-                                <!--   {'class': 'SqlSelectColumn',                        -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
-                                <!--    'column_alias': 'booking_paid_at__year'}           -->
-                                <!-- col24 =                                                             -->
-                                <!--   {'class': 'SqlSelectColumn',                                      -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10031),          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
-                                <!-- col25 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
-                                <!-- col26 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
-                                <!-- col27 =                                                            -->
-                                <!--   {'class': 'SqlSelectColumn',                                     -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
-                                <!-- col28 =                                                              -->
-                                <!--   {'class': 'SqlSelectColumn',                                       -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
-                                <!-- col29 =                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
-                                <!-- col30 =                                                                 -->
-                                <!--   {'class': 'SqlSelectColumn',                                          -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
-                                <!-- col31 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
-                                <!-- col32 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
-                                <!-- col33 =                                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                                   -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
-                                <!-- col34 =                                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                                -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
-                                <!-- col35 =                                                                  -->
-                                <!--   {'class': 'SqlSelectColumn',                                           -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10042),               -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
-                                <!-- col36 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
-                                <!-- col37 =                                                                         -->
-                                <!--   {'class': 'SqlSelectColumn',                                                  -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
-                                <!-- col38 =                                                                           -->
-                                <!--   {'class': 'SqlSelectColumn',                                                    -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
-                                <!-- col39 =                                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                                 -->
-                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
-                                <!-- col40 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10047),  -->
-                                <!--    'column_alias': 'listing'}                               -->
-                                <!-- col41 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),  -->
-                                <!--    'column_alias': 'guest'}                                 -->
-                                <!-- col42 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10049),  -->
-                                <!--    'column_alias': 'host'}                                  -->
-                                <!-- col43 =                                                     -->
-                                <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10050),  -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
-                                <!-- col44 =                                                          -->
-                                <!--   {'class': 'SqlSelectColumn',                                   -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10051),       -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
-                                <!-- col45 =                                                        -->
-                                <!--   {'class': 'SqlSelectColumn',                                 -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10052),     -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
-                                <!-- col46 =                                                       -->
-                                <!--   {'class': 'SqlSelectColumn',                                -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),    -->
-                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
-                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
-                                <!-- where = None -->
-                                <SqlSelectQueryFromClauseNode>
-                                    <!-- description = Read From a Select Query -->
-                                    <!-- node_id = tfc_10001 -->
-                                </SqlSelectQueryFromClauseNode>
-                            </SqlSelectStatementNode>
+                            <SqlSelectQueryFromClauseNode>
+                                <!-- description = Read From a Select Query -->
+                                <!-- node_id = tfc_10001 -->
+                            </SqlSelectQueryFromClauseNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_query__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -16,6 +15,6 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_1
-) subq_3
+) subq_2
 GROUP BY
   ds

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/BigQuerySqlClient/test_render_write_to_table_query__query0.sql
@@ -6,7 +6,6 @@ CREATE TABLE ***************************.test_table AS (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ CREATE TABLE ***************************.test_table AS (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_1
-  ) subq_3
+  ) subq_2
   GROUP BY
     ds
 )

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_query__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -16,6 +15,6 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_1
-) subq_3
+) subq_2
 GROUP BY
   ds

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/DuckDbSqlClient/test_render_write_to_table_query__query0.sql
@@ -6,7 +6,6 @@ CREATE TABLE ***************************.test_table AS (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ CREATE TABLE ***************************.test_table AS (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_1
-  ) subq_3
+  ) subq_2
   GROUP BY
     ds
 )

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_query__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -16,6 +15,6 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_1
-) subq_3
+) subq_2
 GROUP BY
   ds

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/PostgresSqlClient/test_render_write_to_table_query__query0.sql
@@ -6,7 +6,6 @@ CREATE TABLE ***************************.test_table AS (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ CREATE TABLE ***************************.test_table AS (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_1
-  ) subq_3
+  ) subq_2
   GROUP BY
     ds
 )

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_query__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -16,6 +15,6 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_1
-) subq_3
+) subq_2
 GROUP BY
   ds

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/RedshiftSqlClient/test_render_write_to_table_query__query0.sql
@@ -6,7 +6,6 @@ CREATE TABLE ***************************.test_table AS (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ CREATE TABLE ***************************.test_table AS (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_1
-  ) subq_3
+  ) subq_2
   GROUP BY
     ds
 )

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_query__query0.sql
@@ -5,7 +5,6 @@ SELECT
   , SUM(bookings) AS bookings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
-  -- Pass Only Additive Measures
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements:
   --   ['bookings', 'ds']
@@ -16,6 +15,6 @@ FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_1
-) subq_3
+) subq_2
 GROUP BY
   ds

--- a/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_write_to_table_query__query0.sql
+++ b/metricflow/test/snapshots/test_rendered_query.py/MetricFlowExplainResult/SnowflakeSqlClient/test_render_write_to_table_query__query0.sql
@@ -6,7 +6,6 @@ CREATE TABLE ***************************.test_table AS (
     , SUM(bookings) AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
-    -- Pass Only Additive Measures
     -- Metric Time Dimension 'ds'
     -- Pass Only Elements:
     --   ['bookings', 'ds']
@@ -17,7 +16,7 @@ CREATE TABLE ***************************.test_table AS (
       -- User Defined SQL Query
       SELECT * FROM ***************************.fct_bookings
     ) bookings_source_src_1
-  ) subq_3
+  ) subq_2
   GROUP BY
     ds
 )


### PR DESCRIPTION
## Extension of https://github.com/transform-data/metricflow/pull/183
Previously, we supported semi-additive measures in a way that you would only be allowed to take the non-additive dimension and perform a MIN/MAX aggregation against the full time range and get values from that big "window". In this PR, we break this down such that if the `non_additive_dimension` is passed in the query as a group by, it would do a `GROUP BY` in the inner query which enables us to have `windows` of the granularity passed in the query.

These are the two scenarios 
- `query --metrics ... --dimensions non_additive_dim(__week/__month/__year)`
    - Uses the granularity of `non_additive_dim` as the window to perform min/max
- `query --metrics ... --dimensions dim1 (--where non_additive_dim between X AND Y)`
    - Does a min/max of the full window (either `FULL RANGE` or between `X and Y`)

## Changes
- defaulted `window_choice` to `MIN` instead of required
- Added the ability to group by a TimeDimension in the `SemiAdditiveJoinNode` inner query so that we can perform window filters on different granularity windows instead of just on the full time range.
- Refactored the way we build the `SemiAdditiveJoinNode`
  - Reverted the changes in `SourceNodeBuilder`
  - Build the `SemiAdditiveJoinNode` in the `DataflowPlanBuilder` so that we can alter the node depending on the query spec
  - This also fixes the bug in which constraints was not working properly for semi additive measures

## Examples
```
if we have a data set that includes "account_balances,user,date", we can build a
"latest_account_balance_by_user" data set using this node by filtering the data set such that for each user,
we get the MAX(date) and return the account_balance corresponding to that date.

Data transformation example,
| date       | account_balance | user |                             | date       | account_balance | user |
|:-----------|-----------------|-----:|     identifier_specs:       |:-----------|-----------------|-----:|
| 2019-12-31 |            1000 |    u1|       - user                | 2020-01-03 |            2000 |    u1|
| 2020-01-03 |            2000 |    u1| ->  time_dimension_spec: -> | 2020-01-12              1500 |    u2|
| 2020-01-09 |            3000 |    u2|       - date                | 2020-01-12 |            1000 |    u3|
| 2020-01-12 |            1500 |    u2|     agg_by_function:
| 2020-01-12 |            1000 |    u3|       - MAX


Similarly, if we don't provide any identifier_specs, it would end up performing the aggregation filter only on the
time_dimension_spec without any grouping by any identifiers.

Data transformation example,
| date       | account_balance | user |                             | date       | account_balance |
|:-----------|-----------------|-----:|     identifier_specs:       |:-----------|----------------:|
| 2019-12-31 |            1000 |    u1|                             | 2020-01-12 |            2500 |
| 2020-01-03 |            2000 |    u1| ->  time_dimension_spec: ->
| 2020-01-09 |            3000 |    u2|       - date
| 2020-01-12 |            1500 |    u2|     agg_by_function:
| 2020-01-12 |            1000 |    u3|       - MAX


Additionally, we can aggregate against 'windows' of a dataset. For example, if we group by a non_additive time dimension,
we perform the MIN/MAX filtering on the granularity window provided in that group by instead of the full time range.

Data transformation example,
| date       | account_balance | user |                                  | date       | account_balance |
|:-----------|-----------------|-----:|     identifier_specs:            |:-----------|----------------:|
| 2019-12-31 |            1500 |    u1|     time_dimension_spec:         | 2019-12-31 |            1500 |
| 2020-01-03 |            2000 |    u1| ->    - date                  -> | 2020-01-07 |            3000 |
| 2020-01-09 |            3000 |    u2|     agg_by_function:             | 2020-01-14 |            3250 |
| 2020-01-12 |            1500 |    u2|       - MIN
| 2020-01-14 |            1250 |    u3|     queried_time_dimension_spec:
| 2020-01-14 |            2000 |    u2|       - date__week
| 2020-01-15 |            4000 |    u1|
```