### PR TITLE
Centralize Join Validity Logic

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -26,7 +26,7 @@ from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
 from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.execution.executor import SequentialPlanExecutor
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.object_utils import pformat_big_objects, random_id
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_execution import DataflowToExecutionPlanConverter

--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -9,6 +9,7 @@ from typing import List, TypeVar, Generic, Tuple
 from metricflow.aggregation_properties import AggregationState
 from metricflow.column_assoc import ColumnAssociation
 from metricflow.dataclass_serialization import SerializableDataclass
+from metricflow.references import ElementReference
 from metricflow.specs import (
     MeasureSpec,
     DimensionSpec,
@@ -42,10 +43,26 @@ class DataSourceReference(ModelReference):
 
 @dataclass(frozen=True)
 class DataSourceElementReference(ModelReference):
-    """A reference to an element definition in a data source definition in the model."""
+    """A reference to an element definition in a data source definition in the model.
+
+    TODO: Fields should be *Reference objects.
+    """
 
     data_source_name: str
     element_name: str
+
+    @staticmethod
+    def create_from_references(  # noqa: D
+        data_source_reference: DataSourceReference, element_reference: ElementReference
+    ) -> DataSourceElementReference:
+        return DataSourceElementReference(
+            data_source_name=data_source_reference.data_source_name,
+            element_name=element_reference.element_name,
+        )
+
+    @property
+    def data_source_reference(self) -> DataSourceReference:  # noqa: D
+        return DataSourceReference(self.data_source_name)
 
     def is_from(self, ref: DataSourceReference) -> bool:
         """Returns true if this reference is from the same data source as the supplied reference."""

--- a/metricflow/model/semantic_model.py
+++ b/metricflow/model/semantic_model.py
@@ -1,6 +1,7 @@
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MetricSemantics
+from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
+from metricflow.model.semantics.metric_semantics import MetricSemantics
 from metricflow.protocols.semantics import DataSourceSemanticsAccessor, MetricSemanticsAccessor
 
 

--- a/metricflow/model/semantics/data_source_semantics.py
+++ b/metricflow/model/semantics/data_source_semantics.py
@@ -1,182 +1,29 @@
-from __future__ import annotations
-
 import logging
 from collections import defaultdict
 from copy import deepcopy
-from typing import Dict, List, Set, Optional, Sequence, Tuple, FrozenSet
+from typing import Dict, List, Optional, Set, Sequence
 
-from metricflow.errors.errors import (
-    DuplicateMetricError,
-    MetricNotFoundError,
-    NonExistentMeasureError,
-    InvalidDataSourceError,
-)
-from metricflow.instances import DataSourceReference, DataSourceElementReference
 from metricflow.aggregation_properties import AggregationType
+from metricflow.errors.errors import InvalidDataSourceError
+from metricflow.instances import DataSourceReference, DataSourceElementReference
 from metricflow.model.objects.data_source import DataSource, DataSourceOrigin
 from metricflow.model.objects.elements.dimension import Dimension
 from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.elements.measure import Measure
-from metricflow.model.objects.metric import Metric, MetricType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.element_group import ElementGrouper
-from metricflow.model.semantics.linkable_spec_resolver import (
-    ValidLinkableSpecResolver,
-    LinkableElementProperties,
-)
-from metricflow.model.spec_converters import MeasureConverter, WhereConstraintConverter
+from metricflow.model.spec_converters import MeasureConverter
 from metricflow.references import (
-    DimensionReference,
-    IdentifierReference,
-    LinkableElementReference,
     MeasureReference,
-    MetricReference,
     TimeDimensionReference,
+    DimensionReference,
+    LinkableElementReference,
+    IdentifierReference,
 )
-from metricflow.specs import (
-    LinkableInstanceSpec,
-    MeasureSpec,
-    MetricInputMeasureSpec,
-    MetricSpec,
-    NonAdditiveDimensionSpec,
-)
+from metricflow.specs import NonAdditiveDimensionSpec, MeasureSpec
 
 logger = logging.getLogger(__name__)
-
-MAX_JOIN_HOPS = 2
-
-
-class MetricSemantics:  # noqa: D
-    def __init__(  # noqa: D
-        self, user_configured_model: UserConfiguredModel, data_source_semantics: DataSourceSemantics
-    ) -> None:
-        self._user_configured_model = user_configured_model
-        self._metrics: Dict[MetricReference, Metric] = {}
-        self._data_source_semantics = data_source_semantics
-
-        # Dict from the name of the metric to the hash.
-        self._metric_hashes: Dict[MetricReference, str] = {}
-
-        for metric in self._user_configured_model.metrics:
-            self.add_metric(metric)
-
-        self._linkable_spec_resolver = ValidLinkableSpecResolver(
-            user_configured_model=self._user_configured_model,
-            max_identifier_links=MAX_JOIN_HOPS,
-        )
-
-    def element_specs_for_metrics(
-        self,
-        metric_references: List[MetricReference],
-        with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
-        without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
-    ) -> List[LinkableInstanceSpec]:
-        """Dimensions common to all metrics requested (intersection)"""
-
-        all_linkable_specs = self._linkable_spec_resolver.get_linkable_elements_for_metrics(
-            metric_references=metric_references,
-            with_any_of=with_any_property,
-            without_any_of=without_any_property,
-        ).as_spec_set
-
-        return sorted(all_linkable_specs.as_tuple, key=lambda x: x.qualified_name)
-
-    def get_metrics(self, metric_references: List[MetricReference]) -> List[Metric]:  # noqa: D
-        res = []
-        for metric_reference in metric_references:
-            if metric_reference not in self._metrics:
-                raise MetricNotFoundError(
-                    f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered"
-                )
-            res.append(self._metrics[metric_reference])
-
-        return res
-
-    @property
-    def metric_references(self) -> List[MetricReference]:  # noqa: D
-        return list(self._metrics.keys())
-
-    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
-        if metric_reference not in self._metrics:
-            raise MetricNotFoundError(f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered")
-        return self._metrics[metric_reference]
-
-    def add_metric(self, metric: Metric) -> None:
-        """Add metric, validating presence of required measures"""
-        metric_reference = MetricReference(element_name=metric.name)
-        if metric_reference in self._metrics:
-            raise DuplicateMetricError(f"Metric `{metric.name}` has already been registered")
-        for measure_reference in metric.measure_references:
-            if measure_reference not in self._data_source_semantics.measure_references:
-                raise NonExistentMeasureError(
-                    f"Metric `{metric.name}` references measure `{measure_reference}` which has not been registered"
-                )
-        self._metrics[metric_reference] = metric
-        self._metric_hashes[metric_reference] = metric.definition_hash
-
-    @property
-    def valid_hashes(self) -> Set[str]:
-        """Return all of the hashes of the metric definitions."""
-        return set(self._metric_hashes.values())
-
-    def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
-        """Return the measure specs required to compute the metric."""
-        metric = self.get_metric(metric_reference)
-        input_measure_specs: List[MetricInputMeasureSpec] = []
-
-        for input_measure in metric.input_measures:
-            spec_constraint = (
-                WhereConstraintConverter.convert_to_spec_where_constraint(
-                    data_source_semantics=self._data_source_semantics,
-                    where_constraint=input_measure.constraint,
-                )
-                if input_measure.constraint is not None
-                else None
-            )
-            measure_spec = MeasureSpec(
-                element_name=input_measure.name,
-                non_additive_dimension_spec=self._data_source_semantics.non_additive_dimension_specs_by_measure.get(
-                    input_measure.measure_reference
-                ),
-            )
-            spec = MetricInputMeasureSpec(
-                measure_spec=measure_spec,
-                constraint=spec_constraint,
-                alias=input_measure.alias,
-            )
-            input_measure_specs.append(spec)
-
-        return tuple(input_measure_specs)
-
-    def contains_cumulative_metric(self, metric_references: Sequence[MetricReference]) -> bool:
-        """Returns true if any of the specs correspond to a cumulative metric."""
-        for metric_reference in metric_references:
-            if self.get_metric(metric_reference).type == MetricType.CUMULATIVE:
-                return True
-        return False
-
-    def metric_input_specs_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricSpec, ...]:
-        """Return the metric specs referenced by the metric. Current use case is for derived metrics."""
-        metric = self.get_metric(metric_reference)
-        input_metric_specs: List[MetricSpec] = []
-
-        for input_metric in metric.input_metrics:
-            spec_constraint = (
-                WhereConstraintConverter.convert_to_spec_where_constraint(
-                    data_source_semantics=self._data_source_semantics,
-                    where_constraint=input_metric.constraint,
-                )
-                if input_metric.constraint is not None
-                else None
-            )
-            spec = MetricSpec(
-                element_name=input_metric.name,
-                constraint=spec_constraint,
-                alias=input_metric.alias,
-            )
-            input_metric_specs.append(spec)
-        return tuple(input_metric_specs)
 
 
 class DataSourceSemantics:

--- a/metricflow/model/semantics/linkable_element_properties.py
+++ b/metricflow/model/semantics/linkable_element_properties.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import FrozenSet
+
+
+class LinkableElementProperties(Enum):
+    """The properties associated with a valid linkable element.
+
+    Local means an element that is defined within the same data source as the measure. This definition is used
+    throughout the related classes.
+    """
+
+    # A local element as per above definition.
+    LOCAL = "local"
+    # A local dimension that is prefixed with a local primary identifier.
+    LOCAL_LINKED = "local_linked"
+    # An element that was joined to the measure data source by an identifier.
+    JOINED = "joined"
+    # An element that was joined to the measure data source by joining multiple data sources.
+    MULTI_HOP = "multi_hop"
+    # A time dimension that is a version of a time dimension in a data source, but at a different granularity.
+    DERIVED_TIME_GRANULARITY = "derived_time_granularity"
+    # Refers to an identifier, not a dimension.
+    IDENTIFIER = "identifier"
+    # After an intersection operation.
+    INTERSECTED = "intersected"
+
+    @staticmethod
+    def all_properties() -> FrozenSet[LinkableElementProperties]:  # noqa: D
+        return frozenset(
+            {
+                LinkableElementProperties.LOCAL,
+                LinkableElementProperties.LOCAL_LINKED,
+                LinkableElementProperties.JOINED,
+                LinkableElementProperties.MULTI_HOP,
+                LinkableElementProperties.DERIVED_TIME_GRANULARITY,
+            }
+        )

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -6,13 +6,17 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Tuple, Sequence, Dict, List, Optional, FrozenSet
 
+from metricflow.instances import DataSourceReference
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import DimensionType, Dimension
 from metricflow.model.objects.elements.identifier import IdentifierType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.valid_join import DataSourceJoinValidator
 from metricflow.object_utils import pformat_big_objects, flatten_nested_sequence
-from metricflow.references import MeasureReference, MetricReference
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
+from metricflow.references import MeasureReference
+from metricflow.references import MetricReference
 from metricflow.specs import (
     DEFAULT_TIME_GRANULARITY,
     LinkableSpecSet,
@@ -377,16 +381,20 @@ class ValidLinkableSpecResolver:
     def __init__(
         self,
         user_configured_model: UserConfiguredModel,
+        data_source_semantics: DataSourceSemanticsAccessor,
         max_identifier_links: int,
     ) -> None:
         """Constructor.
 
         Args:
             user_configured_model: the model to use.
+            data_source_semantics: used to look up identifiers for a data source.
             max_identifier_links: the maximum number of joins to do when computing valid elements.
         """
         self._user_configured_model = user_configured_model
-        self._data_sources = self._user_configured_model.data_sources
+        # Sort data sources by name for consistency in building derived objects.
+        self._data_sources = sorted(self._user_configured_model.data_sources, key=lambda x: x.name)
+        self._join_validator = DataSourceJoinValidator(data_source_semantics)
 
         assert max_identifier_links >= 0
         self._max_identifier_links = max_identifier_links
@@ -397,8 +405,7 @@ class ValidLinkableSpecResolver:
 
         for data_source in self._data_sources:
             for identifier in data_source.identifiers:
-                if identifier.type in (IdentifierType.PRIMARY, IdentifierType.UNIQUE):
-                    self._identifier_to_data_source[identifier.reference.element_name].append(data_source)
+                self._identifier_to_data_source[identifier.reference.element_name].append(data_source)
 
         self._metric_to_linkable_element_sets: Dict[str, List[LinkableElementSet]] = {}
 
@@ -483,10 +490,22 @@ class ValidLinkableSpecResolver:
             ambiguous_linkable_identifiers=(),
         )
 
-    def _get_data_sources_with_joinable_identifier(self, identifier_name: str) -> Sequence[DataSource]:
+    def _get_data_sources_with_joinable_identifier(
+        self,
+        left_data_source_reference: DataSourceReference,
+        identifier_reference: IdentifierReference,
+    ) -> Sequence[DataSource]:
         # May switch to non-cached implementation.
-        data_sources = self._identifier_to_data_source[identifier_name]
-        return data_sources
+        data_sources = self._identifier_to_data_source[identifier_reference.element_name]
+        valid_data_sources = []
+        for data_source in data_sources:
+            if self._join_validator.is_valid_data_source_join(
+                left_data_source_reference=left_data_source_reference,
+                right_data_source_reference=data_source.reference,
+                on_identifier_reference=identifier_reference,
+            ):
+                valid_data_sources.append(data_source)
+        return valid_data_sources
 
     def _get_linkable_element_set_for_measure(self, measure_reference: MeasureReference) -> LinkableElementSet:
         """Get the valid linkable elements for the given measure."""
@@ -498,7 +517,10 @@ class ValidLinkableSpecResolver:
 
         # Create 1-hop elements
         for identifier in measure_data_source.identifiers:
-            data_sources = self._get_data_sources_with_joinable_identifier(identifier.reference.element_name)
+            data_sources = self._get_data_sources_with_joinable_identifier(
+                left_data_source_reference=measure_data_source.reference,
+                identifier_reference=identifier.reference,
+            )
             for data_source in data_sources:
                 if data_source.name == measure_data_source.name:
                     continue
@@ -568,18 +590,22 @@ class ValidLinkableSpecResolver:
         self, measure_data_source: DataSource, current_join_path: DataSourceJoinPath
     ) -> Sequence[DataSourceJoinPath]:
         """Generate the set of possible paths that are 1 data source join longer that the "current_join_path"."""
