### PR TITLE
BUG: window_groupings should not need to be in query dimensions

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -658,10 +658,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             )
         if non_additive_dimension_spec:
             extraneous_linkable_specs = LinkableSpecSet.merge(
-                (
-                    extraneous_linkable_specs,
-                    LinkableSpecSet(time_dimension_specs=(non_additive_dimension_spec.as_time_dimension_spec,)),
-                )
+                (extraneous_linkable_specs, non_additive_dimension_spec.linkable_specs)
             )
 
         required_linkable_specs = LinkableSpecSet.merge((queried_linkable_specs, extraneous_linkable_specs))

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -303,8 +303,14 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
         return hash_strings(values)
 
     @property
-    def as_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D
-        return TimeDimensionSpec.from_name(self.name)
+    def linkable_specs(self) -> LinkableSpecSet:  # noqa: D
+        return LinkableSpecSet(
+            dimension_specs=(),
+            time_dimension_specs=(TimeDimensionSpec.from_name(self.name),),
+            identifier_specs=tuple(
+                LinklessIdentifierSpec.from_element_name(identifier_name) for identifier_name in self.window_groupings
+            ),
+        )
 
     def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
         if not isinstance(other, NonAdditiveDimensionSpec):
@@ -337,16 +343,6 @@ class MeasureSpec(InstanceSpec):  # noqa: D
     @property
     def as_reference(self) -> MeasureReference:  # noqa: D
         return MeasureReference(element_name=self.element_name)
-
-    @property
-    def linkable_specs(self) -> LinkableSpecSet:  # noqa: D
-        return LinkableSpecSet(
-            dimension_specs=(),
-            time_dimension_specs=(self.non_additive_dimension_spec.as_time_dimension_spec,)
-            if self.non_additive_dimension_spec
-            else (),
-            identifier_specs=(),
-        )
 
 
 @dataclass(frozen=True)

--- a/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
+++ b/metricflow/test/integration/test_cases/itest_semi_additive_measure.yaml
@@ -30,6 +30,40 @@ integration_test:
       a.user
 ---
 integration_test:
+  name: semi_additive_measure_query_with_identifier_grouping_no_group_by
+  description: |
+    Tests selecting a measure with semi additive properties with a window_grouping that are not in the query group by
+  model: SIMPLE_MODEL
+  metrics: ["current_account_balance_by_user"]
+  group_bys: ["metric_time__week"]
+  check_query: |
+    SELECT
+      a.metric_time__week
+      , SUM(a.current_account_balance_by_user) AS current_account_balance_by_user
+    FROM (
+      SELECT
+        ds
+        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS metric_time__week
+        , user_id AS user
+        , account_balance AS current_account_balance_by_user
+      FROM {{ source_schema }}.fct_accounts
+    ) a
+    INNER JOIN (
+      SELECT
+        user_id AS user
+        , {{ render_date_trunc("ds", TimeGranularity.WEEK) }} AS metric_time__week
+        , MAX(ds) AS ds
+      FROM {{ source_schema }}.fct_accounts
+      GROUP BY
+        metric_time__week
+        , user_id
+    ) b
+    ON
+      a.ds = b.ds AND a.user = b.user
+    GROUP BY
+      a.metric_time__week
+---
+integration_test:
   name: semi_additive_measure_query
   description: Tests selecting a measure with semi additive properties
   model: SIMPLE_MODEL


### PR DESCRIPTION
### Context
Currently for a semi-additive measure, we can optionally add a set of identifiers to designate the grain to apply the non-additive filter. From a recent merge #253, we modified the implementation of where we did this filter join, which caused an edge case bug in which we have a window_grouping that is not passed as a dimension in the query which causes an `Invalid identifier '<one of the window_groupings that was not in query>'` Error.

### Solution
Similar to adding the non-additive dimension as an extraneous linkable spec, we add all the `window_groupings` identifiers to that extraneous_linkable_spec set so that we can reference the identifiers properly during the query.