### PR TITLE
Make assert_exactly_one_arg_set behave as documented

### DIFF
--- a/metricflow/object_utils.py
+++ b/metricflow/object_utils.py
@@ -20,7 +20,7 @@ def assert_exactly_one_arg_set(**kwargs) -> None:  # type: ignore
     """Throws an assertion error if 0 or more than 1 argument is not None."""
     num_set = 0
     for value in kwargs.values():
-        if value:
+        if value is not None:
             num_set += 1
 
     assert num_set == 1, f"{num_set} argument(s) set instead of 1 in arguments: {kwargs}"


### PR DESCRIPTION
This helper function should be asserting that exactly one of a set
of Optional arguments is set to a non-None value, but it is in fact
asserting that exactly one is truthy. That's surprising.
