### PR TITLE
Use INNER JOIN for derived metrics when combining metrics

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -46,6 +46,7 @@ from metricflow.specs import (
     TimeDimensionSpec,
     SpecWhereClauseConstraint,
 )
+from metricflow.sql.sql_plan import SqlJoinType
 from metricflow.time.time_granularity import TimeGranularity
 from metricflow.visitor import Visitable, VisitorOutputT
 
@@ -902,7 +903,9 @@ class CombineMetricsNode(Generic[SourceDataSetT], ComputedMetricsOutput[SourceDa
     def __init__(  # noqa: D
         self,
         parent_nodes: Sequence[ComputedMetricsOutput[SourceDataSetT]],
+        join_type: SqlJoinType = SqlJoinType.FULL_OUTER,
     ) -> None:
+        self._join_type = join_type
         super().__init__(node_id=self.create_unique_id(), parent_nodes=list(parent_nodes))
 
     @classmethod
@@ -915,6 +918,11 @@ class CombineMetricsNode(Generic[SourceDataSetT], ComputedMetricsOutput[SourceDa
     @property
     def description(self) -> str:  # noqa: D
         return "Combine Metrics"
+
+    @property
+    def join_type(self) -> SqlJoinType:
+        """The type of join used for combining metrics."""
+        return self._join_type
 
 
 class ConstrainTimeRangeNode(AggregatedMeasuresOutput[SourceDataSetT], BaseOutput[SourceDataSetT]):

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1335,7 +1335,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                         table_aliases_in_coalesce=parent_source_table_aliases[:i],
                         table_alias_on_right_equality=parent_source_table_aliases[i],
                     ).transform(linkable_spec_set),
-                    join_type=SqlJoinType.FULL_OUTER,
+                    join_type=node.join_type,
                 )
             )
 

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -526,7 +526,7 @@ integration_test:
       GROUP BY
         ds
     ) a
-    FULL OUTER JOIN (
+    INNER JOIN (
       SELECT
         SUM(1) AS lux_listings
         , created_at AS metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
@@ -141,7 +141,7 @@ FROM (
         subq_2.metric_time
     ) subq_3
   ) subq_8
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_7.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
@@ -30,7 +30,7 @@ FROM (
     GROUP BY
       metric_time
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
@@ -153,7 +153,7 @@ FROM (
             subq_2.metric_time
         ) subq_3
       ) subq_8
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_7.metric_time
@@ -290,7 +290,7 @@ FROM (
         subq_8.metric_time = subq_9.metric_time
     ) subq_10
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time
@@ -425,7 +425,7 @@ FROM (
   ) subq_20
   ON
     subq_19.metric_time = subq_20.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -42,7 +42,7 @@ FROM (
         GROUP BY
           metric_time
       ) subq_31
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -68,7 +68,7 @@ FROM (
         subq_31.metric_time = subq_32.metric_time
     ) subq_33
   ) subq_42
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -92,7 +92,7 @@ FROM (
   ) subq_43
   ON
     subq_42.metric_time = subq_43.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
@@ -141,7 +141,7 @@ FROM (
         subq_2.metric_time
     ) subq_3
   ) subq_8
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_7.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
@@ -30,7 +30,7 @@ FROM (
     GROUP BY
       metric_time
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
@@ -153,7 +153,7 @@ FROM (
             subq_2.metric_time
         ) subq_3
       ) subq_8
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_7.metric_time
@@ -290,7 +290,7 @@ FROM (
         subq_8.metric_time = subq_9.metric_time
     ) subq_10
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time
@@ -425,7 +425,7 @@ FROM (
   ) subq_20
   ON
     subq_19.metric_time = subq_20.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -42,7 +42,7 @@ FROM (
         GROUP BY
           metric_time
       ) subq_31
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -68,7 +68,7 @@ FROM (
         subq_31.metric_time = subq_32.metric_time
     ) subq_33
   ) subq_42
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -92,7 +92,7 @@ FROM (
   ) subq_43
   ON
     subq_42.metric_time = subq_43.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
@@ -141,7 +141,7 @@ FROM (
         subq_2.metric_time
     ) subq_3
   ) subq_8
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_7.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
@@ -30,7 +30,7 @@ FROM (
     GROUP BY
       metric_time
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
@@ -153,7 +153,7 @@ FROM (
             subq_2.metric_time
         ) subq_3
       ) subq_8
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_7.metric_time
@@ -290,7 +290,7 @@ FROM (
         subq_8.metric_time = subq_9.metric_time
     ) subq_10
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time
@@ -425,7 +425,7 @@ FROM (
   ) subq_20
   ON
     subq_19.metric_time = subq_20.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -42,7 +42,7 @@ FROM (
         GROUP BY
           metric_time
       ) subq_31
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -68,7 +68,7 @@ FROM (
         subq_31.metric_time = subq_32.metric_time
     ) subq_33
   ) subq_42
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -92,7 +92,7 @@ FROM (
   ) subq_43
   ON
     subq_42.metric_time = subq_43.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
