### PR TITLE
Factor join building logic out of DataflowToSqlQueryPlanBuilder

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -302,13 +302,19 @@ class JoinOverTimeRangeNode(Generic[SourceDataSetT], BaseOutput[SourceDataSetT])
 
         Args:
             parent_node: node with standard output
-            metric_time_dimension_reference: the name of the virtual time dimension used in queries to refer to the time
-            dimension that each measure should be aggregated by.
+            metric_time_dimension_reference: the name of the virtual time dimension used in queries to refer to the
+            time dimension that each measure should be aggregated by.
             window: time window to join over
-            grain_to_date: indicates time range should start from the beginning of this time granularity (eg month to day)
+            grain_to_date: indicates time range should start from the beginning of this time granularity
+            (eg month to day)
             node_id: Override the node ID with this value
             time_range_constraint: time range to aggregate over
         """
+        if window and grain_to_date:
+            raise RuntimeError(
+                f"This node cannot be initialized with both window and grain_to_date set. This configuration should "
+                f"have been prevented by model validation. window: {window}. grain_to_date: {grain_to_date}."
+            )
         self._parent_node = parent_node
         self._grain_to_date = grain_to_date
         self._window = window

--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -26,7 +26,7 @@ class DataSet:
 
     @property
     def metric_time_dimension_instances(self) -> Sequence[TimeDimensionInstance]:
-        """Extracts all TimeDimensionInstances from the InstanceSet associated with this DataSet"""
+        """Extracts all metric time TimeDimensionInstances from the InstanceSet associated with this DataSet"""
         return tuple(
             time_dimension_instance
             for time_dimension_instance in self.instance_set.time_dimension_instances

--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import logging
+from typing import Sequence
 
-from metricflow.instances import (
-    InstanceSet,
-)
+from metricflow.instances import InstanceSet, TimeDimensionInstance
 from metricflow.model.validations.unique_valid_name import MetricFlowReservedKeywords
 from metricflow.references import TimeDimensionReference
 from metricflow.specs import TimeDimensionSpec
@@ -24,6 +23,15 @@ class DataSet:
     def instance_set(self) -> InstanceSet:
         """Returns the instances contained in this dataset."""
         return self._instance_set
+
+    @property
+    def metric_time_dimension_instances(self) -> Sequence[TimeDimensionInstance]:
+        """Extracts all TimeDimensionInstances from the InstanceSet associated with this DataSet"""
+        return tuple(
+            time_dimension_instance
+            for time_dimension_instance in self.instance_set.time_dimension_instances
+            if time_dimension_instance.spec.element_name == DataSet.metric_time_dimension_name()
+        )
 
     @staticmethod
     def metric_time_dimension_reference() -> TimeDimensionReference:

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -399,8 +399,8 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
 
             sql_join_descs.append(
                 SqlQueryPlanJoinBuilder.make_base_output_join_description(
-                    annotated_left_data_set=AnnotatedSqlDataSet(data_set=from_data_set, alias=from_data_set_alias),
-                    annotated_right_data_set=AnnotatedSqlDataSet(data_set=right_data_set, alias=right_data_set_alias),
+                    left_data_set=AnnotatedSqlDataSet(data_set=from_data_set, alias=from_data_set_alias),
+                    right_data_set=AnnotatedSqlDataSet(data_set=right_data_set, alias=right_data_set_alias),
                     join_description=join_description,
                 )
             )

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from metricflow.sql.sql_plan import SqlExpressionNode, SqlJoinDescription, SqlJoinType, SqlSelectStatementNode
+from metricflow.sql.sql_exprs import (
+    SqlColumnReference,
+    SqlColumnReferenceExpression,
+    SqlComparison,
+    SqlComparisonExpression,
+    SqlLogicalExpression,
+    SqlLogicalOperator,
+)
+
+
+@dataclass(frozen=True)
+class ColumnEqualityDescription:
+    """Helper class to enumerate columns that should be equal between sources in a join."""
+
+    left_column_alias: str
+    right_column_alias: str
+
+
+class SqlQueryPlanJoinBuilder:
+    """Helper class for constructing various join components in a SqlQueryPlan"""
+
+    @staticmethod
+    def make_sql_join_description(
+        right_source_node: SqlSelectStatementNode,
+        left_source_alias: str,
+        right_source_alias: str,
+        column_equality_descriptions: Sequence[ColumnEqualityDescription],
+        join_type: SqlJoinType,
+        additional_on_conditions: Sequence[SqlExpressionNode] = tuple(),
+    ) -> SqlJoinDescription:
+        """Make a join description where the condition is a set of equality comparisons between columns.
+
+        Typically the columns in column_equality_descriptions are identifiers we are trying to match,
+        although they may include things like dimension partitions or time dimension columns where an
+        equality is expected.
+
+        Args:
+            right_source_node: node representing the join target, may be either a table or subquery
+            left_source_alias: string alias identifier for the join source
+            right_source_alias: string alias identifier for the join target
+            column_equality_descriptions: set of equality constraints for the ON statement
+            join_type: type of SQL join, e.g., LEFT, INNER, etc.
+            additional_on_conditions: set of additional constraints to add in the ON statement (via AND)
+        """
+        assert len(column_equality_descriptions) > 0
+
+        and_conditions: List[SqlExpressionNode] = []
+        for column_equality_description in column_equality_descriptions:
+            and_conditions.append(
+                SqlComparisonExpression(
+                    left_expr=SqlColumnReferenceExpression(
+                        SqlColumnReference(
+                            table_alias=left_source_alias,
+                            column_name=column_equality_description.left_column_alias,
+                        )
+                    ),
+                    comparison=SqlComparison.EQUALS,
+                    right_expr=SqlColumnReferenceExpression(
+                        SqlColumnReference(
+                            table_alias=right_source_alias,
+                            column_name=column_equality_description.right_column_alias,
+                        )
+                    ),
+                )
+            )
+        and_conditions += additional_on_conditions
+
+        on_condition: SqlExpressionNode
+        if len(and_conditions) == 1:
+            on_condition = and_conditions[0]
+        else:
+            on_condition = SqlLogicalExpression(operator=SqlLogicalOperator.AND, args=tuple(and_conditions))
+
+        return SqlJoinDescription(
+            right_source=right_source_node,
+            right_source_alias=right_source_alias,
+            on_condition=on_condition,
+            join_type=join_type,
+        )

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -36,44 +36,27 @@ def _make_validity_window_on_condition(
         {start_dimension_name} >= metric_time AND ({end_dimension_name} < metric_time OR {end_dimension_name} IS NULL)
 
     """
