### PR TITLE
Add Async Query / Cancel Methods to SqlClient

### DIFF
--- a/metricflow/protocols/async_sql_client.py
+++ b/metricflow/protocols/async_sql_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, Sequence
+
+from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet
+from metricflow.sql.sql_bind_parameters import SqlBindParameters
+
+
+class AsyncSqlClient(SqlClient, Protocol):
+    """Defines methods for executing SQL statements asynchronously."""
+
+    def async_query(
+        self,
+        statement: str,
+        bind_parameters: SqlBindParameters = SqlBindParameters(),
+        tags: SqlRequestTagSet = SqlRequestTagSet(),
+    ) -> SqlRequestId:
+        """Execute a query asynchronously."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def async_request_result(self, request_id: SqlRequestId) -> SqlRequestResult:
+        """Wait until a async query has finished, and then return the result"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def async_execute(
+        self,
+        statement: str,
+        bind_parameters: SqlBindParameters = SqlBindParameters(),
+        tags: SqlRequestTagSet = SqlRequestTagSet(),
+    ) -> SqlRequestId:
+        """Execute a statement that does not return values asynchronously."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:
+        """Make a best-effort at canceling requests that have a superset of the given tags.
+
+        Returns the number of cancellation commands sent.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def active_requests(self) -> Sequence[SqlRequestId]:
+        """Return requests that are still in progress.
+
+        If the results for a request have not yet been fetched with async_request_result(), it's considered in progress.
+        """
+        raise NotImplementedError

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -186,6 +186,7 @@ class SqlEngineAttributes(Protocol):
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str]
     timestamp_type_name: ClassVar[Optional[str]]
+    random_function_name: ClassVar[str]
 
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer]

--- a/metricflow/protocols/sql_request.py
+++ b/metricflow/protocols/sql_request.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import typing
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
+from operator import itemgetter
+from typing import Optional, Sequence, Dict
+
+import pandas as pd
+from pydantic import Field
+
+from metricflow.model.objects.base import FrozenBaseModel
+from metricflow.object_utils import assert_exactly_one_arg_set
+
+
+@dataclass(frozen=True)
+class SqlRequestId:
+    """Identifies a request (i.e. a call to SqlClient.query() or SqlClient.execute()) to the SQL engine."""
+
+    id_str: str
+
+    def __repr__(self) -> str:  # noqa: D
+        return self.id_str
+
+
+@dataclass(frozen=True)
+class SqlRequestResult:
+    """The result from a request to the SQL engine."""
+
+    df: Optional[pd.DataFrame] = None
+    exception: Optional[Exception] = None
+
+    def __post_init__(self) -> None:  # noqa: D
+        assert_exactly_one_arg_set(df=self.df, exception=self.exception)
+
+
+class SqlRequestTagSet(FrozenBaseModel):
+    """Set of tags as a Pydantic model for easy serialization."""
+
+    # Using strings to make for cleaner serialized output. Clients should not use this field directly.
+    tag_dict: typing.OrderedDict[str, str] = Field(default_factory=OrderedDict)
+
+    @property
+    def tags(self) -> Sequence[SqlRequestTag]:  # noqa: D
+        return tuple(SqlRequestTag(key, value) for key, value in self.tag_dict.items())
+
+    @staticmethod
+    def create_from_dict(tag_dict: Dict[SqlRequestTagKey, str]) -> SqlRequestTagSet:  # noqa: D
+        str_tag_dict = {tag_key_enum.value: value for tag_key_enum, value in tag_dict.items()}
+        sorted_tuples = tuple(sorted(str_tag_dict.items(), key=itemgetter(0, 1)))
+        return SqlRequestTagSet(tag_dict=OrderedDict(sorted_tuples))
+
+    @staticmethod
+    def create_from_request_id(request_id: SqlRequestId) -> SqlRequestTagSet:
+        """Create a tag set that only includes the tag for the request ID."""
+        tag_dict = OrderedDict()
+        tag_dict[SqlRequestTagKey.REQUEST_ID_KEY.value] = request_id.id_str
+        return SqlRequestTagSet(tag_dict=tag_dict)
+
+    def add_request_id(self, request_id: SqlRequestId) -> SqlRequestTagSet:
+        """Adds the request ID tag to this set."""
+        tag_dict = OrderedDict()
+        tag_dict[SqlRequestTagKey.REQUEST_ID_KEY.value] = request_id.id_str
+        return SqlRequestTagSet.combine((self, SqlRequestTagSet(tag_dict=tag_dict)))
+
+    @staticmethod
+    def combine(tag_sets: Sequence[SqlRequestTagSet]) -> SqlRequestTagSet:  # noqa: D
+        tag_dict: OrderedDict[str, str] = OrderedDict()
+        for tag_set in tag_sets:
+            for key, value in tag_set.tag_dict.items():
+                if key in tag_dict and tag_dict[key] != value:
+                    raise RuntimeError(
+                        f"Can't combine tag sets due to a conflicting value for key: {key}. Conflicting values are "
+                        f"at least: {value} and {tag_dict[key]}"
+                    )
+                tag_dict[key] = value
+
+        return SqlRequestTagSet(tag_dict=tag_dict)
+
+    @property
+    def request_id(self) -> Optional[SqlRequestId]:
+        """The value of the request ID tag."""
+        tag_value = self.tag_dict.get(SqlRequestTagKey.REQUEST_ID_KEY.value)
+        if tag_value:
+            return SqlRequestId(tag_value)
+        return None
+
+    def is_subset_of(self, tag_set: SqlRequestTagSet) -> bool:  # noqa: D
+        return self.tag_dict.items() <= tag_set.tag_dict.items()
+
+
+@dataclass(frozen=True)
+class SqlRequestTag:
+    """A key / value that can be used ot label requests to the SQL engine"""
+
+    key: str
+    value: str
+
+
+class SqlRequestTagKey(Enum):
+    """Specific tags used by the system."""
+
+    REQUEST_ID_KEY = "MF_REQUEST_ID"

