### PR TITLE
Improve support for None types in Databricks create_table_from_dataframe

### DIFF
--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -43,7 +43,7 @@ def make_df(  # type: ignore [misc]
             new_row = []
             # Change the type of the column if it's in time_columns
             for i, column in enumerate(columns):
-                if column in time_columns:
+                if column in time_columns and row[i] is not None:
                     # ts_suffix = " 00:00:00" if ":" not in row[i] else ""
                     # ts_input = row[i] + ts_suffix
                     new_row.append(dateutil.parser.parse(row[i]))

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -81,6 +81,9 @@ def test_create_table_from_dataframe(  # noqa: D
         data=[
             (1, "abc", 1.23, False, "2020-01-01"),
             (2, "def", 4.56, True, "2020-01-02"),
+            (3, "ghi", 1.1, False, None),  # Test NaT type
+            (None, "jkl", None, True, "2020-01-03"),  # Test NaN types
+            (3, None, 1.2, None, "2020-01-04"),  # Test None types for NA conversions
         ],
     )
     sql_table = SqlTable(schema_name=mf_test_session_state.mf_source_schema, table_name=_random_table())


### PR DESCRIPTION
In other client implementations of create_table_from_dataframe, we
rely on the pandas.io.sql.to_sql method to convert dataframe types
to SQLAlchemy types and then issue a query via SQLAlchemy. This
uses the infer_dtype method to change any object type columns
into something more refined, since object is assigned by default
to columns containing None type values. The Pandas library also
applies a mask to convert NA types to None, which SQLAlchemy can
then insert as the appropriate null value type.

Our logic only partially covered these cases, with the result that
any None-type input in a numeric or timestamp column would fail to
upload, since Databricks naturally can't understand the `numpy.nan`
or `pandas.NaT` values that result. Worse, without the inference
in place, any boolean type column containing a None value would
be converted to a STRING type in the CREATE TABLE statement logic.

This change addresses both of these problems, and extends our
integration test for create_table_as_dataframe to include None-typed
values as inputs on all of the column types we check.
