### PR TITLE
Actions cleanup: use more recent Poetry and Python versions

### DIFF
--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install dependencies
         run: make install

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Snowflake configs
-        run: pytest metricflow/test/
+        run: poetry run pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_SNOWFLAKE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_SNOWFLAKE_PWD }}
@@ -69,7 +69,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Redshift configs
-        run: pytest metricflow/test/
+        run: poetry run pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_REDSHIFT_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_REDSHIFT_PWD }}
@@ -102,7 +102,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with BigQuery configs
-        run: pytest metricflow/test/
+        run: poetry run pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
@@ -135,7 +135,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with Databricks configs
-        run: pytest metricflow/test/
+        run: poetry run pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
@@ -183,7 +183,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with PostgreSQL configs
-        run: pytest metricflow/test/
+        run: poetry run pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -17,10 +17,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:
@@ -50,10 +50,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:
@@ -83,10 +83,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:
@@ -116,10 +116,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:
@@ -164,10 +164,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -30,7 +30,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Deps
         run: cd metricflow && poetry install
@@ -63,7 +63,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Deps
         run: cd metricflow && poetry install
@@ -96,7 +96,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Deps
         run: cd metricflow && poetry install
@@ -129,7 +129,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Deps
         run: cd metricflow && poetry install
@@ -177,7 +177,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Deps
         run: cd metricflow && poetry install

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         env:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
   postgres-tests:
-    name: PostgreSQL Tests
+    name: Metricflow Unit Tests - PostgreSQL
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: poetry install
 
       - name: Run MetricFlow Unit tests suites
-        run: pytest metricflow/test
+        run: poetry run pytest metricflow/test
         env:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
   postgres-tests:
@@ -82,7 +82,7 @@ jobs:
         run: cd metricflow && poetry install
 
       - name: Run MetricFlow unit tests with PostgreSQL configs
-        run: pytest metricflow/test/
+        run: poetry run pytest metricflow/test/
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -11,14 +11,17 @@ jobs:
   metricflow-unit-tests:
     name: MetricFlow Unit Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
 
       - uses: actions/cache@v2
         with:
@@ -60,10 +63,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -8,8 +8,8 @@ on:
       - reopened
       - synchronize
 jobs:
-  metricflow-unit-tests:
-    name: MetricFlow Unit Tests
+  metricflow-unit-tests-duckdb:
+    name: MetricFlow Unit Tests - DuckDB
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,8 +40,8 @@ jobs:
         run: poetry run pytest metricflow/test
         env:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
-  postgres-tests:
-    name: Metricflow Unit Tests - PostgreSQL
+  metricflow-unit-tests-postgres:
+    name: MetricFlow Unit Tests - PostgreSQL
     runs-on: ubuntu-latest
 
     services:
@@ -86,3 +86,12 @@ jobs:
         env:
           MF_SQL_ENGINE_URL: postgresql://postgres@localhost:5432/metricflow
           MF_SQL_ENGINE_PASSWORD: postgres
+  metricflow-unit-tests:
+    name: MetricFlow Unit Tests
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [metricflow-unit-tests-duckdb, metricflow-unit-tests-postgres]
+
+    steps:
+      - name: Check success
+        run: test ${{ needs.metricflow-unit-tests-duckdb.result }} = 'success' -a ${{ needs.metricflow-unit-tests-postgres.result }} = 'success'

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Metricflow
         run: poetry install
@@ -73,7 +73,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Deps
         run: cd metricflow && poetry install

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -33,7 +33,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install Poetry
-        run: pip install poetry==1.1.15 && poetry config virtualenvs.create false
+        run: pip install poetry
 
       - name: Install Metricflow
         run: poetry install

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Our actions were pinned to Poetry 1.1.15 due to an outstanding issue 
with virtual env creation configuration. For historical reasons, we were
also testing exclusively in Python 3.8.

This PR moves us to a model where we're using the latest Poetry version
for build management, and running all actions against Python 3.9 (our latest
supported Python version) EXCEPT our core unit tests, which are run against
all supported Python versions.

This shift to matrixed Python versions presents a separate issue, resolved here
as well, where our merge-blocking unit test job is effectively forked into N
separate jobs, one for each version. Since branch protection is bound to job
name, and the job names are generated in the matrix configuration, we'd need
to keep updating the branch protection against every python version we test.

The solution used here is to have the required job depend on success for all
upstream job via the `needs` keyword, the `always()` condition for running,
and a test against input job status. This will always fail if any of its input jobs
fails, and always succeed if all of its input jobs succeed.