### PR TITLE
Add private field support in metric locked_metadata

### DIFF
--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -39,7 +39,7 @@ jobs:
         run: poetry install
 
       - name: Generate JSON Schema
-        run: python3 metricflow/model/parsing/explicit_schema.py
+        run: python metricflow/model/parsing/explicit_schema.py
 
       - name: Schema Consistency Check
         run: |

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -39,7 +39,7 @@ jobs:
         run: poetry install
 
       - name: Generate JSON Schema
-        run: python metricflow/model/parsing/explicit_schema.py
+        run: poetry run python metricflow/model/parsing/explicit_schema.py
 
       - name: Schema Consistency Check
         run: |

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -324,6 +324,9 @@
                 "increase_is_good": {
                     "type": "boolean"
                 },
+                "private": {
+                    "type": "boolean"
+                },
                 "tags": {
                     "items": {
                         "type": "string"

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -72,6 +72,7 @@ locked_metadata_schema = {
             "type": "array",
             "items": {"type": "string"},
         },
+        "private": {"type": "boolean"},
     },
     "additionalProperties": False,
 }

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -230,6 +230,7 @@ metric:
     tags:
       - "Finance"
       - "Monthly"
+    private: true
   type_params:
     measures:
       - txn_revenue


### PR DESCRIPTION
## What Changed

Following the example PR https://github.com/transform-data/metricflow/pull/261, we are adding a new field called `private` in metric `locked_metadata` field in our internal schema. This field will be used to allow more granular access control for a metric.

Note that this change is taking place in MetricFlow because that is where schema's internal lives. However, it doesn't actually add or change any features of metricflow for the community. 