### PR TITLE
Fix schema for metric inputs to derived metrics

### DIFF
--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -86,18 +86,13 @@ metric_input_measure_schema = {
 
 metric_input_schema = {
     "$id": "metric_input_schema",
-    "oneOf": [
-        {"type": "string"},
-        {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "constraint": {"type": "string"},
-                "alias": {"type": "string"},
-            },
-            "additionalProperties": False,
-        },
-    ],
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "constraint": {"type": "string"},
+        "alias": {"type": "string"},
+    },
+    "additionalProperties": False,
 }
 
 metric_type_params_schema = {

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -619,26 +619,19 @@
         },
         "metric_input_schema": {
             "$id": "metric_input_schema",
-            "oneOf": [
-                {
+            "additionalProperties": false,
+            "properties": {
+                "alias": {
                     "type": "string"
                 },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "alias": {
-                            "type": "string"
-                        },
-                        "constraint": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
+                "constraint": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
-            ]
+            },
+            "type": "object"
         },
         "metric_type_params": {
             "$id": "metric_type_params",


### PR DESCRIPTION
The schema for metric inputs to derived metrics allows for a list
of either string or metric input struct, but the Pydantic object
only accepts this latter. This removes the option from the
schema for the sake of consistency, and also to ensure any editor
plugins based on the jsonschema provide the correct completion
hints.