### PR TITLE
Make derived metrics tests use double types

### DIFF
--- a/metricflow/test/compare_df.py
+++ b/metricflow/test/compare_df.py
@@ -1,7 +1,7 @@
 import logging
 import math
 import pandas as pd
-
+from typing import SupportsFloat
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +22,8 @@ def _dataframes_contain_same_data(
             # NaNs can't be compared for equality.
             if pd.isna(expected.iloc[c, r]) and pd.isna(actual.iloc[c, r]):
                 pass
-            elif isinstance(expected.iloc[c, r], float) and isinstance(actual.iloc[c, r], float):
-                if not math.isclose(expected.iloc[c, r], actual.iloc[c, r]):
+            elif isinstance(expected.iloc[c, r], SupportsFloat) and isinstance(actual.iloc[c, r], SupportsFloat):
+                if not math.isclose(expected.iloc[c, r], actual.iloc[c, r], rel_tol=1e-6):
                     return False
             elif (
                 isinstance(expected.iloc[c, r], pd.Timestamp)

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -504,7 +504,7 @@ metric:
     - support@transformdata.io
   type: derived
   type_params:
-    expr: (bookings - ref_bookings) / bookings
+    expr: (bookings - ref_bookings) * 1.0 / bookings
     metrics:
       - name: referred_bookings
         alias: ref_bookings
@@ -517,7 +517,7 @@ metric:
     - support@transformdata.io
   type: derived
   type_params:
-    expr: bookings / lux_listing
+    expr: bookings * 1.0 / NULLIF(lux_listing, 0)
     metrics:
       - name: bookings
       - name: listings
@@ -533,7 +533,7 @@ metric:
     - support@transformdata.io
   type: derived
   type_params:
-    expr: non_referred + (instant / bookings)
+    expr: non_referred + (instant * 1.0 / bookings)
     metrics:
       - name: non_referred_bookings_pct
         alias: non_referred
@@ -541,3 +541,4 @@ metric:
         alias: instant
       - name: bookings
 ---
+

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -496,7 +496,7 @@ integration_test:
   group_bys: ["metric_time"]
   check_query: |
     SELECT
-      (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+      (bookings - ref_bookings) / CAST(bookings AS {{ double_data_type_name }}) AS non_referred_bookings_pct
       , metric_time
     FROM (
       SELECT
@@ -516,7 +516,7 @@ integration_test:
   group_bys: ["metric_time"]
   check_query: |
     SELECT
-      bookings / lux_listings AS bookings_per_lux_listing_derived
+      bookings / CAST(NULLIF(lux_listings, 0) AS {{ double_data_type_name }}) AS bookings_per_lux_listing_derived
       , a.metric_time
     FROM (
       SELECT
@@ -545,7 +545,7 @@ integration_test:
   group_bys: ["metric_time"]
   check_query: |
     SELECT
-      (instant_bookings / bookings) + ((bookings - ref_bookings) / bookings) AS instant_plus_non_referred_bookings_pct
+      (instant_bookings / CAST(bookings AS {{ double_data_type_name }})) + ((bookings - ref_bookings) / CAST(bookings AS {{ double_data_type_name }})) AS instant_plus_non_referred_bookings_pct
       , metric_time
     FROM (
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_10.metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_22.metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_10.metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_22.metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_10.metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_22.metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_10.metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_22.metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_10.metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_22.metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_10.metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , (bookings - ref_bookings) / bookings AS non_referred_bookings_pct
+  , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_22.metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_10.metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Compute Metrics via Expressions
 SELECT
   metric_time
-  , non_referred + (instant / bookings) AS instant_plus_non_referred_bookings_pct
+  , non_referred + (instant * 1.0 / bookings) AS instant_plus_non_referred_bookings_pct
 FROM (
   -- Combine Metrics
   SELECT
@@ -13,7 +13,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time
-      , (bookings - ref_bookings) / bookings AS non_referred
+      , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
       -- Combine Metrics
       SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
@@ -6,10 +6,10 @@
         <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
         <!--    'column_alias': 'metric_time'}                         -->
-        <!-- col1 =                                                                                        -->
-        <!--   {'class': 'SqlSelectColumn',                                                                -->
-        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=(bookings - ref_bookings) / bookings),  -->
-        <!--    'column_alias': 'non_referred_bookings_pct'}                                               -->
+        <!-- col1 =                                                                                              -->
+        <!--   {'class': 'SqlSelectColumn',                                                                      -->
+        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=(bookings - ref_bookings) * 1.0 / bookings),  -->
+        <!--    'column_alias': 'non_referred_bookings_pct'}                                                     -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- where = None -->
         <SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -6,10 +6,10 @@
         <!--   {'class': 'SqlSelectColumn',                            -->
         <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
         <!--    'column_alias': 'metric_time'}                         -->
-        <!-- col1 =                                                                                       -->
-        <!--   {'class': 'SqlSelectColumn',                                                               -->
-        <!--    'expr': SqlStringExpression(node_id=str_1 sql_expr=non_referred + (instant / bookings)),  -->
-        <!--    'column_alias': 'instant_plus_non_referred_bookings_pct'}                                 -->
+        <!-- col1 =                                                                                             -->
+        <!--   {'class': 'SqlSelectColumn',                                                                     -->
+        <!--    'expr': SqlStringExpression(node_id=str_1 sql_expr=non_referred + (instant * 1.0 / bookings)),  -->
+        <!--    'column_alias': 'instant_plus_non_referred_bookings_pct'}                                       -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
         <!-- where = None -->
         <SqlSelectStatementNode>
@@ -52,10 +52,10 @@
                 <!--   {'class': 'SqlSelectColumn',                            -->
                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
-                <!-- col1 =                                                                                        -->
-                <!--   {'class': 'SqlSelectColumn',                                                                -->
-                <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=(bookings - ref_bookings) / bookings),  -->
-                <!--    'column_alias': 'non_referred'}                                                            -->
+                <!-- col1 =                                                                                              -->
+                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=(bookings - ref_bookings) * 1.0 / bookings),  -->
+                <!--    'column_alias': 'non_referred'}                                                                  -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>


### PR DESCRIPTION
The derived metrics tests were all implicitly checking BIGINT types,
since that's what SUM returns. This changes them to use DOUBLE
for proper ratio computation, which will bring the answers in line
with expectation based on manual calculation against the table fixtures.

Note we cannot do explicit casting in the metric definition expr because
DOUBLE types are not consistently named across engines, so we rely on
the implicit casting shorthand of multiplying by a double literal.
