### PR TITLE
BUG: use metric_time instead of ds

### DIFF
--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -115,30 +115,30 @@ integration_test:
   description: Tests selecting a semi-additive measure with a group by window
   model: SIMPLE_MODEL
   metrics: ["total_account_balance_first_day"]
-  group_bys: ["ds__week"]
+  group_bys: ["metric_time__week"]
   check_query: |
     SELECT
-      a.ds__week
+      a.metric_time__week
       , SUM(a.total_account_balance_first_day) AS total_account_balance_first_day
     FROM (
       SELECT
         ds
-        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS ds__week
+        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS metric_time__week
         , account_balance AS total_account_balance_first_day
       FROM {{ source_schema }}.fct_accounts
     ) a
     INNER JOIN (
       SELECT
         MIN(ds) AS ds
-        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS ds__week
+        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS metric_time__week
       FROM {{ source_schema }}.fct_accounts
       GROUP BY
-        ds__week
+        metric_time__week
     ) b
     ON
       a.ds = b.ds
     GROUP BY
-      a.ds__week
+      a.metric_time__week
 ---
 integration_test:
   name: semi_additive_measure_query_with_where_constraint

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -205,8 +205,7 @@ def test_case(
     )
 
     actual = query_result.result_df
-    print(actual)
-    print(query_result.sql)
+
     expected = sql_client.query(
         jinja2.Template(case.check_query, undefined=jinja2.StrictUndefined,).render(
             source_schema=mf_test_session_state.mf_source_schema,


### PR DESCRIPTION
### Context
We want to support the use of `metric_time` instead of `ds` in queries when we pass it as a dimension.