### PR TITLE
Add tags to locked_metadata

### DIFF
--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -321,6 +321,12 @@
                 "increase_is_good": {
                     "type": "boolean"
                 },
+                "tags": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "tier": {
                     "type": [
                         "string",

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -66,6 +66,10 @@ locked_metadata_schema = {
         "display_name": {"type": "string"},
         "tier": {"type": ["string", "integer"]},
         "increase_is_good": {"type": "boolean"},
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
     },
     "additionalProperties": False,
 }

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -227,6 +227,9 @@ metric:
   type: cumulative
   locked_metadata:
     value_format: "$$,.2f" # we need to double dollars here since string template reserves dollar sign.
+    tags:
+      - "Finance"
+      - "Monthly"
   type_params:
     measures:
       - txn_revenue
@@ -241,6 +244,8 @@ metric:
   constraint: lux_or_normal_listing != 'LUX_TEST_ID'
   locked_metadata:
     value_format: ""
+    tags:
+      - "Listings"
   type_params:
     measures:
       - listings
@@ -276,6 +281,9 @@ metric:
   type: expr
   locked_metadata:
     value_format: ",d"
+    tags:
+      - "Bookings"
+      - "Views"
   type_params:
     expr: "booking_value * views"
     measures:
@@ -293,6 +301,9 @@ metric:
     denominator: bookers
   locked_metadata:
     value_format: ",.2f"
+    tags:
+      - "Bookings"
+      - "Bookers"
 ---
 metric:
   name: bookings_per_view
@@ -305,6 +316,9 @@ metric:
     denominator: views
   locked_metadata:
     value_format: ",.2f"
+    tags:
+      - "Bookings"
+      - "Views"
 ---
 metric:
   name: bookings_per_listing
@@ -314,6 +328,9 @@ metric:
   type: ratio
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Bookings"
+      - "Listings"
   type_params:
     numerator: bookings
     denominator: listings
@@ -326,6 +343,9 @@ metric:
   type: ratio
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Bookings"
+      - "Finance"
   type_params:
     numerator: bookings
     denominator: booking_value
@@ -360,6 +380,8 @@ metric:
   type: ratio
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Bookings"
   type_params:
     numerator:
       name: average_booking_value
@@ -377,6 +399,9 @@ metric:
   type: ratio
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Bookings"
+      - "Lux"
   type_params:
     numerator:
       name: average_booking_value
@@ -394,6 +419,9 @@ metric:
   type: expr
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Bookings"
+      - "Lux"
   type_params:
     expr: "average_booking_value * bookings / NULLIF(booking_value, 0)"
     measures:
@@ -413,6 +441,8 @@ metric:
   type: ratio
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Bookings"
   type_params:
     numerator:
       name: booking_value
@@ -431,6 +461,8 @@ metric:
   type: ratio
   locked_metadata:
     value_format: ".2%"
+    tags:
+      - "Finance"
   type_params:
     numerator:
       name: total_account_balance_first_day


### PR DESCRIPTION
**NOTE**
Transform's internal schema, `schemas_internal.py`, is in MetricFlow. We might one day change that, but for the time being it is where it is. Which means to modify `schemas_internal.py` we have to do so in MetricFlow.

# What's Changed
This PR adds a concept of tags to `locked_metadata` of `schemas_internal.py` for internal metric tagging functionality we're working on.