### PR TITLE
Add `extra_detail` to data warehouse validation errors raised from exceptions

### DIFF
--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from math import floor
 from time import perf_counter
+import traceback
 from typing import Callable, List, Optional, Tuple
 from metricflow.dataflow.builder.source_node import SourceNodeBuilder
 from metricflow.dataflow.dataflow_plan import BaseOutput, FilterElementsNode
@@ -448,6 +449,7 @@ class DataWarehouseModelValidator:
                     ValidationError(
                         context=task.context,
                         message=task.error_message + f"\nRecieved following error from data warehouse:\n{e}",
+                        extra_detail="".join(traceback.format_tb(e.__traceback__)),
                     )
                 )
                 if task.on_fail_subtasks:


### PR DESCRIPTION
We're having some spec building issues when building specs for the measure based data warehouse validations. It's extra hard to debug because currently we don't return the exception stacktrace information. Without this it's hard to see what is going on. This commit adds the exception stacktrace information to the `extra_details` section of the validation error. Note, from a CLI perspective `extra_details` aren't printed out by default. They are only printed when `--verbose-issues` is specified