--- a/metricflow/sql_clients/async_request.py
+++ b/metricflow/sql_clients/async_request.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Optional
+
+import pandas as pd
+from pydantic import ValidationError
+
+from metricflow.object_utils import pformat_big_objects
+from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet
+from metricflow.sql.sql_bind_parameters import SqlBindParameters
+
+
+logger = logging.getLogger(__name__)
+
+
+class SqlStatementCommentMetadata:
+    """Helps to add a comment to SQL statements to encode metadata (e.g. tags).
+
+    Added at the end as some engines remove leading comments:
+    https://docs.snowflake.com/en/release-notes/2017-04.html#queries-leading-comments-removed-during-execution
+
+    Example:
+        SELECT 1
+    ->
+        -- MF_REQUEST_METADATA: {"tag_dict": {"MF_REQUEST_ID": "mf_rid__tmhulwkt"}}
+        SELECT 1
+    """
+
+    _TAG_PREFIX = "-- MF_REQUEST_METADATA: "
+
+    @staticmethod
+    def add_tag_metadata_as_comment(sql_statement: str, tag_set: SqlRequestTagSet) -> str:  # noqa: D
+        if tag_set.tags:
+            return sql_statement + "\n" + SqlStatementCommentMetadata._TAG_PREFIX + tag_set.json()
+        else:
+            return sql_statement
+
+    @staticmethod
+    def parse_tag_metadata_in_comments(sql_statement: str) -> Optional[SqlRequestTagSet]:  # noqa: D
+        tag_sets = []
+        for line in sql_statement.split("\n"):
+            if line.startswith(SqlStatementCommentMetadata._TAG_PREFIX):
+                try:
+                    json_str = line[len(SqlStatementCommentMetadata._TAG_PREFIX) :]
+                    tag_sets.append(SqlRequestTagSet.parse_raw(json_str))
+                except ValidationError:
+                    logger.exception(f"Unable to parse tag metadata from line: {line}")
+        if len(tag_sets) > 1:
+            logger.error(
+                f"Got multiple tag sets from parsing comments:\n"
+                f"{pformat_big_objects(tag_sets)}\n"
+                f"Using the first one."
+            )
+
+        return tag_sets[0] if len(tag_sets) > 0 else None
+
+
+class SqlRequestExecutorThread(threading.Thread):
+    """Thread that helps to execute a request to the SQL engine asynchronously."""
+
+    def __init__(  # noqa: D
+        self,
+        sql_client: SqlClient,
+        request_id: SqlRequestId,
+        statement: str,
+        bind_parameters: SqlBindParameters,
+        user_tags: SqlRequestTagSet,
+        is_query: bool = True,
+    ) -> None:
+        """Initializer.
+
+        Args:
+            sql_client: SQL client used to execute statements.
+            request_id: The request ID associated with the statement.
+            statement: The statement to execute.
+            bind_parameters: The parameters to use for the statement.
+            user_tags: Tags that should be associated with the request for the statement.
+            is_query: Whether the request is for .query (returns data) or .execute (does not return data)
+        """
+        self._sql_client = sql_client
+        self._request_id = request_id
+        self._statement = statement
+        self._bind_parameters = bind_parameters
+        self._user_tags = user_tags
+        self._result: Optional[SqlRequestResult] = None
+        self._is_query = is_query
+        super().__init__(name=f"Async Execute SQL Request ID: {request_id}", daemon=True)
+
+    def run(self) -> None:  # noqa: D
+        start_time = time.time()
+        try:
+            statement = SqlStatementCommentMetadata.add_tag_metadata_as_comment(
+                self._statement, self._user_tags.add_request_id(self._request_id)
+            )
+            logger.info(f"Running {self._request_id}")
+            if self._is_query:
+                df = self._sql_client.query(statement, self._bind_parameters)
+                self._result = SqlRequestResult(df=df)
+            else:
+                self._sql_client.execute(statement, self._bind_parameters)
+                self._result = SqlRequestResult(df=pd.DataFrame())
+            logger.info(f"Successfully executed {self._request_id} in {time.time() - start_time:.2f}s")
+        except Exception as e:
+            logger.exception(
+                f"Unsuccessfully executed {self._request_id} in {time.time() - start_time:.2f}s with exception:"
+            )
+            self._result = SqlRequestResult(exception=e)
+
+    @property
+    def result(self) -> SqlRequestResult:  # noqa: D
+        assert self._result is not None, ".result() should only be called once the thread is finished running"
+        return self._result
+
+    @property
+    def request_id(self) -> SqlRequestId:  # noqa: D
+        return self._request_id

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -13,7 +13,7 @@ from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 
-class BigQueryEngineAttributes:
+class BigQueryEngineAttributes(SqlEngineAttributes):
     """Engine-specific attributes for the BigQuery query engine
 
     This is an implementation of the SqlEngineAttributes protocol for BigQuery
@@ -34,6 +34,7 @@ class BigQueryEngineAttributes:
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "FLOAT64"
     timestamp_type_name: ClassVar[Optional[str]] = "DATETIME"
+    random_function_name: ClassVar[str] = "RAND"
 
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = BigQuerySqlQueryPlanRenderer()

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -5,7 +5,9 @@ from typing import ClassVar, Optional, Sequence
 
 import sqlalchemy
 
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.big_query import BigQuerySqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -13,7 +15,7 @@ from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 
-class BigQueryEngineAttributes(SqlEngineAttributes):
+class BigQueryEngineAttributes:
     """Engine-specific attributes for the BigQuery query engine
 
     This is an implementation of the SqlEngineAttributes protocol for BigQuery
