### PR TITLE
Add building a UserConfiguredModel from a dbt Manifest

### DIFF
--- a/metricflow/model/parsing/dbt_dir_to_model.py
+++ b/metricflow/model/parsing/dbt_dir_to_model.py
@@ -1,6 +1,7 @@
 from dbt.lib import get_dbt_config
 from dbt import tracking
 from dbt.parser.manifest import ManifestLoader as DbtManifestLoader, Manifest as DbtManifest
+from metricflow.model.model_transformer import ModelTransformer
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
 from metricflow.model.transformations.dbt_to_metricflow import DbtManifestTransformer
 
@@ -18,4 +19,7 @@ def get_dbt_project_manifest(directory: str) -> DbtManifest:
 def parse_dbt_project_to_model(directory: str) -> ModelBuildResult:
     """Parse dbt model files in the given directory to a UserConfiguredModel."""
     manifest = get_dbt_project_manifest(directory=directory)
-    return DbtManifestTransformer(manifest=manifest).build_user_configured_model()
+    build_result = DbtManifestTransformer(manifest=manifest).build_user_configured_model()
+    transformed_model = ModelTransformer.pre_validation_transform_model(model=build_result.model)
+    transformed_model = ModelTransformer.post_validation_transform_model(model=transformed_model)
+    return ModelBuildResult(model=transformed_model, issues=build_result.issues)

--- a/metricflow/model/parsing/dbt_dir_to_model.py
+++ b/metricflow/model/parsing/dbt_dir_to_model.py
@@ -2,7 +2,7 @@ from dbt.lib import get_dbt_config
 from dbt import tracking
 from dbt.parser.manifest import ManifestLoader as DbtManifestLoader, Manifest as DbtManifest
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
-from metricflow.model.transformations.dbt_to_metricflow import transform_manifest_into_user_configured_model
+from metricflow.model.transformations.dbt_to_metricflow import DbtManifestTransformer
 
 
 def get_dbt_project_manifest(directory: str) -> DbtManifest:
@@ -18,4 +18,4 @@ def get_dbt_project_manifest(directory: str) -> DbtManifest:
 def parse_dbt_project_to_model(directory: str) -> ModelBuildResult:
     """Parse dbt model files in the given directory to a UserConfiguredModel."""
     manifest = get_dbt_project_manifest(directory=directory)
-    return transform_manifest_into_user_configured_model(manifest=manifest)
+    return DbtManifestTransformer(manifest=manifest).build_user_configured_model()

--- a/metricflow/model/parsing/dbt_dir_to_model.py
+++ b/metricflow/model/parsing/dbt_dir_to_model.py
@@ -1,8 +1,8 @@
 from dbt.lib import get_dbt_config
 from dbt import tracking
 from dbt.parser.manifest import ManifestLoader as DbtManifestLoader, Manifest as DbtManifest
-from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
+from metricflow.model.transformations.dbt_to_metricflow import transform_manifest_into_user_configured_model
 
 
 def get_dbt_project_manifest(directory: str) -> DbtManifest:
@@ -17,10 +17,5 @@ def get_dbt_project_manifest(directory: str) -> DbtManifest:
 
 def parse_dbt_project_to_model(directory: str) -> ModelBuildResult:
     """Parse dbt model files in the given directory to a UserConfiguredModel."""
-
-    manifest = get_dbt_project_manifest(directory=directory)  # noqa: F841
-
-    # TODO: Implement transforming dbt_metrics into a UserConfiguredModel
-    raise NotImplementedError("Transforming dbt metrics into a Metricflow UserConfiguredModel has not been implemented")
-
-    return ModelBuildResult(model=UserConfiguredModel(data_sources=[], metrics=[], materializations=[]))
+    manifest = get_dbt_project_manifest(directory=directory)
+    return transform_manifest_into_user_configured_model(manifest=manifest)

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -53,20 +53,19 @@ def _db_table_from_model_node(node: DbtModelNode) -> str:  # noqa: D
     return f"{node.database}.{node.schema}.{node.name}"
 
 
