### PR TITLE
Enable pre-commit typechecking for dbt packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
-    -   id: black
+      - id: black
         verbose: true
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
@@ -13,9 +13,23 @@ repos:
 
   - repo: https://github.com/pre-commit/mirrors-mypy # configured via mypy.ini
     rev: v0.931
-    hooks:  # passing args: [] ensures we do not silently ignore imports (default) and instead explicitly configure in mypy.ini
+    hooks: # passing args: [] ensures we do not silently ignore imports (default) and instead explicitly configure in mypy.ini
       - id: mypy
         name: mypy_metricflow
         args: [--ignore-missing-imports, --show-error-codes]
         verbose: true
-        additional_dependencies: [sqlalchemy,sqlalchemy2-stubs,types-flask,types-requests,types-PyYAML,types-jinja2,types-attrs,types-tabulate,pytest, python-dateutil, types-python-dateutil]
+        additional_dependencies:
+          [
+            sqlalchemy,
+            sqlalchemy2-stubs,
+            types-flask,
+            types-requests,
+            types-PyYAML,
+            types-jinja2,
+            types-attrs,
+            types-tabulate,
+            pytest,
+            python-dateutil,
+            types-python-dateutil,
+            dbt-core,
+          ]

--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -65,7 +65,9 @@ class DbtManifestTransformer:
         dimension should be primary for
         """
         if not self._time_dimension_stats:
-            self._time_dimension_stats = self.collect_time_dimension_stats(dbt_metrics=self.manifest.metrics.values())
+            self._time_dimension_stats = self.collect_time_dimension_stats(
+                dbt_metrics=list(self.manifest.metrics.values())
+            )
 
         return self._time_dimension_stats
 
@@ -73,7 +75,8 @@ class DbtManifestTransformer:
         """Returns a DbtModelNode based on the `DbtMetric.model`
 
         `DbtMetric.model` string values should either be a model name, or a
-        dbt [ref] (https://docs.getdbt.com/reference/dbt-jinja-functions/ref) object for a model. A dbt `ref` contains either one or two
+        dbt [ref] (https://docs.getdbt.com/reference/dbt-jinja-functions/ref)
+        object for a model. A dbt `ref` contains either one or two
         strings. If two strings are specified, the first is the target package
         and the second is the target model. If only one string is specified
         then it represents the target model.
@@ -108,7 +111,7 @@ class DbtManifestTransformer:
             node = self.manifest.resolve_ref(
                 target_model_name=target_model,
                 target_model_package=target_package,
-                current_project=self.manifest.metadata.project_id,
+                current_project=self.manifest.metadata.project_id or "",
                 node_package=dbt_metric.package_name,
             )
             assert isinstance(
@@ -339,7 +342,7 @@ class DbtManifestTransformer:
         # dimenson for the data source that is built for the `DbtMetric.model`
         time_stats_for_metric_models: Dict[str, Dict[str, int]] = {}
         for dbt_metric in dbt_metrics:
-            if dbt_metric.calculation_method != "derived":
+            if dbt_metric.calculation_method != "derived" and dbt_metric.model is not None:
                 if dbt_metric.timestamp not in time_dimensions:
                     time_dimensions[dbt_metric.timestamp] = []
 


### PR DESCRIPTION
Metricflow has an override in its .pre-commit-config to ignore all
missing imports, which means third party packages simply don't get
typechecked in any case where the mypy invocation is mediated by
pre-commit (which is roughly all of them, for us).

This means the dbt integration was done with a relative minimum of
typechecker support.

Here we enable dbt typchecking in the .pre-commit-config (the remaining
changes were an unfortunate side effect of auto-formatting) by adding
dbt-core to the dependency list, and clean up the typing errors this
exposed as a result.

Note these fixes are just wallpapering over the underlying issues, so
more robust changes may be warranted.