@@ -112,4 +114,7 @@ class BigQuerySqlClient(SqlAlchemySqlClient):
             return [x.replace(schema_name + ".", "") for x in schema_dot_tables]
 
     def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
         raise NotImplementedError

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -53,7 +53,7 @@ class DatabricksEngineAttributes(SqlEngineAttributes):
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE"
     timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
-
+    random_function_name: ClassVar[str] = "RANDOM"
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DefaultSqlQueryPlanRenderer()
 

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -9,7 +9,9 @@ import sqlalchemy
 from databricks import sql
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.protocols.sql_client import SqlEngineAttributes, SqlEngine
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_clients.base_sql_client_implementation import BaseSqlClientImplementation
@@ -35,7 +37,7 @@ PANDAS_TO_SQL_DTYPES = {
 }
 
 
-class DatabricksEngineAttributes(SqlEngineAttributes):
+class DatabricksEngineAttributes:
     """SQL engine attributes for Databricks."""
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DATABRICKS
@@ -232,3 +234,6 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
         """Check if SQL statement is renaming a table."""
         stmt_uppercased = stmt.upper()
         return SQL_RENAME in stmt_uppercased and SQL_ALTER_TABLE in stmt_uppercased
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -35,6 +35,7 @@ class DuckDbEngineAttributes(SqlEngineAttributes):
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE"
     timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
