### PR TITLE
Update Databricks client attribute: indexes aren't supported

### DIFF
--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -32,7 +32,7 @@ class DatabricksEngineAttributes(SqlEngineAttributes):
     # SQL Engine capabilities
     date_trunc_supported: ClassVar[bool] = True
     full_outer_joins_supported: ClassVar[bool] = True
-    indexes_supported: ClassVar[bool] = True
+    indexes_supported: ClassVar[bool] = False
     multi_threading_supported: ClassVar[bool] = True
     timestamp_type_supported: ClassVar[bool] = True
     timestamp_to_string_comparison_supported: ClassVar[bool] = True


### PR DESCRIPTION
Update Databricks client to reflect the fact that indexes are not supported.