### PR TITLE
Remove `update_cron` Default From Mutability

### DIFF
--- a/metricflow/model/objects/data_source.py
+++ b/metricflow/model/objects/data_source.py
@@ -61,9 +61,7 @@ class DataSource(HashableBaseModel, ModelWithMetadataParsing):
     measures: Sequence[Measure] = []
     dimensions: Sequence[Dimension] = []
 
-    mutability: Mutability = Mutability(
-        type=MutabilityType.FULL_MUTATION, type_params=MutabilityTypeParams(update_cron="0 0,12 * * *")
-    )
+    mutability: Mutability = Mutability(type=MutabilityType.FULL_MUTATION)
 
     origin: DataSourceOrigin = DataSourceOrigin.SOURCE
     metadata: Optional[Metadata]


### PR DESCRIPTION
This PR removes the `update_cron` default as it is not used in the open source project so it will be confusing.