+    left_time_column_expr = SqlColumnReferenceExpression(
+        SqlColumnReference(table_alias=left_source_alias, column_name=left_source_time_dimension_name)
+    )
+    window_start_column_expr = SqlColumnReferenceExpression(
+        SqlColumnReference(table_alias=right_source_alias, column_name=window_start_dimension_name)
+    )
+    window_end_column_expr = SqlColumnReferenceExpression(
+        SqlColumnReference(table_alias=right_source_alias, column_name=window_end_dimension_name)
+    )
+
     window_start_condition = SqlComparisonExpression(
-        left_expr=SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=left_source_alias,
-                column_name=left_source_time_dimension_name,
-            )
-        ),
+        left_expr=left_time_column_expr,
         comparison=SqlComparison.GREATER_THAN_OR_EQUALS,
-        right_expr=SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=right_source_alias,
-                column_name=window_start_dimension_name,
-            )
-        ),
+        right_expr=window_start_column_expr,
     )
     window_end_by_time = SqlComparisonExpression(
-        left_expr=SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=left_source_alias,
-                column_name=left_source_time_dimension_name,
-            )
-        ),
+        left_expr=left_time_column_expr,
         comparison=SqlComparison.LESS_THAN,
-        right_expr=SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=right_source_alias,
-                column_name=window_end_dimension_name,
-            )
-        ),
+        right_expr=window_end_column_expr,
     )
-    window_end_is_null = SqlIsNullExpression(
-        SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=right_source_alias,
-                column_name=window_end_dimension_name,
-            )
-        )
-    )
+    window_end_is_null = SqlIsNullExpression(window_end_column_expr)
     window_end_condition = SqlLogicalExpression(
         operator=SqlLogicalOperator.OR, args=(window_end_by_time, window_end_is_null)
     )

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, TypeVar
+from typing import List, Optional, Sequence, Tuple, TypeVar
 
