### PR TITLE
Add validation to ensure validity param specifications are correct

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -6,7 +6,7 @@ from typing import List, Sequence
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.parsing.dir_to_model import ModelBuildResult
 from metricflow.model.validations.agg_time_dimension import AggregationTimeDimensionRule
-from metricflow.model.validations.data_sources import DataSourceTimeDimensionWarningsRule
+from metricflow.model.validations.data_sources import DataSourceTimeDimensionWarningsRule, DataSourceValidityWindowRule
 from metricflow.model.validations.dimension_const import DimensionConsistencyRule
 from metricflow.model.validations.element_const import ElementConsistencyRule
 from metricflow.model.validations.identifiers import (
@@ -43,6 +43,7 @@ class ModelValidator:
         CountAggregationExprRule(),
         DataSourceMeasuresUniqueRule(),
         DataSourceTimeDimensionWarningsRule(),
+        DataSourceValidityWindowRule(),
         DimensionConsistencyRule(),
         ElementConsistencyRule(),
         IdentifierConfigRule(),

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -155,6 +155,27 @@ def parse_yaml_file_paths_to_model(
                 " try manually typing up the problem file instead of copy and pasting"
             ) from e
 
+    return parse_yaml_files_to_validation_ready_model(
+        yaml_config_files=yaml_config_files,
+        apply_pre_transformations=apply_pre_transformations,
+        apply_post_transformations=apply_post_transformations,
+        raise_issues_as_exceptions=raise_issues_as_exceptions,
+    )
+
+
+def parse_yaml_files_to_validation_ready_model(
+    yaml_config_files: List[YamlConfigFile],
+    apply_pre_transformations: Optional[bool] = True,
+    apply_post_transformations: Optional[bool] = True,
+    raise_issues_as_exceptions: bool = True,
+) -> ModelBuildResult:
+    """Parse and transform the given set of in-memory YamlConfigFiles to a UserConfigured model
+
+    This model result is, by default, validation-ready, although different callsites (mainly in testing)
+    might wish to override the transformation state.
+
+    TODO: Restructure this module and provide an improved API for managing these different input types
+    """
     build_result = parse_yaml_files_to_model(yaml_config_files)
     model = build_result.model
     assert model

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -89,3 +89,79 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
                 )
 
         return issues
+
+
+class DataSourceValidityWindowRule(ModelValidationRule):
+    """Checks validity windows in data sources to ensure they comply with runtime requirements"""
+
+    @staticmethod
+    @validate_safely(whats_being_done="checking correctness of the time dimension validity parameters in the model")
+    def validate_model(model: UserConfiguredModel) -> List[ValidationIssueType]:
+        """Checks the validity param definitions in every data source in the model"""
+        issues: List[ValidationIssueType] = []
+
+        for data_source in model.data_sources:
+            issues.extend(DataSourceValidityWindowRule._validate_data_source(data_source=data_source))
+
+        return issues
+
+    @staticmethod
+    @validate_safely(
+        whats_being_done="checking the data source's validity parameters for compatibility with runtime requirements"
+    )
+    def _validate_data_source(data_source: DataSource) -> List[ValidationIssueType]:
+        """Runs assertions on data sources with validity parameters set on one or more time dimensions"""
+
+        issues: List[ValidationIssueType] = []
+
+        validity_param_dims = [dim for dim in data_source.dimensions if dim.validity_params is not None]
+
+        if not validity_param_dims:
+            return issues
+
+        context = DataSourceContext(
+            file_context=FileContext.from_metadata(metadata=data_source.metadata),
+            data_source=DataSourceReference(data_source_name=data_source.name),
+        )
+        requirements = (
+            "Data sources using dimension validity params to define a validity window must have exactly two time "
+            "dimensions with validity params specified - one marked `is_start` and the other marked `is_end`."
+        )
+        num_start_dims = len(
+            [dim for dim in validity_param_dims if dim.validity_params and dim.validity_params.is_start]
+        )
+        num_end_dims = len([dim for dim in validity_param_dims if dim.validity_params and dim.validity_params.is_end])
+
+        if len(validity_param_dims) == 1 and num_start_dims == 1 and num_end_dims == 1:
+            # Defining a single point window, such as one might find in a daily snapshot table keyed on date,
+            # is not currently supported.
+            error = ValidationError(
+                context=context,
+                message=(
+                    f"Data source {data_source.name} has a single validity param dimension that defines its window: "
+                    f"{validity_param_dims}. This is not a currently supported configuration! {requirements}"
+                ),
+            )
+            issues.append(error)
+        elif len(validity_param_dims) != 2:
+            error = ValidationError(
+                context=context,
+                message=(
+                    f"Data source {data_source.name} has {len(validity_param_dims)} validity param dimensions defined:"
+                    f"{validity_param_dims}. There must be either zero or two! If you wish to define a validity "
+                    f"for this data source, please follow these requirements. {requirements}"
+                ),
+            )
+            issues.append(error)
+        elif num_start_dims != 1 or num_end_dims != 1:
+            # Validity windows must define both a start and an end, and there should be exactly one
+            error = ValidationError(
+                context=context,
+                message=(
+                    f"Data source {data_source.name} has two validity param dimensions defined, but does not have "
+                    f"exactly one each marked with is_start and is_end: {validity_param_dims}. {requirements}"
+                ),
+            )
+            issues.append(error)
+
+        return issues

