### PR TITLE
Added Validator for non_additive_dimension property

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -19,6 +19,7 @@ from metricflow.model.validations.measures import (
     DataSourceMeasuresUniqueRule,
     MeasureConstraintAliasesRule,
     MetricMeasuresRule,
+    MeasuresNonAdditiveDimensionRule,
 )
 from metricflow.model.validations.metrics import CumulativeMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
@@ -52,6 +53,7 @@ class ModelValidator:
         ValidMaterializationRule(),
         AggregationTimeDimensionRule(),
         ReservedKeywordsRule(),
+        MeasuresNonAdditiveDimensionRule(),
     )
 
     def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES, max_workers: int = 1) -> None:


### PR DESCRIPTION
## Context
_This should be merged after this https://github.com/transform-data/metricflow/pull/253 goes in._ **actually this can be merged prior to this**

With the addition to semi-additive measures. We introduced a new `non_additive_dimension` property on measures. There are a few cases in which we need to validate such that the config is correct and ensures that the resultant query that is built is well-formed. There are 3 cases in that needs to be validated for a valid `non_additive_dimension`

1. `non_additive_dimension.name` must be a valid time-dimension in the data source
2. `non_additive_dimension.window_choice` must be either `min` or `max`
3. `non_additive_dimension_window_groupings` must be valid identifiers in the data source