### PR TITLE
Add Isolation Level Support to SqlClient

### DIFF
--- a/metricflow/protocols/async_sql_client.py
+++ b/metricflow/protocols/async_sql_client.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Protocol, Sequence
+from typing import Protocol, Sequence, Optional
 
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.sql_client import SqlClient, SqlIsolationLevel
 from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 
@@ -16,6 +16,7 @@ class AsyncSqlClient(SqlClient, Protocol):
         statement: str,
         bind_parameters: SqlBindParameters = SqlBindParameters(),
         tags: SqlRequestTagSet = SqlRequestTagSet(),
+        isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> SqlRequestId:
         """Execute a query asynchronously."""
         raise NotImplementedError
@@ -31,6 +32,7 @@ class AsyncSqlClient(SqlClient, Protocol):
         statement: str,
         bind_parameters: SqlBindParameters = SqlBindParameters(),
         tags: SqlRequestTagSet = SqlRequestTagSet(),
+        isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> SqlRequestId:
         """Execute a statement that does not return values asynchronously."""
         raise NotImplementedError

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -25,6 +25,18 @@ class SqlEngine(Enum):
     MYSQL = "MySQL"
 
 
+class SqlIsolationLevel(Enum):
+    """Describes the isolation levels used to execute SQL queries. Values are passed as options to SQLAlchemy."""
+
+    READ_UNCOMMITTED = "READ_UNCOMMITTED"
+    READ_COMMITTED = "READ_COMMITTED"
+    REPEATABLE_READ = "REPEATABLE_READ"
+    SNAPSHOT = "SNAPSHOT"
+    # Unique to Databricks.
+    WRITE_SERIALIZABLE = "WRITE_SERIALIZABLE"
+    SERIALIZABLE = "SERIALIZABLE"
+
+
 class SqlClient(Protocol):
     """Base interface for SqlClient instances used inside MetricFlow.
 
@@ -175,6 +187,9 @@ class SqlEngineAttributes(Protocol):
     sql_engine_type: ClassVar[SqlEngine]
 
     # SQL Engine capabilities
+    # The isolation levels supported as options through the SqlClient API. This may be a subset of the isolation levels
+    # supported by the engine until implementation / testing is complete.
+    supported_isolation_levels: ClassVar[Sequence[SqlIsolationLevel]]
     date_trunc_supported: ClassVar[bool]
     full_outer_joins_supported: ClassVar[bool]
     indexes_supported: ClassVar[bool]

--- a/metricflow/sql_clients/async_request.py
+++ b/metricflow/sql_clients/async_request.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
 import logging
-import threading
-import time
 from typing import Optional
 
-import pandas as pd
 from pydantic import ValidationError
 
 from metricflow.object_utils import pformat_big_objects
-from metricflow.protocols.sql_client import SqlClient
-from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet
-from metricflow.sql.sql_bind_parameters import SqlBindParameters
-
+from metricflow.protocols.sql_request import SqlRequestTagSet
 
 logger = logging.getLogger(__name__)
 
@@ -57,64 +51,3 @@ class SqlStatementCommentMetadata:
             )
 
         return tag_sets[0] if len(tag_sets) > 0 else None
-
-
-class SqlRequestExecutorThread(threading.Thread):
-    """Thread that helps to execute a request to the SQL engine asynchronously."""
-
-    def __init__(  # noqa: D
-        self,
-        sql_client: SqlClient,
-        request_id: SqlRequestId,
-        statement: str,
-        bind_parameters: SqlBindParameters,
-        user_tags: SqlRequestTagSet,
-        is_query: bool = True,
-    ) -> None:
-        """Initializer.
-
-        Args:
-            sql_client: SQL client used to execute statements.
-            request_id: The request ID associated with the statement.
-            statement: The statement to execute.
-            bind_parameters: The parameters to use for the statement.
-            user_tags: Tags that should be associated with the request for the statement.
-            is_query: Whether the request is for .query (returns data) or .execute (does not return data)
-        """
-        self._sql_client = sql_client
-        self._request_id = request_id
-        self._statement = statement
-        self._bind_parameters = bind_parameters
-        self._user_tags = user_tags
-        self._result: Optional[SqlRequestResult] = None
-        self._is_query = is_query
-        super().__init__(name=f"Async Execute SQL Request ID: {request_id}", daemon=True)
-
-    def run(self) -> None:  # noqa: D
-        start_time = time.time()
-        try:
-            statement = SqlStatementCommentMetadata.add_tag_metadata_as_comment(
-                self._statement, self._user_tags.add_request_id(self._request_id)
-            )
-            logger.info(f"Running {self._request_id}")
-            if self._is_query:
-                df = self._sql_client.query(statement, self._bind_parameters)
-                self._result = SqlRequestResult(df=df)
-            else:
-                self._sql_client.execute(statement, self._bind_parameters)
-                self._result = SqlRequestResult(df=pd.DataFrame())
-            logger.info(f"Successfully executed {self._request_id} in {time.time() - start_time:.2f}s")
-        except Exception as e:
-            logger.exception(
-                f"Unsuccessfully executed {self._request_id} in {time.time() - start_time:.2f}s with exception:"
-            )
-            self._result = SqlRequestResult(exception=e)
-
-    @property
-    def result(self) -> SqlRequestResult:  # noqa: D
-        assert self._result is not None, ".result() should only be called once the thread is finished running"
-        return self._result
-
-    @property
-    def request_id(self) -> SqlRequestId:  # noqa: D
-        return self._request_id

--- a/metricflow/sql_clients/base_sql_client_implementation.py
+++ b/metricflow/sql_clients/base_sql_client_implementation.py
@@ -17,9 +17,11 @@ from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.protocols.sql_client import (
     SqlEngineAttributes,
 )
+from metricflow.protocols.sql_client import SqlIsolationLevel
 from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
-from metricflow.sql_clients.async_request import SqlRequestExecutorThread
+from metricflow.sql_clients.async_request import SqlStatementCommentMetadata
+from metricflow.sql_clients.common_client import check_isolation_level
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +38,7 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
     INDENT = "    "
 
     def __init__(self) -> None:  # noqa: D
-        self._request_id_to_thread: Dict[SqlRequestId, SqlRequestExecutorThread] = {}
+        self._request_id_to_thread: Dict[SqlRequestId, BaseSqlClientImplementation.SqlRequestExecutorThread] = {}
         self._state_lock = threading.Lock()
 
     def generate_health_check_tests(self, schema_name: str) -> List[Tuple[str, Any]]:  # type: ignore
@@ -92,6 +94,7 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
             sql_bind_parameters: The parameter replacement mapping for filling in
                 concrete values for SQL query parameters.
         """