--- a/metricflow/test/model/validations/helpers.py
+++ b/metricflow/test/model/validations/helpers.py
@@ -1,14 +1,48 @@
+import textwrap
 from typing import List, Optional, Sequence
 
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.engine.models import Dimension
-from metricflow.model.objects.common import FileSlice, Metadata
+from metricflow.model.objects.common import FileSlice, Metadata, YamlConfigFile
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
 from metricflow.model.objects.data_source import DataSource, DataSourceOrigin, Mutability
 from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.materialization import Materialization, MaterializationDestination
 from metricflow.model.objects.metric import Metric, MetricType, MetricTypeParams
+
+
+def base_model_file() -> YamlConfigFile:
+    """Returns a YamlConfigFile with the inputs for a basic valid model
+
+    This is useful to seed a simple error-free model, which can easily be extended with YAML inputs
+    containing specific validation triggers.
+    """
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: sample_data_source
+          sql_table: some_schema.source_table
+          identifiers:
+            - name: example_identifier
+              type: primary
+              role: test_role
+              entity: other_identifier
+              expr: example_id
+          measures:
+            - name: num_sample_rows
+              agg: sum
+              expr: 1
+              create_metric: true
+          dimensions:
+            - name: ds
+              type: time
+              type_params:
+                time_granularity: day
+                is_primary: true
+        """
+    )
+    return YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
 
 
 def default_meta() -> Metadata:

--- a/metricflow/test/model/validations/test_validity_param_definitions.py
+++ b/metricflow/test/model/validations/test_validity_param_definitions.py
@@ -1,0 +1,250 @@
+import pytest
+import textwrap
+
+from metricflow.model.objects.common import YamlConfigFile
+from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_validation_ready_model
+from metricflow.model.model_validator import ModelValidator
+from metricflow.model.validations.validator_helpers import ModelValidationException
+from metricflow.test.model.validations.helpers import base_model_file
+
+
+def test_validity_window_configuration() -> None:
+    """Tests to ensure a data source with a properly configured validity window passes validation"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window_start
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: true
+            - name: window_end
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_end: true
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    validation_result = ModelValidator().validate_model(model.model)
+
+    assert not validation_result.issues.has_blocking_issues, (
+        f"Found blocking issues validating model with validity window properly configured: "
+        f"{[x.as_readable_str() for x in validation_result.issues.errors]}"
+    )
+
+
+def test_validity_window_must_have_a_start() -> None:
+    """Tests validation asserting a validity window end has a corresponding start"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window_end
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_end: true
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    with pytest.raises(ModelValidationException, match="has 1 validity param dimensions defined"):
+        ModelValidator().checked_validations(model.model)
+
+
+def test_validity_window_must_have_an_end() -> None:
+    """Tests validation asserting a validity window start has a corresponding end"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window_start
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: true
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    with pytest.raises(ModelValidationException, match="has 1 validity param dimensions defined"):
+        ModelValidator().checked_validations(model.model)
+
+
+def test_validity_window_uses_two_dimensions() -> None:
+    """Tests validation asserting validity window endpoints are defined in separate dimensions
+
+    Note: This test should be removed when support for single column validity window joins is added
+    """
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: true
+                  is_end: true
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    with pytest.raises(ModelValidationException, match="single validity param dimension that defines its window"):
+        ModelValidator().checked_validations(model.model)
+
+
+def test_two_dimension_validity_windows_must_not_overload_start_and_end() -> None:
+    """Tests validation asserting that a validity window does not set is_start and is_end on one dimension"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window_start
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: true
+            - name: window_end
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: true
+                  is_end: true
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    with pytest.raises(ModelValidationException, match="does not have exactly one each"):
+        ModelValidator().checked_validations(model.model)
+
+
+def test_multiple_validity_windows_are_invalid() -> None:
+    """Tests validation asserting that no more than 1 validity window can exist in a data source"""
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window_start_one
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: true
+            - name: window_end_one
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_end: true
+            - name: window_start_two
+              type: time
+              type_params:
+                time_granularity: week
+                validity_params:
+                  is_start: true
+            - name: window_end_two
+              type: time
+              type_params:
+                time_granularity: week
+                validity_params:
+                  is_end: true
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    with pytest.raises(ModelValidationException, match="has 4 validity param dimensions defined"):
+        ModelValidator().checked_validations(model.model)
+
+
+def test_empty_validity_windows_are_invalid() -> None:
+    """Tests validation asserting that validity windows cannot be specified if they are empty"""
+
+    yaml_contents = textwrap.dedent(
+        """\
+        data_source:
+          name: scd_data_source
+          sql_table: some_schema.scd_table
+          identifiers:
+            - name: scd_key
+              type: primary
+          dimensions:
+            - name: country
+              type: categorical
+            - name: window_start
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_end: false
+            - name: window_end
+              type: time
+              type_params:
+                time_granularity: day
+                validity_params:
+                  is_start: false
+        """
+    )
+    validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
+
+    with pytest.raises(ModelValidationException, match="does not have exactly one each"):
+        ModelValidator().checked_validations(model.model)


### PR DESCRIPTION
The validity params for defining an SCD window on a data source must
conform to certain specifications, otherwise we will not be able to
properly handle them and users could encounter strange runtime
failures.

This PR adds the relevant validation checks and assertions, along
with a test suite for the new validation. It also reshuffles some of our
parsing/validation functions to enable isolated testing on specific
custom model elements.