+    random_function_name: ClassVar[str] = "RANDOM"
 
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DuckDbSqlQueryPlanRenderer()

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -7,7 +7,9 @@ import sqlalchemy
 from sqlalchemy.pool import StaticPool
 
 from metricflow.dataflow.sql_table import SqlTable
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -17,7 +19,7 @@ from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 logger = logging.getLogger(__name__)
 
 
-class DuckDbEngineAttributes(SqlEngineAttributes):
+class DuckDbEngineAttributes:
     """Engine-specific attributes for the DuckDb query engine"""
 
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DUCKDB
@@ -99,3 +101,6 @@ class DuckDbSqlClient(SqlAlchemySqlClient):
                 df=df,
                 chunk_size=chunk_size,
             )
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -32,6 +32,7 @@ class PostgresEngineAttributes(SqlEngineAttributes):
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE PRECISION"
     timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
+    random_function_name: ClassVar[str] = "RANDOM"
 
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = PostgresSQLSqlQueryPlanRenderer()

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -2,7 +2,10 @@ import logging
 from typing import ClassVar, Mapping, Optional, Sequence, Union
 
 import sqlalchemy
-from metricflow.protocols.sql_client import SqlEngineAttributes, SqlEngine
+
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.postgres import PostgresSQLSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
@@ -11,7 +14,7 @@ from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 logger = logging.getLogger(__name__)
 
 
-class PostgresEngineAttributes(SqlEngineAttributes):
+class PostgresEngineAttributes:
     """Engine-specific attributes for the Postgres query engine
 
     This is an implementation of the SqlEngineAttributes protocol for Postgres
@@ -88,4 +91,7 @@ class PostgresSqlClient(SqlAlchemySqlClient):
         return PostgresEngineAttributes()
 
     def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
         raise NotImplementedError

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -33,6 +33,7 @@ class RedshiftEngineAttributes(SqlEngineAttributes):
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE PRECISION"
     timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
+    random_function_name: ClassVar[str] = "RANDOM"
 
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = RedshiftSqlQueryPlanRenderer()

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -3,7 +3,9 @@ from typing import ClassVar, Optional, Mapping, Union, Sequence
 
 import sqlalchemy
 
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
@@ -12,7 +14,7 @@ from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 logger = logging.getLogger(__name__)
 
 
-class RedshiftEngineAttributes(SqlEngineAttributes):
+class RedshiftEngineAttributes:
     """Engine-specific attributes for the Redshift query engine
 
     This is an implementation of the SqlEngineAttributes protocol for Redshift
@@ -89,4 +91,7 @@ class RedshiftSqlClient(SqlAlchemySqlClient):
         return RedshiftEngineAttributes()
 
     def cancel_submitted_queries(self) -> None:  # noqa: D
+        raise NotImplementedError
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
         raise NotImplementedError

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -38,6 +38,7 @@ class SnowflakeEngineAttributes(SqlEngineAttributes):
     # SQL Dialect replacement strings
     double_data_type_name: ClassVar[str] = "DOUBLE"
     timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
+    random_function_name: ClassVar[str] = "RANDOM"
 
     # MetricFlow attributes
     sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DefaultSqlQueryPlanRenderer()

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -10,7 +10,9 @@ import pandas as pd
 import sqlalchemy
 from sqlalchemy.exc import ProgrammingError
 
-from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngineAttributes
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -18,7 +20,7 @@ from metricflow.sql_clients.common_client import SqlDialect, not_empty
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
 
