### PR TITLE
Prevent measure definitions in data sources with validity windows

### DIFF
--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -164,4 +164,16 @@ class DataSourceValidityWindowRule(ModelValidationRule):
             )
             issues.append(error)
 
+        if data_source.measures:
+            # Temporarily block measure definitions in data sources with validity windows set
+            error = ValidationError(
+                context=context,
+                message=(
+                    f"Data source {data_source.name} has both measures and validity param dimensions defined. This "
+                    f"is not currently supported! Please remove either the measures or the validity params. "
+                    f"Measures: {data_source.measures}. Validity param dimensions: {validity_param_dims}"
+                ),
+            )
+            issues.append(error)
+
         return issues

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -127,10 +127,13 @@ class DataSourceValidityWindowRule(ModelValidationRule):
             "Data sources using dimension validity params to define a validity window must have exactly two time "
             "dimensions with validity params specified - one marked `is_start` and the other marked `is_end`."
         )
-        num_start_dims = len(
-            [dim for dim in validity_param_dims if dim.validity_params and dim.validity_params.is_start]
-        )
-        num_end_dims = len([dim for dim in validity_param_dims if dim.validity_params and dim.validity_params.is_end])
+        validity_param_dimension_names = [dim.name for dim in validity_param_dims]
+        start_dim_names = [
+            dim.name for dim in validity_param_dims if dim.validity_params and dim.validity_params.is_start
+        ]
+        end_dim_names = [dim.name for dim in validity_param_dims if dim.validity_params and dim.validity_params.is_end]
+        num_start_dims = len(start_dim_names)
+        num_end_dims = len(end_dim_names)
 
         if len(validity_param_dims) == 1 and num_start_dims == 1 and num_end_dims == 1:
             # Defining a single point window, such as one might find in a daily snapshot table keyed on date,
@@ -139,7 +142,9 @@ class DataSourceValidityWindowRule(ModelValidationRule):
                 context=context,
                 message=(
                     f"Data source {data_source.name} has a single validity param dimension that defines its window: "
-                    f"{validity_param_dims}. This is not a currently supported configuration! {requirements}"
+                    f"`{validity_param_dimension_names[0]}`. This is not a currently supported configuration! "
+                    f"{requirements} If you have one column defining a window, as in a daily snapshot table, you can "
+                    f"define a separate dimension and increment the time value in the `expr` field as a work-around."
                 ),
             )
             issues.append(error)
@@ -147,31 +152,36 @@ class DataSourceValidityWindowRule(ModelValidationRule):
             error = ValidationError(
                 context=context,
                 message=(
-                    f"Data source {data_source.name} has {len(validity_param_dims)} validity param dimensions defined:"
-                    f"{validity_param_dims}. There must be either zero or two! If you wish to define a validity "
-                    f"for this data source, please follow these requirements. {requirements}"
+                    f"Data source {data_source.name} has {len(validity_param_dims)} dimensions defined with validity "
+                    f"params. They are: {validity_param_dimension_names}. There must be either zero or two! "
+                    f"If you wish to define a validity window for this data source, please follow these requirements: "
+                    f"{requirements}"
                 ),
             )
             issues.append(error)
         elif num_start_dims != 1 or num_end_dims != 1:
             # Validity windows must define both a start and an end, and there should be exactly one
+            start_dim_names = []
             error = ValidationError(
                 context=context,
                 message=(
                     f"Data source {data_source.name} has two validity param dimensions defined, but does not have "
-                    f"exactly one each marked with is_start and is_end: {validity_param_dims}. {requirements}"
+                    f"exactly one each marked with is_start and is_end! Dimensions: {validity_param_dimension_names}. "
+                    f"is_start dimensions: {start_dim_names}. is_end dimensions: {end_dim_names}. {requirements}"
                 ),
             )
             issues.append(error)
 
         if data_source.measures:
             # Temporarily block measure definitions in data sources with validity windows set
+            measure_names = [measure.name for measure in data_source.measures]
             error = ValidationError(
                 context=context,
                 message=(
                     f"Data source {data_source.name} has both measures and validity param dimensions defined. This "
                     f"is not currently supported! Please remove either the measures or the validity params. "
-                    f"Measures: {data_source.measures}. Validity param dimensions: {validity_param_dims}"
+                    f"Measure names: {measure_names}. Validity param dimension names: "
+                    f"{validity_param_dimension_names}."
                 ),
             )
             issues.append(error)

--- a/metricflow/test/model/validations/test_validity_param_definitions.py
+++ b/metricflow/test/model/validations/test_validity_param_definitions.py
@@ -70,7 +70,7 @@ def test_validity_window_must_have_a_start() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has 1 validity param dimensions defined"):
+    with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
         ModelValidator().checked_validations(model.model)
 
 
@@ -98,7 +98,7 @@ def test_validity_window_must_have_an_end() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has 1 validity param dimensions defined"):
+    with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
         ModelValidator().checked_validations(model.model)
 
 
@@ -211,7 +211,7 @@ def test_multiple_validity_windows_are_invalid() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has 4 validity param dimensions defined"):
+    with pytest.raises(ModelValidationException, match="has 4 dimensions defined with validity params"):
         ModelValidator().checked_validations(model.model)
 
 


### PR DESCRIPTION
Defining measures in an SCD-style data source is a bit tricky,
because it's unclear when (or if) the user wants the measure to be
globally aggregable vs semi-additive to the validity windows.

While we sort out the right model syntax for this, we will prevent
measure definitions in data sources with validity windows to ensure
there is no mismatch between framework behavior and user expectations
with regard to how these things are aggregated.

This PR also includes some related error message cleanup.