@@ -141,7 +141,7 @@ FROM (
         subq_2.metric_time
     ) subq_3
   ) subq_8
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_7.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
@@ -30,7 +30,7 @@ FROM (
     GROUP BY
       metric_time
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
@@ -153,7 +153,7 @@ FROM (
             subq_2.metric_time
         ) subq_3
       ) subq_8
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_7.metric_time
@@ -290,7 +290,7 @@ FROM (
         subq_8.metric_time = subq_9.metric_time
     ) subq_10
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time
@@ -425,7 +425,7 @@ FROM (
   ) subq_20
   ON
     subq_19.metric_time = subq_20.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -42,7 +42,7 @@ FROM (
         GROUP BY
           metric_time
       ) subq_31
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -68,7 +68,7 @@ FROM (
         subq_31.metric_time = subq_32.metric_time
     ) subq_33
   ) subq_42
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -92,7 +92,7 @@ FROM (
   ) subq_43
   ON
     subq_42.metric_time = subq_43.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
@@ -141,7 +141,7 @@ FROM (
         subq_2.metric_time
     ) subq_3
   ) subq_8
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_7.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
@@ -30,7 +30,7 @@ FROM (
     GROUP BY
       metric_time
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
@@ -153,7 +153,7 @@ FROM (
             subq_2.metric_time
         ) subq_3
       ) subq_8
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_7.metric_time
@@ -290,7 +290,7 @@ FROM (
         subq_8.metric_time = subq_9.metric_time
     ) subq_10
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time
@@ -425,7 +425,7 @@ FROM (
   ) subq_20
   ON
     subq_19.metric_time = subq_20.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -42,7 +42,7 @@ FROM (
         GROUP BY
           metric_time
       ) subq_31
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -68,7 +68,7 @@ FROM (
         subq_31.metric_time = subq_32.metric_time
     ) subq_33
   ) subq_42
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -92,7 +92,7 @@ FROM (
   ) subq_43
   ON
     subq_42.metric_time = subq_43.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
@@ -141,7 +141,7 @@ FROM (
         subq_2.metric_time
     ) subq_3
   ) subq_8
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_7.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
@@ -30,7 +30,7 @@ FROM (
     GROUP BY
       metric_time
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
@@ -153,7 +153,7 @@ FROM (
             subq_2.metric_time
         ) subq_3
       ) subq_8
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
           subq_7.metric_time
@@ -290,7 +290,7 @@ FROM (
         subq_8.metric_time = subq_9.metric_time
     ) subq_10
   ) subq_19
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_14.metric_time
@@ -425,7 +425,7 @@ FROM (
   ) subq_20
   ON
     subq_19.metric_time = subq_20.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
       subq_18.metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -42,7 +42,7 @@ FROM (
         GROUP BY
           metric_time
       ) subq_31
-      FULL OUTER JOIN (
+      INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
@@ -68,7 +68,7 @@ FROM (
         subq_31.metric_time = subq_32.metric_time
     ) subq_33
   ) subq_42
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
@@ -92,7 +92,7 @@ FROM (
   ) subq_43
   ON
     subq_42.metric_time = subq_43.metric_time
-  FULL OUTER JOIN (
+  INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
@@ -33,7 +33,7 @@
             <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
             <!--    'right_source_alias': 'subq_9',                          -->
             <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
-            <!--    'join_type': SqlJoinType.FULL_OUTER}                     -->
+            <!--    'join_type': SqlJoinType.INNER}                          -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -37,13 +37,13 @@
             <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),   -->
             <!--    'right_source_alias': 'subq_20',                         -->
             <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1),  -->
-            <!--    'join_type': SqlJoinType.FULL_OUTER}                     -->
+            <!--    'join_type': SqlJoinType.INNER}                          -->
             <!-- join_1 =                                                    -->
             <!--   {'class': 'SqlJoinDescription',                           -->
             <!--    'right_source': SqlSelectStatementNode(node_id=ss_24),   -->
             <!--    'right_source_alias': 'subq_21',                         -->
             <!--    'on_condition': SqlComparisonExpression(node_id=cmp_2),  -->
-            <!--    'join_type': SqlJoinType.FULL_OUTER}                     -->
+            <!--    'join_type': SqlJoinType.INNER}                          -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->
@@ -79,7 +79,7 @@
                     <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
                     <!--    'right_source_alias': 'subq_9',                          -->
                     <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0),  -->
-                    <!--    'join_type': SqlJoinType.FULL_OUTER}                     -->
+                    <!--    'join_type': SqlJoinType.INNER}                          -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Compute Metrics via Expressions -->


### PR DESCRIPTION
## Context
With the merge of Derived Metrics, we supported the ability to reference metrics and build an expr out of it. The way we aggregate all the metrics data is through the `CombineMetricsNode` which utilizes a `FULL OUTER JOIN` to combine the metric data. This would mean that there are cases where some metrics would return rows of `NaN` or `null` values because it doesn't have data associated to the metric time that other metrics have. This would result in the final result having `NaN` or `null` value. 

## Changes
With further discussions on https://github.com/transform-data/metricflow/pull/281#discussion_r998590378, we decided to use an `INNER JOIN` when combining metrics for derived metrics so that we don't have null values in the results.