### PR TITLE
Enumerate Future SQL Engines

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -49,7 +49,7 @@ from metricflow.inference.runner import InferenceProgressReporter, InferenceRunn
 from metricflow.model.data_warehouse_model_validator import DataWarehouseModelValidator
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.protocols.sql_client import SupportedSqlEngine
+from metricflow.protocols.sql_client import SqlEngine
 from metricflow.engine.utils import model_build_result_from_config, path_to_models
 from metricflow.model.parsing.config_linter import ConfigLinter
 from metricflow.model.validations.validator_helpers import ModelValidationResults
@@ -943,7 +943,7 @@ def infer(
         " If you find any bugs or feel like something is not behaving as it should, feel free to open an issue on the Metricflow Github repo: https://github.com/transform-data/metricflow/issues \n"
     )
 
-    if cfg.sql_client.sql_engine_attributes.sql_engine_type is not SupportedSqlEngine.SNOWFLAKE:
+    if cfg.sql_client.sql_engine_attributes.sql_engine_type is not SqlEngine.SNOWFLAKE:
         click.echo(
             "Data Source Inference is currently only supported for Snowflake. "
             "We will add support for all the other warehouses before it becomes a "

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -63,7 +63,7 @@ from metricflow.plan_conversion.spec_transforms import (
 )
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.protocols.sql_client import SqlEngineAttributes, SupportedSqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes, SqlEngine
 from metricflow.specs import (
     ColumnAssociationResolver,
     MetricSpec,
@@ -1320,7 +1320,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
 
         # TODO: Make this a more generally accessible attribute instead of checking against the
         # BigQuery-ness of the engine
-        use_column_alias_in_group_by = sql_engine_attributes.sql_engine_type is SupportedSqlEngine.BIGQUERY
+        use_column_alias_in_group_by = sql_engine_attributes.sql_engine_type is SqlEngine.BIGQUERY
 
         for optimizer in SqlQueryOptimizerConfiguration.optimizers_for_level(
             optimization_level, use_column_alias_in_group_by=use_column_alias_in_group_by

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -10,8 +10,8 @@ from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from pandas import DataFrame
 
 
-class SupportedSqlEngine(Enum):
-    """Enumeration of DB engines currently supported by MetricFlow"""
+class SqlEngine(Enum):
+    """Enumeration of SQL engines, including ones that are not yet supported."""
 
     BIGQUERY = "BigQuery"
     DUCKDB = "DuckDB"
@@ -19,6 +19,9 @@ class SupportedSqlEngine(Enum):
     POSTGRES = "Postgres"
     SNOWFLAKE = "Snowflake"
     DATABRICKS = "Databricks"
+
+    # Not yet supported.
+    MYSQL = "MySQL"
 
 
 class SqlClient(Protocol):
@@ -163,7 +166,7 @@ class SqlEngineAttributes(Protocol):
     caused by changes to the protocol itself when inheritance is used.
     """
 
-    sql_engine_type: ClassVar[SupportedSqlEngine]
+    sql_engine_type: ClassVar[SqlEngine]
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool]

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Optional, List
 
 import sqlalchemy
 
-from metricflow.protocols.sql_client import SupportedSqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
 from metricflow.sql.render.big_query import BigQuerySqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -19,7 +19,7 @@ class BigQueryEngineAttributes:
     This is an implementation of the SqlEngineAttributes protocol for BigQuery
     """
 
-    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.BIGQUERY
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.BIGQUERY
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -10,7 +10,7 @@ from databricks import sql
 
 from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.base_sql_client_implementation import BaseSqlClientImplementation
-from metricflow.protocols.sql_client import SqlEngineAttributes, SupportedSqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes, SqlEngine
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
@@ -35,7 +35,7 @@ PANDAS_TO_SQL_DTYPES = {
 class DatabricksEngineAttributes(SqlEngineAttributes):
     """SQL engine attributes for Databricks."""
 
-    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.DATABRICKS
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DATABRICKS
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -7,7 +7,7 @@ import sqlalchemy
 from sqlalchemy.pool import StaticPool
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.protocols.sql_client import SupportedSqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
 from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class DuckDbEngineAttributes(SqlEngineAttributes):
     """Engine-specific attributes for the DuckDb query engine"""
 
-    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.DUCKDB
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DUCKDB
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -2,7 +2,7 @@ import logging
 from typing import ClassVar, Mapping, Optional, Sequence, Union
 
 import sqlalchemy
-from metricflow.protocols.sql_client import SqlEngineAttributes, SupportedSqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes, SqlEngine
 from metricflow.sql.render.postgres import PostgresSQLSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
@@ -17,7 +17,7 @@ class PostgresEngineAttributes(SqlEngineAttributes):
     This is an implementation of the SqlEngineAttributes protocol for Postgres
     """
 
-    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.POSTGRES
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.POSTGRES
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -3,7 +3,7 @@ from typing import ClassVar, Optional, Mapping, Union, Sequence
 
 import sqlalchemy
 
-from metricflow.protocols.sql_client import SupportedSqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
 from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
@@ -18,7 +18,7 @@ class RedshiftEngineAttributes(SqlEngineAttributes):
     This is an implementation of the SqlEngineAttributes protocol for Redshift
     """
 
-    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.REDSHIFT
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.REDSHIFT
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -10,7 +10,7 @@ import pandas as pd
 import sqlalchemy
 from sqlalchemy.exc import ProgrammingError
 
-from metricflow.protocols.sql_client import SupportedSqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -24,7 +24,7 @@ class SnowflakeEngineAttributes(SqlEngineAttributes):
     This is an implementation of the SqlEngineAttributes protocol for Snowflake
     """
 
-    sql_engine_type: ClassVar[SupportedSqlEngine] = SupportedSqlEngine.SNOWFLAKE
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.SNOWFLAKE
 
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.object_utils import assert_values_exhausted, random_id
-from metricflow.protocols.sql_client import SqlClient, SupportedSqlEngine
+from metricflow.protocols.sql_client import SqlClient, SqlEngine
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_clients.sql_utils import make_df
 from metricflow.test.compare_df import assert_dataframes_equal
@@ -144,9 +144,9 @@ def test_dry_run_of_bad_query_raises_exception(sql_client: SqlClient) -> None:  
 def _issue_sleep_query(sql_client: SqlClient, sleep_time: int) -> None:
     """Issue a query that sleeps for a given number of seconds"""
     engine_type = sql_client.sql_engine_attributes.sql_engine_type
-    if engine_type == SupportedSqlEngine.SNOWFLAKE:
+    if engine_type == SqlEngine.SNOWFLAKE:
         sql_client.execute(f"CALL system$wait({sleep_time}, 'SECONDS')")
-    elif engine_type in (SupportedSqlEngine.BIGQUERY, SupportedSqlEngine.REDSHIFT, SupportedSqlEngine.DATABRICKS):
+    elif engine_type in (SqlEngine.BIGQUERY, SqlEngine.REDSHIFT, SqlEngine.DATABRICKS):
         raise RuntimeError(f"Sleep yet not supported with {engine_type}")
 
     assert_values_exhausted(engine_type)
@@ -155,13 +155,13 @@ def _issue_sleep_query(sql_client: SqlClient, sleep_time: int) -> None:
 def _supports_sleep_query(sql_client: SqlClient) -> bool:
     """Returns true if the given SQL client is supported by _issue_sleep_query()"""
     engine_type = sql_client.sql_engine_attributes.sql_engine_type
-    if engine_type == SupportedSqlEngine.SNOWFLAKE:
+    if engine_type == SqlEngine.SNOWFLAKE:
         return True
     elif engine_type in (
-        SupportedSqlEngine.DUCKDB,
-        SupportedSqlEngine.BIGQUERY,
-        SupportedSqlEngine.REDSHIFT,
-        SupportedSqlEngine.DATABRICKS,
+        SqlEngine.DUCKDB,
+        SqlEngine.BIGQUERY,
+        SqlEngine.REDSHIFT,
+        SqlEngine.DATABRICKS,
     ):
         return False
 
@@ -189,7 +189,7 @@ def test_cancel_submitted_queries(  # noqa: D
     timer_task = threading.Timer(0.5, cancel_submitted_queries)
     timer_task.start()
     with pytest.raises(ProgrammingError):
-        if sql_client.sql_engine_attributes.sql_engine_type == SupportedSqlEngine.SNOWFLAKE:
+        if sql_client.sql_engine_attributes.sql_engine_type == SqlEngine.SNOWFLAKE:
             _issue_sleep_query(sql_client, 5)
 
 


### PR DESCRIPTION
This PR adds enumerations for SQL engines that are not yet supported. There are some intermediate development uses cases where this is helpful.