+
         start = time.time()
         logger.info(
             f"Running query:"
@@ -110,6 +113,7 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
         stmt: str,
         sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
     ) -> None:
+
         start = time.time()
         logger.info(
             f"Running query:"
@@ -154,12 +158,22 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
         raise NotImplementedError
 
     @abstractmethod
-    def _engine_specific_query_implementation(self, stmt: str, bind_params: SqlBindParameters) -> pd.DataFrame:
+    def _engine_specific_query_implementation(
+        self,
+        stmt: str,
+        bind_params: SqlBindParameters,
+        isolation_level: Optional[SqlIsolationLevel] = None,
+    ) -> pd.DataFrame:
         """Sub-classes should implement this to query the engine."""
         pass
 
     @abstractmethod
-    def _engine_specific_execute_implementation(self, stmt: str, bind_params: SqlBindParameters) -> None:
+    def _engine_specific_execute_implementation(
+        self,
+        stmt: str,
+        bind_params: SqlBindParameters,
+        isolation_level: Optional[SqlIsolationLevel] = None,
+    ) -> None:
         """Sub-classes should implement this to execute a statement that doesn't return results."""
         pass
 
@@ -223,15 +237,18 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
         statement: str,
         bind_parameters: SqlBindParameters = SqlBindParameters(),
         tags: SqlRequestTagSet = SqlRequestTagSet(),
+        isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> SqlRequestId:
+        check_isolation_level(self, isolation_level)
         with self._state_lock:
             request_id = SqlRequestId(f"mf_rid__{random_id()}")
-            thread = SqlRequestExecutorThread(
+            thread = BaseSqlClientImplementation.SqlRequestExecutorThread(
                 sql_client=self,
                 request_id=request_id,
                 statement=statement,
                 bind_parameters=bind_parameters,
                 user_tags=tags,
+                isolation_level=isolation_level,
             )
             self._request_id_to_thread[request_id] = thread
             self._request_id_to_thread[request_id].start()
@@ -242,23 +259,26 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
         statement: str,
         bind_parameters: SqlBindParameters = SqlBindParameters(),
         tags: SqlRequestTagSet = SqlRequestTagSet(),
+        isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> SqlRequestId:
+        check_isolation_level(self, isolation_level)
         with self._state_lock:
             request_id = SqlRequestId(f"mf_rid__{random_id()}")
-            thread = SqlRequestExecutorThread(
+            thread = BaseSqlClientImplementation.SqlRequestExecutorThread(
                 sql_client=self,
                 request_id=request_id,
                 statement=statement,
                 bind_parameters=bind_parameters,
                 user_tags=tags,
                 is_query=False,
+                isolation_level=isolation_level,
             )
             self._request_id_to_thread[request_id] = thread
             self._request_id_to_thread[request_id].start()
             return request_id
 
     def async_request_result(self, query_id: SqlRequestId) -> SqlRequestResult:  # noqa: D
-        thread: Optional[SqlRequestExecutorThread] = None
+        thread: Optional[BaseSqlClientImplementation.SqlRequestExecutorThread] = None
         with self._state_lock:
             thread = self._request_id_to_thread.get(query_id)
             if thread is None:
@@ -275,3 +295,82 @@ class BaseSqlClientImplementation(ABC, AsyncSqlClient):
     def active_requests(self) -> Sequence[SqlRequestId]:  # noqa: D
         with self._state_lock:
             return tuple(executor_thread.request_id for executor_thread in self._request_id_to_thread.values())
+
+    class SqlRequestExecutorThread(threading.Thread):
+        """Thread that helps to execute a request to the SQL engine asynchronously."""
+
+        def __init__(  # noqa: D
+            self,
+            sql_client: BaseSqlClientImplementation,
+            request_id: SqlRequestId,
+            statement: str,
+            bind_parameters: SqlBindParameters,
+            user_tags: SqlRequestTagSet,
+            is_query: bool = True,
+            isolation_level: Optional[SqlIsolationLevel] = None,
+        ) -> None:
+            """Initializer.
+
+            Args:
+                sql_client: SQL client used to execute statements.
+                request_id: The request ID associated with the statement.
+                statement: The statement to execute.
+                bind_parameters: The parameters to use for the statement.
+                user_tags: Tags that should be associated with the request for the statement.
+                is_query: Whether the request is for .query (returns data) or .execute (does not return data)
+                isolation_level: The isolation level to use for the query.
+            """
+            self._sql_client = sql_client
+            self._request_id = request_id
+            self._statement = statement
+            self._bind_parameters = bind_parameters
+            self._user_tags = user_tags
+            self._result: Optional[SqlRequestResult] = None
+            self._is_query = is_query
+            self._isolation_level = isolation_level
+            super().__init__(name=f"Async Execute SQL Request ID: {request_id}", daemon=True)
+
+        def run(self) -> None:  # noqa: D
+            start_time = time.time()
+            try:
+                statement = SqlStatementCommentMetadata.add_tag_metadata_as_comment(
+                    self._statement, self._user_tags.add_request_id(self._request_id)
+                )
+                logger.info(
+                    f"Running {self._request_id} asynchronously:\n\n"
+                    f"{textwrap.indent(self._statement, prefix=BaseSqlClientImplementation.INDENT)}\n"
+                    + (
+                        f"\nwith parameters: {dict(self._bind_parameters.param_dict)}"
+                        if self._bind_parameters.param_dict
+                        else ""
+                    )
+                )
+                if self._is_query:
+                    df = self._sql_client._engine_specific_query_implementation(
+                        statement,
+                        self._bind_parameters,
+                        self._isolation_level,
+                    )
+                    self._result = SqlRequestResult(df=df)
+                else:
+                    self._sql_client._engine_specific_execute_implementation(
+                        statement,
+                        self._bind_parameters,
+                        self._isolation_level,
+                    )
+                    self._result = SqlRequestResult(df=pd.DataFrame())
+                logger.info(f"Successfully executed {self._request_id} in {time.time() - start_time:.2f}s")
+            except Exception as e:
+                logger.exception(
+                    f"Unsuccessfully executed {self._request_id} in {time.time() - start_time:.2f}s with exception:"
+                )
+                self._result = SqlRequestResult(exception=e)
+
+        @property
+        def result(self) -> SqlRequestResult:  # noqa: D
+            assert self._result is not None, ".result() should only be called once the thread is finished running"
+            return self._result
+
+        @property
+        def request_id(self) -> SqlRequestId:  # noqa: D
+            return self._request_id

--- a/metricflow/sql_clients/big_query.py
+++ b/metricflow/sql_clients/big_query.py
@@ -10,7 +10,7 @@ import sqlalchemy
 from google.cloud import bigquery
 from google.cloud.bigquery import QueryJob
 
-from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngine, SqlIsolationLevel
 from metricflow.protocols.sql_client import (
     SqlEngineAttributes,
 )
@@ -34,6 +34,7 @@ class BigQueryEngineAttributes:
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.BIGQUERY
 
     # SQL Engine capabilities
+    supported_isolation_levels: ClassVar[Sequence[SqlIsolationLevel]] = ()
     date_trunc_supported: ClassVar[bool] = True
     full_outer_joins_supported: ClassVar[bool] = True
     indexes_supported: ClassVar[bool] = False

--- a/metricflow/sql_clients/common_client.py
+++ b/metricflow/sql_clients/common_client.py
@@ -1,6 +1,7 @@
 from typing import Optional, TypeVar
 
 from metricflow.object_utils import ExtendedEnum
+from metricflow.protocols.sql_client import SqlClient, SqlIsolationLevel
 
 
 class SqlDialect(ExtendedEnum):
@@ -24,3 +25,12 @@ def not_empty(value: Optional[T], component_name: str, url: str) -> T:
         raise ValueError(f"Missing {component_name} in {url}")
     else:
         return value
+
+
+def check_isolation_level(sql_client: SqlClient, isolation_level: Optional[SqlIsolationLevel] = None) -> None:
+    """Throws an exception if the isolation level is not supported by the engine."""
+    if (
+        isolation_level is not None
+        and isolation_level not in sql_client.sql_engine_attributes.supported_isolation_levels
+    ):
+        raise NotImplementedError(f"Isolation level not yet supported: {isolation_level}")

--- a/metricflow/sql_clients/postgres.py
+++ b/metricflow/sql_clients/postgres.py
@@ -4,7 +4,7 @@ from typing import ClassVar, Mapping, Optional, Sequence, Union
 
 import sqlalchemy
 
-from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngine, SqlIsolationLevel
 from metricflow.protocols.sql_client import SqlEngineAttributes
 from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.postgres import PostgresSQLSqlQueryPlanRenderer
@@ -25,6 +25,7 @@ class PostgresEngineAttributes:
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.POSTGRES
 
     # SQL Engine capabilities
+    supported_isolation_levels: ClassVar[Sequence[SqlIsolationLevel]] = ()
     date_trunc_supported: ClassVar[bool] = True
     full_outer_joins_supported: ClassVar[bool] = True
     indexes_supported: ClassVar[bool] = True

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -4,7 +4,7 @@ from typing import ClassVar, Optional, Mapping, Union, Sequence
 
 import sqlalchemy
 
-from metricflow.protocols.sql_client import SqlEngine
+from metricflow.protocols.sql_client import SqlEngine, SqlIsolationLevel
 from metricflow.protocols.sql_client import SqlEngineAttributes
 from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
@@ -25,6 +25,12 @@ class RedshiftEngineAttributes:
     sql_engine_type: ClassVar[SqlEngine] = SqlEngine.REDSHIFT
 
     # SQL Engine capabilities
+    supported_isolation_levels: ClassVar[Sequence[SqlIsolationLevel]] = (
+        SqlIsolationLevel.READ_UNCOMMITTED,
+        SqlIsolationLevel.READ_COMMITTED,
+        SqlIsolationLevel.REPEATABLE_READ,
+        SqlIsolationLevel.SERIALIZABLE,
+    )
     date_trunc_supported: ClassVar[bool] = True
     full_outer_joins_supported: ClassVar[bool] = True
     indexes_supported: ClassVar[bool] = False

--- a/metricflow/test/sql_clients/test_async.py
+++ b/metricflow/test/sql_clients/test_async.py
@@ -84,3 +84,12 @@ def test_cancel_request(  # noqa: D
 
     assert async_sql_client.async_request_result(request_id).exception is not None
     assert num_cancelled == 1
+
+
+def test_isolation_level(  # noqa: D
+    mf_test_session_state: MetricFlowTestSessionState, async_sql_client: AsyncSqlClient
+) -> None:
+    for isolation_level in async_sql_client.sql_engine_attributes.supported_isolation_levels:
+        logger.info(f"Testing isolation level: {isolation_level}")
+        request_id = async_sql_client.async_query("SELECT 1", isolation_level=isolation_level)
+        async_sql_client.async_request_result(request_id)


### PR DESCRIPTION
This PR adds an isolation level option to the SQL client to handle concurrency applications.