### PR TITLE
Use AsyncSqlClient in API / Execution Plan

### DIFF
--- a/metricflow/api/metricflow_client.py
+++ b/metricflow/api/metricflow_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-
 from typing import Dict, List, Optional
 
 from metricflow.configuration.config_handler import ConfigHandler
@@ -20,7 +19,7 @@ from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.validations.validator_helpers import ModelValidationResults
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql_clients.common_client import not_empty
 from metricflow.sql_clients.sql_utils import make_sql_client_from_config
@@ -54,7 +53,7 @@ class MetricFlowClient:
 
     def __init__(
         self,
-        sql_client: SqlClient,
+        sql_client: AsyncSqlClient,
         user_configured_model: UserConfiguredModel,
         system_schema: str,
     ):

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -1,17 +1,16 @@
 import logging
-
 from logging.handlers import TimedRotatingFileHandler
 from typing import Dict, Optional
 
-from metricflow.errors.errors import SqlClientCreationException, MetricFlowInitException
 from metricflow.configuration.config_handler import ConfigHandler
 from metricflow.configuration.constants import CONFIG_DBT_PROFILE, CONFIG_DBT_REPO, CONFIG_DBT_TARGET, CONFIG_DWH_SCHEMA
 from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.engine.utils import build_user_configured_model_from_config, build_user_configured_model_from_dbt_config
-from metricflow.model.semantic_model import SemanticModel
-from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql_clients.sql_utils import make_sql_client_from_config
+from metricflow.errors.errors import SqlClientCreationException, MetricFlowInitException
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model.semantic_model import SemanticModel
+from metricflow.protocols.async_sql_client import AsyncSqlClient
+from metricflow.sql_clients.sql_utils import make_sql_client_from_config
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ class CLIContext:
     def __init__(self) -> None:  # noqa: D
         self.verbose = False
         self._mf: Optional[MetricFlowEngine] = None
-        self._sql_client: Optional[SqlClient] = None
+        self._sql_client: Optional[AsyncSqlClient] = None
         self._user_configured_model: Optional[UserConfiguredModel] = None
         self._semantic_model: Optional[SemanticModel] = None
         self._mf_system_schema: Optional[str] = None
@@ -67,7 +66,7 @@ class CLIContext:
             raise SqlClientCreationException from e
 
     @property
-    def sql_client(self) -> SqlClient:  # noqa: D
+    def sql_client(self) -> AsyncSqlClient:  # noqa: D
         if self._sql_client is None:
             # Initialize the SqlClient if not set
             self.__initialize_sql_client()

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -17,9 +17,11 @@ from metricflow.dataflow.builder.source_node import SourceNodeBuilder
 from metricflow.dataflow.dataflow_plan import DataflowPlan
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.convert_data_source import DataSourceToDataSetConverter
+from metricflow.dataset.data_source_adapter import DataSourceDataSet
 from metricflow.engine.models import Dimension, Materialization, Metric
 from metricflow.engine.time_source import ServerTimeSource
 from metricflow.engine.utils import build_user_configured_model_from_config
+from metricflow.errors.errors import ExecutionException, MaterializationNotFoundError
 from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
 from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.execution.executor import SequentialPlanExecutor
@@ -30,18 +32,16 @@ from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationR
 from metricflow.plan_conversion.dataflow_to_execution import DataflowToExecutionPlanConverter
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.plan_conversion.time_spine import TimeSpineSource, TimeSpineTableBuilder
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.query.query_parser import MetricFlowQueryParser
-from metricflow.specs import ColumnAssociationResolver, MetricFlowQuerySpec
 from metricflow.references import MetricReference
+from metricflow.specs import ColumnAssociationResolver, MetricFlowQuerySpec
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
-from metricflow.time.time_source import TimeSource
-from metricflow.dataset.data_source_adapter import DataSourceDataSet
-from metricflow.errors.errors import ExecutionException, MaterializationNotFoundError
-from metricflow.sql_clients.sql_utils import make_sql_client_from_config
 from metricflow.sql_clients.common_client import not_empty
+from metricflow.sql_clients.sql_utils import make_sql_client_from_config
 from metricflow.telemetry.models import TelemetryLevel
 from metricflow.telemetry.reporter import TelemetryReporter, log_call
+from metricflow.time.time_source import TimeSource
 
 logger = logging.getLogger(__name__)
 _telemetry_reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)
