### PR TITLE
Show underlying error from query or execution

### DIFF
--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -175,7 +175,9 @@ def sync_execute(  # noqa: D
 
     result = async_sql_client.async_request_result(request_id)
     if result.exception:
-        raise SqlClientException("Got an exception when trying to execute a statement") from result.exception
+        raise SqlClientException(
+            f"Got an exception when trying to execute a statement: {result.exception}"
+        ) from result.exception
     return
 
 
@@ -195,6 +197,8 @@ def sync_query(  # noqa: D
 
     result = async_sql_client.async_request_result(request_id)
     if result.exception:
-        raise SqlClientException("Got an exception when trying to execute a statement") from result.exception
+        raise SqlClientException(
+            f"Got an exception when trying to execute a statement: {result.exception}"
+        ) from result.exception
     assert result.df is not None, "A dataframe should have been returned if there was no error"
     return result.df


### PR DESCRIPTION
The current way of raising the exception is burying the actual error, so we get errors like this:
<img width="523" alt="image" src="https://user-images.githubusercontent.com/26731294/202782602-6c2be588-0944-4060-9e1a-f01ff4f3b268.png">

Instead of this, which is much more helpful:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/26731294/202782430-7e6e704a-5bd7-4ca3-be3c-3be75ae3c635.png">

Changing to the latter here!