-        data_source = current_join_path.last_data_source
+        last_data_source_in_path = current_join_path.last_data_source
         new_join_paths = []
 
-        for identifier in data_source.identifiers:
+        for identifier in last_data_source_in_path.identifiers:
             identifier_name = identifier.reference.element_name
 
+            # Don't create cycles in the join path by joining on the same identifier.
             if identifier_name in set(x.join_on_identifier for x in current_join_path.path_elements):
                 continue
 
-            data_sources_that_can_be_joined = self._get_data_sources_with_joinable_identifier(identifier_name)
+            data_sources_that_can_be_joined = self._get_data_sources_with_joinable_identifier(
+                left_data_source_reference=last_data_source_in_path.reference,
+                identifier_reference=identifier.reference,
+            )
             for data_source in data_sources_that_can_be_joined:
-                # Don't create cycles in the join path by not repeating a data source in the path.
+                # Don't create cycles in the join path by repeating a data source in the path.
                 if data_source.name == measure_data_source.name or any(
                     tuple(x.data_source.name == data_source.name for x in current_join_path.path_elements)
                 ):

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -4,13 +4,13 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from enum import Enum
 from typing import Tuple, Sequence, Dict, List, Optional, FrozenSet
 
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import DimensionType, Dimension
 from metricflow.model.objects.elements.identifier import IdentifierType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.object_utils import pformat_big_objects, flatten_nested_sequence
 from metricflow.references import MeasureReference, MetricReference
 from metricflow.specs import (
@@ -24,41 +24,6 @@ from metricflow.specs import (
 from metricflow.time.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
-
-
-class LinkableElementProperties(Enum):
-    """The properties associated with a valid linkable element.
-
-    Local means an element that is defined within the same data source as the measure. This definition is used
-    throughout the related classes.
-    """
-
-    # A local element as per above definition.
-    LOCAL = "local"
-    # A local dimension that is prefixed with a local primary identifier.
-    LOCAL_LINKED = "local_linked"
-    # An element that was joined to the measure data source by an identifier.
-    JOINED = "joined"
-    # An element that was joined to the measure data source by joining multiple data sources.
-    MULTI_HOP = "multi_hop"
-    # A time dimension that is a version of a time dimension in a data source, but at a different granularity.
-    DERIVED_TIME_GRANULARITY = "derived_time_granularity"
-    # Refers to an identifier, not a dimension.
-    IDENTIFIER = "identifier"
-    # After an intersection operation.
-    INTERSECTED = "intersected"
-
-    @staticmethod
-    def all_properties() -> FrozenSet[LinkableElementProperties]:  # noqa: D
-        return frozenset(
-            {
-                LinkableElementProperties.LOCAL,
-                LinkableElementProperties.LOCAL_LINKED,
-                LinkableElementProperties.JOINED,
-                LinkableElementProperties.MULTI_HOP,
-                LinkableElementProperties.DERIVED_TIME_GRANULARITY,
-            }
-        )
 
 
 @dataclass(frozen=True)

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -6,7 +6,8 @@ from metricflow.errors.errors import MetricNotFoundError, DuplicateMetricError, 
 from metricflow.model.objects.metric import Metric, MetricType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
-from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver, LinkableElementProperties
+from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.spec_converters import WhereConstraintConverter
 from metricflow.references import MetricReference
 from metricflow.specs import MetricSpec, LinkableInstanceSpec, MetricInputMeasureSpec, MeasureSpec

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -1,0 +1,149 @@
+import logging
+
+from typing import Dict, List, FrozenSet, Set, Tuple, Sequence
+
+from metricflow.errors.errors import MetricNotFoundError, DuplicateMetricError, NonExistentMeasureError
+from metricflow.model.objects.metric import Metric, MetricType
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
+from metricflow.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver, LinkableElementProperties
+from metricflow.model.spec_converters import WhereConstraintConverter
+from metricflow.references import MetricReference
+from metricflow.specs import MetricSpec, LinkableInstanceSpec, MetricInputMeasureSpec, MeasureSpec
+
+
+logger = logging.getLogger(__name__)
+
+MAX_JOIN_HOPS = 2
+
+class MetricSemantics:  # noqa: D
+    def __init__(  # noqa: D
+        self, user_configured_model: UserConfiguredModel, data_source_semantics: DataSourceSemantics
+    ) -> None:
+        self._user_configured_model = user_configured_model
+        self._metrics: Dict[MetricReference, Metric] = {}
+        self._data_source_semantics = data_source_semantics
+
+        # Dict from the name of the metric to the hash.
+        self._metric_hashes: Dict[MetricReference, str] = {}
+
+        for metric in self._user_configured_model.metrics:
+            self.add_metric(metric)
+
+        self._linkable_spec_resolver = ValidLinkableSpecResolver(
+            user_configured_model=self._user_configured_model,
+            max_identifier_links=MAX_JOIN_HOPS,
+        )
+
+    def element_specs_for_metrics(
+        self,
+        metric_references: List[MetricReference],
+        with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
+        without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
+    ) -> List[LinkableInstanceSpec]:
+        """Dimensions common to all metrics requested (intersection)"""
+
+        all_linkable_specs = self._linkable_spec_resolver.get_linkable_elements_for_metrics(
+            metric_references=metric_references,
+            with_any_of=with_any_property,
+            without_any_of=without_any_property,
+        ).as_spec_set
+
+        return sorted(all_linkable_specs.as_tuple, key=lambda x: x.qualified_name)
+
+    def get_metrics(self, metric_references: List[MetricReference]) -> List[Metric]:  # noqa: D
+        res = []
+        for metric_reference in metric_references:
+            if metric_reference not in self._metrics:
+                raise MetricNotFoundError(
+                    f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered"
+                )
+            res.append(self._metrics[metric_reference])
+
+        return res
+
+    @property
+    def metric_references(self) -> List[MetricReference]:  # noqa: D
+        return list(self._metrics.keys())
+
+    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
+        if metric_reference not in self._metrics:
+            raise MetricNotFoundError(f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered")
+        return self._metrics[metric_reference]
+
+    def add_metric(self, metric: Metric) -> None:
+        """Add metric, validating presence of required measures"""
+        metric_reference = MetricReference(element_name=metric.name)
+        if metric_reference in self._metrics:
+            raise DuplicateMetricError(f"Metric `{metric.name}` has already been registered")
+        for measure_reference in metric.measure_references:
+            if measure_reference not in self._data_source_semantics.measure_references:
+                raise NonExistentMeasureError(
+                    f"Metric `{metric.name}` references measure `{measure_reference}` which has not been registered"
+                )
+        self._metrics[metric_reference] = metric
+        self._metric_hashes[metric_reference] = metric.definition_hash
+
+    @property
+    def valid_hashes(self) -> Set[str]:
+        """Return all of the hashes of the metric definitions."""
+        return set(self._metric_hashes.values())
+
+    def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
+        """Return the measure specs required to compute the metric."""
+        metric = self.get_metric(metric_reference)
+        input_measure_specs: List[MetricInputMeasureSpec] = []
+
+        for input_measure in metric.input_measures:
+            spec_constraint = (
+                WhereConstraintConverter.convert_to_spec_where_constraint(
+                    data_source_semantics=self._data_source_semantics,
+                    where_constraint=input_measure.constraint,
+                )
+                if input_measure.constraint is not None
+                else None
+            )
+            measure_spec = MeasureSpec(
+                element_name=input_measure.name,
+                non_additive_dimension_spec=self._data_source_semantics.non_additive_dimension_specs_by_measure.get(
+                    input_measure.measure_reference
+                ),
+            )
+            spec = MetricInputMeasureSpec(
+                measure_spec=measure_spec,
+                constraint=spec_constraint,
+                alias=input_measure.alias,
+            )
+            input_measure_specs.append(spec)
+
+        return tuple(input_measure_specs)
+
+    def contains_cumulative_metric(self, metric_references: Sequence[MetricReference]) -> bool:
+        """Returns true if any of the specs correspond to a cumulative metric."""
+        for metric_reference in metric_references:
+            if self.get_metric(metric_reference).type == MetricType.CUMULATIVE:
+                return True
+        return False
+
+    def metric_input_specs_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricSpec, ...]:
+        """Return the metric specs referenced by the metric. Current use case is for derived metrics."""
+        metric = self.get_metric(metric_reference)
+        input_metric_specs: List[MetricSpec] = []
+
+        for input_metric in metric.input_metrics:
+            spec_constraint = (
+                WhereConstraintConverter.convert_to_spec_where_constraint(
+                    data_source_semantics=self._data_source_semantics,
+                    where_constraint=input_metric.constraint,
+                )
+                if input_metric.constraint is not None
+                else None
+            )
+            spec = MetricSpec(
+                element_name=input_metric.name,
+                constraint=spec_constraint,
+                alias=input_metric.alias,
+            )
+            input_metric_specs.append(spec)
+        return tuple(input_metric_specs)
+

--- a/metricflow/model/semantics/metric_semantics.py
+++ b/metricflow/model/semantics/metric_semantics.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 MAX_JOIN_HOPS = 2
 
+
 class MetricSemantics:  # noqa: D
     def __init__(  # noqa: D
         self, user_configured_model: UserConfiguredModel, data_source_semantics: DataSourceSemantics
@@ -33,6 +34,7 @@ class MetricSemantics:  # noqa: D
 
         self._linkable_spec_resolver = ValidLinkableSpecResolver(
             user_configured_model=self._user_configured_model,
+            data_source_semantics=data_source_semantics,
             max_identifier_links=MAX_JOIN_HOPS,
         )
 
@@ -147,4 +149,3 @@ class MetricSemantics:  # noqa: D
             )
             input_metric_specs.append(spec)
         return tuple(input_metric_specs)
-

--- a/metricflow/model/semantics/valid_join.py
+++ b/metricflow/model/semantics/valid_join.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from metricflow.instances import DataSourceReference, DataSourceElementReference, InstanceSet
+from metricflow.model.objects.elements.identifier import IdentifierType
+from metricflow.object_utils import pformat_big_objects
+from metricflow.protocols.semantics import DataSourceSemanticsAccessor
+from metricflow.references import IdentifierReference
+
+
+@dataclass(frozen=True)
+class DataSourceIdentifierJoinType:
+    """Describe a type of join between data sources where identifiers are of the listed types."""
+
+    left_identifier_type: IdentifierType
+    right_identifier_type: IdentifierType
+
+
+class DataSourceJoinValidator:
+    """Checks to see if a join between two data sources should be allowed."""
+
+    # Valid joins are the non-fanout joines.
+    _VALID_IDENTIFIER_JOINS = (
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.PRIMARY, right_identifier_type=IdentifierType.PRIMARY
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.PRIMARY, right_identifier_type=IdentifierType.UNIQUE
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.UNIQUE, right_identifier_type=IdentifierType.PRIMARY
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.UNIQUE, right_identifier_type=IdentifierType.UNIQUE
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.PRIMARY
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.UNIQUE
+        ),
+    )
+
+    _INVALID_IDENTIFIER_JOINS = (
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.PRIMARY, right_identifier_type=IdentifierType.FOREIGN
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.UNIQUE, right_identifier_type=IdentifierType.FOREIGN
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.FOREIGN
+        ),
+    )
+
+    def __init__(self, data_source_semantics: DataSourceSemanticsAccessor) -> None:  # noqa: D
+        self._data_source_semantics = data_source_semantics
+
+    def is_valid_data_source_join(
+        self,
+        left_data_source_reference: DataSourceReference,
+        right_data_source_reference: DataSourceReference,
+        on_identifier_reference: IdentifierReference,
+    ) -> bool:
+        """Return true if we should allow a join with the given parameters to resolve a query."""
+        left_identifier = self._data_source_semantics.get_identifier_in_data_source(
+            DataSourceElementReference.create_from_references(left_data_source_reference, on_identifier_reference)
+        )
+
+        right_identifier = self._data_source_semantics.get_identifier_in_data_source(
+            DataSourceElementReference.create_from_references(right_data_source_reference, on_identifier_reference)
+        )
+        if left_identifier is None:
+            return False
+        if right_identifier is None:
+            return False
+
+        join_type = DataSourceIdentifierJoinType(left_identifier.type, right_identifier.type)
+
+        if join_type in DataSourceJoinValidator._VALID_IDENTIFIER_JOINS:
+            return True
+        elif join_type in DataSourceJoinValidator._INVALID_IDENTIFIER_JOINS:
+            return False
+
+        raise RuntimeError(f"Join type not handled: {join_type}")
+
+    @staticmethod
+    def _data_source_of_identifier_in_instance_set(
+        instance_set: InstanceSet,
+        identifier_reference: IdentifierReference,
+    ) -> DataSourceReference:
+        """Return the data source where the identifier was defined in the instance set."""
+        matching_instances = []
+        for identifier_instance in instance_set.identifier_instances:
+            assert len(identifier_instance.defined_from) == 1
+            if (
+                len(identifier_instance.spec.identifier_links) == 0
+                and identifier_instance.spec.reference == identifier_reference
+            ):
+                matching_instances.append(identifier_instance)
+
+        assert len(matching_instances) == 1, (
+            f"Not exactly 1 matching identifier instances found: {matching_instances} for {identifier_reference} in "
+            f"{pformat_big_objects(instance_set)}"
+        )
+        return matching_instances[0].origin_data_source_reference.data_source_reference
+
+    def is_valid_instance_set_join(
+        self,
+        left_instance_set: InstanceSet,
+        right_instance_set: InstanceSet,
+        on_identifier_reference: IdentifierReference,
+    ) -> bool:
+        """Return true if the instance sets can be joined using the given identifier."""
+        return self.is_valid_data_source_join(
+            left_data_source_reference=DataSourceJoinValidator._data_source_of_identifier_in_instance_set(
+                instance_set=left_instance_set, identifier_reference=on_identifier_reference
+            ),
+            right_data_source_reference=DataSourceJoinValidator._data_source_of_identifier_in_instance_set(
+                instance_set=right_instance_set,
+                identifier_reference=on_identifier_reference,
+            ),
+            on_identifier_reference=on_identifier_reference,
+        )

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -13,7 +13,7 @@ from metricflow.dataflow.dataflow_plan import (
     JoinDescription,
 )
 from metricflow.model.objects.elements.identifier import IdentifierType