-from metricflow.dataflow.dataflow_plan import JoinOverTimeRangeNode
+from metricflow.dataflow.dataflow_plan import JoinDescription, JoinOverTimeRangeNode
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.sql.sql_plan import SqlExpressionNode, SqlJoinDescription, SqlJoinType, SqlSelectStatementNode
 from metricflow.sql.sql_exprs import (
@@ -19,6 +19,66 @@ from metricflow.sql.sql_exprs import (
 )
 
 SqlDataSetT = TypeVar("SqlDataSetT", bound=SqlDataSet)
+
+
+def _make_validity_window_on_condition(
+    left_source_alias: str,
+    left_source_time_dimension_name: str,
+    right_source_alias: str,
+    window_start_dimension_name: str,
+    window_end_dimension_name: str,
+) -> Tuple[SqlExpressionNode, ...]:
+    """Helper to convert a validity window join description to a renderable SQL expresssion
+
+    Takes in a join description consisting of a start and end time dimension spec, and generates
+    a node representing the equivalent of this expression:
+
+        {start_dimension_name} >= metric_time AND ({end_dimension_name} < metric_time OR {end_dimension_name} IS NULL)
+
+    """
+    window_start_condition = SqlComparisonExpression(
+        left_expr=SqlColumnReferenceExpression(
+            SqlColumnReference(
+                table_alias=left_source_alias,
+                column_name=left_source_time_dimension_name,
+            )
+        ),
+        comparison=SqlComparison.GREATER_THAN_OR_EQUALS,
+        right_expr=SqlColumnReferenceExpression(
+            SqlColumnReference(
+                table_alias=right_source_alias,
+                column_name=window_start_dimension_name,
+            )
+        ),
+    )
+    window_end_by_time = SqlComparisonExpression(
+        left_expr=SqlColumnReferenceExpression(
+            SqlColumnReference(
+                table_alias=left_source_alias,
+                column_name=left_source_time_dimension_name,
+            )
+        ),
+        comparison=SqlComparison.LESS_THAN,
+        right_expr=SqlColumnReferenceExpression(
+            SqlColumnReference(
+                table_alias=right_source_alias,
+                column_name=window_end_dimension_name,
+            )
+        ),
+    )
+    window_end_is_null = SqlIsNullExpression(
+        SqlColumnReferenceExpression(
+            SqlColumnReference(
+                table_alias=right_source_alias,
+                column_name=window_end_dimension_name,
+            )
+        )
+    )
+    window_end_condition = SqlLogicalExpression(
+        operator=SqlLogicalOperator.OR, args=(window_end_by_time, window_end_is_null)
+    )
+
+    return (window_start_condition, window_end_condition)
 
 
 @dataclass(frozen=True)
@@ -44,7 +104,7 @@ class AnnotatedSqlDataSet:
 
     data_set: SqlDataSet
     alias: str
-    _metric_time_column_name: Optional[str]
+    _metric_time_column_name: Optional[str] = None
 
     @property
     def metric_time_column_name(self) -> str:
@@ -135,6 +195,116 @@ class SqlQueryPlanJoinBuilder:
             right_source_alias=right_source_alias,
             on_condition=on_condition,
             join_type=join_type,
+        )
+
+    @staticmethod
+    def make_base_output_join_description(
+        annotated_left_data_set: AnnotatedSqlDataSet,
+        annotated_right_data_set: AnnotatedSqlDataSet,
+        join_description: JoinDescription,
+    ) -> SqlJoinDescription:
+        """Make a join description to link two base output DataSets by matching identifiers
+
+        In addition to the identifier equality condition, this will ensure datasets are joined on all partition
+        columns and account for validity windows, if those are defined in one of the datasets.
+        """
+        from_data_set = annotated_left_data_set.data_set
+        from_data_set_alias = annotated_left_data_set.alias
+        right_data_set = annotated_right_data_set.data_set
+        right_data_set_alias = annotated_right_data_set.alias
+
+        join_on_identifier = join_description.join_on_identifier
+
+        # Figure out which columns in the "from" data set correspond to the identifier that we want to join on.
+        # The column associations tell us which columns correspond to which instances in the data set.
+        from_data_set_identifier_column_associations = from_data_set.column_associations_for_identifier(
+            join_on_identifier
+        )
+        from_data_set_identifier_cols = [c.column_name for c in from_data_set_identifier_column_associations]
+
+        # Figure out which columns in the "right" data set correspond to the identifier that we want to join on.
+        right_data_set_column_associations = right_data_set.column_associations_for_identifier(join_on_identifier)
+        right_data_set_identifier_cols = [c.column_name for c in right_data_set_column_associations]
+
+        assert len(from_data_set_identifier_cols) == len(
+            right_data_set_identifier_cols
+        ), f"Cannot construct join - the number of columns on the left ({from_data_set_identifier_cols}) side of the join does not match the right ({right_data_set_identifier_cols})"
+
+        # We have the columns that we need to "join on" in the query, so add it to the list of join descriptions to
+        # use later.
+        column_equality_descriptions = []
+        for idx in range(len(from_data_set_identifier_cols)):
+            column_equality_descriptions.append(
+                ColumnEqualityDescription(
+                    left_column_alias=from_data_set_identifier_cols[idx],
+                    right_column_alias=right_data_set_identifier_cols[idx],
+                )
+            )
+        # Add the partition columns as well.
+        for dimension_join_description in join_description.join_on_partition_dimensions:
+            column_equality_descriptions.append(
+                ColumnEqualityDescription(
+                    left_column_alias=from_data_set.column_association_for_dimension(
+                        dimension_join_description.start_node_dimension_spec
+                    ).column_name,
+                    right_column_alias=right_data_set.column_association_for_dimension(
+                        dimension_join_description.node_to_join_dimension_spec
+                    ).column_name,
+                )
+            )
+
+        for time_dimension_join_description in join_description.join_on_partition_time_dimensions:
+            column_equality_descriptions.append(
+                ColumnEqualityDescription(
+                    left_column_alias=from_data_set.column_association_for_time_dimension(
+                        time_dimension_join_description.start_node_time_dimension_spec
+                    ).column_name,
+                    right_column_alias=right_data_set.column_association_for_time_dimension(
+                        time_dimension_join_description.node_to_join_time_dimension_spec
+                    ).column_name,
+                )
+            )
+
+        if join_description.validity_window is None:
+            validity_conditions: Tuple[SqlExpressionNode, ...] = tuple()
+        else:
+            # The join to base output node requires a metric_time dimension to process a join against an
+            # a dataset with a validity window specified, as that dataset represents an SCD data source
+            # We fetch the metric time instance with the smallest granularity and shortest identifier link path,
+            # since this will be used in the ON statement for the join against the validity window.
+            from_data_set_metric_time_dimension_instances = sorted(
+                from_data_set.metric_time_dimension_instances,
+                key=lambda x: (x.spec.time_granularity.to_int(), len(x.spec.identifier_links)),
+            )
+            assert from_data_set_metric_time_dimension_instances, (
+                f"Cannot process join to data set with alias {right_data_set_alias} because it has a validity "
+                f"window set: {join_description.validity_window}, but source data set with alias "
+                f"{from_data_set_alias} does not have a metric time dimension we can use for the window join!"
+            )
+            from_data_set_time_dimension_name = from_data_set.column_association_for_time_dimension(
+                from_data_set_metric_time_dimension_instances[0].spec,
+            ).column_name
+            window_start_dimension_name = right_data_set.column_association_for_time_dimension(
+                join_description.validity_window.window_start_dimension
+            ).column_name
+            window_end_dimension_name = right_data_set.column_association_for_time_dimension(
+                join_description.validity_window.window_end_dimension
+            ).column_name
+            validity_conditions = _make_validity_window_on_condition(
+                left_source_alias=from_data_set_alias,
+                left_source_time_dimension_name=from_data_set_time_dimension_name,
+                right_source_alias=right_data_set_alias,
+                window_start_dimension_name=window_start_dimension_name,
+                window_end_dimension_name=window_end_dimension_name,
+            )
+
+        return SqlQueryPlanJoinBuilder.make_sql_join_description(
+            right_source_node=right_data_set.sql_select_node,
+            left_source_alias=from_data_set_alias,
+            right_source_alias=right_data_set_alias,
+            column_equality_descriptions=column_equality_descriptions,
+            join_type=SqlJoinType.LEFT_OUTER,
+            additional_on_conditions=validity_conditions,
         )
 
     @staticmethod

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -444,6 +444,12 @@ FROM (
     ON
       (
         (
+          subq_8.ds = subq_17.ds
+        ) OR (
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
+        )
+      ) AND (
+        (
           subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
@@ -451,12 +457,6 @@ FROM (
           ) AND (
             subq_17.listing__country_latest IS NULL
           )
-        )
-      ) AND (
-        (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
   ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -71,6 +71,12 @@ INNER JOIN (
 ON
   (
     (
+      subq_28.ds = subq_37.ds
+    ) OR (
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+    )
+  ) AND (
+    (
       subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
@@ -78,11 +84,5 @@ ON
       ) AND (
         subq_37.listing__country_latest IS NULL
       )
-    )
-  ) AND (
-    (
-      subq_28.ds = subq_37.ds
-    ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0.sql
@@ -153,12 +153,14 @@ FROM (
             (
               subq_2.listing = subq_4.listing
             ) AND (
-              subq_2.metric_time >= subq_4.window_start
-            ) AND (
               (
-                subq_2.metric_time < subq_4.window_end
-              ) OR (
-                subq_4.window_end IS NULL
+                subq_2.metric_time >= subq_4.window_start
+              ) AND (
+                (
+                  subq_2.metric_time < subq_4.window_end
+                ) OR (
+                  subq_4.window_end IS NULL
+                )
               )
             )
         ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -31,12 +31,14 @@ FROM (
     (
       subq_12.listing = listings_src_10019.listing_id
     ) AND (
-      subq_12.metric_time >= listings_src_10019.active_from
-    ) AND (
       (
-        subq_12.metric_time < listings_src_10019.active_to
-      ) OR (
-        listings_src_10019.active_to IS NULL
+        subq_12.metric_time >= listings_src_10019.active_from
+      ) AND (
+        (
+          subq_12.metric_time < listings_src_10019.active_to
+        ) OR (
+          listings_src_10019.active_to IS NULL
+        )
       )
     )
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0.sql
@@ -398,11 +398,9 @@ FROM (
     ) subq_14
     ON
       (
-        (
-          subq_10.metric_time = subq_14.metric_time
-        ) OR (
-          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
-        )
+        subq_10.metric_time = subq_14.metric_time
+      ) OR (
+        (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
       )
   ) subq_15
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0_optimized.sql
@@ -71,10 +71,8 @@ FROM (
   ) subq_31
   ON
     (
-      (
-        subq_27.metric_time = subq_31.metric_time
-      ) OR (
-        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
-      )
+      subq_27.metric_time = subq_31.metric_time
+    ) OR (
+      (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
     )
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -287,11 +287,9 @@ FROM (
     ) subq_9
     ON
       (
-        (
-          subq_5.metric_time = subq_9.metric_time
-        ) OR (
-          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-        )
+        subq_5.metric_time = subq_9.metric_time
+      ) OR (
+        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
       )
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -49,9 +49,7 @@ INNER JOIN (
 ) subq_21
 ON
   (
-    (
-      subq_17.metric_time = subq_21.metric_time
-    ) OR (
-      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
-    )
+    subq_17.metric_time = subq_21.metric_time
+  ) OR (
+    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -232,12 +232,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.window_end
-          ) OR (
-            subq_7.window_end IS NULL
+            subq_2.metric_time >= subq_7.window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.window_end
+            ) OR (
+              subq_7.window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -37,12 +37,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.window_end
-    ) OR (
-      subq_18.window_end IS NULL
+      subq_13.metric_time >= subq_18.window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.window_end
+      ) OR (
+        subq_18.window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -218,12 +218,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.lux_listing__window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.lux_listing__window_end
-          ) OR (
-            subq_7.lux_listing__window_end IS NULL
+            subq_2.metric_time >= subq_7.lux_listing__window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.lux_listing__window_end
+            ) OR (
+              subq_7.lux_listing__window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -40,12 +40,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.lux_listing__window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.lux_listing__window_end
-    ) OR (
-      subq_18.lux_listing__window_end IS NULL
+      subq_13.metric_time >= subq_18.lux_listing__window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.lux_listing__window_end
+      ) OR (
+        subq_18.lux_listing__window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -444,6 +444,12 @@ FROM (
     ON
       (
         (
+          subq_8.ds = subq_17.ds
+        ) OR (
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
+        )
+      ) AND (
+        (
           subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
@@ -451,12 +457,6 @@ FROM (
           ) AND (
             subq_17.listing__country_latest IS NULL
           )
-        )
-      ) AND (
-        (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
   ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -71,6 +71,12 @@ INNER JOIN (
 ON
   (
     (
+      subq_28.ds = subq_37.ds
+    ) OR (
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+    )
+  ) AND (
+    (
       subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
@@ -78,11 +84,5 @@ ON
       ) AND (
         subq_37.listing__country_latest IS NULL
       )
-    )
-  ) AND (
-    (
-      subq_28.ds = subq_37.ds
-    ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -153,12 +153,14 @@ FROM (
             (
               subq_2.listing = subq_4.listing
             ) AND (
-              subq_2.metric_time >= subq_4.window_start
-            ) AND (
               (
-                subq_2.metric_time < subq_4.window_end
-              ) OR (
-                subq_4.window_end IS NULL
+                subq_2.metric_time >= subq_4.window_start
+              ) AND (
+                (
+                  subq_2.metric_time < subq_4.window_end
+                ) OR (
+                  subq_4.window_end IS NULL
+                )
               )
             )
         ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -31,12 +31,14 @@ FROM (
     (
       subq_12.listing = listings_src_10019.listing_id
     ) AND (
-      subq_12.metric_time >= listings_src_10019.active_from
-    ) AND (
       (
-        subq_12.metric_time < listings_src_10019.active_to
-      ) OR (
-        listings_src_10019.active_to IS NULL
+        subq_12.metric_time >= listings_src_10019.active_from
+      ) AND (
+        (
+          subq_12.metric_time < listings_src_10019.active_to
+        ) OR (
+          listings_src_10019.active_to IS NULL
+        )
       )
     )
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint__plan0.sql
@@ -398,11 +398,9 @@ FROM (
     ) subq_14
     ON
       (
-        (
-          subq_10.metric_time = subq_14.metric_time
-        ) OR (
-          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
-        )
+        subq_10.metric_time = subq_14.metric_time
+      ) OR (
+        (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
       )
   ) subq_15
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -71,10 +71,8 @@ FROM (
   ) subq_31
   ON
     (
-      (
-        subq_27.metric_time = subq_31.metric_time
-      ) OR (
-        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
-      )
+      subq_27.metric_time = subq_31.metric_time
+    ) OR (
+      (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
     )
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -287,11 +287,9 @@ FROM (
     ) subq_9
     ON
       (
-        (
-          subq_5.metric_time = subq_9.metric_time
-        ) OR (
-          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-        )
+        subq_5.metric_time = subq_9.metric_time
+      ) OR (
+        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
       )
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -49,9 +49,7 @@ INNER JOIN (
 ) subq_21
 ON
   (
-    (
-      subq_17.metric_time = subq_21.metric_time
-    ) OR (
-      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
-    )
+    subq_17.metric_time = subq_21.metric_time
+  ) OR (
+    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -232,12 +232,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.window_end
-          ) OR (
-            subq_7.window_end IS NULL
+            subq_2.metric_time >= subq_7.window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.window_end
+            ) OR (
+              subq_7.window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -37,12 +37,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.window_end
-    ) OR (
-      subq_18.window_end IS NULL
+      subq_13.metric_time >= subq_18.window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.window_end
+      ) OR (
+        subq_18.window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -218,12 +218,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.lux_listing__window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.lux_listing__window_end
-          ) OR (
-            subq_7.lux_listing__window_end IS NULL
+            subq_2.metric_time >= subq_7.lux_listing__window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.lux_listing__window_end
+            ) OR (
+              subq_7.lux_listing__window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -40,12 +40,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.lux_listing__window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.lux_listing__window_end
-    ) OR (
-      subq_18.lux_listing__window_end IS NULL
+      subq_13.metric_time >= subq_18.lux_listing__window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.lux_listing__window_end
+      ) OR (
+        subq_18.lux_listing__window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -444,6 +444,12 @@ FROM (
     ON
       (
         (
+          subq_8.ds = subq_17.ds
+        ) OR (
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
+        )
+      ) AND (
+        (
           subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
@@ -451,12 +457,6 @@ FROM (
           ) AND (
             subq_17.listing__country_latest IS NULL
           )
-        )
-      ) AND (
-        (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
   ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -71,6 +71,12 @@ INNER JOIN (
 ON
   (
     (
+      subq_28.ds = subq_37.ds
+    ) OR (
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+    )
+  ) AND (
+    (
       subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
@@ -78,11 +84,5 @@ ON
       ) AND (
         subq_37.listing__country_latest IS NULL
       )
-    )
-  ) AND (
-    (
-      subq_28.ds = subq_37.ds
-    ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -153,12 +153,14 @@ FROM (
             (
               subq_2.listing = subq_4.listing
             ) AND (
-              subq_2.metric_time >= subq_4.window_start
-            ) AND (
               (
-                subq_2.metric_time < subq_4.window_end
-              ) OR (
-                subq_4.window_end IS NULL
+                subq_2.metric_time >= subq_4.window_start
+              ) AND (
+                (
+                  subq_2.metric_time < subq_4.window_end
+                ) OR (
+                  subq_4.window_end IS NULL
+                )
               )
             )
         ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -31,12 +31,14 @@ FROM (
     (
       subq_12.listing = listings_src_10019.listing_id
     ) AND (
-      subq_12.metric_time >= listings_src_10019.active_from
-    ) AND (
       (
-        subq_12.metric_time < listings_src_10019.active_to
-      ) OR (
-        listings_src_10019.active_to IS NULL
+        subq_12.metric_time >= listings_src_10019.active_from
+      ) AND (
+        (
+          subq_12.metric_time < listings_src_10019.active_to
+        ) OR (
+          listings_src_10019.active_to IS NULL
+        )
       )
     )
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0.sql
@@ -398,11 +398,9 @@ FROM (
     ) subq_14
     ON
       (
-        (
-          subq_10.metric_time = subq_14.metric_time
-        ) OR (
-          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
-        )
+        subq_10.metric_time = subq_14.metric_time
+      ) OR (
+        (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
       )
   ) subq_15
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -71,10 +71,8 @@ FROM (
   ) subq_31
   ON
     (
-      (
-        subq_27.metric_time = subq_31.metric_time
-      ) OR (
-        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
-      )
+      subq_27.metric_time = subq_31.metric_time
+    ) OR (
+      (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
     )
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -287,11 +287,9 @@ FROM (
     ) subq_9
     ON
       (
-        (
-          subq_5.metric_time = subq_9.metric_time
-        ) OR (
-          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-        )
+        subq_5.metric_time = subq_9.metric_time
+      ) OR (
+        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
       )
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -49,9 +49,7 @@ INNER JOIN (
 ) subq_21
 ON
   (
-    (
-      subq_17.metric_time = subq_21.metric_time
-    ) OR (
-      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
-    )
+    subq_17.metric_time = subq_21.metric_time
+  ) OR (
+    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -232,12 +232,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.window_end
-          ) OR (
-            subq_7.window_end IS NULL
+            subq_2.metric_time >= subq_7.window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.window_end
+            ) OR (
+              subq_7.window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -37,12 +37,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.window_end
-    ) OR (
-      subq_18.window_end IS NULL
+      subq_13.metric_time >= subq_18.window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.window_end
+      ) OR (
+        subq_18.window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -218,12 +218,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.lux_listing__window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.lux_listing__window_end
-          ) OR (
-            subq_7.lux_listing__window_end IS NULL
+            subq_2.metric_time >= subq_7.lux_listing__window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.lux_listing__window_end
+            ) OR (
+              subq_7.lux_listing__window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -40,12 +40,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.lux_listing__window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.lux_listing__window_end
-    ) OR (
-      subq_18.lux_listing__window_end IS NULL
+      subq_13.metric_time >= subq_18.lux_listing__window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.lux_listing__window_end
+      ) OR (
+        subq_18.lux_listing__window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -444,6 +444,12 @@ FROM (
     ON
       (
         (
+          subq_8.ds = subq_17.ds
+        ) OR (
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
+        )
+      ) AND (
+        (
           subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
@@ -451,12 +457,6 @@ FROM (
           ) AND (
             subq_17.listing__country_latest IS NULL
           )
-        )
-      ) AND (
-        (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
   ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -71,6 +71,12 @@ INNER JOIN (
 ON
   (
     (
+      subq_28.ds = subq_37.ds
+    ) OR (
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+    )
+  ) AND (
+    (
       subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
@@ -78,11 +84,5 @@ ON
       ) AND (
         subq_37.listing__country_latest IS NULL
       )
-    )
-  ) AND (
-    (
-      subq_28.ds = subq_37.ds
-    ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -153,12 +153,14 @@ FROM (
             (
               subq_2.listing = subq_4.listing
             ) AND (
-              subq_2.metric_time >= subq_4.window_start
-            ) AND (
               (
-                subq_2.metric_time < subq_4.window_end
-              ) OR (
-                subq_4.window_end IS NULL
+                subq_2.metric_time >= subq_4.window_start
+              ) AND (
+                (
+                  subq_2.metric_time < subq_4.window_end
+                ) OR (
+                  subq_4.window_end IS NULL
+                )
               )
             )
         ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -31,12 +31,14 @@ FROM (
     (
       subq_12.listing = listings_src_10019.listing_id
     ) AND (
-      subq_12.metric_time >= listings_src_10019.active_from
-    ) AND (
       (
-        subq_12.metric_time < listings_src_10019.active_to
-      ) OR (
-        listings_src_10019.active_to IS NULL
+        subq_12.metric_time >= listings_src_10019.active_from
+      ) AND (
+        (
+          subq_12.metric_time < listings_src_10019.active_to
+        ) OR (
+          listings_src_10019.active_to IS NULL
+        )
       )
     )
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0.sql
@@ -398,11 +398,9 @@ FROM (
     ) subq_14
     ON
       (
-        (
-          subq_10.metric_time = subq_14.metric_time
-        ) OR (
-          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
-        )
+        subq_10.metric_time = subq_14.metric_time
+      ) OR (
+        (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
       )
   ) subq_15
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -71,10 +71,8 @@ FROM (
   ) subq_31
   ON
     (
-      (
-        subq_27.metric_time = subq_31.metric_time
-      ) OR (
-        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
-      )
+      subq_27.metric_time = subq_31.metric_time
+    ) OR (
+      (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
     )
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -287,11 +287,9 @@ FROM (
     ) subq_9
     ON
       (
-        (
-          subq_5.metric_time = subq_9.metric_time
-        ) OR (
-          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-        )
+        subq_5.metric_time = subq_9.metric_time
+      ) OR (
+        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
       )
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -49,9 +49,7 @@ INNER JOIN (
 ) subq_21
 ON
   (
-    (
-      subq_17.metric_time = subq_21.metric_time
-    ) OR (
-      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
-    )
+    subq_17.metric_time = subq_21.metric_time
+  ) OR (
+    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -232,12 +232,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.window_end
-          ) OR (
-            subq_7.window_end IS NULL
+            subq_2.metric_time >= subq_7.window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.window_end
+            ) OR (
+              subq_7.window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -37,12 +37,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.window_end
-    ) OR (
-      subq_18.window_end IS NULL
+      subq_13.metric_time >= subq_18.window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.window_end
+      ) OR (
+        subq_18.window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -218,12 +218,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.lux_listing__window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.lux_listing__window_end
-          ) OR (
-            subq_7.lux_listing__window_end IS NULL
+            subq_2.metric_time >= subq_7.lux_listing__window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.lux_listing__window_end
+            ) OR (
+              subq_7.lux_listing__window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -40,12 +40,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.lux_listing__window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.lux_listing__window_end
-    ) OR (
-      subq_18.lux_listing__window_end IS NULL
+      subq_13.metric_time >= subq_18.lux_listing__window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.lux_listing__window_end
+      ) OR (
+        subq_18.lux_listing__window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -444,6 +444,12 @@ FROM (
     ON
       (
         (
+          subq_8.ds = subq_17.ds
+        ) OR (
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
+        )
+      ) AND (
+        (
           subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
@@ -451,12 +457,6 @@ FROM (
           ) AND (
             subq_17.listing__country_latest IS NULL
           )
-        )
-      ) AND (
-        (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
   ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -71,6 +71,12 @@ INNER JOIN (
 ON
   (
     (
+      subq_28.ds = subq_37.ds
+    ) OR (
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+    )
+  ) AND (
+    (
       subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
@@ -78,11 +84,5 @@ ON
       ) AND (
         subq_37.listing__country_latest IS NULL
       )
-    )
-  ) AND (
-    (
-      subq_28.ds = subq_37.ds
-    ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -153,12 +153,14 @@ FROM (
             (
               subq_2.listing = subq_4.listing
             ) AND (
-              subq_2.metric_time >= subq_4.window_start
-            ) AND (
               (
-                subq_2.metric_time < subq_4.window_end
-              ) OR (
-                subq_4.window_end IS NULL
+                subq_2.metric_time >= subq_4.window_start
+              ) AND (
+                (
+                  subq_2.metric_time < subq_4.window_end
+                ) OR (
+                  subq_4.window_end IS NULL
+                )
               )
             )
         ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -31,12 +31,14 @@ FROM (
     (
       subq_12.listing = listings_src_10019.listing_id
     ) AND (
-      subq_12.metric_time >= listings_src_10019.active_from
-    ) AND (
       (
-        subq_12.metric_time < listings_src_10019.active_to
-      ) OR (
-        listings_src_10019.active_to IS NULL
+        subq_12.metric_time >= listings_src_10019.active_from
+      ) AND (
+        (
+          subq_12.metric_time < listings_src_10019.active_to
+        ) OR (
+          listings_src_10019.active_to IS NULL
+        )
       )
     )
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0.sql
@@ -398,11 +398,9 @@ FROM (
     ) subq_14
     ON
       (
-        (
-          subq_10.metric_time = subq_14.metric_time
-        ) OR (
-          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
-        )
+        subq_10.metric_time = subq_14.metric_time
+      ) OR (
+        (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
       )
   ) subq_15
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -71,10 +71,8 @@ FROM (
   ) subq_31
   ON
     (
-      (
-        subq_27.metric_time = subq_31.metric_time
-      ) OR (
-        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
-      )
+      subq_27.metric_time = subq_31.metric_time
+    ) OR (
+      (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
     )
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -287,11 +287,9 @@ FROM (
     ) subq_9
     ON
       (
-        (
-          subq_5.metric_time = subq_9.metric_time
-        ) OR (
-          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-        )
+        subq_5.metric_time = subq_9.metric_time
+      ) OR (
+        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
       )
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -49,9 +49,7 @@ INNER JOIN (
 ) subq_21
 ON
   (
-    (
-      subq_17.metric_time = subq_21.metric_time
-    ) OR (
-      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
-    )
+    subq_17.metric_time = subq_21.metric_time
+  ) OR (
+    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -232,12 +232,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.window_end
-          ) OR (
-            subq_7.window_end IS NULL
+            subq_2.metric_time >= subq_7.window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.window_end
+            ) OR (
+              subq_7.window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -37,12 +37,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.window_end
-    ) OR (
-      subq_18.window_end IS NULL
+      subq_13.metric_time >= subq_18.window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.window_end
+      ) OR (
+        subq_18.window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -218,12 +218,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.lux_listing__window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.lux_listing__window_end
-          ) OR (
-            subq_7.lux_listing__window_end IS NULL
+            subq_2.metric_time >= subq_7.lux_listing__window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.lux_listing__window_end
+            ) OR (
+              subq_7.lux_listing__window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -40,12 +40,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.lux_listing__window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.lux_listing__window_end
-    ) OR (
-      subq_18.lux_listing__window_end IS NULL
+      subq_13.metric_time >= subq_18.lux_listing__window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.lux_listing__window_end
+      ) OR (
+        subq_18.lux_listing__window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -444,6 +444,12 @@ FROM (
     ON
       (
         (
+          subq_8.ds = subq_17.ds
+        ) OR (
+          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
+        )
+      ) AND (
+        (
           subq_8.listing__country_latest = subq_17.listing__country_latest
         ) OR (
           (
@@ -451,12 +457,6 @@ FROM (
           ) AND (
             subq_17.listing__country_latest IS NULL
           )
-        )
-      ) AND (
-        (
-          subq_8.ds = subq_17.ds
-        ) OR (
-          (subq_8.ds IS NULL) AND (subq_17.ds IS NULL)
         )
       )
   ) subq_18

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0_optimized.sql
@@ -71,6 +71,12 @@ INNER JOIN (
 ON
   (
     (
+      subq_28.ds = subq_37.ds
+    ) OR (
+      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
+    )
+  ) AND (
+    (
       subq_28.listing__country_latest = subq_37.listing__country_latest
     ) OR (
       (
@@ -78,11 +84,5 @@ ON
       ) AND (
         subq_37.listing__country_latest IS NULL
       )
-    )
-  ) AND (
-    (
-      subq_28.ds = subq_37.ds
-    ) OR (
-      (subq_28.ds IS NULL) AND (subq_37.ds IS NULL)
     )
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -153,12 +153,14 @@ FROM (
             (
               subq_2.listing = subq_4.listing
             ) AND (
-              subq_2.metric_time >= subq_4.window_start
-            ) AND (
               (
-                subq_2.metric_time < subq_4.window_end
-              ) OR (
-                subq_4.window_end IS NULL
+                subq_2.metric_time >= subq_4.window_start
+              ) AND (
+                (
+                  subq_2.metric_time < subq_4.window_end
+                ) OR (
+                  subq_4.window_end IS NULL
+                )
               )
             )
         ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -31,12 +31,14 @@ FROM (
     (
       subq_12.listing = listings_src_10019.listing_id
     ) AND (
-      subq_12.metric_time >= listings_src_10019.active_from
-    ) AND (
       (
-        subq_12.metric_time < listings_src_10019.active_to
-      ) OR (
-        listings_src_10019.active_to IS NULL
+        subq_12.metric_time >= listings_src_10019.active_from
+      ) AND (
+        (
+          subq_12.metric_time < listings_src_10019.active_to
+        ) OR (
+          listings_src_10019.active_to IS NULL
+        )
       )
     )
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0.sql
@@ -398,11 +398,9 @@ FROM (
     ) subq_14
     ON
       (
-        (
-          subq_10.metric_time = subq_14.metric_time
-        ) OR (
-          (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
-        )
+        subq_10.metric_time = subq_14.metric_time
+      ) OR (
+        (subq_10.metric_time IS NULL) AND (subq_14.metric_time IS NULL)
       )
   ) subq_15
 ) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint__plan0_optimized.sql
@@ -71,10 +71,8 @@ FROM (
   ) subq_31
   ON
     (
-      (
-        subq_27.metric_time = subq_31.metric_time
-      ) OR (
-        (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
-      )
+      subq_27.metric_time = subq_31.metric_time
+    ) OR (
+      (subq_27.metric_time IS NULL) AND (subq_31.metric_time IS NULL)
     )
 ) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -287,11 +287,9 @@ FROM (
     ) subq_9
     ON
       (
-        (
-          subq_5.metric_time = subq_9.metric_time
-        ) OR (
-          (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
-        )
+        subq_5.metric_time = subq_9.metric_time
+      ) OR (
+        (subq_5.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
       )
   ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -49,9 +49,7 @@ INNER JOIN (
 ) subq_21
 ON
   (
-    (
-      subq_17.metric_time = subq_21.metric_time
-    ) OR (
-      (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
-    )
+    subq_17.metric_time = subq_21.metric_time
+  ) OR (
+    (subq_17.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
   )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -232,12 +232,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.window_end
-          ) OR (
-            subq_7.window_end IS NULL
+            subq_2.metric_time >= subq_7.window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.window_end
+            ) OR (
+              subq_7.window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -37,12 +37,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.window_end
-    ) OR (
-      subq_18.window_end IS NULL
+      subq_13.metric_time >= subq_18.window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.window_end
+      ) OR (
+        subq_18.window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -218,12 +218,14 @@ FROM (
         (
           subq_2.listing = subq_7.listing
         ) AND (
-          subq_2.metric_time >= subq_7.lux_listing__window_start
-        ) AND (
           (
-            subq_2.metric_time < subq_7.lux_listing__window_end
-          ) OR (
-            subq_7.lux_listing__window_end IS NULL
+            subq_2.metric_time >= subq_7.lux_listing__window_start
+          ) AND (
+            (
+              subq_2.metric_time < subq_7.lux_listing__window_end
+            ) OR (
+              subq_7.lux_listing__window_end IS NULL
+            )
           )
         )
     ) subq_8

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -40,12 +40,14 @@ ON
   (
     subq_13.listing = subq_18.listing
   ) AND (
-    subq_13.metric_time >= subq_18.lux_listing__window_start
-  ) AND (
     (
-      subq_13.metric_time < subq_18.lux_listing__window_end
-    ) OR (
-      subq_18.lux_listing__window_end IS NULL
+      subq_13.metric_time >= subq_18.lux_listing__window_start
+    ) AND (
+      (
+        subq_13.metric_time < subq_18.lux_listing__window_end
+      ) OR (
+        subq_18.lux_listing__window_end IS NULL
+      )
     )
   )
 GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
@@ -114,7 +114,7 @@
                             <!--    'right_source': SqlSelectStatementNode(node_id=ss_4),  -->
                             <!--    'right_source_alias': 'subq_4',                        -->
                             <!--    'join_type': SqlJoinType.LEFT_OUTER,                   -->
-                            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}    -->
+                            <!--    'on_condition': SqlLogicalExpression(node_id=lo_2)}    -->
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description =                               -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
@@ -4,11 +4,11 @@
         <!-- node_id = ss_10 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_113),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_111),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_114),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_112),  -->
         <!--    'column_alias': 'family_bookings'}                     -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
         <!-- where = None -->
@@ -17,7 +17,7 @@
             <!-- node_id = ss_9 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_112),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_110),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
@@ -26,7 +26,7 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_112),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_110),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -36,11 +36,11 @@
                 <!-- node_id = ss_8 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_110),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_108),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_109),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_107),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
@@ -49,15 +49,15 @@
                     <!-- node_id = ss_7 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_108),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_106),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_107),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_105),  -->
                     <!--    'column_alias': 'listing__capacity'}                   -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_106),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_104),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                     <!-- where =                                                              -->
@@ -69,15 +69,15 @@
                         <!-- node_id = ss_6 -->
                         <!-- col0 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_105),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_103),  -->
                         <!--    'column_alias': 'metric_time'}                         -->
                         <!-- col1 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_104),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_102),  -->
                         <!--    'column_alias': 'listing__capacity'}                   -->
                         <!-- col2 =                                                    -->
                         <!--   {'class': 'SqlSelectColumn',                            -->
-                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_103),  -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_101),  -->
                         <!--    'column_alias': 'bookings'}                            -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                         <!-- where = None -->
@@ -86,27 +86,27 @@
                             <!-- node_id = ss_5 -->
                             <!-- col0 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_98),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_96),  -->
                             <!--    'column_alias': 'metric_time'}                        -->
-                            <!-- col1 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_101),  -->
-                            <!--    'column_alias': 'listing__window_start'}               -->
+                            <!-- col1 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_99),  -->
+                            <!--    'column_alias': 'listing__window_start'}              -->
                             <!-- col2 =                                                    -->
                             <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_102),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_100),  -->
                             <!--    'column_alias': 'listing__window_end'}                 -->
                             <!-- col3 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_99),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_97),  -->
                             <!--    'column_alias': 'listing'}                            -->
-                            <!-- col4 =                                                    -->
-                            <!--   {'class': 'SqlSelectColumn',                            -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_100),  -->
-                            <!--    'column_alias': 'listing__capacity'}                   -->
+                            <!-- col4 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_98),  -->
+                            <!--    'column_alias': 'listing__capacity'}                  -->
                             <!-- col5 =                                                   -->
                             <!--   {'class': 'SqlSelectColumn',                           -->
-                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_97),  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_95),  -->
                             <!--    'column_alias': 'bookings'}                           -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                             <!-- join_0 =                                                  -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint__plan0.xml
@@ -60,7 +60,7 @@
                 <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),  -->
                 <!--    'right_source_alias': 'subq_14',                        -->
                 <!--    'join_type': SqlJoinType.INNER,                         -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_2)}     -->
+                <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_constraint_with_reused_measure__plan0.xml
@@ -52,7 +52,7 @@
                 <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
                 <!--    'right_source_alias': 'subq_9',                         -->
                 <!--    'join_type': SqlJoinType.INNER,                         -->
-                <!--    'on_condition': SqlLogicalExpression(node_id=lo_2)}     -->
+                <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
                 <!-- where = None -->
                 <SqlSelectStatementNode>
                     <!-- description = Aggregate Measures -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
@@ -93,7 +93,7 @@
                     <!--    'right_source': SqlSelectStatementNode(node_id=ss_8),  -->
                     <!--    'right_source_alias': 'subq_7',                        -->
                     <!--    'join_type': SqlJoinType.LEFT_OUTER,                   -->
-                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}    -->
+                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_2)}    -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                               -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
@@ -4,15 +4,15 @@
         <!-- node_id = ss_12 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_210),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
         <!--    'column_alias': 'listing__user__home_state_latest'}    -->
         <!-- col2 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_211),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_209),  -->
         <!--    'column_alias': 'bookings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
