### PR TITLE
Databricks: Enable secondary connection for table renames

### DIFF
--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -61,9 +61,14 @@ class DatabricksEngineAttributes(SqlEngineAttributes):
 class DatabricksSqlClient(BaseSqlClientImplementation):
     """Client used to connect to Databricks engine."""
 
-    def __init__(  # noqa: D
+    def __init__(
         self, host: str, http_path: str, access_token: str, http_path_for_table_renames: Optional[str] = None
     ) -> None:
+        """Instantiate client.
+
+        Note: Databricks SQL warehouse connections using S3 do not allow table renames. In this case, users must
+        specify an HTTP path that points to a cluster that can be used for table renames.
+        """
         self.host = host
         self.http_path = http_path
         self.access_token = access_token

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -115,11 +115,11 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
             http_path_for_table_renames=http_path_for_table_renames,
         )
 
-    def get_connection(self, table_rename: bool = False) -> sql.client.Connection:
+    def get_connection(self, is_table_rename: bool = False) -> sql.client.Connection:
         """Get connection to Databricks cluster/warehouse."""
         return sql.connect(
             server_hostname=self.host,
-            http_path=self.http_path_for_table_renames if table_rename else self.http_path,
+            http_path=self.http_path_for_table_renames if is_table_rename else self.http_path,
             access_token=self.access_token,
         )
 


### PR DESCRIPTION
When using databricks-sql-connector, you can connect using a cluster or a SQL warehouse. Some users prefer SQL warehouse because it can be more affordable. If your Databricks connection uses S3, however, you will get an error when you try to rename tables. We fix this issue for cluster connections by setting this config: `spark.databricks.delta.alterTable.rename.enabledOnAWS=true`. That config is not supported for SQL warehouse connections, so users are unable to rename tables when using a SQL warehouse connection with S3.
To work around this this for users who want to use S3 with a SQL warehouse, we will require them to specify a cluster connection to use exclusively for table renames. We can specify which connection to use by changing the HTTP path used when connecting to Databricks.