### PR TITLE
Fix DuckDB Concurrency Issues

### DIFF
--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -215,3 +215,14 @@ def test_update_params_with_same_key_different_values() -> None:  # noqa: D
 
     with pytest.raises(RuntimeError):
         bind_params0.update(bind_params1)
+
+
+def test_list_tables(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
+    source_schema = mf_test_session_state.mf_source_schema
+    sql_table = SqlTable(schema_name=source_schema, table_name=_random_table())
+    table_count_before_create = len(sql_client.list_tables(source_schema))
+    sql_client.create_table_as_select(sql_table, _select_x_as_y(sql_client))
+    table_list = sql_client.list_tables(source_schema)
+    table_count_after_create = len(table_list)
+    assert table_count_after_create == table_count_before_create + 1
+    assert len([x for x in table_list if x == sql_table.table_name]) == 1


### PR DESCRIPTION
* Using a Lock instead of RLock as DuckDB can throw odd errors with concurrent queries, even in the same thread.
* Protecting `list_tables` with a lock as it also accesses the engine.