### PR TITLE
If a data source's measures all have an `agg_time_dimension`, a primary time dimension is not requried

### DIFF
--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -177,7 +177,6 @@ class DataSourceToDataSetConverter:
         self,
         data_source_name: str,
         measures: Sequence[Measure],
-        measure_time_dimension_spec: TimeDimensionSpec,
         table_alias: str,
     ) -> Tuple[Sequence[MeasureInstance], Sequence[SqlSelectColumn]]:
         # Convert all elements to instances
@@ -387,11 +386,9 @@ class DataSourceToDataSetConverter:
 
         # Handle measures
         if len(data_source.measures) > 0:
-            primary_time_dimension = self._find_primary_time_dimension(data_source)
             measure_instances, select_columns = self._convert_measures(
                 data_source_name=data_source.name,
                 measures=data_source.measures,
-                measure_time_dimension_spec=primary_time_dimension,
                 table_alias=from_source_alias,
             )
             all_measure_instances.extend(measure_instances)

--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -352,26 +352,6 @@ class DataSourceToDataSetConverter:
                 )
         return identifier_instances, select_columns
 
-    @staticmethod
-    def _find_primary_time_dimension(data_source: DataSource) -> TimeDimensionSpec:
-        # If a data source has measures, it should have a primary time dimension. Find it and use it to set the time
-        # dimension for the measure.
-        primary_time_dimensions = [dimension for dimension in data_source.dimensions if dimension.is_primary_time]
-        assert len(primary_time_dimensions) == 1, (
-            f"Data source ({data_source}) with measures should have exactly 1 primary time dimension, found "
-            f"{len(primary_time_dimensions)}: {primary_time_dimensions}."
-        )
-        primary_time_dimension = primary_time_dimensions[0]
-        assert (
-            primary_time_dimension.type_params and primary_time_dimension.type_params.time_granularity
-        ), f"Primary time dimension missing time granularity: {primary_time_dimension}"
-
-        return TimeDimensionSpec(
-            element_name=primary_time_dimension.reference.element_name,
-            identifier_links=(),
-            time_granularity=primary_time_dimension.type_params.time_granularity,
-        )
-
     def create_sql_source_data_set(self, data_source: DataSource) -> DataSourceDataSet:
         """Create an SQL source data set from a data source in the model."""
 

--- a/metricflow/model/validations/data_sources.py
+++ b/metricflow/model/validations/data_sources.py
@@ -63,7 +63,13 @@ class DataSourceTimeDimensionWarningsRule(ModelValidationRule):
                             )
                         )
 
-        if len(primary_time_dimensions) == 0 and len(data_source.measures) > 0:
+        # A data source must have a primary time dimension if it has
+        # any measures that don't have an `agg_time_dimension` set
+        if (
+            len(primary_time_dimensions) == 0
+            and len(data_source.measures) > 0
+            and any(measure.agg_time_dimension is None for measure in data_source.measures)
+        ):
             issues.append(
                 ValidationError(
                     context=DataSourceContext(


### PR DESCRIPTION
We added the concept of measure `agg_time_dimension` in #158. Which means that it's no longer required for a data source with measures to have a primary time dimension, so long as every measure has an `agg_time_dimension` set. This PR catches validations up to that reality. 