### PR TITLE
Enable the ability to not pass dimensions in interfaces

### DIFF
--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -78,7 +78,7 @@ class MetricFlowClient:
     def _create_mf_request(
         self,
         metrics: List[str],
-        dimensions: List[str],
+        dimensions: List[str] = [],
         limit: Optional[int] = None,
         start_time: Optional[str] = None,
         end_time: Optional[str] = None,
@@ -106,7 +106,7 @@ class MetricFlowClient:
     def query(
         self,
         metrics: List[str],
-        dimensions: List[str],
+        dimensions: List[str] = [],
         limit: Optional[int] = None,
         start_time: Optional[str] = None,
         end_time: Optional[str] = None,
@@ -147,7 +147,7 @@ class MetricFlowClient:
     def explain(
         self,
         metrics: List[str],
-        dimensions: List[str],
+        dimensions: List[str] = [],
         limit: Optional[int] = None,
         start_time: Optional[str] = None,
         end_time: Optional[str] = None,

--- a/metricflow/cli/custom_click_types.py
+++ b/metricflow/cli/custom_click_types.py
@@ -51,6 +51,9 @@ class SequenceParamType(click.ParamType, Generic[T]):
     def convert(  # noqa: D
         self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]
     ) -> Sequence[T]:
+        if len(value) == 0:
+            return []
+
         str_values = value.split(self.separator)
 
         if len(str_values) < self.min_length:

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -316,7 +316,7 @@ def tutorial(ctx: click.core.Context, cfg: CLIContext, msg: bool, skip_dw: bool,
 def query(
     cfg: CLIContext,
     metrics: List[str],
-    dimensions: List[str],
+    dimensions: List[str] = [],
     where: Optional[str] = None,
     start_time: Optional[dt.datetime] = None,
     end_time: Optional[dt.datetime] = None,

--- a/metricflow/cli/utils.py
+++ b/metricflow/cli/utils.py
@@ -127,6 +127,7 @@ def query_options(function: Callable) -> Callable:
     function = click.option(
         "--dimensions",
         type=click_custom.SequenceParamType(),
+        default="",
         help="Dimensions to group by: syntax is --dimensions ds or for multiple dimensions --dimensions ds,org",
     )(function)
     function = click.option(

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -608,6 +608,12 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         if len(output_nodes) == 1:
             return output_nodes[0]
         else:
+            if len(queried_linkable_specs.as_tuple) == 0:
+                raise NotImplementedError(
+                    "Querying metrics that require a join with no dimensions is not yet supported."
+                    "This can happen with a metric that pulls measures from different data sources, "
+                    "or a metric that pulls measures with different constraints or non-additive dimension specifications."
+                )
             return FilterElementsNode(
                 parent_node=JoinAggregatedMeasuresByGroupByColumnsNode(parent_nodes=output_nodes),
                 include_specs=LinkableInstanceSpec.merge(

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -208,6 +208,9 @@ class MetricFlowQueryParser:
             where_constraint and where_constraint_str
         ), "Both where_constraint and where_constraint_str should not be set"
 
+        if len(group_by_names) == 0:
+            assert len(metric_names) == 1, "Querying for multiple metrics with no dimensions is not yet supported."
+
         parsed_where_constraint: Optional[WhereClauseConstraint]
         if where_constraint_str:
             parsed_where_constraint = WhereClauseConstraint.parse(where_constraint_str)

--- a/metricflow/test/integration/test_cases/itest_simple.yaml
+++ b/metricflow/test/integration/test_cases/itest_simple.yaml
@@ -14,6 +14,43 @@ integration_test:
       is_instant
 ---
 integration_test:
+  name: simple_query_with_no_group_bys
+  description: Tests selecting a metric with no group bys.
+  model: SIMPLE_MODEL
+  metrics: ["booking_value"]
+  group_bys: []
+  check_query: |
+    SELECT
+      SUM(booking_value) AS booking_value
+    FROM {{ source_schema }}.fct_bookings
+---
+integration_test:
+  name: simple_query_with_no_group_bys_time_constraint
+  description: Tests selecting a metric with no group bys and a time constraint.
+  model: SIMPLE_MODEL
+  metrics: ["booking_value"]
+  time_constraint: ["2020-01-01", "2020-01-01"]
+  group_bys: []
+  check_query: |
+    SELECT
+      SUM(booking_value) AS booking_value
+    FROM {{ source_schema }}.fct_bookings
+    WHERE {{ render_time_constraint("ds", "2020-01-01", "2020-01-01") }}
+---
+integration_test:
+  name: simple_query_with_no_group_bys_where_constraint
+  description: Tests selecting a metric with no group bys and a where constraint.
+  model: SIMPLE_MODEL
+  metrics: ["booking_value"]
+  group_bys: []
+  where_constraint: "is_instant"
+  check_query: |
+    SELECT
+      SUM(booking_value) AS booking_value
+    FROM {{ source_schema }}.fct_bookings
+    WHERE is_instant
+---
+integration_test:
   name: simple_query_without_dates_available
   description: Tests selecting a metric and the time dimension with a time constraint.
   model: SIMPLE_MODEL


### PR DESCRIPTION
## Context
Currently, all the interfaces requires dimensions to be a non-empty list of inputs. This should not be the case as it is possible to not pass any dimension which outputs a metric without any group by dimension and returns an aggregate value of just the metric.

### Changes
- In `MetricFlowClient`, remove the requirement of a non-empty dimension input
- In the CLI, remove the requirement of a non-empty dimension input
- Restrict the ability to query for multiple metrics with no group bys due to a bug (Will re-enable once we implement cross join)