@@ -21,11 +21,11 @@
             <!-- node_id = ss_11 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
             <!--    'column_alias': 'listing__user__home_state_latest'}    -->
             <!-- col2 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
@@ -34,11 +34,11 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_208),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_206),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- group_by1 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_207),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
             <!--    'column_alias': 'listing__user__home_state_latest'}    -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -48,15 +48,15 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_205),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_204),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
                 <!--    'column_alias': 'listing__user__home_state_latest'}    -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_203),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -65,27 +65,27 @@
                     <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_196),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_201),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
                     <!--    'column_alias': 'listing__window_start'}               -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_202),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
                     <!--    'column_alias': 'listing__window_end'}                 -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_199),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
                     <!--    'column_alias': 'listing'}                             -->
                     <!-- col4 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_200),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_198),  -->
                     <!--    'column_alias': 'listing__user__home_state_latest'}    -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_197),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_195),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                     <!-- join_0 =                                                  -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
@@ -93,7 +93,7 @@
                     <!--    'right_source': SqlSelectStatementNode(node_id=ss_8),  -->
                     <!--    'right_source_alias': 'subq_7',                        -->
                     <!--    'join_type': SqlJoinType.LEFT_OUTER,                   -->
-                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}    -->
+                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_2)}    -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description =                               -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
@@ -4,15 +4,15 @@
         <!-- node_id = ss_12 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_188),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                        -->
         <!--   {'class': 'SqlSelectColumn',                                -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),      -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),      -->
         <!--    'column_alias': 'listing__lux_listing__is_confirmed_lux'}  -->
         <!-- col2 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_189),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_187),  -->
         <!--    'column_alias': 'bookings'}                            -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
