### PR TITLE
added validator for derived metrics

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -22,7 +22,7 @@ from metricflow.model.validations.measures import (
     MetricMeasuresRule,
     MeasuresNonAdditiveDimensionRule,
 )
-from metricflow.model.validations.metrics import CumulativeMetricRule
+from metricflow.model.validations.metrics import CumulativeMetricRule, DerivedMetricRule
 from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.reserved_keywords import ReservedKeywordsRule
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
@@ -39,6 +39,7 @@ class ModelValidator:
     """A Validator that acts on UserConfiguredModel"""
 
     DEFAULT_RULES = (
+        DerivedMetricRule(),
         CountAggregationExprRule(),
         DataSourceMeasuresUniqueRule(),
         DataSourceTimeDimensionWarningsRule(),


### PR DESCRIPTION
## Context
With the addition of derived metrics, we need to validate that they are correctly configured.

## Cases
1. Derived metrics allows you to attach an alias to an input metric. The alias must be unique from the other aliases and other input metric names.
2. Validates that the input metric provided exists in the model