### PR TITLE
use MetricReference as the key for MetricSemantics

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -152,8 +152,9 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         compute_metrics_nodes: List[ComputedMetricsOutput[SqlDataSetT]] = []
         for metric_spec in query_spec.metric_specs:
             logger.info(f"Generating compute metrics node for {metric_spec}")
-            metric = self._metric_semantics.get_metric(metric_spec)
-            metric_input_measure_specs = self._metric_semantics.measures_for_metric(metric_spec)
+            metric_reference = metric_spec.as_reference
+            metric = self._metric_semantics.get_metric(metric_reference)
+            metric_input_measure_specs = self._metric_semantics.measures_for_metric(metric_reference)
 
             logger.info(
                 f"For {metric_spec}, needed measures are:\n"

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -12,14 +12,13 @@ from metricflow.model.objects.elements.dimension import DimensionType, Dimension
 from metricflow.model.objects.elements.identifier import IdentifierType
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.object_utils import pformat_big_objects, flatten_nested_sequence
-from metricflow.references import MeasureReference
+from metricflow.references import MeasureReference, MetricReference
 from metricflow.specs import (
     DEFAULT_TIME_GRANULARITY,
     LinkableSpecSet,
     DimensionSpec,
     TimeDimensionSpec,
     IdentifierSpec,
-    MetricSpec,
     IdentifierReference,
 )
 from metricflow.time.time_granularity import TimeGranularity
@@ -583,16 +582,16 @@ class ValidLinkableSpecResolver:
 
     def get_linkable_elements_for_metrics(
         self,
-        metric_specs: Sequence[MetricSpec],
+        metric_references: Sequence[MetricReference],
         with_any_of: FrozenSet[LinkableElementProperties],
         without_any_of: FrozenSet[LinkableElementProperties],
     ) -> LinkableElementSet:
         """Gets the valid linkable elements that are common to all requested metrics."""
         linkable_element_sets = []
-        for metric_spec in metric_specs:
-            element_sets = self._metric_to_linkable_element_sets.get(metric_spec.element_name)
+        for metric_reference in metric_references:
+            element_sets = self._metric_to_linkable_element_sets.get(metric_reference.element_name)
             if not element_sets:
-                raise ValueError(f"Unknown metric: {metric_spec} in element set")
+                raise ValueError(f"Unknown metric: {metric_reference} in element set")
             metric_result = LinkableElementSet.intersection(
                 [x.filter(with_any_of=with_any_of, without_any_of=without_any_of) for x in element_sets]
             )

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -31,6 +31,7 @@ from metricflow.references import (
     IdentifierReference,
     LinkableElementReference,
     MeasureReference,
+    MetricReference,
     TimeDimensionReference,
 )
 from metricflow.specs import (
@@ -51,11 +52,11 @@ class MetricSemantics:  # noqa: D
         self, user_configured_model: UserConfiguredModel, data_source_semantics: DataSourceSemantics
     ) -> None:
         self._user_configured_model = user_configured_model
-        self._metrics: Dict[MetricSpec, Metric] = {}
+        self._metrics: Dict[MetricReference, Metric] = {}
         self._data_source_semantics = data_source_semantics
 
         # Dict from the name of the metric to the hash.
-        self._metric_hashes: Dict[MetricSpec, str] = {}
+        self._metric_hashes: Dict[MetricReference, str] = {}
 
         for metric in self._user_configured_model.metrics:
             self.add_metric(metric)
@@ -67,59 +68,65 @@ class MetricSemantics:  # noqa: D
 
     def element_specs_for_metrics(
         self,
-        metric_specs: List[MetricSpec],
+        metric_references: List[MetricReference],
         with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
         without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
     ) -> List[LinkableInstanceSpec]:
         """Dimensions common to all metrics requested (intersection)"""
 
         all_linkable_specs = self._linkable_spec_resolver.get_linkable_elements_for_metrics(
-            metric_specs=metric_specs,
+            metric_references=metric_references,
             with_any_of=with_any_property,
             without_any_of=without_any_property,
         ).as_spec_set
 
         return sorted(all_linkable_specs.as_tuple, key=lambda x: x.qualified_name)
 
-    def get_metrics(self, metric_names: List[MetricSpec]) -> List[Metric]:  # noqa: D
+    def get_metrics(self, metric_references: List[MetricReference]) -> List[Metric]:  # noqa: D
         res = []
-        for metric_name in metric_names:
-            if metric_name not in self._metrics:
-                raise MetricNotFoundError(f"Unable to find metric `{metric_name}`. Perhaps it has not been registered")
-            res.append(self._metrics[metric_name])
+        for metric_reference in metric_references:
+            if metric_reference not in self._metrics:
+                raise MetricNotFoundError(
+                    f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered"
+                )
+            res.append(self._metrics[metric_reference])
 
         return res
 
     @property
-    def metric_names(self) -> List[MetricSpec]:  # noqa: D
+    def metric_references(self) -> List[MetricReference]:  # noqa: D
         return list(self._metrics.keys())
 
-    def get_metric(self, metric_name: MetricSpec) -> Metric:  # noqa:D
-        if metric_name not in self._metrics:
-            raise MetricNotFoundError(f"Unable to find metric `{metric_name}`. Perhaps it has not been registered")
-        return self._metrics[metric_name]
+    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
+        if metric_reference not in self._metrics:
+            raise MetricNotFoundError(f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered")
+        return self._metrics[metric_reference]
+
+    def get_metric_spec(self, metric_reference: MetricReference) -> MetricSpec:  # noqa: D
+        metric = self.get_metric(metric_reference)
+        return MetricSpec(element_name=metric.name)
 
     def add_metric(self, metric: Metric) -> None:
         """Add metric, validating presence of required measures"""
-        metric_spec = MetricSpec(element_name=metric.name)
-        if metric_spec in self._metrics:
+        metric_reference = MetricReference(element_name=metric.name)
+        if metric_reference in self._metrics:
             raise DuplicateMetricError(f"Metric `{metric.name}` has already been registered")
         for measure_reference in metric.measure_references:
             if measure_reference not in self._data_source_semantics.measure_references:
                 raise NonExistentMeasureError(
                     f"Metric `{metric.name}` references measure `{measure_reference}` which has not been registered"
                 )
-        self._metrics[metric_spec] = metric
-        self._metric_hashes[metric_spec] = metric.definition_hash
+        self._metrics[metric_reference] = metric
+        self._metric_hashes[metric_reference] = metric.definition_hash
 
     @property
     def valid_hashes(self) -> Set[str]:
         """Return all of the hashes of the metric definitions."""
         return set(self._metric_hashes.values())
 
-    def measures_for_metric(self, metric_spec: MetricSpec) -> Tuple[MetricInputMeasureSpec, ...]:
+    def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
         """Return the measure specs required to compute the metric."""
-        metric = self.get_metric(metric_spec)
+        metric = self.get_metric(metric_reference)
         input_measure_specs: List[MetricInputMeasureSpec] = []
 
         for input_measure in metric.input_measures:
@@ -146,10 +153,10 @@ class MetricSemantics:  # noqa: D
 
         return tuple(input_measure_specs)
 
-    def contains_cumulative_metric(self, metric_specs: Sequence[MetricSpec]) -> bool:
+    def contains_cumulative_metric(self, metric_references: Sequence[MetricReference]) -> bool:
         """Returns true if any of the specs correspond to a cumulative metric."""
-        for metric_spec in metric_specs:
-            if self.get_metric(metric_spec).type == MetricType.CUMULATIVE:
+        for metric_reference in metric_references:
+            if self.get_metric(metric_reference).type == MetricType.CUMULATIVE:
                 return True
         return False
 

--- a/metricflow/model/semantics/semantic_containers.py
+++ b/metricflow/model/semantics/semantic_containers.py
@@ -38,7 +38,6 @@ from metricflow.specs import (
     LinkableInstanceSpec,
     MeasureSpec,
     MetricInputMeasureSpec,
-    MetricSpec,
     NonAdditiveDimensionSpec,
 )
 
@@ -101,10 +100,6 @@ class MetricSemantics:  # noqa: D
         if metric_reference not in self._metrics:
             raise MetricNotFoundError(f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered")
         return self._metrics[metric_reference]
-
-    def get_metric_spec(self, metric_reference: MetricReference) -> MetricSpec:  # noqa: D
-        metric = self.get_metric(metric_reference)
-        return MetricSpec(element_name=metric.name)
 
     def add_metric(self, metric: Metric) -> None:
         """Add metric, validating presence of required measures"""

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -925,7 +925,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         metric_select_columns = []
         metric_instances = []
         for metric_spec in node.metric_specs:
-            metric = self._metric_semantics.get_metric(metric_spec)
+            metric = self._metric_semantics.get_metric(metric_spec.as_reference)
 
             metric_expr: Optional[SqlExpressionNode] = None
             if metric.type is MetricType.RATIO:

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -19,7 +19,13 @@ from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.metric import Metric
 from metricflow.model.semantics.element_group import ElementGrouper
 from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
-from metricflow.references import DimensionReference, IdentifierReference, MeasureReference, TimeDimensionReference
+from metricflow.references import (
+    DimensionReference,
+    IdentifierReference,
+    MeasureReference,
+    MetricReference,
+    TimeDimensionReference,
+)
 from metricflow.specs import (
     LinkableInstanceSpec,
     MeasureSpec,
@@ -135,7 +141,7 @@ class MetricSemanticsAccessor(Protocol):
     @abstractmethod
     def element_specs_for_metrics(
         self,
-        metric_specs: List[MetricSpec],
+        metric_references: List[MetricReference],
         with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
         without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
     ) -> List[LinkableInstanceSpec]:
@@ -143,18 +149,23 @@ class MetricSemanticsAccessor(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def get_metrics(self, metric_names: List[MetricSpec]) -> List[Metric]:
+    def get_metrics(self, metric_references: List[MetricReference]) -> List[Metric]:
         """Retrieve the Metric model objects associated with the provided metric specs"""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def metric_names(self) -> List[MetricSpec]:
-        """Return the metric specs"""
+    def metric_references(self) -> List[MetricReference]:
+        """Return the metric references"""
         raise NotImplementedError
 
     @abstractmethod
-    def get_metric(self, metric_name: MetricSpec) -> Metric:  # noqa:D
+    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_metric_spec(self, metric_reference: MetricReference) -> MetricSpec:  # noqa: D
+        """Returns a resolved metric spec by reference."""
         raise NotImplementedError
 
     @property
@@ -164,11 +175,11 @@ class MetricSemanticsAccessor(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def measures_for_metric(self, metric_spec: MetricSpec) -> Tuple[MetricInputMeasureSpec, ...]:
+    def measures_for_metric(self, metric_reference: MetricReference) -> Tuple[MetricInputMeasureSpec, ...]:
         """Return the measure specs required to compute the metric."""
         raise NotImplementedError
 
     @abstractmethod
-    def contains_cumulative_metric(self, metric_specs: Sequence[MetricSpec]) -> bool:
+    def contains_cumulative_metric(self, metric_references: Sequence[MetricReference]) -> bool:
         """Returns true if any of the specs correspond to a cumulative metric."""
         raise NotImplementedError

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -30,7 +30,6 @@ from metricflow.specs import (
     LinkableInstanceSpec,
     MeasureSpec,
     MetricInputMeasureSpec,
-    MetricSpec,
     NonAdditiveDimensionSpec,
 )
 
@@ -161,11 +160,6 @@ class MetricSemanticsAccessor(Protocol):
 
     @abstractmethod
     def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_metric_spec(self, metric_reference: MetricReference) -> MetricSpec:  # noqa: D
-        """Returns a resolved metric spec by reference."""
         raise NotImplementedError
 
     @property

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -22,7 +22,7 @@ from metricflow.model.spec_converters import WhereConstraintConverter
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.object_utils import pformat_big_objects
 from metricflow.query.query_exceptions import InvalidQueryException
-from metricflow.references import DimensionReference, IdentifierReference, TimeDimensionReference
+from metricflow.references import DimensionReference, IdentifierReference, MetricReference, TimeDimensionReference
 from metricflow.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
@@ -92,7 +92,7 @@ class MetricFlowQueryParser:
             else:
                 raise RuntimeError(f"Unhandled linkable type: {dimension.type}")
 
-        self._known_metric_names = set(self._metric_semantics.metric_names)
+        self._known_metric_names = set(self._metric_semantics.metric_references)
         self._metric_time_dimension_reference = DataSet.metric_time_dimension_reference()
         self._time_granularity_solver = TimeGranularitySolver(
             semantic_model=self._model,
@@ -160,12 +160,12 @@ class MetricFlowQueryParser:
 
     def _validate_linkable_specs(
         self,
-        metric_specs: Tuple[MetricSpec, ...],
+        metric_references: Tuple[MetricReference, ...],
         all_linkable_specs: LinkableInstanceSpecs,
         time_dimension_specs: Tuple[TimeDimensionSpec, ...],
     ) -> None:
         invalid_group_bys = self._get_invalid_linkable_specs(
-            metric_specs=metric_specs,
+            metric_references=metric_references,
             dimension_specs=all_linkable_specs.dimension_specs,
             time_dimension_specs=time_dimension_specs,
             identifier_specs=all_linkable_specs.identifier_specs,
@@ -173,7 +173,7 @@ class MetricFlowQueryParser:
         if len(invalid_group_bys) > 0:
             valid_group_by_names_for_metrics = sorted(
                 x.qualified_name
-                for x in self._metric_semantics.element_specs_for_metrics(metric_specs=list(metric_specs))
+                for x in self._metric_semantics.element_specs_for_metrics(metric_references=list(metric_references))
             )
             # Create suggestions for invalid dimensions in case the user made a typo.
             suggestion_sections = {}
@@ -186,7 +186,7 @@ class MetricFlowQueryParser:
                 suggestion_sections[section_key] = section_value
             raise UnableToSatisfyQueryError(
                 f"Dimensions {[x.qualified_name for x in invalid_group_bys]} cannot be "
-                f"resolved for metrics {[x.qualified_name for x in metric_specs]}. The invalid dimension may not "
+                f"resolved for metrics {[x.element_name for x in metric_references]}. The invalid dimension may not "
                 f"exist, require an ambiguous join (e.g. a join path that can be satisfied in multiple ways), "
                 f"or require a fanout join.",
                 context=suggestion_sections,
@@ -217,7 +217,10 @@ class MetricFlowQueryParser:
         else:
             parsed_where_constraint = where_constraint
 
-        metric_specs = self._parse_metric_names(metric_names)
+        metric_references = self._parse_metric_names(metric_names)
+        metric_specs = tuple(
+            self._metric_semantics.get_metric_spec(metric_reference) for metric_reference in metric_references
+        )
 
         if time_constraint_start is None:
             time_constraint_start = TimeRangeConstraint.ALL_TIME_BEGIN()
@@ -262,10 +265,10 @@ class MetricFlowQueryParser:
             # If the time constraint is all time, just ignore and not render
             time_constraint = None
 
-        requested_linkable_specs = self._parse_linkable_element_names(group_by_names, metric_specs)
+        requested_linkable_specs = self._parse_linkable_element_names(group_by_names, metric_references)
         partial_time_dimension_spec_replacements = (
             self._time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
-                metric_specs=metric_specs,
+                metric_references=metric_references,
                 partial_time_dimension_specs=requested_linkable_specs.partial_time_dimension_specs,
                 metric_time_dimension_reference=self._metric_time_dimension_reference,
                 time_granularity=time_granularity,
@@ -280,35 +283,35 @@ class MetricFlowQueryParser:
             time_dimension_spec for _, time_dimension_spec in partial_time_dimension_spec_replacements.items()
         )
 
-        self._time_granularity_solver.validate_time_granularity(metric_specs, time_dimension_specs)
+        self._time_granularity_solver.validate_time_granularity(metric_references, time_dimension_specs)
 
         order_by_specs = self._parse_order_by(order or [], partial_time_dimension_spec_replacements)
 
-        for metric_spec in metric_specs:
-            metric = self._metric_semantics.get_metric(metric_spec)
+        for metric_reference in metric_references:
+            metric = self._metric_semantics.get_metric(metric_reference)
             if metric.constraint is not None:
                 all_linkable_specs = self._parse_linkable_element_names(
                     qualified_linkable_names=all_group_by_names + metric.constraint.linkable_names,
-                    metric_specs=(metric_spec,),
+                    metric_references=(metric_reference,),
                 )
                 self._validate_linkable_specs(
-                    metric_specs=(metric_spec,),
+                    metric_references=(metric_reference,),
                     all_linkable_specs=all_linkable_specs,
                     time_dimension_specs=time_dimension_specs,
                 )
         all_linkable_specs = self._parse_linkable_element_names(
             qualified_linkable_names=all_group_by_names,
-            metric_specs=metric_specs,
+            metric_references=metric_references,
         )
         self._validate_linkable_specs(
-            metric_specs=metric_specs,
+            metric_references=metric_references,
             all_linkable_specs=all_linkable_specs,
             time_dimension_specs=time_dimension_specs,
         )
 
         self._validate_order_by_specs(
             order_by_specs=order_by_specs,
-            metric_specs=metric_specs,
+            metric_references=metric_references,
             linkable_specs=LinkableSpecSet(
                 dimension_specs=requested_linkable_specs.dimension_specs,
                 time_dimension_specs=time_dimension_specs,
@@ -320,7 +323,7 @@ class MetricFlowQueryParser:
         if time_constraint:
             logger.info(f"Time constraint before adjustment is {time_constraint}")
             time_constraint = self._adjust_time_range_constraint(
-                metric_specs=metric_specs,
+                metric_references=metric_references,
                 time_dimension_specs=time_dimension_specs,
                 time_range_constraint=time_constraint,
             )
@@ -335,7 +338,7 @@ class MetricFlowQueryParser:
             )
             and not time_granularity
         ):
-            if self._metrics_have_same_time_granularities(metric_specs):
+            if self._metrics_have_same_time_granularities(metric_references=metric_references):
                 _, replace_with_time_dimension_spec = self._find_replacement_for_metric_time_dimension(
                     partial_time_dimension_spec_replacements
                 )
@@ -371,11 +374,16 @@ class MetricFlowQueryParser:
     def _validate_order_by_specs(
         self,
         order_by_specs: Sequence[OrderBySpec],
-        metric_specs: Sequence[MetricSpec],
+        metric_references: Sequence[MetricReference],
         linkable_specs: LinkableSpecSet,
     ) -> None:
         """Checks that the order by specs references an item in the query."""
 
+        # TODO: this is a workaround
+        # Need to figure out whether we should clean up OrderBySpec or if we have to actually pass a fully resolved MetricSpec here
+        metric_specs = [
+            MetricSpec(element_name=metric_reference.element_name) for metric_reference in metric_references
+        ]
         for order_by_spec in order_by_specs:
             if not (
                 order_by_spec.item in metric_specs
@@ -387,12 +395,12 @@ class MetricFlowQueryParser:
 
     def _adjust_time_range_constraint(
         self,
-        metric_specs: Sequence[MetricSpec],
+        metric_references: Sequence[MetricReference],
         time_dimension_specs: Sequence[TimeDimensionSpec],
         time_range_constraint: TimeRangeConstraint,
     ) -> TimeRangeConstraint:
         """Adjust the time range constraint so that it matches the boundaries of the granularity of the result."""
-        self._time_granularity_solver.validate_time_granularity(metric_specs, time_dimension_specs)
+        self._time_granularity_solver.validate_time_granularity(metric_references, time_dimension_specs)
 
         smallest_primary_time_granularity_in_query = self._find_smallest_metric_time_dimension_spec_granularity(
             time_dimension_specs
@@ -402,7 +410,7 @@ class MetricFlowQueryParser:
 
         else:
             _, adjusted_to_granularity = self._time_granularity_solver.local_dimension_granularity_range(
-                metric_specs=metric_specs,
+                metric_references=metric_references,
                 local_time_dimension_reference=self._metric_time_dimension_reference,
             )
         logger.info(f"Adjusted primary time granularity is {adjusted_to_granularity}")
@@ -436,9 +444,9 @@ class MetricFlowQueryParser:
                 return True
         return False
 
-    def _metrics_have_same_time_granularities(self, metric_specs: Sequence[MetricSpec]) -> bool:
+    def _metrics_have_same_time_granularities(self, metric_references: Sequence[MetricReference]) -> bool:
         (min_granularity, max_granularity,) = self._time_granularity_solver.local_dimension_granularity_range(
-            metric_specs=metric_specs,
+            metric_references=metric_references,
             local_time_dimension_reference=self._metric_time_dimension_reference,
         )
         return min_granularity == max_granularity
@@ -462,22 +470,22 @@ class MetricFlowQueryParser:
         else:
             return None
 
-    def _parse_metric_names(self, metric_names: Sequence[str]) -> Tuple[MetricSpec, ...]:
+    def _parse_metric_names(self, metric_names: Sequence[str]) -> Tuple[MetricReference, ...]:
         """Converts metric names into metric names. An exception is thrown if the name is invalid."""
 
         # The config must be lower-case, so we lower case for case-insensitivity against query inputs from the user.
         metric_names = [x.lower() for x in metric_names]
 
-        known_metric_names = set(self._metric_semantics.metric_names)
-        metric_specs: List[MetricSpec] = []
+        known_metric_names = set(self._metric_semantics.metric_references)
+        metric_references: List[MetricReference] = []
         for metric_name in metric_names:
-            metric_spec = MetricSpec(element_name=metric_name)
-            if metric_spec not in known_metric_names:
+            metric_reference = MetricReference(element_name=metric_name)
+            if metric_reference not in known_metric_names:
                 suggestions = {
                     f"Suggestions for '{metric_name}'": pformat_big_objects(
                         MetricFlowQueryParser._top_fuzzy_matches(
                             item=metric_name,
-                            candidate_items=[x.qualified_name for x in self._metric_semantics.metric_names],
+                            candidate_items=[x.element_name for x in self._metric_semantics.metric_references],
                         )
                     )
                 }
@@ -485,11 +493,11 @@ class MetricFlowQueryParser:
                     f"Unknown metric: '{metric_name}'",
                     context=suggestions,
                 )
-            metric_specs.append(metric_spec)
-        return tuple(metric_specs)
+            metric_references.append(metric_reference)
+        return tuple(metric_references)
 
     def _parse_linkable_element_names(
-        self, qualified_linkable_names: Sequence[str], metric_specs: Sequence[MetricSpec]
+        self, qualified_linkable_names: Sequence[str], metric_references: Sequence[MetricReference]
     ) -> LinkableInstanceSpecs:
         """Convert the linkable spec names into the respective specification objects."""
 
@@ -527,7 +535,7 @@ class MetricFlowQueryParser:
                 identifier_specs.append(IdentifierSpec(element_name=element_name, identifier_links=identifier_links))
             else:
                 valid_group_by_names_for_metrics = sorted(
-                    x.qualified_name for x in self._metric_semantics.element_specs_for_metrics(list(metric_specs))
+                    x.qualified_name for x in self._metric_semantics.element_specs_for_metrics(list(metric_references))
                 )
 
                 suggestions = {
@@ -552,7 +560,7 @@ class MetricFlowQueryParser:
 
     def _get_invalid_linkable_specs(
         self,
-        metric_specs: Tuple[MetricSpec, ...],
+        metric_references: Tuple[MetricReference, ...],
         dimension_specs: Tuple[DimensionSpec, ...],
         time_dimension_specs: Tuple[TimeDimensionSpec, ...],
         identifier_specs: Tuple[IdentifierSpec, ...],
@@ -560,7 +568,9 @@ class MetricFlowQueryParser:
         """Checks that each requested linkable instance can be retrieved for the given metric"""
         invalid_linkable_specs: List[LinkableInstanceSpec] = []
         # TODO: distinguish between dimensions that invalid via typo vs ambiguous join path
-        valid_linkable_specs = self._metric_semantics.element_specs_for_metrics(metric_specs=list(metric_specs))
+        valid_linkable_specs = self._metric_semantics.element_specs_for_metrics(
+            metric_references=list(metric_references)
+        )
 
         for dimension_spec in dimension_specs:
             if dimension_spec not in valid_linkable_specs:
@@ -597,7 +607,7 @@ class MetricFlowQueryParser:
                 descending = True
             parsed_name = StructuredLinkableSpecName.from_name(order_by_name)
 
-            if MetricSpec(element_name=parsed_name.element_name) in self._known_metric_names:
+            if MetricReference(element_name=parsed_name.element_name) in self._known_metric_names:
                 if parsed_name.time_granularity:
                     raise InvalidQueryException(
                         f"Order by item '{order_by_name}' references a metric but has a time granularity"

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -218,9 +218,7 @@ class MetricFlowQueryParser:
             parsed_where_constraint = where_constraint
 
         metric_references = self._parse_metric_names(metric_names)
-        metric_specs = tuple(
-            self._metric_semantics.get_metric_spec(metric_reference) for metric_reference in metric_references
-        )
+        metric_specs = tuple(MetricSpec.from_reference(metric_reference) for metric_reference in metric_references)
 
         if time_constraint_start is None:
             time_constraint_start = TimeRangeConstraint.ALL_TIME_BEGIN()
@@ -381,9 +379,7 @@ class MetricFlowQueryParser:
 
         # TODO: this is a workaround
         # Need to figure out whether we should clean up OrderBySpec or if we have to actually pass a fully resolved MetricSpec here
-        metric_specs = [
-            MetricSpec(element_name=metric_reference.element_name) for metric_reference in metric_references
-        ]
+        metric_specs = [MetricSpec.from_reference(metric_reference) for metric_reference in metric_references]
         for order_by_spec in order_by_specs:
             if not (
                 order_by_spec.item in metric_specs

--- a/metricflow/references.py
+++ b/metricflow/references.py
@@ -51,3 +51,8 @@ class TimeDimensionReference(DimensionReference):  # noqa: D
 
     def dimension_reference(self) -> DimensionReference:  # noqa: D
         return DimensionReference(element_name=self.element_name)
+
+
+@dataclass(frozen=True)
+class MetricReference(ElementReference):  # noqa: D
+    pass

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -367,6 +367,11 @@ class MetricSpec(InstanceSpec):  # noqa: D
     def as_reference(self) -> MetricReference:  # noqa: D
         return MetricReference(element_name=self.element_name)
 
+    @staticmethod
+    def from_reference(reference: MetricReference) -> MetricSpec:
+        """Initialize from a metric reference instance"""
+        return MetricSpec(element_name=reference.element_name)
+
 
 @dataclass(frozen=True)
 class MetricInputMeasureSpec(SerializableDataclass):

--- a/metricflow/specs.py
+++ b/metricflow/specs.py
@@ -21,7 +21,13 @@ from metricflow.constraints.time_constraint import TimeRangeConstraint
 from metricflow.dataclass_serialization import SerializableDataclass
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow.object_utils import assert_exactly_one_arg_set, hash_strings
-from metricflow.references import DimensionReference, MeasureReference, TimeDimensionReference, IdentifierReference
+from metricflow.references import (
+    DimensionReference,
+    MeasureReference,
+    MetricReference,
+    TimeDimensionReference,
+    IdentifierReference,
+)
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.time.time_granularity import TimeGranularity
 
@@ -356,6 +362,10 @@ class MetricSpec(InstanceSpec):  # noqa: D
     @property
     def qualified_name(self) -> str:  # noqa: D
         return self.element_name
+
+    @property
+    def as_reference(self) -> MetricReference:  # noqa: D
+        return MetricReference(element_name=self.element_name)
 
 
 @dataclass(frozen=True)

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -9,7 +9,7 @@ from metricflow.model.semantics.linkable_spec_resolver import (
     LinkableElementProperties,
 )
 from metricflow.model.semantics.semantic_containers import MAX_JOIN_HOPS
-from metricflow.specs import MetricSpec
+from metricflow.references import MetricReference
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ def simple_model_spec_resolver(simple_semantic_model: SemanticModel) -> ValidLin
 
 def test_linkable_spec_resolver(simple_model_spec_resolver: ValidLinkableSpecResolver) -> None:  # noqa: D
     result = simple_model_spec_resolver.get_linkable_elements_for_metrics(
-        metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="views")],
+        metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
         with_any_of=LinkableElementProperties.all_properties(),
         without_any_of=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
     ).as_spec_set
@@ -66,12 +66,12 @@ def test_linkable_spec_resolver(simple_model_spec_resolver: ValidLinkableSpecRes
 
 def property_check_helper(  # noqa: D
     spec_resolver: ValidLinkableSpecResolver,
-    metric_specs: Sequence[MetricSpec],
+    metric_references: Sequence[MetricReference],
     element_property: LinkableElementProperties,
     expected_names: Sequence[str],
 ) -> None:
     results = spec_resolver.get_linkable_elements_for_metrics(
-        metric_specs=metric_specs,
+        metric_references=metric_references,
         with_any_of=frozenset({element_property}),
         without_any_of=frozenset(),
     ).as_spec_set.as_tuple
@@ -83,7 +83,7 @@ def property_check_helper(  # noqa: D
 def test_local_property(simple_model_spec_resolver: ValidLinkableSpecResolver) -> None:  # noqa: D
     property_check_helper(
         spec_resolver=simple_model_spec_resolver,
-        metric_specs=[MetricSpec(element_name="listings")],
+        metric_references=[MetricReference(element_name="listings")],
         element_property=LinkableElementProperties.LOCAL,
         expected_names=[
             "capacity_latest",
@@ -121,7 +121,7 @@ def test_local_property(simple_model_spec_resolver: ValidLinkableSpecResolver) -
 def test_local_linked_property(simple_model_spec_resolver: ValidLinkableSpecResolver) -> None:  # noqa: D
     property_check_helper(
         spec_resolver=simple_model_spec_resolver,
-        metric_specs=[MetricSpec(element_name="listings")],
+        metric_references=[MetricReference(element_name="listings")],
         element_property=LinkableElementProperties.LOCAL_LINKED,
         expected_names=[
             "listing__capacity_latest",
@@ -144,7 +144,7 @@ def test_local_linked_property(simple_model_spec_resolver: ValidLinkableSpecReso
 def test_joined_property(simple_model_spec_resolver: ValidLinkableSpecResolver) -> None:  # noqa: D
     property_check_helper(
         spec_resolver=simple_model_spec_resolver,
-        metric_specs=[MetricSpec(element_name="listings")],
+        metric_references=[MetricReference(element_name="listings")],
         element_property=LinkableElementProperties.JOINED,
         expected_names=[
             "listing__lux_listing",
@@ -173,7 +173,7 @@ def test_multi_hop_property(multi_hop_join_semantic_model: SemanticModel) -> Non
     )
     property_check_helper(
         spec_resolver=multi_hop_spec_resolver,
-        metric_specs=[MetricSpec(element_name="txn_count")],
+        metric_references=[MetricReference(element_name="txn_count")],
         element_property=LinkableElementProperties.MULTI_HOP,
         expected_names=[
             "account_id__customer_id__country",
@@ -192,7 +192,7 @@ def test_multi_hop_property(multi_hop_join_semantic_model: SemanticModel) -> Non
 def test_derived_time_granularity_property(simple_model_spec_resolver: ValidLinkableSpecResolver) -> None:  # noqa: D
     property_check_helper(
         spec_resolver=simple_model_spec_resolver,
-        metric_specs=[MetricSpec(element_name="listings")],
+        metric_references=[MetricReference(element_name="listings")],
         element_property=LinkableElementProperties.DERIVED_TIME_GRANULARITY,
         expected_names=[
             "created_at__month",
@@ -226,7 +226,7 @@ def test_derived_time_granularity_property(simple_model_spec_resolver: ValidLink
 def test_identifier_property(simple_model_spec_resolver: ValidLinkableSpecResolver) -> None:  # noqa: D
     property_check_helper(
         spec_resolver=simple_model_spec_resolver,
-        metric_specs=[MetricSpec(element_name="listings")],
+        metric_references=[MetricReference(element_name="listings")],
         element_property=LinkableElementProperties.IDENTIFIER,
         expected_names=["listing", "listing__lux_listing", "user", "user__company"],
     )

--- a/metricflow/test/model/test_data_source_container.py
+++ b/metricflow/test/model/test_data_source_container.py
@@ -7,7 +7,7 @@ from metricflow.model.semantics.data_source_container import PydanticDataSourceC
 from metricflow.model.semantics.linkable_spec_resolver import LinkableElementProperties
 from metricflow.model.semantics.semantic_containers import DataSourceSemantics, MetricSemantics
 from metricflow.references import IdentifierReference, MeasureReference
-from metricflow.specs import MetricSpec
+from metricflow.references import MetricReference
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ def test_elements_for_metric(new_metric_semantics: MetricSemantics) -> None:  # 
         [
             x.qualified_name
             for x in new_metric_semantics.element_specs_for_metrics(
-                [MetricSpec(element_name="views")],
+                [MetricReference(element_name="views")],
                 without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
             )
         ]
@@ -157,7 +157,7 @@ def test_elements_for_metric(new_metric_semantics: MetricSemantics) -> None:  # 
     }
 
     local_specs = new_metric_semantics.element_specs_for_metrics(
-        metric_specs=[MetricSpec(element_name="views")],
+        metric_references=[MetricReference(element_name="views")],
         with_any_property=frozenset({LinkableElementProperties.LOCAL}),
         without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
     )
@@ -175,7 +175,7 @@ def test_local_linked_elements_for_metric(new_metric_semantics: MetricSemantics)
         [
             x.qualified_name
             for x in new_metric_semantics.element_specs_for_metrics(
-                [MetricSpec(element_name="listings")],
+                [MetricReference(element_name="listings")],
                 with_any_property=frozenset({LinkableElementProperties.LOCAL_LINKED}),
                 without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
             )

--- a/metricflow/test/time/test_time_granularity_solver.py
+++ b/metricflow/test/time/test_time_granularity_solver.py
@@ -11,7 +11,7 @@ from metricflow.dataset.dataset import DataSet
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.specs import MetricSpec
+from metricflow.references import MetricReference
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH, MTD_SPEC_YEAR, MTD_REFERENCE
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.time.time_granularity_solver import (
@@ -49,21 +49,21 @@ def time_granularity_solver(  # noqa: D
 
 def test_validate_day_granuarity_for_day_metric(time_granularity_solver: TimeGranularitySolver) -> None:  # noqa: D
     time_granularity_solver.validate_time_granularity(
-        metric_specs=[MetricSpec(element_name="bookings")],
+        metric_references=[MetricReference(element_name="bookings")],
         time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.DAY)],
     )
 
 
 def test_validate_month_granuarity_for_day_metric(time_granularity_solver: TimeGranularitySolver) -> None:  # noqa: D
     time_granularity_solver.validate_time_granularity(
-        metric_specs=[MetricSpec(element_name="bookings")],
+        metric_references=[MetricReference(element_name="bookings")],
         time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.MONTH)],
     )
 
 
 def test_validate_month_granuarity_for_month_metric(time_granularity_solver: TimeGranularitySolver) -> None:  # noqa: D
     time_granularity_solver.validate_time_granularity(
-        metric_specs=[MetricSpec(element_name="bookings_monthly")],
+        metric_references=[MetricReference(element_name="bookings_monthly")],
         time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.MONTH)],
     )
 
@@ -72,7 +72,7 @@ def test_validate_month_granuarity_for_day_and_month_metrics(  # noqa: D
     time_granularity_solver: TimeGranularitySolver,
 ) -> None:
     time_granularity_solver.validate_time_granularity(
-        metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="bookings_monthly")],
+        metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="bookings_monthly")],
         time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.MONTH)],
     )
 
@@ -81,7 +81,7 @@ def test_validate_year_granularity_for_day_and_month_metrics(  # noqa: D
     time_granularity_solver: TimeGranularitySolver,
 ) -> None:
     time_granularity_solver.validate_time_granularity(
-        metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="bookings_monthly")],
+        metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="bookings_monthly")],
         time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.YEAR)],
     )
 
@@ -89,7 +89,7 @@ def test_validate_year_granularity_for_day_and_month_metrics(  # noqa: D
 def test_validate_day_granuarity_for_month_metric(time_granularity_solver: TimeGranularitySolver) -> None:  # noqa: D
     with pytest.raises(RequestTimeGranularityException):
         time_granularity_solver.validate_time_granularity(
-            metric_specs=[MetricSpec(element_name="bookings_monthly")],
+            metric_references=[MetricReference(element_name="bookings_monthly")],
             time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.DAY)],
         )
 
@@ -99,7 +99,10 @@ def test_validate_day_granularity_for_day_and_month_metric(  # noqa: D
 ) -> None:
     with pytest.raises(RequestTimeGranularityException):
         time_granularity_solver.validate_time_granularity(
-            metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="bookings_monthly")],
+            metric_references=[
+                MetricReference(element_name="bookings"),
+                MetricReference(element_name="bookings_monthly"),
+            ],
             time_dimension_specs=[DataSet.metric_time_dimension_spec(TimeGranularity.DAY)],
         )
 
@@ -109,7 +112,7 @@ PARTIAL_PTD_SPEC = PartialTimeDimensionSpec(element_name=DataSet.metric_time_dim
 
 def test_granularity_solution_for_day_metric(time_granularity_solver: TimeGranularitySolver) -> None:  # noqa: D
     assert time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
-        metric_specs=[MetricSpec(element_name="bookings")],
+        metric_references=[MetricReference(element_name="bookings")],
         partial_time_dimension_specs=[PARTIAL_PTD_SPEC],
         metric_time_dimension_reference=MTD_REFERENCE,
     ) == {
@@ -119,7 +122,7 @@ def test_granularity_solution_for_day_metric(time_granularity_solver: TimeGranul
 
 def test_granularity_solution_for_month_metric(time_granularity_solver: TimeGranularitySolver) -> None:  # noqa: D
     assert time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
-        metric_specs=[MetricSpec(element_name="bookings_monthly")],
+        metric_references=[MetricReference(element_name="bookings_monthly")],
         partial_time_dimension_specs=[PARTIAL_PTD_SPEC],
         metric_time_dimension_reference=MTD_REFERENCE,
     ) == {
@@ -131,7 +134,7 @@ def test_granularity_solution_for_day_and_month_metrics(  # noqa: D
     time_granularity_solver: TimeGranularitySolver,
 ) -> None:
     assert time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
-        metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="bookings_monthly")],
+        metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="bookings_monthly")],
         partial_time_dimension_specs=[PARTIAL_PTD_SPEC],
         metric_time_dimension_reference=MTD_REFERENCE,
     ) == {PARTIAL_PTD_SPEC: MTD_SPEC_MONTH}
@@ -141,7 +144,7 @@ def test_time_granularity_parameter(  # noqa: D
     time_granularity_solver: TimeGranularitySolver,
 ) -> None:
     assert time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
-        metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="bookings_monthly")],
+        metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="bookings_monthly")],
         partial_time_dimension_specs=[PARTIAL_PTD_SPEC],
         metric_time_dimension_reference=MTD_REFERENCE,
         time_granularity=TimeGranularity.YEAR,
@@ -153,7 +156,10 @@ def test_invalid_time_granularity_parameter(  # noqa: D
 ) -> None:
     with pytest.raises(RequestTimeGranularityException, match="Can't use time granularity.*"):
         time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
-            metric_specs=[MetricSpec(element_name="bookings"), MetricSpec(element_name="bookings_monthly")],
+            metric_references=[
+                MetricReference(element_name="bookings"),
+                MetricReference(element_name="bookings_monthly"),
+            ],
             partial_time_dimension_specs=[PARTIAL_PTD_SPEC],
             metric_time_dimension_reference=MTD_REFERENCE,
             time_granularity=TimeGranularity.DAY,


### PR DESCRIPTION
## Context
We currently use `MetricSpec` as a key for everything in `MetricSemantics`. This restricts us from adding properties to `MetricSpec` as we are using `MetricSpec(element_name="..")` as the key and if we were to add any properties it would end up not matching. For example,
```
MetricSpec(element_name="metric", alias="test") 
     would not match 
MetricSpec(element_name="metric")
```
So in order to resolve this, replace all the usage of `MetricSpec` where we treat it as a key and replace it with `MetricReference`.