@@ -21,11 +21,11 @@
             <!-- node_id = ss_11 -->
             <!-- col0 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- col1 =                                                        -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),      -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),      -->
             <!--    'column_alias': 'listing__lux_listing__is_confirmed_lux'}  -->
             <!-- col2 =                                                              -->
             <!--   {'class': 'SqlSelectColumn',                                      -->
@@ -34,11 +34,11 @@
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
             <!-- group_by0 =                                               -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_186),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_184),  -->
             <!--    'column_alias': 'metric_time'}                         -->
             <!-- group_by1 =                                                   -->
             <!--   {'class': 'SqlSelectColumn',                                -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_185),      -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),      -->
             <!--    'column_alias': 'listing__lux_listing__is_confirmed_lux'}  -->
             <!-- where = None -->
             <SqlSelectStatementNode>
@@ -48,15 +48,15 @@
                 <!-- node_id = ss_10 -->
                 <!-- col0 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_183),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
                 <!--    'column_alias': 'metric_time'}                         -->
                 <!-- col1 =                                                        -->
                 <!--   {'class': 'SqlSelectColumn',                                -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_182),      -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),      -->
                 <!--    'column_alias': 'listing__lux_listing__is_confirmed_lux'}  -->
                 <!-- col2 =                                                    -->
                 <!--   {'class': 'SqlSelectColumn',                            -->
-                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_181),  -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
                 <!--    'column_alias': 'bookings'}                            -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
