### PR TITLE
add unit field support in metric locked_metadata 

### DIFF
--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -339,6 +339,9 @@
                         "integer"
                     ]
                 },
+                "unit": {
+                    "type": "string"
+                },
                 "value_format": {
                     "type": "string"
                 }

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -73,6 +73,7 @@ locked_metadata_schema = {
             "items": {"type": "string"},
         },
         "private": {"type": "boolean"},
+        "unit": {"type": "string"},
     },
     "additionalProperties": False,
 }

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -231,6 +231,7 @@ metric:
       - "Finance"
       - "Monthly"
     private: true
+    unit: "dollars"
   type_params:
     measures:
       - txn_revenue


### PR DESCRIPTION
Following the example PR https://github.com/transform-data/metricflow/pull/261 and https://github.com/transform-data/metricflow/pull/320, we are adding a new field called unit in metric locked_metadata field in our internal schema. This field will be used to display and store the unit associated with a metric.

Note that this change is taking place in MetricFlow because that is where schema's internal lives. However, it doesn't actually add or change any features of metricflow for the community.