### PR TITLE
Make creating folders thread/process safe

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -258,8 +258,7 @@ def tutorial(ctx: click.core.Context, cfg: CLIContext, msg: bool, skip_dw: bool,
 
     # Seed sample model file
     model_path = os.path.join(cfg.config.dir_path, "sample_models")
-    if not os.path.exists(model_path):
-        pathlib.Path(model_path).mkdir(parents=True)
+    pathlib.Path(model_path).mkdir(parents=True, exist_ok=True)
     click.echo(f"🤖 Attempting to generate model configs to your local filesystem in '{str(model_path)}'.")
     spinner = Halo(text="Dropping tables...", spinner="dots")
     spinner.start()

--- a/metricflow/configuration/config_handler.py
+++ b/metricflow/configuration/config_handler.py
@@ -10,9 +10,8 @@ class ConfigHandler(YamlFileHandler):
 
     def __init__(self) -> None:  # noqa: D
         # Create config directory if not exist
-        if not os.path.exists(self.dir_path):
-            dir_path = pathlib.Path(self.dir_path)
-            dir_path.mkdir(parents=True)
+        dir_path = pathlib.Path(self.dir_path)
+        dir_path.mkdir(parents=True, exist_ok=True)
         super().__init__(yaml_file_path=self.file_path)
 
     @property


### PR DESCRIPTION
I encountered the issue when importing metricflow in multi threading / multi processing env.


```
../metricflow/metricflow/__init__.py:1: in <module>
    from metricflow.api.metricflow_client import MetricFlowClient  # noqa: D
../metricflow/metricflow/api/metricflow_client.py:10: in <module>
    from metricflow.engine.metricflow_engine import (
../metricflow/metricflow/engine/metricflow_engine.py:47: in <module>
    _telemetry_reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)
../metricflow/metricflow/telemetry/reporter.py:39: in __init__
    self._email = os.getenv(TelemetryReporter.ENV_EMAIL_OVERRIDE) or ConfigHandler().get_value(CONFIG_EMAIL)
../metricflow/metricflow/configuration/config_handler.py:15: in __init__
    dir_path.mkdir(parents=True)
../../../.pyenv/versions/3.9.7/lib/python3.9/pathlib.py:1323: in mkdir
    self._accessor.mkdir(self, mode)
E   FileExistsError: [Errno 17] File exists: '/Users/congleishi/.metricflow'
```