@@ -65,27 +65,27 @@
                     <!-- node_id = ss_9 -->
                     <!-- col0 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_174),  -->
                     <!--    'column_alias': 'metric_time'}                         -->
                     <!-- col1 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_179),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
                     <!--    'column_alias': 'listing__lux_listing__window_start'}  -->
                     <!-- col2 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),  -->
                     <!--    'column_alias': 'listing__lux_listing__window_end'}    -->
                     <!-- col3 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_177),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
                     <!--    'column_alias': 'listing'}                             -->
                     <!-- col4 =                                                        -->
                     <!--   {'class': 'SqlSelectColumn',                                -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_178),      -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_176),      -->
                     <!--    'column_alias': 'listing__lux_listing__is_confirmed_lux'}  -->
                     <!-- col5 =                                                    -->
                     <!--   {'class': 'SqlSelectColumn',                            -->
-                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_175),  -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_173),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                     <!-- join_0 =                                                  -->


### PR DESCRIPTION
The DataflowToSqlQueryPlanConverter is enormously long and difficult to read
due to the sheer number of node-specific operations it manages. In particular,
join building logic includes a number of ancillary, heavily overlapping helper
functions plus a fair bit of metadata juggling in service of constructing
SqlJoinDescription objects to describe how the join should be rendered.

This PR moves most of the SqlJoinDescription building into a dedicated helper
class, and refactors the individual methods to make them more tightly focused
and hopefully easier to understand.

The lone exception is the join described in the visitor method for combining metrics,
as this logic is already delegated to a special InstanceSetTransform, and moving it
did not appear to be a meaningful improvement.