-from metricflow.model.semantics.semantic_containers import MAX_JOIN_HOPS
+from metricflow.model.semantics.metric_semantics import MAX_JOIN_HOPS
 from metricflow.object_utils import pformat_big_objects
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.protocols.semantics import DataSourceSemanticsAccessor

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -18,14 +18,15 @@ from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import Metric
 from metricflow.model.semantics.element_group import ElementGrouper
-from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.references import (
     DimensionReference,
     IdentifierReference,
     MeasureReference,
-    MetricReference,
     TimeDimensionReference,
+    MetricReference,
 )
+
 from metricflow.specs import (
     LinkableInstanceSpec,
     MeasureSpec,

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 def simple_model_spec_resolver(simple_semantic_model: SemanticModel) -> ValidLinkableSpecResolver:  # noqa: D
     return ValidLinkableSpecResolver(
         user_configured_model=simple_semantic_model.user_configured_model,
+        data_source_semantics=simple_semantic_model.data_source_semantics,
         max_identifier_links=MAX_JOIN_HOPS,
     )
 
@@ -169,6 +170,7 @@ def test_joined_property(simple_model_spec_resolver: ValidLinkableSpecResolver) 
 def test_multi_hop_property(multi_hop_join_semantic_model: SemanticModel) -> None:  # noqa: D
     multi_hop_spec_resolver = ValidLinkableSpecResolver(
         user_configured_model=multi_hop_join_semantic_model.user_configured_model,
+        data_source_semantics=multi_hop_join_semantic_model.data_source_semantics,
         max_identifier_links=MAX_JOIN_HOPS,
     )
     property_check_helper(

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -6,8 +6,8 @@ import pytest
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.semantics.linkable_spec_resolver import (
     ValidLinkableSpecResolver,
-    LinkableElementProperties,
 )
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.metric_semantics import MAX_JOIN_HOPS
 from metricflow.references import MetricReference
 

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -8,7 +8,7 @@ from metricflow.model.semantics.linkable_spec_resolver import (
     ValidLinkableSpecResolver,
     LinkableElementProperties,
 )
-from metricflow.model.semantics.semantic_containers import MAX_JOIN_HOPS
+from metricflow.model.semantics.metric_semantics import MAX_JOIN_HOPS
 from metricflow.references import MetricReference
 
 logger = logging.getLogger(__name__)

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -4,7 +4,7 @@ import pytest
 
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
-from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
 from metricflow.model.semantics.metric_semantics import MetricSemantics
 from metricflow.references import IdentifierReference, MeasureReference

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -5,7 +5,8 @@ import pytest
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantics.data_source_container import PydanticDataSourceContainer
 from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
-from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MetricSemantics
+from metricflow.model.semantics.data_source_semantics import DataSourceSemantics
+from metricflow.model.semantics.metric_semantics import MetricSemantics
 from metricflow.references import IdentifierReference, MeasureReference
 from metricflow.references import MetricReference
 


### PR DESCRIPTION
This PR adds a class to centralize the logic that is used to figure out whether a join between data sources using a specific identifier. To resolve circular dependencies, some of the semantics classes were factored out.