-def _dimensions_from_dbt_metric_dimensions(dimensions: List[str]) -> List[Dimension]:  # noqa: D
-    built_dimensions = []
-    for dimension in dimensions:
-        built_dimensions.append(
+def _build_dimensions(dbt_metric: DbtMetric) -> List[Dimension]:  # noqa: D
+    dimensions = []
+
+    # Build dimensions specifically from DbtMetric.dimensions list
+    for dimension in dbt_metric.dimensions:
+        dimensions.append(
             Dimension(
                 name=dimension,
                 type=DimensionType.CATEGORICAL,
             )
         )
-    return built_dimensions
 
-
-def _build_dimensions(dbt_metric: DbtMetric) -> List[Dimension]:  # noqa: D
-    dimensions = _dimensions_from_dbt_metric_dimensions(dimensions=dbt_metric.dimensions)
+    # Add DbtMetric.timestamp as a time dimension
     dimensions.append(
         Dimension(
             name=dbt_metric.timestamp,

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
-from typing import List
+from operator import xor
+import traceback
+from typing import Dict, List, Set
 from dbt.contracts.graph.parsed import ParsedMetric as DbtMetric, ParsedModelNode as DbtModelNode
 from dbt.exceptions import ref_invalid_args
 from dbt.contracts.graph.manifest import Manifest as DbtManifest
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
+from metricflow.model.objects.elements.identifier import Identifier
+from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
+from metricflow.model.validations.validator_helpers import ModelValidationResults, ValidationError, ValidationIssue
 from metricflow.time.time_granularity import TimeGranularity
 
 
@@ -92,15 +97,94 @@ def dbt_metric_to_metricflow_elements(dbt_metric: DbtMetric, manifest: DbtManife
     return TransformedDbtMetric(data_source=data_source, metrics=[])
 
 
-def transform_manifest_into_user_configured_model(manifest: DbtManifest) -> ModelBuildResult:  # noqa: D
-    data_sources = {}
-    metrics = []
-    for dbt_metric in manifest.metrics.values():
-        transformed_dbt_metric = dbt_metric_to_metricflow_elements(dbt_metric=dbt_metric, manifest=manifest)
-        if transformed_dbt_metric.data_source.name not in data_sources:
-            data_sources[transformed_dbt_metric.data_source.name] = transformed_dbt_metric.data_source
-        else:
-            raise NotImplementedError("Merging two data sources has not been implemented")
-        metrics.extend(transformed_dbt_metric.metrics)
+def merge_data_sources(data_sources: List[DataSource]) -> DataSource:  # noqa: D
+    if len(data_sources) == 1:
+        return data_sources[0]
 
-    return ModelBuildResult(model=UserConfiguredModel(data_sources=list(data_sources.values()), metrics=metrics))
+    measures: Set[Measure] = set()
+    identifiers: Set[Identifier] = set()
+    dimensions: Set[Dimension] = set()
+    names: List[str] = []
+    descriptions: List[str] = []
+    sql_tables: List[str] = []
+    sql_queries: List[str] = []
+    dbt_models: List[str] = []
+    for data_source in data_sources:
+        names.append(data_source.name) if data_source.name else None
+        descriptions.append(data_source.description) if data_source.description else None
+        sql_tables.append(data_source.sql_table) if data_source.sql_table else None
+        sql_queries.append(data_source.sql_query) if data_source.sql_query else None
+        dbt_models.append(data_source.dbt_model) if data_source.dbt_model else None
+        measures = measures.union(set(data_source.measures)) if data_source.measures else measures
+        identifiers = identifiers.union(set(data_source.identifiers)) if data_source.identifiers else identifiers
+        dimensions = dimensions.union(set(data_source.dimensions)) if data_source.dimensions else dimensions
+
+    set_names = set(names)
+    set_descriptions = set(descriptions)
+    set_sql_tables = set(sql_tables)
+    set_sql_queries = set(sql_queries)
+    set_dbt_models = set(dbt_models)
+
+    assert len(set_names) == 1, "Cannot merge data sources, all data sources to merge must have same name"
+    assert (
+        len(set_descriptions) <= 1
+    ), "Cannot merge data sources, all data sources to merge must have same descritpion (or none)"
+    assert (
+        len(set_sql_tables) <= 1
+    ), "Cannot merge data sources, all data sources to merge must have same sql_table (or none)"
+    assert (
+        len(set_sql_queries) <= 1
+    ), "Cannot merge data sources, all data sources to merge must have same sql_query (or none)"
+    assert xor(
+        len(set_sql_tables) == 1, len(set_sql_queries) == 1
+    ), "Cannot merge data sources, definitions for both sql_table and sql_query exist"
+    assert (
+        len(set_dbt_models) <= 1
+    ), "Cannot merge data sources, all data sources to merge must have same dbt_model (or none)"
+
+    return DataSource(
+        name=list(set_names)[0],
+        description=list(set_descriptions)[0] if set_descriptions else None,
+        sql_table=list(set_sql_tables)[0] if set_sql_tables else None,
+        sql_query=list(set_sql_queries)[0] if set_sql_queries else None,
+        dbt_model=list(set_dbt_models)[0] if set_dbt_models else None,
+        dimensions=list(dimensions),
+        identifiers=list(identifiers),
+        measures=list(measures),
+    )
+
+
+def transform_manifest_into_user_configured_model(manifest: DbtManifest) -> ModelBuildResult:  # noqa: D
+    data_sources_map: Dict[str, List[DataSource]] = {}
+    metrics = []
+    issues: List[ValidationIssue] = []
+    for dbt_metric in manifest.metrics.values():
+        # TODO: Handle derived dbt metrics
+        if dbt_metric.calculation_method == "derived":
+            continue
+        else:
+            transformed_dbt_metric = dbt_metric_to_metricflow_elements(dbt_metric=dbt_metric, manifest=manifest)
+            if transformed_dbt_metric.data_source.name not in data_sources_map:
+                data_sources_map[transformed_dbt_metric.data_source.name] = [transformed_dbt_metric.data_source]
+            else:
+                data_sources_map[transformed_dbt_metric.data_source.name].append(transformed_dbt_metric.data_source)
+            metrics.extend(transformed_dbt_metric.metrics)
+
+    # As it might be the case that we generated many of the same data source,
+    # we need to merge / dedupe them
+    deduped_data_sources = []
+    for name, data_sources in data_sources_map.items():
+        try:
+            deduped_data_sources.append(merge_data_sources(data_sources))
+        except Exception as e:
+            issues.append(
+                ValidationError(
+                    message=f"Failed to merge data sources with the name `{name}`",
+                    extra_detail="".join(traceback.format_tb(e.__traceback__)),
+                )
+            )
+
+    return ModelBuildResult(
+        model=UserConfiguredModel(data_sources=list(deduped_data_sources), metrics=metrics),
+        issues=ModelValidationResults.from_issues_sequence(issues=issues),
+    )

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -109,7 +109,9 @@ class DbtManifestTransformer:
 
         return self._resolved_dbt_model_refs[hashed]
 
-    def _db_table_from_model_node(self, node: DbtModelNode) -> str:  # noqa: D
+    @classmethod
+    def db_table_from_model_node(cls, node: DbtModelNode) -> str:
+        """Get the '.' joined database table name of a DbtModelNode"""
         return f"{node.database}.{node.schema}.{node.name}"
 
     def _build_dimension(self, name: str, dbt_metric: DbtMetric) -> Dimension:  # noqa: D
@@ -160,7 +162,7 @@ class DbtManifestTransformer:
 
     def _build_data_source(self, dbt_metric: DbtMetric) -> DataSource:  # noqa: D
         metric_model_ref = self.resolve_metric_model_ref(dbt_metric=dbt_metric)
-        data_source_table = self._db_table_from_model_node(metric_model_ref)
+        data_source_table = self.db_table_from_model_node(metric_model_ref)
         return DataSource(
             name=metric_model_ref.name,
             description=metric_model_ref.description,

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -191,7 +191,18 @@ class DbtManifestTransformer:
             measures=[self.build_measure(dbt_metric)],
         )
 
-    def _where_clause_from_filters(self, filters: List[DbtMetricFilter]) -> str:  # noqa: D
+    @classmethod
+    def build_where_stmt_from_filters(cls, filters: List[DbtMetricFilter]) -> str:
+        """Builds an SQL 'where' statement from the passed in filters
+
+        Each dbt filter has a field, an operator, and a value. With these dbt
+        forms the individual statment '{field} {operator} {value}' and joins
+        them with an 'AND'. Thus we do the same.
+
+        Note:
+            TODO: We could probably replace this with whatever method dbt uses to
+            build the statement.
+        """
         clauses = [f"{filter.field} {filter.operator} {filter.value}" for filter in filters]
         return " AND ".join(clauses)
 
@@ -199,7 +210,7 @@ class DbtManifestTransformer:
         where_clause_constraint: Optional[WhereClauseConstraint] = None
         if dbt_metric.filters:
             where_clause_constraint = WhereClauseConstraint(
-                where=self._where_clause_from_filters(filters=dbt_metric.filters),
+                where=self.build_where_stmt_from_filters(filters=dbt_metric.filters),
                 linkable_names=[filter.field for filter in dbt_metric.filters],
             )
 

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -236,7 +236,8 @@ class DbtManifestTransformer:
             constraint=where_clause_constraint,
         )
 
-    def dbt_metric_to_metricflow_elements(self, dbt_metric: DbtMetric) -> TransformedDbtMetric:  # noqa: D
+    def dbt_metric_to_metricflow_elements(self, dbt_metric: DbtMetric) -> TransformedDbtMetric:
+        """Builds a MetricFlow data source and proxy metric for the given DbtMetric"""
         data_source = self.build_data_source_for_metric(dbt_metric)
         proxy_metric = self.build_proxy_metric(dbt_metric)
         return TransformedDbtMetric(data_source=data_source, metric=proxy_metric)

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -114,7 +114,9 @@ class DbtManifestTransformer:
         """Get the '.' joined database table name of a DbtModelNode"""
         return f"{node.database}.{node.schema}.{node.name}"
 
-    def _build_dimension(self, name: str, dbt_metric: DbtMetric) -> Dimension:  # noqa: D
+    def _build_dimension(self, name: str, dbt_metric: DbtMetric) -> Dimension:
+        """Helper for `build_dimenions which builds either a categorical or time dimension"""
+
         if name in self.time_dimension_stats.keys():
             return Dimension(
                 name=name,
@@ -129,7 +131,8 @@ class DbtManifestTransformer:
                 type=DimensionType.CATEGORICAL,
             )
 
-    def _build_dimensions(self, dbt_metric: DbtMetric) -> List[Dimension]:  # noqa: D
+    def build_dimensions(self, dbt_metric: DbtMetric) -> List[Dimension]:
+        """Given a DbtMetric, builds all the associated MetricFlow dimensions"""
         dimensions = []
 
         # Build dimensions specifically from DbtMetric.dimensions list
@@ -176,7 +179,7 @@ class DbtManifestTransformer:
             description=metric_model_ref.description,
             sql_table=data_source_table,
             dbt_model=data_source_table,
-            dimensions=self._build_dimensions(dbt_metric),
+            dimensions=self.build_dimensions(dbt_metric),
             measures=[self._build_measure(dbt_metric)],
         )
 

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -36,254 +36,266 @@ CALC_METHOD_TO_MEASURE_TYPE: Dict[str, AggregationType] = {
 }
 
 
-def _resolve_metric_model_ref(manifest: DbtManifest, dbt_metric: DbtMetric) -> DbtModelNode:  # noqa: D
-    if dbt_metric.model[:4] != "ref(":
-        raise RuntimeError("Can only resolve refs for ref strings that begin with `ref(`")
-    ref_parts = dbt_metric.model[4:-1].split(",")
-    target_model = None
-    target_package = None
+class DbtManifestTransformer:
+    """The DbtManifestTransform is a class used to transform dbt Manifests into MetricFlow UserConfiguredModels
 
-    if len(ref_parts) == 1:
-        target_model = ref_parts[0].strip(" \"'\t\r\n")
-    elif len(ref_parts) == 2:
-        target_package = ref_parts[0].strip(" \"'\t\r\n")
-        target_model = ref_parts[1].strip(" \"'\t\r\n")
-    else:
-        ref_invalid_args(dbt_metric.name, ref_parts)
+    This helps keep track of state objects while transforming the Manifest into a
+    UserConfiguredModel, ensuring like dbt Node elements are rendered only once and
+    allowing us to pass around fewer arguments (reducing the mental load)
+    """
 
-    node = manifest.resolve_ref(
-        target_model_name=target_model,
-        target_model_package=target_package,
-        current_project=manifest.metadata.project_id,
-        node_package=dbt_metric.package_name,
-    )
-    assert isinstance(
-        node, DbtModelNode
-    ), f"Ref `{dbt_metric.model}` resolved to {node}, which is not of type `{DbtModelNode.__name__}`"
-    return node
+    def __init__(self, manifest: DbtManifest) -> None:
+        """Constructor.
 
+        Args:
+            manifest: A dbt Manifest object
+        """
+        self.manifest = manifest
 
-def _db_table_from_model_node(node: DbtModelNode) -> str:  # noqa: D
-    return f"{node.database}.{node.schema}.{node.name}"
+    def _resolve_metric_model_ref(self, dbt_metric: DbtMetric) -> DbtModelNode:  # noqa: D
+        if dbt_metric.model[:4] != "ref(":
+            raise RuntimeError("Can only resolve refs for ref strings that begin with `ref(`")
+        ref_parts = dbt_metric.model[4:-1].split(",")
+        target_model = None
+        target_package = None
 
-
-def _build_dimension(name: str, dbt_metric: DbtMetric, time_dimension_stats: Dict[str, List[str]]) -> Dimension:
-    if name in time_dimension_stats.keys():
-        return Dimension(
-            name=name,
-            type=DimensionType.TIME,
-            type_params=DimensionTypeParams(
-                is_primary=dbt_metric.model in time_dimension_stats[name], time_granularity=TimeGranularity.DAY
-            ),
-        )
-    else:
-        return Dimension(
-            name=name,
-            type=DimensionType.CATEGORICAL,
-        )
-
-
-def _build_dimensions(dbt_metric: DbtMetric, time_dimension_stats: Dict[str, List[str]]) -> List[Dimension]:  # noqa: D
-    dimensions = []
-
-    # Build dimensions specifically from DbtMetric.dimensions list
-    for dimension in dbt_metric.dimensions:
-        dimensions.append(
-            _build_dimension(name=dimension, dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats)
-        )
-
-    # Add DbtMetric.timestamp as a time dimension
-    dimensions.append(
-        _build_dimension(name=dbt_metric.timestamp, dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats)
-    )
-
-    # We need to deduplicate the filters because a field could be the same in
-    # two filters. For example, if two filters exist for `amount`, one with
-    # `>= 500` and the other `< 1000`, but only one dimension should be created
-    distinct_dbt_metric_filter_fields = set([filter.field for filter in dbt_metric.filters])
-    # Add dimension per distinct filter field
-    # exclude when field is also listed as a DbtMetric.dimension
-    # exclude when field is also the DbtMetric.timestamp
-    for filter_field in distinct_dbt_metric_filter_fields:
-        if filter_field not in dbt_metric.dimensions and filter_field != dbt_metric.timestamp:
-            dimensions.append(
-                _build_dimension(name=filter_field, dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats)
-            )
-
-    return dimensions
-
-
-def _build_measure(dbt_metric: DbtMetric) -> Measure:  # noqa: D
-    return Measure(
-        name=dbt_metric.name,
-        agg=CALC_METHOD_TO_MEASURE_TYPE[dbt_metric.calculation_method],
-        expr=dbt_metric.expression,
-        agg_time_dimension=dbt_metric.timestamp,
-    )
-
-
-def _build_data_source(
-    dbt_metric: DbtMetric, manifest: DbtManifest, time_dimension_stats: Dict[str, List[str]]
-) -> DataSource:  # noqa: D
-    metric_model_ref: DbtModelNode = _resolve_metric_model_ref(
-        manifest=manifest,
-        dbt_metric=dbt_metric,
-    )
-    data_source_table = _db_table_from_model_node(metric_model_ref)
-    return DataSource(
-        name=metric_model_ref.name,
-        description=metric_model_ref.description,
-        sql_table=data_source_table,
-        dbt_model=data_source_table,
-        dimensions=_build_dimensions(dbt_metric, time_dimension_stats),
-        measures=[_build_measure(dbt_metric)],
-    )
-
-
-def _where_clause_from_filters(filters: List[DbtMetricFilter]) -> str:  # noqa: D
-    clauses = [f"{filter.field} {filter.operator} {filter.value}" for filter in filters]
-    return " AND ".join(clauses)
-
-
-def _build_proxy_metric(dbt_metric: DbtMetric) -> Metric:  # noqa: D
-    where_clause_constraint: Optional[WhereClauseConstraint] = None
-    if dbt_metric.filters:
-        where_clause_constraint = WhereClauseConstraint(
-            where=_where_clause_from_filters(filters=dbt_metric.filters),
-            linkable_names=[filter.field for filter in dbt_metric.filters],
-        )
-
-    return Metric(
-        name=dbt_metric.name,
-        description=dbt_metric.description,
-        type=MetricType.MEASURE_PROXY,
-        type_params=MetricTypeParams(
-            measure=MetricInputMeasure(name=dbt_metric.name),
-        ),
-        constraint=where_clause_constraint,
-    )
-
-
-def dbt_metric_to_metricflow_elements(  # noqa: D
-    dbt_metric: DbtMetric, manifest: DbtManifest, time_dimension_stats: Dict[str, List[str]]
-) -> TransformedDbtMetric:
-    data_source = _build_data_source(dbt_metric, manifest, time_dimension_stats)
-    proxy_metric = _build_proxy_metric(dbt_metric)
-    return TransformedDbtMetric(data_source=data_source, metric=proxy_metric)
-
-
-def merge_data_sources(data_sources: List[DataSource]) -> DataSource:  # noqa: D
-    if len(data_sources) == 1:
-        return data_sources[0]
-
-    measures: Set[Measure] = set()
-    identifiers: Set[Identifier] = set()
-    dimensions: Set[Dimension] = set()
-    names: List[str] = []
-    descriptions: List[str] = []
-    sql_tables: List[str] = []
-    sql_queries: List[str] = []
-    dbt_models: List[str] = []
-    for data_source in data_sources:
-        names.append(data_source.name) if data_source.name else None
-        descriptions.append(data_source.description) if data_source.description else None
-        sql_tables.append(data_source.sql_table) if data_source.sql_table else None
-        sql_queries.append(data_source.sql_query) if data_source.sql_query else None
-        dbt_models.append(data_source.dbt_model) if data_source.dbt_model else None
-        measures = measures.union(set(data_source.measures)) if data_source.measures else measures
-        identifiers = identifiers.union(set(data_source.identifiers)) if data_source.identifiers else identifiers
-        dimensions = dimensions.union(set(data_source.dimensions)) if data_source.dimensions else dimensions
-
-    set_names = set(names)
-    set_descriptions = set(descriptions)
-    set_sql_tables = set(sql_tables)
-    set_sql_queries = set(sql_queries)
-    set_dbt_models = set(dbt_models)
-
-    assert len(set_names) == 1, "Cannot merge data sources, all data sources to merge must have same name"
-    assert (
-        len(set_descriptions) <= 1
-    ), "Cannot merge data sources, all data sources to merge must have same descritpion (or none)"
-    assert (
-        len(set_sql_tables) <= 1
-    ), "Cannot merge data sources, all data sources to merge must have same sql_table (or none)"
-    assert (
-        len(set_sql_queries) <= 1
-    ), "Cannot merge data sources, all data sources to merge must have same sql_query (or none)"
-    assert xor(
-        len(set_sql_tables) == 1, len(set_sql_queries) == 1
-    ), "Cannot merge data sources, definitions for both sql_table and sql_query exist"
-    assert (
-        len(set_dbt_models) <= 1
-    ), "Cannot merge data sources, all data sources to merge must have same dbt_model (or none)"
-
-    return DataSource(
-        name=list(set_names)[0],
-        description=list(set_descriptions)[0] if set_descriptions else None,
-        sql_table=list(set_sql_tables)[0] if set_sql_tables else None,
-        sql_query=list(set_sql_queries)[0] if set_sql_queries else None,
-        dbt_model=list(set_dbt_models)[0] if set_dbt_models else None,
-        dimensions=list(dimensions),
-        identifiers=list(identifiers),
-        measures=list(measures),
-    )
-
-
-def collect_time_dimension_names_from_metrics(dbt_metrics: List[DbtMetric]) -> Dict[str, List[str]]:  # noqa: D
-    time_dimensions: Dict[str, List[str]] = {}
-    time_stats_for_metric_models: Dict[str, Dict[str, int]] = {}
-    for dbt_metric in dbt_metrics:
-        if dbt_metric.calculation_method != "derived":
-            if dbt_metric.timestamp not in time_dimensions:
-                time_dimensions[dbt_metric.timestamp] = []
-
-            if dbt_metric.model not in time_stats_for_metric_models:
-                time_stats_for_metric_models[dbt_metric.model] = {dbt_metric.timestamp: 1}
-            else:
-                time_stats_for_metric_models[dbt_metric.model][dbt_metric.timestamp] += 1
-
-    for metric_model, time_stats in time_stats_for_metric_models.items():
-        primary_time_dim = max(time_stats, key=time_stats.get)  # type: ignore
-        time_dimensions[primary_time_dim].append(metric_model)
-
-    return time_dimensions
-
-
-def transform_manifest_into_user_configured_model(manifest: DbtManifest) -> ModelBuildResult:  # noqa: D
-    data_sources_map: Dict[str, List[DataSource]] = {}
-    metrics = []
-    issues: List[ValidationIssue] = []
-    time_dimension_stats = collect_time_dimension_names_from_metrics(manifest.metrics.values())
-
-    for dbt_metric in manifest.metrics.values():
-        # TODO: Handle derived dbt metrics
-        if dbt_metric.calculation_method == "derived":
-            continue
+        if len(ref_parts) == 1:
+            target_model = ref_parts[0].strip(" \"'\t\r\n")
+        elif len(ref_parts) == 2:
+            target_package = ref_parts[0].strip(" \"'\t\r\n")
+            target_model = ref_parts[1].strip(" \"'\t\r\n")
         else:
-            transformed_dbt_metric = dbt_metric_to_metricflow_elements(
-                dbt_metric=dbt_metric, manifest=manifest, time_dimension_stats=time_dimension_stats
-            )
-            if transformed_dbt_metric.data_source.name not in data_sources_map:
-                data_sources_map[transformed_dbt_metric.data_source.name] = [transformed_dbt_metric.data_source]
-            else:
-                data_sources_map[transformed_dbt_metric.data_source.name].append(transformed_dbt_metric.data_source)
-            metrics.append(transformed_dbt_metric.metric)
+            ref_invalid_args(dbt_metric.name, ref_parts)
 
-    # As it might be the case that we generated many of the same data source,
-    # we need to merge / dedupe them
-    deduped_data_sources = []
-    for name, data_sources in data_sources_map.items():
-        try:
-            deduped_data_sources.append(merge_data_sources(data_sources))
-        except Exception as e:
-            issues.append(
-                ValidationError(
-                    message=f"Failed to merge data sources with the name `{name}`",
-                    extra_detail="".join(traceback.format_tb(e.__traceback__)),
+        node = self.manifest.resolve_ref(
+            target_model_name=target_model,
+            target_model_package=target_package,
+            current_project=self.manifest.metadata.project_id,
+            node_package=dbt_metric.package_name,
+        )
+        assert isinstance(
+            node, DbtModelNode
+        ), f"Ref `{dbt_metric.model}` resolved to {node}, which is not of type `{DbtModelNode.__name__}`"
+        return node
+
+    def _db_table_from_model_node(self, node: DbtModelNode) -> str:  # noqa: D
+        return f"{node.database}.{node.schema}.{node.name}"
+
+    def _build_dimension(
+        self, name: str, dbt_metric: DbtMetric, time_dimension_stats: Dict[str, List[str]]
+    ) -> Dimension:
+        if name in time_dimension_stats.keys():
+            return Dimension(
+                name=name,
+                type=DimensionType.TIME,
+                type_params=DimensionTypeParams(
+                    is_primary=dbt_metric.model in time_dimension_stats[name], time_granularity=TimeGranularity.DAY
+                ),
+            )
+        else:
+            return Dimension(
+                name=name,
+                type=DimensionType.CATEGORICAL,
+            )
+
+    def _build_dimensions(
+        self, dbt_metric: DbtMetric, time_dimension_stats: Dict[str, List[str]]
+    ) -> List[Dimension]:  # noqa: D
+        dimensions = []
+
+        # Build dimensions specifically from DbtMetric.dimensions list
+        for dimension in dbt_metric.dimensions:
+            dimensions.append(
+                self._build_dimension(name=dimension, dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats)
+            )
+
+        # Add DbtMetric.timestamp as a time dimension
+        dimensions.append(
+            self._build_dimension(
+                name=dbt_metric.timestamp, dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats
+            )
+        )
+
+        # We need to deduplicate the filters because a field could be the same in
+        # two filters. For example, if two filters exist for `amount`, one with
+        # `>= 500` and the other `< 1000`, but only one dimension should be created
+        distinct_dbt_metric_filter_fields = set([filter.field for filter in dbt_metric.filters])
+        # Add dimension per distinct filter field
+        # exclude when field is also listed as a DbtMetric.dimension
+        # exclude when field is also the DbtMetric.timestamp
+        for filter_field in distinct_dbt_metric_filter_fields:
+            if filter_field not in dbt_metric.dimensions and filter_field != dbt_metric.timestamp:
+                dimensions.append(
+                    self._build_dimension(
+                        name=filter_field, dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats
+                    )
                 )
+
+        return dimensions
+
+    def _build_measure(self, dbt_metric: DbtMetric) -> Measure:  # noqa: D
+        return Measure(
+            name=dbt_metric.name,
+            agg=CALC_METHOD_TO_MEASURE_TYPE[dbt_metric.calculation_method],
+            expr=dbt_metric.expression,
+            agg_time_dimension=dbt_metric.timestamp,
+        )
+
+    def _build_data_source(
+        self, dbt_metric: DbtMetric, time_dimension_stats: Dict[str, List[str]]
+    ) -> DataSource:  # noqa: D
+        metric_model_ref = self._resolve_metric_model_ref(dbt_metric=dbt_metric)
+        data_source_table = self._db_table_from_model_node(metric_model_ref)
+        return DataSource(
+            name=metric_model_ref.name,
+            description=metric_model_ref.description,
+            sql_table=data_source_table,
+            dbt_model=data_source_table,
+            dimensions=self._build_dimensions(dbt_metric, time_dimension_stats),
+            measures=[self._build_measure(dbt_metric)],
+        )
+
+    def _where_clause_from_filters(self, filters: List[DbtMetricFilter]) -> str:  # noqa: D
+        clauses = [f"{filter.field} {filter.operator} {filter.value}" for filter in filters]
+        return " AND ".join(clauses)
+
+    def _build_proxy_metric(self, dbt_metric: DbtMetric) -> Metric:  # noqa: D
+        where_clause_constraint: Optional[WhereClauseConstraint] = None
+        if dbt_metric.filters:
+            where_clause_constraint = WhereClauseConstraint(
+                where=self._where_clause_from_filters(filters=dbt_metric.filters),
+                linkable_names=[filter.field for filter in dbt_metric.filters],
             )
 
-    return ModelBuildResult(
-        model=UserConfiguredModel(data_sources=list(deduped_data_sources), metrics=metrics),
-        issues=ModelValidationResults.from_issues_sequence(issues=issues),
-    )
+        return Metric(
+            name=dbt_metric.name,
+            description=dbt_metric.description,
+            type=MetricType.MEASURE_PROXY,
+            type_params=MetricTypeParams(
+                measure=MetricInputMeasure(name=dbt_metric.name),
+            ),
+            constraint=where_clause_constraint,
+        )
+
+    def dbt_metric_to_metricflow_elements(  # noqa: D
+        self, dbt_metric: DbtMetric, time_dimension_stats: Dict[str, List[str]]
+    ) -> TransformedDbtMetric:
+        data_source = self._build_data_source(dbt_metric, time_dimension_stats)
+        proxy_metric = self._build_proxy_metric(dbt_metric)
+        return TransformedDbtMetric(data_source=data_source, metric=proxy_metric)
+
+    @classmethod
+    def merge_data_sources(cls, data_sources: List[DataSource]) -> DataSource:  # noqa: D
+        if len(data_sources) == 1:
+            return data_sources[0]
+
+        measures: Set[Measure] = set()
+        identifiers: Set[Identifier] = set()
+        dimensions: Set[Dimension] = set()
+        names: List[str] = []
+        descriptions: List[str] = []
+        sql_tables: List[str] = []
+        sql_queries: List[str] = []
+        dbt_models: List[str] = []
+        for data_source in data_sources:
+            names.append(data_source.name) if data_source.name else None
+            descriptions.append(data_source.description) if data_source.description else None
+            sql_tables.append(data_source.sql_table) if data_source.sql_table else None
+            sql_queries.append(data_source.sql_query) if data_source.sql_query else None
+            dbt_models.append(data_source.dbt_model) if data_source.dbt_model else None
+            measures = measures.union(set(data_source.measures)) if data_source.measures else measures
+            identifiers = identifiers.union(set(data_source.identifiers)) if data_source.identifiers else identifiers
+            dimensions = dimensions.union(set(data_source.dimensions)) if data_source.dimensions else dimensions
+
+        set_names = set(names)
+        set_descriptions = set(descriptions)
+        set_sql_tables = set(sql_tables)
+        set_sql_queries = set(sql_queries)
+        set_dbt_models = set(dbt_models)
+
+        assert len(set_names) == 1, "Cannot merge data sources, all data sources to merge must have same name"
+        assert (
+            len(set_descriptions) <= 1
+        ), "Cannot merge data sources, all data sources to merge must have same descritpion (or none)"
+        assert (
+            len(set_sql_tables) <= 1
+        ), "Cannot merge data sources, all data sources to merge must have same sql_table (or none)"
+        assert (
+            len(set_sql_queries) <= 1
+        ), "Cannot merge data sources, all data sources to merge must have same sql_query (or none)"
+        assert xor(
+            len(set_sql_tables) == 1, len(set_sql_queries) == 1
+        ), "Cannot merge data sources, definitions for both sql_table and sql_query exist"
+        assert (
+            len(set_dbt_models) <= 1
+        ), "Cannot merge data sources, all data sources to merge must have same dbt_model (or none)"
+
+        return DataSource(
+            name=list(set_names)[0],
+            description=list(set_descriptions)[0] if set_descriptions else None,
+            sql_table=list(set_sql_tables)[0] if set_sql_tables else None,
+            sql_query=list(set_sql_queries)[0] if set_sql_queries else None,
+            dbt_model=list(set_dbt_models)[0] if set_dbt_models else None,
+            dimensions=list(dimensions),
+            identifiers=list(identifiers),
+            measures=list(measures),
+        )
+
+    @classmethod
+    def collect_time_dimension_names_from_metrics(cls, dbt_metrics: List[DbtMetric]) -> Dict[str, List[str]]:  # noqa: D
+        time_dimensions: Dict[str, List[str]] = {}
+        time_stats_for_metric_models: Dict[str, Dict[str, int]] = {}
+        for dbt_metric in dbt_metrics:
+            if dbt_metric.calculation_method != "derived":
+                if dbt_metric.timestamp not in time_dimensions:
+                    time_dimensions[dbt_metric.timestamp] = []
+
+                if dbt_metric.model not in time_stats_for_metric_models:
+                    time_stats_for_metric_models[dbt_metric.model] = {dbt_metric.timestamp: 1}
+                else:
+                    time_stats_for_metric_models[dbt_metric.model][dbt_metric.timestamp] += 1
+
+        for metric_model, time_stats in time_stats_for_metric_models.items():
+            primary_time_dim = max(time_stats, key=time_stats.get)  # type: ignore
+            time_dimensions[primary_time_dim].append(metric_model)
+
+        return time_dimensions
+
+    def build_user_configured_model(self) -> ModelBuildResult:  # noqa: D
+        data_sources_map: Dict[str, List[DataSource]] = {}
+        metrics = []
+        issues: List[ValidationIssue] = []
+        time_dimension_stats = self.collect_time_dimension_names_from_metrics(self.manifest.metrics.values())
+
+        for dbt_metric in self.manifest.metrics.values():
+            # TODO: Handle derived dbt metrics
+            if dbt_metric.calculation_method == "derived":
+                continue
+            else:
+                transformed_dbt_metric = self.dbt_metric_to_metricflow_elements(
+                    dbt_metric=dbt_metric, time_dimension_stats=time_dimension_stats
+                )
+                if transformed_dbt_metric.data_source.name not in data_sources_map:
+                    data_sources_map[transformed_dbt_metric.data_source.name] = [transformed_dbt_metric.data_source]
+                else:
+                    data_sources_map[transformed_dbt_metric.data_source.name].append(transformed_dbt_metric.data_source)
+                metrics.append(transformed_dbt_metric.metric)
+
+        # As it might be the case that we generated many of the same data source,
+        # we need to merge / dedupe them
+        deduped_data_sources = []
+        for name, data_sources in data_sources_map.items():
+            try:
+                deduped_data_sources.append(self.merge_data_sources(data_sources))
+            except Exception as e:
+                issues.append(
+                    ValidationError(
+                        message=f"Failed to merge data sources with the name `{name}`",
+                        extra_detail="".join(traceback.format_tb(e.__traceback__)),
+                    )
+                )
+
+        return ModelBuildResult(
+            model=UserConfiguredModel(data_sources=list(deduped_data_sources), metrics=metrics),
+            issues=ModelValidationResults.from_issues_sequence(issues=issues),
+        )

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -160,7 +160,15 @@ class DbtManifestTransformer:
             agg_time_dimension=dbt_metric.timestamp,
         )
 
-    def _build_data_source(self, dbt_metric: DbtMetric) -> DataSource:  # noqa: D
+    def build_data_source_for_metric(self, dbt_metric: DbtMetric) -> DataSource:
+        """Attemps to build a data source for a given DbtMetric
+
+        Raises:
+            RuntimeError: A data source can't be built for `derived` dbt metrics
+        """
+        if dbt_metric.calculation_method == "derived":
+            raise RuntimeError("Cannot build a MetricFlow data source for `derived` DbtMetric")
+
         metric_model_ref = self.resolve_metric_model_ref(dbt_metric=dbt_metric)
         data_source_table = self.db_table_from_model_node(metric_model_ref)
         return DataSource(
@@ -195,7 +203,7 @@ class DbtManifestTransformer:
         )
 
     def dbt_metric_to_metricflow_elements(self, dbt_metric: DbtMetric) -> TransformedDbtMetric:  # noqa: D
-        data_source = self._build_data_source(dbt_metric)
+        data_source = self.build_data_source_for_metric(dbt_metric)
         proxy_metric = self._build_proxy_metric(dbt_metric)
         return TransformedDbtMetric(data_source=data_source, metric=proxy_metric)
 

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -25,10 +25,10 @@ def _resolve_metric_model_ref(manifest: DbtManifest, dbt_metric: DbtMetric) -> D
     target_package = None
 
     if len(ref_parts) == 1:
-        target_model = ref_parts[0].strip()
+        target_model = ref_parts[0].strip(" \"'\t\r\n")
     elif len(ref_parts) == 2:
-        target_package = ref_parts[0].strip()
-        target_model = ref_parts[1].strip()
+        target_package = ref_parts[0].strip(" \"'\t\r\n")
+        target_model = ref_parts[1].strip(" \"'\t\r\n")
     else:
         ref_invalid_args(dbt_metric.name, ref_parts)
 
@@ -38,7 +38,9 @@ def _resolve_metric_model_ref(manifest: DbtManifest, dbt_metric: DbtMetric) -> D
         current_project=manifest.metadata.project_id,
         node_package=dbt_metric.package_name,
     )
-    assert isinstance(node, DbtModelNode)
+    assert isinstance(
+        node, DbtModelNode
+    ), f"Ref `{dbt_metric.model}` resolved to {node}, which is not of type `{DbtModelNode.__name__}`"
     return node
 
 

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -1,7 +1,8 @@
+from collections import defaultdict
 from dataclasses import dataclass
 from operator import xor
 import traceback
-from typing import Dict, List, Optional, Set
+from typing import DefaultDict, Dict, List, Optional, Set
 from dbt.contracts.graph.parsed import ParsedMetric as DbtMetric, ParsedModelNode as DbtModelNode
 from dbt.contracts.graph.unparsed import MetricFilter as DbtMetricFilter
 from dbt.exceptions import ref_invalid_args
@@ -359,9 +360,11 @@ class DbtManifestTransformer:
         """Builds a UserConfiguredModel from the manifest of the instance
 
         Note:
-            Currently skips DbtMetric that are `derived`
+            TODO: This currently skips DbtMetric that are `derived`. Once MetricFlow
+            supports derived metrics, we'll need to add that functionality to
+            handle dbt derived metrics -> metricflow derived metrics.
         """
-        data_sources_map: Dict[str, List[DataSource]] = {}
+        data_sources_map: DefaultDict[str, List[DataSource]] = defaultdict(list)
         metrics = []
         issues: List[ValidationIssue] = []
 
@@ -371,10 +374,7 @@ class DbtManifestTransformer:
                 continue
             else:
                 transformed_dbt_metric = self.dbt_metric_to_metricflow_elements(dbt_metric=dbt_metric)
-                if transformed_dbt_metric.data_source.name not in data_sources_map:
-                    data_sources_map[transformed_dbt_metric.data_source.name] = [transformed_dbt_metric.data_source]
-                else:
-                    data_sources_map[transformed_dbt_metric.data_source.name].append(transformed_dbt_metric.data_source)
+                data_sources_map[transformed_dbt_metric.data_source.name].append(transformed_dbt_metric.data_source)
                 metrics.append(transformed_dbt_metric.metric)
 
         # As it might be the case that we generated many of the same data source,

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -155,7 +155,15 @@ class DbtManifestTransformer:
 
         return dimensions
 
-    def _build_measure(self, dbt_metric: DbtMetric) -> Measure:  # noqa: D
+    def build_measure(self, dbt_metric: DbtMetric) -> Measure:
+        """Attemps to build a measure for a given DbtMetric
+
+        Raises:
+            RuntimeError: A measure can't be built for `derived` dbt metrics
+        """
+        if dbt_metric.calculation_method == "derived":
+            raise RuntimeError("Cannot build a MetricFlow measure for `derived` DbtMetric")
+
         return Measure(
             name=dbt_metric.name,
             agg=CALC_METHOD_TO_MEASURE_TYPE[dbt_metric.calculation_method],
@@ -180,7 +188,7 @@ class DbtManifestTransformer:
             sql_table=data_source_table,
             dbt_model=data_source_table,
             dimensions=self.build_dimensions(dbt_metric),
-            measures=[self._build_measure(dbt_metric)],
+            measures=[self.build_measure(dbt_metric)],
         )
 
     def _where_clause_from_filters(self, filters: List[DbtMetricFilter]) -> str:  # noqa: D

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -109,7 +109,10 @@ def _build_dimensions(dbt_metric: DbtMetric) -> List[Dimension]:  # noqa: D
 
 def _build_measure(dbt_metric: DbtMetric) -> Measure:  # noqa: D
     return Measure(
-        name=dbt_metric.name, agg=CALC_METHOD_TO_MEASURE_TYPE[dbt_metric.calculation_method], expr=dbt_metric.expression
+        name=dbt_metric.name,
+        agg=CALC_METHOD_TO_MEASURE_TYPE[dbt_metric.calculation_method],
+        expr=dbt_metric.expression,
+        agg_time_dimension=dbt_metric.timestamp,
     )
 
 

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -253,16 +253,16 @@ class DbtManifestTransformer:
         return TransformedDbtMetric(data_source=data_source, metric=proxy_metric)
 
     @classmethod
-    def merge_data_sources(cls, data_sources: List[DataSource]) -> DataSource:
-        """Attemps to merge a list of data sources into a single data source
+    def deduplicate_data_sources(cls, data_sources: List[DataSource]) -> DataSource:
+        """Attempts to deduplicate a list of data sources into a single data source
 
         Because each DbtMetric (which isn't `derived`) creates a data source,
-        and many DbtMetric can create the same data source with the differring
-        numbers and defintions for dimensions and measures, we need a way to
-        deduplicate/merge them. This function does that. It requires that the
-        base information (name/table/query/description/etc) of the data source
-        not be variable and that dimensions/measures/identifers with the same
-        name have the same attributes.
+        and many DbtMetric can create the same data source with differring
+        defintions for dimensions and measures, we need a way to deduplicate/merge
+        them. This function does that. It requires that the base information
+        (name/table/query/description/etc) of the data source not be variable and
+        that dimensions/measures/identifers with the same name have the same
+        attributes.
         """
 
         if len(data_sources) == 1:
@@ -382,7 +382,7 @@ class DbtManifestTransformer:
         deduped_data_sources = []
         for name, data_sources in data_sources_map.items():
             try:
-                deduped_data_sources.append(self.merge_data_sources(data_sources))
+                deduped_data_sources.append(self.deduplicate_data_sources(data_sources))
             except Exception as e:
                 issues.append(
                     ValidationError(

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -1,0 +1,80 @@
+from typing import List, Union
+from dbt.contracts.graph.parsed import ParsedMetric as DbtMetric, ParsedModelNode as DbtModelNode
+from dbt.exceptions import ref_invalid_args
+from dbt.contracts.graph.manifest import Manifest as DbtManifest
+from metricflow.model.objects.data_source import DataSource
+from metricflow.model.objects.elements.dimension import Dimension, DimensionType
+from metricflow.model.objects.metric import Metric
+from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.parsing.dir_to_model import ModelBuildResult
+
+
+def _resolve_metric_model_ref(manifest: DbtManifest, dbt_metric: DbtMetric) -> DbtModelNode:  # noqa: D
+    if dbt_metric.model[:4] != "ref(":
+        raise RuntimeError("Can only resolve refs for ref strings that begin with `ref(`")
+    ref_parts = dbt_metric.model[4:-1].split(",")
+    target_model = None
+    target_package = None
+
+    if len(ref_parts) == 1:
+        target_model = ref_parts[0].strip()
+    elif len(ref_parts) == 2:
+        target_package = ref_parts[0].strip()
+        target_model = ref_parts[1].strip()
+    else:
+        ref_invalid_args(dbt_metric.name, ref_parts)
+
+    node = manifest.resolve_ref(
+        target_model_name=target_model,
+        target_model_package=target_package,
+        current_project=manifest.metadata.project_id,
+        node_package=dbt_metric.package_name,
+    )
+    assert isinstance(node, DbtModelNode)
+    return node
+
+
+def _db_table_from_model_node(node: DbtModelNode) -> str:  # noqa: D
+    return f"{node.database}.{node.schema}.{node.name}"
+
+
+def _build_dimensions(dimensions: List[str]) -> List[Dimension]:  # noqa: D
+    built_dimensions = []
+    for dimension in dimensions:
+        built_dimensions.append(
+            Dimension(
+                name=dimension,
+                type=DimensionType.CATEGORICAL,
+            )
+        )
+    return built_dimensions
+
+
+def _build_data_source(dbt_metric: DbtMetric, manifest: DbtManifest) -> DataSource:  # noqa: D
+    metric_model_ref: DbtModelNode = _resolve_metric_model_ref(
+        manifest=manifest,
+        dbt_metric=dbt_metric,
+    )
+    data_source_table = _db_table_from_model_node(metric_model_ref)
+    return DataSource(
+        name=metric_model_ref.name,
+        description=metric_model_ref.description,
+        sql_table=data_source_table,
+        dbt_model=data_source_table,
+        dimensions=_build_dimensions(dbt_metric.dimensions),
+    )
+
+
+def dbt_metric_to_metricflow_elements(  # noqa: D
+    dbt_metric: DbtMetric, manifest: DbtManifest
+) -> List[Union[DataSource, Metric]]:
+    data_source = _build_data_source(dbt_metric, manifest)
+    return [data_source]
+
+
+def transform_manifest_into_user_configured_model(manifest: DbtManifest) -> ModelBuildResult:  # noqa: D
+    elements = []
+    for dbt_metric in manifest.metrics.values():
+        elements += dbt_metric_to_metricflow_elements(dbt_metric=dbt_metric, manifest=manifest)
+    raise NotImplementedError("`transform_manifest_into_user_configured_model` isn't finished")
+    return ModelBuildResult(model=UserConfiguredModel(data_sources=[], metrics=[], materializations=[]))

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -346,7 +346,12 @@ class DbtManifestTransformer:
 
         return time_dimensions
 
-    def build_user_configured_model(self) -> ModelBuildResult:  # noqa: D
+    def build_user_configured_model(self) -> ModelBuildResult:
+        """Builds a UserConfiguredModel from the manifest of the instance
+
+        Note:
+            Currently skips DbtMetric that are `derived`
+        """
         data_sources_map: Dict[str, List[DataSource]] = {}
         metrics = []
         issues: List[ValidationIssue] = []

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -3,10 +3,11 @@ from dbt.contracts.graph.parsed import ParsedMetric as DbtMetric, ParsedModelNod
 from dbt.exceptions import ref_invalid_args
 from dbt.contracts.graph.manifest import Manifest as DbtManifest
 from metricflow.model.objects.data_source import DataSource
-from metricflow.model.objects.elements.dimension import Dimension, DimensionType
+from metricflow.model.objects.elements.dimension import Dimension, DimensionType, DimensionTypeParams
 from metricflow.model.objects.metric import Metric
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
+from metricflow.time.time_granularity import TimeGranularity
 
 
 def _resolve_metric_model_ref(manifest: DbtManifest, dbt_metric: DbtMetric) -> DbtModelNode:  # noqa: D
@@ -38,7 +39,7 @@ def _db_table_from_model_node(node: DbtModelNode) -> str:  # noqa: D
     return f"{node.database}.{node.schema}.{node.name}"
 
 
-def _build_dimensions(dimensions: List[str]) -> List[Dimension]:  # noqa: D
+def _dimensions_from_dbt_metric_dimensions(dimensions: List[str]) -> List[Dimension]:  # noqa: D
     built_dimensions = []
     for dimension in dimensions:
         built_dimensions.append(
@@ -48,6 +49,18 @@ def _build_dimensions(dimensions: List[str]) -> List[Dimension]:  # noqa: D
             )
         )
     return built_dimensions
+
+
+def _build_dimensions(dbt_metric: DbtMetric) -> List[Dimension]:  # noqa: D
+    dimensions = _dimensions_from_dbt_metric_dimensions(dimensions=dbt_metric.dimensions)
+    dimensions.append(
+        Dimension(
+            name=dbt_metric.timestamp,
+            type=DimensionType.TIME,
+            type_params=DimensionTypeParams(time_granularity=TimeGranularity.DAY),
+        )
+    )
+    return dimensions
 
 
 def _build_data_source(dbt_metric: DbtMetric, manifest: DbtManifest) -> DataSource:  # noqa: D
@@ -61,7 +74,7 @@ def _build_data_source(dbt_metric: DbtMetric, manifest: DbtManifest) -> DataSour
         description=metric_model_ref.description,
         sql_table=data_source_table,
         dbt_model=data_source_table,
-        dimensions=_build_dimensions(dbt_metric.dimensions),
+        dimensions=_build_dimensions(dbt_metric),
     )
 
 


### PR DESCRIPTION
This builds on #279. It takes a dbt `Manifest` and builds a `UserConfiguredModel` based on the manifest's `metrics`. I believe the only thing that is missing is that this skips dbt metrics which have a `calculation_method` of `derived` because we are currently building out MetricFlow's ability to support derived metrics, and thus we'll add in a later PR.

## Testing

With this version of metricflow installed to your virtual env
```
$ python
>>> from metricflow.model.parsing import dbt_dir_to_model
>>> dbt_dir_to_model.parse_dbt_project_to_model("/path/to/dbt/project/root")
ModelBuildResult(...)
```

## Stacked PR
* feature-branch--issue-266-dbt-integration
  * #279 
    * #280 👈 You are here
      * #288  