@@ -301,7 +301,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def __init__(
         self,
         semantic_model: SemanticModel,
-        sql_client: SqlClient,
+        sql_client: AsyncSqlClient,
         system_schema: str,
         time_source: TimeSource = ServerTimeSource(),
         column_association_resolver: Optional[ColumnAssociationResolver] = None,

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -10,10 +10,10 @@ from typing import List, Sequence, Optional, Tuple
 import jinja2
 import pandas as pd
 
-from metricflow.protocols.sql_client import SqlClient
-from metricflow.dag.mf_dag import DagNode, MetricFlowDag, NodeId, DisplayedProperty
 from metricflow.dag.id_generation import EXEC_NODE_READ_SQL_QUERY, EXEC_NODE_WRITE_TO_TABLE
+from metricflow.dag.mf_dag import DagNode, MetricFlowDag, NodeId, DisplayedProperty
 from metricflow.dataflow.sql_table import SqlTable
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.visitor import Visitable
 
@@ -93,7 +93,7 @@ class SelectSqlQueryToDataFrameTask(ExecutionPlanTask):
 
     def __init__(  # noqa: D
         self,
-        sql_client: SqlClient,
+        sql_client: AsyncSqlClient,
         sql_query: str,
         execution_parameters: SqlBindParameters,
         parent_nodes: Optional[List[ExecutionPlanTask]] = None,
@@ -144,7 +144,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
 
     def __init__(  # noqa: D
         self,
-        sql_client: SqlClient,
+        sql_client: AsyncSqlClient,
         sql_query: str,
         execution_parameters: SqlBindParameters,
         output_table: SqlTable,

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -37,6 +37,7 @@ from metricflow.model.validations.validator_helpers import (
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.plan_conversion.time_spine import TimeSpineSource
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs import DimensionSpec, LinkableInstanceSpec, MeasureSpec
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -398,7 +399,7 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_metric_tasks(
-        cls, model: UserConfiguredModel, sql_client: SqlClient, system_schema: str
+        cls, model: UserConfiguredModel, sql_client: AsyncSqlClient, system_schema: str
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the metrics of the model"""
         mf_engine = MetricFlowEngine(
@@ -434,7 +435,7 @@ class DataWarehouseModelValidator:
     them (assuming the model has passed these validations before use).
     """
 
-    def __init__(self, sql_client: SqlClient, system_schema: str) -> None:  # noqa: D
+    def __init__(self, sql_client: AsyncSqlClient, system_schema: str) -> None:  # noqa: D
         self._sql_client = sql_client
         self._sql_schema = system_schema
 

--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Generic, Tuple, Optional, Union
 
-from metricflow.protocols.sql_client import SqlClient
 from metricflow.dag.id_generation import IdGeneratorRegistry, SQL_QUERY_PLAN_PREFIX, EXEC_PLAN_PREFIX
 from metricflow.dataflow.dataflow_plan import (
     SourceDataSetT,
@@ -20,6 +19,7 @@ from metricflow.execution.execution_plan import (
     SelectSqlQueryToTableTask,
 )
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter, SqlDataSetT
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.specs import OutputColumnNameOverride
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_plan import SqlSelectStatementNode, SqlSelectColumn, SqlQueryPlan
@@ -35,7 +35,7 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
         self,
         sql_plan_converter: DataflowToSqlQueryPlanConverter[SqlDataSetT],
         sql_plan_renderer: SqlQueryPlanRenderer,
-        sql_client: SqlClient,
+        sql_client: AsyncSqlClient,
         output_column_name_overrides: Tuple[OutputColumnNameOverride, ...] = (),
     ) -> None:
         """Constructor.

--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -83,7 +83,7 @@ def make_sql_client(url: str, password: str) -> AsyncSqlClient:
         raise ValueError(f"Unknown dialect: `{dialect}` in URL {url}")
 
 
-def make_sql_client_from_config(handler: YamlFileHandler) -> SqlClient:
+def make_sql_client_from_config(handler: YamlFileHandler) -> AsyncSqlClient:
     """Construct a SqlClient given a yaml file config."""
 
     url = handler.url

--- a/metricflow/test/api/conftest.py
+++ b/metricflow/test/api/conftest.py
@@ -3,21 +3,21 @@ import pytest
 from metricflow.api.metricflow_client import MetricFlowClient
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 
 
 @pytest.fixture
 def mf_client(
     create_simple_model_tables: bool,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     simple_semantic_model: SemanticModel,
     time_spine_source: TimeSpineSource,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> MetricFlowClient:
     """Fixture for MetricFlowClient."""
     return MetricFlowClient(
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         user_configured_model=simple_semantic_model.user_configured_model,
         system_schema=mf_test_session_state.mf_system_schema,
     )

--- a/metricflow/test/execution/test_tasks.py
+++ b/metricflow/test/execution/test_tasks.py
@@ -1,4 +1,3 @@
-from metricflow.protocols.sql_client import SqlClient
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.execution.execution_plan import (
     ExecutionPlan,
@@ -7,14 +6,15 @@ from metricflow.execution.execution_plan import (
 )
 from metricflow.execution.executor import SequentialPlanExecutor
 from metricflow.object_utils import random_id
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_clients.sql_utils import make_df
 from metricflow.test.compare_df import assert_dataframes_equal
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 
 
-def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D
-    task = SelectSqlQueryToDataFrameTask(sql_client, "SELECT 1 AS foo", SqlBindParameters())
+def test_read_sql_task(async_sql_client: AsyncSqlClient) -> None:  # noqa: D
+    task = SelectSqlQueryToDataFrameTask(async_sql_client, "SELECT 1 AS foo", SqlBindParameters())
     execution_plan = ExecutionPlan("plan0", leaf_tasks=[task])
 
     results = SequentialPlanExecutor().execute_plan(execution_plan)
@@ -26,17 +26,19 @@ def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D
     assert_dataframes_equal(
         actual=task_result.df,
         expected=make_df(
-            sql_client=sql_client,
+            sql_client=async_sql_client,
             columns=["foo"],
             data=[(1,)],
         ),
     )
 
 
-def test_write_table_task(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
+def test_write_table_task(  # noqa: D
+    mf_test_session_state: MetricFlowTestSessionState, async_sql_client: AsyncSqlClient
+) -> None:
     output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
     task = SelectSqlQueryToTableTask(
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         sql_query="SELECT 1 AS foo",
         execution_parameters=SqlBindParameters(),
         output_table=output_table,
@@ -46,14 +48,14 @@ def test_write_table_task(mf_test_session_state: MetricFlowTestSessionState, sql
     results = SequentialPlanExecutor().execute_plan(execution_plan)
 
     assert not results.contains_task_errors
-    assert sql_client.table_exists(output_table)
+    assert async_sql_client.table_exists(output_table)
 
     assert_dataframes_equal(
-        actual=sql_client.query(f"SELECT * FROM {output_table.sql}"),
+        actual=async_sql_client.query(f"SELECT * FROM {output_table.sql}"),
         expected=make_df(
-            sql_client=sql_client,
+            sql_client=async_sql_client,
             columns=["foo"],
             data=[(1,)],
         ),
     )
-    sql_client.drop_table(output_table)
+    async_sql_client.drop_table(output_table)

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from typing import Sequence
+
 import click
 import pytest
-
 from click.testing import CliRunner, Result
-from typing import Sequence
 
 from metricflow.cli.cli_context import CLIContext
 from metricflow.engine.metricflow_engine import MetricFlowEngine
@@ -12,7 +12,7 @@ from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.test_utils import as_datetime
 from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
@@ -20,7 +20,7 @@ from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 @pytest.fixture
 def cli_context(  # noqa: D
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     simple_user_configured_model: UserConfiguredModel,
     time_spine_source: TimeSpineSource,
     mf_test_session_state: MetricFlowTestSessionState,
@@ -29,7 +29,7 @@ def cli_context(  # noqa: D
     semantic_model = SemanticModel(simple_user_configured_model)
     mf_engine = MetricFlowEngine(
         semantic_model=semantic_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         column_association_resolver=DefaultColumnAssociationResolver(semantic_model=semantic_model),
         time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
         time_spine_source=time_spine_source,
@@ -37,7 +37,7 @@ def cli_context(  # noqa: D
     )
     context = CLIContext()
     context._mf = mf_engine
-    context._sql_client = sql_client
+    context._sql_client = async_sql_client
     context._user_configured_model = simple_user_configured_model
     context._semantic_model = semantic_model
     context._mf_system_schema = mf_test_session_state.mf_system_schema

--- a/metricflow/test/integration/conftest.py
+++ b/metricflow/test/integration/conftest.py
@@ -6,6 +6,7 @@ from metricflow.engine.metricflow_engine import MetricFlowEngine
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.time_spine import TimeSpineSource
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.test_utils import as_datetime
@@ -24,7 +25,7 @@ class IntegrationTestHelpers:
 
 @pytest.fixture
 def it_helpers(  # noqa: D
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     create_simple_model_tables: bool,
     simple_semantic_model: SemanticModel,
     time_spine_source: TimeSpineSource,
@@ -33,7 +34,7 @@ def it_helpers(  # noqa: D
     return IntegrationTestHelpers(
         mf_engine=MetricFlowEngine(
             semantic_model=simple_semantic_model,
-            sql_client=sql_client,
+            sql_client=async_sql_client,
             column_association_resolver=DefaultColumnAssociationResolver(semantic_model=simple_semantic_model),
             time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
             time_spine_source=time_spine_source,
@@ -41,5 +42,5 @@ def it_helpers(  # noqa: D
         ),
         mf_system_schema=mf_test_session_state.mf_system_schema,
         source_schema=mf_test_session_state.mf_source_schema,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
     )

--- a/metricflow/test/model/validations/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/validations/test_data_warehouse_tasks.py
@@ -16,7 +16,7 @@ from metricflow.model.objects.elements.dimension import Dimension, DimensionType
 from metricflow.model.objects.elements.identifier import Identifier, IdentifierType
 from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.model.validations.helpers import data_source_with_guaranteed_meta
@@ -43,19 +43,21 @@ def dw_backed_warehouse_validation_model(
 def test_build_data_source_tasks(
     mf_test_session_state: MetricFlowTestSessionState,
     data_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
 ) -> None:  # noqa:D
     tasks = DataWarehouseTaskBuilder.gen_data_source_tasks(
         model=data_warehouse_validation_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
     assert len(tasks) == len(data_warehouse_validation_model.data_sources)
 
 
-def test_task_runner(sql_client: SqlClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
+def test_task_runner(  # noqa: D
+    async_sql_client: AsyncSqlClient, mf_test_session_state: MetricFlowTestSessionState
+) -> None:
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
 
     def good_query() -> Tuple[str, SqlBindParameters]:
@@ -83,13 +85,13 @@ def test_task_runner(sql_client: SqlClient, mf_test_session_state: MetricFlowTes
 
 def test_validate_data_sources(  # noqa: D
     dw_backed_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
 
     issues = dw_validator.validate_data_sources(model)
@@ -112,12 +114,12 @@ def test_validate_data_sources(  # noqa: D
 
 def test_build_dimension_tasks(  # noqa: D
     data_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
         model=data_warehouse_validation_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
     # on data source query with all dimensions
@@ -128,13 +130,13 @@ def test_build_dimension_tasks(  # noqa: D
 
 def test_validate_dimensions(  # noqa: D
     dw_backed_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
 
     issues = dw_validator.validate_dimensions(model)
@@ -152,12 +154,12 @@ def test_validate_dimensions(  # noqa: D
 
 def test_build_identifiers_tasks(  # noqa: D
     data_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_identifier_tasks(
         model=data_warehouse_validation_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
     assert len(tasks) == 1  # on data source query with all identifiers
@@ -166,13 +168,13 @@ def test_build_identifiers_tasks(  # noqa: D
 
 def test_validate_identifiers(  # noqa: D
     dw_backed_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
 
     issues = dw_validator.validate_identifiers(model)
@@ -190,12 +192,12 @@ def test_validate_identifiers(  # noqa: D
 
 def test_build_measure_tasks(  # noqa: D
     data_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_measure_tasks(
         model=data_warehouse_validation_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         system_schema=mf_test_session_state.mf_system_schema,
     )
     assert len(tasks) == 1  # on data source query with all measures
@@ -204,13 +206,13 @@ def test_build_measure_tasks(  # noqa: D
 
 def test_validate_measures(  # noqa: D
     dw_backed_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
 
     issues = dw_validator.validate_measures(model)
@@ -229,13 +231,13 @@ def test_validate_measures(  # noqa: D
 def test_build_metric_tasks(  # noqa: D
     request: FixtureRequest,
     data_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
         model=data_warehouse_validation_model,
         system_schema=mf_test_session_state.mf_system_schema,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
     )
     assert len(tasks) == 1
     (query_string, _params) = tasks[0].query_and_params_callable()
@@ -249,18 +251,18 @@ def test_build_metric_tasks(  # noqa: D
         incomparable_strings_replacement_function=make_schema_replacement_function(
             system_schema=mf_test_session_state.mf_system_schema, source_schema=mf_test_session_state.mf_source_schema
         ),
-        additional_sub_directories_for_snapshots=(sql_client.__class__.__name__,),
+        additional_sub_directories_for_snapshots=(async_sql_client.__class__.__name__,),
     )
 
 
 def test_validate_metrics(  # noqa: D
     dw_backed_warehouse_validation_model: UserConfiguredModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     mf_test_session_state: MetricFlowTestSessionState,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
 
     issues = dw_validator.validate_metrics(model)
@@ -283,7 +285,7 @@ def test_validate_metrics(  # noqa: D
 
     # Validate new metric created by proxy causes an issue (because the column used doesn't exist)
     dw_validator = DataWarehouseModelValidator(
-        sql_client=sql_client, system_schema=mf_test_session_state.mf_system_schema
+        sql_client=async_sql_client, system_schema=mf_test_session_state.mf_system_schema
     )
     issues = dw_validator.validate_metrics(model)
     assert len(issues.all_issues) == 1

--- a/metricflow/test/plan_conversion/test_dataflow_to_execution.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_execution.py
@@ -7,7 +7,7 @@ from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationR
 from metricflow.plan_conversion.dataflow_to_execution import DataflowToExecutionPlanConverter
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.plan_conversion.time_spine import TimeSpineSource
-from metricflow.protocols.sql_client import SqlClient
+from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
@@ -22,7 +22,7 @@ from metricflow.test.plan_utils import assert_execution_plan_text_equal
 
 def make_execution_plan_converter(  # noqa: D
     semantic_model: SemanticModel,
-    sql_client: SqlClient,
+    sql_client: AsyncSqlClient,
     time_spine_source: TimeSpineSource,
 ) -> DataflowToExecutionPlanConverter:
     return DataflowToExecutionPlanConverter[DataSourceDataSet](
@@ -41,7 +41,7 @@ def test_joined_plan(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
     dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
     simple_semantic_model: SemanticModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     time_spine_source: TimeSpineSource,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -60,14 +60,16 @@ def test_joined_plan(  # noqa: D
         )
     )
 
-    to_execution_plan_converter = make_execution_plan_converter(simple_semantic_model, sql_client, time_spine_source)
+    to_execution_plan_converter = make_execution_plan_converter(
+        simple_semantic_model, async_sql_client, time_spine_source
+    )
 
     execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
 
     assert_execution_plan_text_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         execution_plan=execution_plan,
     )
 
@@ -75,7 +77,7 @@ def test_joined_plan(  # noqa: D
 def test_small_combined_metrics_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
     simple_semantic_model: SemanticModel,
     time_spine_source: TimeSpineSource,
@@ -97,7 +99,7 @@ def test_small_combined_metrics_plan(  # noqa: D
 
     to_execution_plan_converter = make_execution_plan_converter(
         semantic_model=simple_semantic_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         time_spine_source=time_spine_source,
     )
     execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
@@ -105,7 +107,7 @@ def test_small_combined_metrics_plan(  # noqa: D
     assert_execution_plan_text_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         execution_plan=execution_plan,
     )
 
@@ -113,7 +115,7 @@ def test_small_combined_metrics_plan(  # noqa: D
 def test_combined_metrics_plan(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
     simple_semantic_model: SemanticModel,
     time_spine_source: TimeSpineSource,
@@ -137,7 +139,7 @@ def test_combined_metrics_plan(  # noqa: D
 
     to_execution_plan_converter = make_execution_plan_converter(
         semantic_model=simple_semantic_model,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         time_spine_source=time_spine_source,
     )
     execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
@@ -145,7 +147,7 @@ def test_combined_metrics_plan(  # noqa: D
     assert_execution_plan_text_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         execution_plan=execution_plan,
     )
 
@@ -155,7 +157,7 @@ def test_multihop_joined_plan(  # noqa: D
     mf_test_session_state: MetricFlowTestSessionState,
     multihop_dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
     multi_hop_join_semantic_model: SemanticModel,
-    sql_client: SqlClient,
+    async_sql_client: AsyncSqlClient,
     time_spine_source: TimeSpineSource,
 ) -> None:
     """Tests a plan getting a measure and a joined dimension."""
@@ -181,7 +183,7 @@ def test_multihop_joined_plan(  # noqa: D
             time_spine_source=time_spine_source,
         ),
         sql_plan_renderer=DefaultSqlQueryPlanRenderer(),
-        sql_client=sql_client,
+        sql_client=async_sql_client,
     )
 
     execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
@@ -189,6 +191,6 @@ def test_multihop_joined_plan(  # noqa: D
     assert_execution_plan_text_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        sql_client=sql_client,
+        sql_client=async_sql_client,
         execution_plan=execution_plan,
     )


### PR DESCRIPTION
This PR exposes AsyncSqlClient in the engine API and the execution plan so that MF can add custom tags to SQL queries that are sent to the DW.