-class SnowflakeEngineAttributes(SqlEngineAttributes):
+class SnowflakeEngineAttributes:
     """Engine-specific attributes for the Snowflake query engine
 
     This is an implementation of the SqlEngineAttributes protocol for Snowflake
@@ -240,3 +242,6 @@ class SnowflakeSqlClient(SqlAlchemySqlClient):
                 for session_id in self._known_session_ids:
                     logger.info(f"Cancelling queries associated with session id: {session_id}")
                     conn.execute(f"SELECT SYSTEM$cancel_all_queries({session_id})")
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -19,14 +19,15 @@ from metricflow.configuration.constants import (
     CONFIG_DWH_HTTP_PATH,
 )
 from metricflow.configuration.yaml_handler import YamlFileHandler
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql_clients.big_query import BigQuerySqlClient
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
+from metricflow.sql_clients.databricks import DatabricksSqlClient
 from metricflow.sql_clients.duckdb import DuckDbSqlClient
 from metricflow.sql_clients.postgres import PostgresSqlClient
 from metricflow.sql_clients.redshift import RedshiftSqlClient
 from metricflow.sql_clients.snowflake import SnowflakeSqlClient
-from metricflow.sql_clients.databricks import DatabricksSqlClient
 
 
 def make_df(  # type: ignore [misc]
@@ -59,7 +60,7 @@ def make_df(  # type: ignore [misc]
     )
 
 
-def make_sql_client(url: str, password: str) -> SqlClient:
+def make_sql_client(url: str, password: str) -> AsyncSqlClient:
     """Build SQL client based on env configs. Used only in tests."""
     dialect_protocol = make_url(url.split(";")[0]).drivername.split("+")
     dialect = SqlDialect(dialect_protocol[0])

--- a/metricflow/sql_clients/sqlalchemy_dialect.py
+++ b/metricflow/sql_clients/sqlalchemy_dialect.py
@@ -10,6 +10,7 @@ import pandas as pd
 import sqlalchemy
 
 from metricflow.dataflow.sql_table import SqlTable
+from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_clients.base_sql_client_implementation import BaseSqlClientImplementation
 
@@ -21,6 +22,7 @@ class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
 
     def __init__(self, engine: sqlalchemy.engine.Engine) -> None:  # noqa: D
         self._engine = engine
+        super().__init__()
 
     @staticmethod
     def build_engine_url(  # noqa: D
@@ -135,3 +137,6 @@ class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
 
         if errors:
             raise ValueError(f"Found errors in the URL: {url}\n" + "\n".join(errors))
+
+    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+        raise NotImplementedError

--- a/metricflow/test/conftest.py
+++ b/metricflow/test/conftest.py
@@ -1,8 +1,9 @@
 # These imports are required to properly set up pytest fixtures.
-from metricflow.test.fixtures.setup_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.cli_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.dataflow_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.id_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.model_fixtures import *  # noqa: F401, F403
+from metricflow.test.fixtures.setup_fixtures import *  # noqa: F401, F403
+from metricflow.test.fixtures.sql_client_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.sql_fixtures import *  # noqa: F401, F403
 from metricflow.test.fixtures.table_fixtures import *  # noqa: F401, F403

--- a/metricflow/test/fixtures/sql_client_fixtures.py
+++ b/metricflow/test/fixtures/sql_client_fixtures.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 from typing import Generator
 
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.sql_clients.sql_utils import make_sql_client
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
@@ -11,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def sql_client(mf_test_session_state: MetricFlowTestSessionState) -> Generator[SqlClient, None, None]:
-    """Provides a base SqlClient for use in integration tests requiring warehouse access."""
+def async_sql_client(mf_test_session_state: MetricFlowTestSessionState) -> Generator[AsyncSqlClient, None, None]:
+    """Provides an AsyncSqlClient requiring warehouse access."""
     sql_client = make_sql_client(
         url=mf_test_session_state.sql_engine_url,
         password=mf_test_session_state.sql_engine_password,
@@ -33,3 +34,11 @@ def sql_client(mf_test_session_state: MetricFlowTestSessionState) -> Generator[S
 
     sql_client.close()
     return None
+
+
+@pytest.fixture(scope="session")
+def sql_client(
+    mf_test_session_state: MetricFlowTestSessionState, async_sql_client: AsyncSqlClient
+) -> Generator[SqlClient, None, None]:
+    """Similar to async_sql_client, but with a smaller feature set."""
+    yield async_sql_client

--- a/metricflow/test/sql_clients/test_async.py
+++ b/metricflow/test/sql_clients/test_async.py
@@ -1,0 +1,86 @@
+import logging
+import textwrap
+import time
+from typing import Optional
+
+import pytest
+
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.protocols.async_sql_client import AsyncSqlClient
+from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.sql_clients.sql_utils import make_df
+from metricflow.test.compare_df import assert_dataframes_equal
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+
+logger = logging.getLogger(__name__)
+
+
+def create_table_with_n_rows(async_sql_client: AsyncSqlClient, schema_name: str, num_rows: int) -> SqlTable:
+    """Create a table with a specific number of rows."""
+    sql_table = SqlTable(
+        schema_name=schema_name,
+        table_name=f"table_with_{num_rows}_rows",
+    )
+    async_sql_client.drop_table(sql_table)
+    async_sql_client.create_table_from_dataframe(
+        sql_table=sql_table,
+        df=make_df(sql_client=async_sql_client, columns=["example_string"], data=(("foo",) for _ in range(num_rows))),
+    )
+    return sql_table
+
+
+def test_async_query(  # noqa: D
+    async_sql_client: AsyncSqlClient, mf_test_session_state: MetricFlowTestSessionState
+) -> None:
+    request_id = async_sql_client.async_query("SELECT 1 AS foo")
+    result = async_sql_client.async_request_result(request_id)
+    assert_dataframes_equal(
+        actual=result.df,
+        expected=make_df(sql_client=async_sql_client, columns=["foo"], data=((1,),)),
+    )
+    assert result.exception is None
+
+
+def test_async_execute(  # noqa: D
+    async_sql_client: AsyncSqlClient, mf_test_session_state: MetricFlowTestSessionState
+) -> None:
+    request_id = async_sql_client.async_execute("SELECT 1 AS foo")
+    result = async_sql_client.async_request_result(request_id)
+    assert result.exception is None
+
+
+def test_cancel_request(  # noqa: D
+    async_sql_client: AsyncSqlClient, mf_test_session_state: MetricFlowTestSessionState
+) -> None:
+    if not async_sql_client.sql_engine_attributes.cancel_submitted_queries_supported:
+        pytest.skip("Cancellation not yet supported in this SQL engine")
+    # Execute a query that will be slow, giving the test the opportunity to cancel it.
+    table_with_1000_rows = create_table_with_n_rows(
+        async_sql_client, mf_test_session_state.mf_system_schema, num_rows=1000
+    )
+    table_with_100_rows = create_table_with_n_rows(
+        async_sql_client, mf_test_session_state.mf_system_schema, num_rows=100
+    )
+
+    request_id = async_sql_client.async_execute(
+        textwrap.dedent(
+            f"""
+            SELECT MAX({async_sql_client.sql_engine_attributes.random_function_name}()) AS max_value
+            FROM {table_with_1000_rows.sql} a
+            CROSS JOIN {table_with_1000_rows.sql} b
+            CROSS JOIN {table_with_1000_rows.sql} c
+            CROSS JOIN {table_with_100_rows.sql} d
+            """
+        )
+    )
+    # Need to wait a little bit as some clients like BQ doesn't show the query as running right away.
+    start_time = time.time()
+    num_cancelled: Optional[int] = None
+    while time.time() - start_time < 30:
+        time.sleep(1)
+        num_cancelled = async_sql_client.cancel_request(SqlRequestTagSet.create_from_request_id(request_id))
+        if num_cancelled > 0:
+            break
+
+    assert async_sql_client.async_request_result(request_id).exception is not None
+    assert num_cancelled == 1


### PR DESCRIPTION
This PR adds an async interface to the query execution methods in `SqlClient` along with the associated query cancellation methods. The cancellation of queries is handled by returning a request ID in the async method, which is later used to call the cancel method. The queries are tagged using serialized metadata that is added as a comment to the query text, which allows for easy inspection of running queries in the DW engine. It also enables cancelling queries from separate `SqlEngine` objects.