### PR TITLE
Fix dbt imports

### DIFF
--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -32,7 +32,7 @@ jobs:
         run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
 
       - name: Install Metricflow
-        run: poetry install -E dbt-snowflake
+        run: poetry install
 
       - name: Run MetricFlow Unit tests suites
         run: pytest metricflow/test

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -36,7 +36,7 @@ jobs:
         run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
 
       - name: Install Metricflow
-        run: poetry install -E dbt-snowflake
+        run: poetry install
 
       - name: Generate JSON Schema
         run: python3 metricflow/model/parsing/explicit_schema.py

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -19,7 +19,7 @@ from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.convert_data_source import DataSourceToDataSetConverter
 from metricflow.engine.models import Dimension, Materialization, Metric
 from metricflow.engine.time_source import ServerTimeSource
-from metricflow.engine.utils import build_user_configured_model_from_config, build_user_configured_model_from_dbt_config
+from metricflow.engine.utils import build_user_configured_model_from_config
 from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
 from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.execution.executor import SequentialPlanExecutor
@@ -276,6 +276,13 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         # Ideally we should put this getting of of CONFIG_DBT_REPO in a helper
         dbt_repo = handler.get_value(CONFIG_DBT_REPO) or ""
         if dbt_repo.lower() in ["yes", "y", "true", "t", "1"]:
+            # This import results in eventually importing dbt, and dbt is an
+            # optional dep meaning it isn't guaranteed to be installed. If the
+            # import is at the top ofthe file MetricFlow will blow up if dbt
+            # isn't installed. Thus by importing it here, we only run into the
+            # exception if this conditional is hit without dbt installed
+            from metricflow.engine.utils import build_user_configured_model_from_dbt_config
+
             semantic_model = SemanticModel(build_user_configured_model_from_dbt_config(handler))
         else:
             semantic_model = SemanticModel(build_user_configured_model_from_config(handler))

--- a/metricflow/engine/utils.py
+++ b/metricflow/engine/utils.py
@@ -7,7 +7,6 @@ from metricflow.configuration.constants import CONFIG_MODEL_PATH
 from metricflow.configuration.yaml_handler import YamlFileHandler
 from metricflow.errors.errors import ModelCreationException
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.model.parsing.dbt_dir_to_model import parse_dbt_project_to_model
 from metricflow.model.parsing.dir_to_model import ModelBuildResult, parse_directory_of_yaml_files_to_model
 from metricflow.sql_clients.common_client import not_empty
 
@@ -52,6 +51,13 @@ def model_build_result_from_dbt_config(
     """
     dbt_models_path = path_to_models(handler=handler)
     try:
+        # This import results in eventually importing dbt, and dbt is an
+        # optional dep meaning it isn't guaranteed to be installed. If the
+        # import is at the top ofthe file MetricFlow will blow up if dbt
+        # isn't installed. Thus by importing it here, we only run into the
+        # exception if this method is called without dbt installed.
+        from metricflow.model.parsing.dbt_dir_to_model import parse_dbt_project_to_model
+
         return parse_dbt_project_to_model(dbt_models_path)
     except Exception as e:
         raise ModelCreationException from e


### PR DESCRIPTION
The `dbt-*` packages are optional. This means that typically they won't be installed, and they shouldn't be installed unless you are actively developing `MetricFlow`/`dbt` functionality or using `MetricFlow`/`dbt` functionality. If `dbt-*` deps aren't installed, imports which eventually lead to dbt imports cause fatal exceptions. To get around this, we've moved the import of methods/classes which lead to dbt imports into the places they get used. Thus the exceptions will now only occur if you try to use dbt functionality without having installed an appropriate `dbt-*` dependency.

Additionally we've reverted changes to some of the github workflows which began installing the `dbt-snowflake` optional dependency.

-----

An example of the errors that were happening which no longer happen:
```
$ make test

ImportError while loading conftest '/Users/tqm/Developer/transform-data/metricflow/metricflow/test/conftest.py'.
metricflow/__init__.py:1: in <module>
    from metricflow.api.metricflow_client import MetricFlowClient  # noqa: D
metricflow/api/metricflow_client.py:11: in <module>
    from metricflow.engine.metricflow_engine import (
metricflow/engine/metricflow_engine.py:22: in <module>
    from metricflow.engine.utils import build_user_configured_model_from_config, build_user_configured_model_from_dbt_config
metricflow/engine/utils.py:10: in <module>
    from metricflow.model.parsing.dbt_dir_to_model import parse_dbt_project_to_model
metricflow/model/parsing/dbt_dir_to_model.py:4: in <module>
    from metricflow.model.transformations.dbt_to_metricflow import DbtManifestTransformer
metricflow/model/transformations/dbt_to_metricflow.py:42: in <module>
    class DbtManifestTransformer:
metricflow/model/transformations/dbt_to_metricflow.py:50: in DbtManifestTransformer
    def __init__(self, manifest: DbtManifest) -> None:
E   NameError: name 'DbtManifest' is not defined
make: *** [test] Error 4
```