### PR TITLE
Update github action dependencies to use latest actions/core

### DIFF
--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Pypi Publish
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}
@@ -55,7 +55,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}
@@ -88,7 +88,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}
@@ -121,7 +121,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}
@@ -169,7 +169,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -194,7 +194,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && failure() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Slack Failure
         uses: kpritam/slack-job-status-action@v1
         with:

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           # cache the python dependencies and precommit-created virtual envs
           path: |

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Run Pre-Commit Linting Hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.8", "3.9"]
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: "3.9"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ env.pythonLocation }}

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4


### PR DESCRIPTION
All CI jobs using actions/cache@v2 and actions/checkout@v2 are throwing
warnings about save-state, node.js build version, or both. 

This is due to cache@v2 and checkout@v2 depending on an older version
of the actions core package. The latest releases of their v3 packages resolve
this issue, so we are updating these dependencies accordingly.
