### PR TITLE
entity draft

### DIFF
--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -130,9 +130,9 @@ class DataSourceToDataSetConverter:
         identifier_links: Tuple[IdentifierReference, ...],
     ) -> IdentifierInstance:
         """Create an identifier instance from the identifier object from a data sourcein the model."""
-        identifier_spec = IdentifierSpec(
-            element_name=identifier.reference.element_name,
-            identifier_links=identifier_links,
+        identifier_spec = IdentifierSpec.from_reference(
+            identifier.reference,
+            identifier_links,
         )
         column_associations = identifier_spec.column_associations(self._column_association_resolver)
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -332,13 +332,13 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             semantic_model=self._semantic_model,
             time_spine_source=self._time_spine_source,
         )
-        self._to_sql_query_plan_converter = DataflowToSqlQueryPlanConverter[DataSourceDataSet](
+        sql_plan_converter = DataflowToSqlQueryPlanConverter[DataSourceDataSet](
             column_association_resolver=self._column_association_resolver,
             semantic_model=self._semantic_model,
             time_spine_source=self._time_spine_source,
         )
         self._to_execution_plan_converter = DataflowToExecutionPlanConverter[DataSourceDataSet](
-            sql_plan_converter=self._to_sql_query_plan_converter,
+            sql_plan_converter=sql_plan_converter,
             sql_plan_renderer=self._sql_client.sql_engine_attributes.sql_query_plan_renderer,
             sql_client=sql_client,
         )

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -75,4 +75,4 @@ class Identifier(HashableBaseModel, ModelWithMetadataParsing):
 
     @property
     def reference(self) -> IdentifierReference:  # noqa: D
-        return IdentifierReference(element_name=self.name)
+        return IdentifierReference(element_name=self.name, entity=self.entity or self.name)

--- a/metricflow/model/spec_converters.py
+++ b/metricflow/model/spec_converters.py
@@ -98,7 +98,8 @@ class WhereConstraintConverter:
                 else:
                     raise RuntimeError(f"Unhandled type: {dimension.type}")
             elif spec_name.element_name in identifier_references:
-                where_constraint_identifiers.append(IdentifierSpec.from_name(spec_name.qualified_name))
+                reference = identifier_references[spec_name.element_name]
+                where_constraint_identifiers.append(IdentifierSpec.from_reference(reference, ()))
             else:
                 raise InvalidQueryException(f"Unknown element: {spec_name}")
 

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -73,7 +73,7 @@ class DefaultColumnAssociationResolver(ColumnAssociationResolver):
         sub_id_references = []
         for data_source in self._semantic_model.user_configured_model.data_sources:
             for identifier in data_source.identifiers:
-                if identifier.reference.element_name == identifier_spec.element_name:
+                if identifier.reference.entity == identifier_spec.entity:
                     sub_id_references = [sub_id.reference for sub_id in identifier.identifiers]
                     break
 

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -300,7 +300,7 @@ class PreDimensionJoinNodeProcessor(Generic[SqlDataSetT]):
         doesn't mean that the node will be useful, but not having common elements definitely means it's not useful.
         """
         relevant_element_names = {x.element_name for x in desired_linkable_specs}.union(
-            {y.element_name for x in desired_linkable_specs for y in x.identifier_links}
+            {y.entity for x in desired_linkable_specs for y in x.identifier_links}
         )
 
         # The metric time dimension is used everywhere, so don't count it unless specifically desired in linkable spec

--- a/metricflow/plan_conversion/sql_dataset.py
+++ b/metricflow/plan_conversion/sql_dataset.py
@@ -41,8 +41,16 @@ class SqlDataSet(DataSet):
         matching_instances = 0
         column_associations_to_return = None
         for linkable_instance in self.instance_set.identifier_instances:
+            # first try and match on the element name, if it fails, match on entity => element_name
+            # no idea why OOO is not used at all
             if (
                 identifier_spec.element_name == linkable_instance.spec.element_name
+                and identifier_spec.identifier_links == linkable_instance.spec.identifier_links
+            ):
+                column_associations_to_return = linkable_instance.associated_columns
+                matching_instances += 1
+            elif (
+                identifier_spec.entity == linkable_instance.spec.element_name
                 and identifier_spec.identifier_links == linkable_instance.spec.identifier_links
             ):
                 column_associations_to_return = linkable_instance.associated_columns

--- a/metricflow/references.py
+++ b/metricflow/references.py
@@ -37,7 +37,11 @@ class DimensionReference(LinkableElementReference):  # noqa: D
 
 @dataclass(frozen=True)
 class IdentifierReference(LinkableElementReference):  # noqa: D
-    pass
+    entity: str = ""
+
+    def __post_init__(self) -> None:
+        """This enables entity for identifier as we want to use the alias during the resolving but the element_name in the query"""
+        object.__setattr__(self, "entity", self.entity or self.element_name)
 
 
 @dataclass(frozen=True)

--- a/metricflow/spec_set_transforms.py
+++ b/metricflow/spec_set_transforms.py
@@ -12,5 +12,5 @@ class ToElementNameSet(InstanceSpecSetTransform[Set[str]]):
             .union({x.element_name for x in spec_set.measure_specs})
             .union({x.element_name for x in spec_set.dimension_specs})
             .union({x.element_name for x in spec_set.time_dimension_specs})
-            .union({x.element_name for x in spec_set.identifier_specs})
+            .union({x.entity for x in spec_set.identifier_specs})
         )


### PR DESCRIPTION
Very naive draft attempt

### Constraints / problems
1. In the `yaml`, `identifiers` can't have the `name` as an `entity` defined in the `file`. I did not add any checks in the validation part for this. For instance,
```yaml
identifiers:
  - name: reported_at
    entity: date
  - name: date  # this can't exist as `entity == date` exists in the file
```
2. Multi hops and more complex things are not tested nor do I think this handles it

### Results

```
>> dev mf list-dimensions gmv

• created_at__date__is_bfcm
• created_at__date__is_holiday
• created_at__is_bfcm
• created_at__is_holiday
• date_primary
• reported_at__date__is_bfcm
• reported_at__date__is_holiday
• reported_at__is_bfcm
• reported_at__is_holiday
```

and
```
dev mf query --metrics gmv --dimensions reported_at__is_bfcm --explain

SELECT
  date_1_src_1.is_bfcm AS reported_at__is_bfcm
  , SUM(subq_3.included_gmv) AS gmv
FROM (
  SELECT
    CONCAT(_merchant_key, _reported_at_date_key) AS reported_at
    , CASE 
  WHEN reported_gmv_inclusion_status = 'Included in Reported GMV' THEN gmv_adjustment_usd
  ELSE 0
  END
   AS included_gmv
  FROM finance.gmv_adjustment_facts gmv_src_2
) subq_3
LEFT OUTER JOIN
  dims.date_1 date_1_src_1
ON
  subq_3.reported_at = date_1_src_1.date
GROUP BY
  reported_at__is_bfcm
```