### PR TITLE
Allow Tags for SQL Requests  in JSON Format

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -20,7 +20,7 @@ from metricflow.execution.execution_plan import (
 )
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter, SqlDataSetT
 from metricflow.protocols.async_sql_client import AsyncSqlClient
-from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.protocols.sql_request import SqlJsonTag
 from metricflow.specs import OutputColumnNameOverride
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_plan import SqlSelectStatementNode, SqlSelectColumn, SqlQueryPlan
@@ -37,7 +37,7 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
         sql_plan_converter: DataflowToSqlQueryPlanConverter[SqlDataSetT],
         sql_plan_renderer: SqlQueryPlanRenderer,
         sql_client: AsyncSqlClient,
-        sql_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_sql_tags: SqlJsonTag = SqlJsonTag(),
         output_column_name_overrides: Tuple[OutputColumnNameOverride, ...] = (),
     ) -> None:
         """Constructor.
@@ -46,13 +46,13 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
             sql_plan_converter: Converts a dataflow plan node to a SQL query plan
             sql_plan_renderer: Converts a SQL query plan to SQL text
             sql_client: The client to use for running queries.
-            sql_tags: Tags to supply to the SQL client when running statements.
+            extra_sql_tags: Tags to supply to the SQL client when running statements.
             output_column_name_overrides: In the output dataframe / table, name output columns in a specific way.
         """
         self._sql_plan_converter = sql_plan_converter
         self._sql_plan_renderer = sql_plan_renderer
         self._sql_client = sql_client
-        self._sql_tags = sql_tags
+        self._sql_tags = extra_sql_tags
         self._output_column_name_overrides = output_column_name_overrides
 
     @staticmethod
@@ -132,7 +132,7 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
                 sql_client=self._sql_client,
                 sql_query=render_result.sql,
                 execution_parameters=render_result.execution_parameters,
-                sql_tags=self._sql_tags,
+                extra_sql_tags=self._sql_tags,
             )
         else:
             leaf_task = SelectSqlQueryToTableTask(
@@ -140,7 +140,7 @@ class DataflowToExecutionPlanConverter(Generic[SqlDataSetT], SinkNodeVisitor[Sql
                 sql_query=render_result.sql,
                 execution_parameters=render_result.execution_parameters,
                 output_table=output_table,
-                sql_tags=self._sql_tags,
+                extra_sql_tags=self._sql_tags,
             )
 
         return ExecutionPlan(

--- a/metricflow/protocols/async_sql_client.py
+++ b/metricflow/protocols/async_sql_client.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Protocol, Sequence, Optional
 
 from metricflow.protocols.sql_client import SqlClient, SqlIsolationLevel
-from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet
+from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet, SqlJsonTag
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 
 
@@ -15,7 +15,7 @@ class AsyncSqlClient(SqlClient, Protocol):
         self,
         statement: str,
         bind_parameters: SqlBindParameters = SqlBindParameters(),
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
         isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> SqlRequestId:
         """Execute a query asynchronously."""
@@ -31,7 +31,7 @@ class AsyncSqlClient(SqlClient, Protocol):
         self,
         statement: str,
         bind_parameters: SqlBindParameters = SqlBindParameters(),
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
         isolation_level: Optional[SqlIsolationLevel] = None,
     ) -> SqlRequestId:
         """Execute a statement that does not return values asynchronously."""

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -10,12 +10,12 @@ from databricks import sql
 
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlEngineAttributes, SqlEngine, SqlIsolationLevel
-from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.protocols.sql_request import SqlRequestTagSet, SqlJsonTag
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
+from metricflow.sql.sql_bind_parameters import SqlColumnType
 from metricflow.sql_clients.base_sql_client_implementation import BaseSqlClientImplementation
 from metricflow.sql_clients.common_client import SqlDialect, check_isolation_level
-from metricflow.sql.sql_bind_parameters import SqlColumnType
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +154,8 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
         stmt: str,
         bind_params: SqlBindParameters,
         isolation_level: Optional[SqlIsolationLevel] = None,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> pd.DataFrame:
         check_isolation_level(self, isolation_level)
         with self.get_connection() as connection:
@@ -177,7 +178,8 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
         stmt: str,
         bind_params: SqlBindParameters,
         isolation_level: Optional[SqlIsolationLevel] = None,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> None:
         """Execute statement, returning nothing."""
         with self.get_connection(self.stmt_is_table_rename(stmt)) as connection:

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -9,7 +9,7 @@ from sqlalchemy.pool import StaticPool
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlEngine, SqlIsolationLevel
 from metricflow.protocols.sql_client import SqlEngineAttributes
-from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.protocols.sql_request import SqlRequestTagSet, SqlJsonTag
 from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -84,7 +84,8 @@ class DuckDbSqlClient(SqlAlchemySqlClient):
         stmt: str,
         bind_params: SqlBindParameters,
         isolation_level: Optional[SqlIsolationLevel] = None,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> pd.DataFrame:
         with self._concurrency_lock:
             return super()._engine_specific_query_implementation(
@@ -96,7 +97,8 @@ class DuckDbSqlClient(SqlAlchemySqlClient):
         stmt: str,
         bind_params: SqlBindParameters,
         isolation_level: Optional[SqlIsolationLevel] = None,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> None:
         with self._concurrency_lock:
             return super()._engine_specific_execute_implementation(

--- a/metricflow/sql_clients/snowflake.py
+++ b/metricflow/sql_clients/snowflake.py
@@ -4,6 +4,7 @@ import json
 import logging
 import threading
 import urllib.parse
+from collections import OrderedDict
 from contextlib import contextmanager
 from typing import ClassVar, Optional, Dict, Iterator, List, Tuple, Any, Set, Sequence
 
@@ -13,7 +14,13 @@ from sqlalchemy.exc import ProgrammingError
 
 from metricflow.protocols.sql_client import SqlEngine, SqlIsolationLevel
 from metricflow.protocols.sql_client import SqlEngineAttributes
-from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.protocols.sql_request import (
+    SqlRequestTagSet,
+    JsonDict,
+    MF_SYSTEM_TAGS_KEY,
+    MF_EXTRA_TAGS_KEY,
+    SqlJsonTag,
+)
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -165,7 +172,8 @@ class SnowflakeSqlClient(SqlAlchemySqlClient):
         self,
         engine: sqlalchemy.engine.Engine,
         isolation_level: Optional[SqlIsolationLevel] = None,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> Iterator[sqlalchemy.engine.Connection]:
         """Context Manager for providing a configured connection.
 
@@ -178,10 +186,16 @@ class SnowflakeSqlClient(SqlAlchemySqlClient):
         with super()._engine_connection(self._engine, isolation_level=isolation_level) as conn:
             # WEEK_START 1 means Monday.
             conn.execute("ALTER SESSION SET WEEK_START = 1;")
-            if tags.tag_dict:
+            combined_tags: JsonDict = OrderedDict()
+            if system_tags.tag_dict:
+                combined_tags[MF_SYSTEM_TAGS_KEY] = system_tags.tag_dict
+            if extra_tags is not None:
+                combined_tags[MF_EXTRA_TAGS_KEY] = extra_tags.json_dict
+
+            if combined_tags:
                 conn.execute(
                     sqlalchemy.text("ALTER SESSION SET QUERY_TAG = :query_tag"),
-                    {"query_tag": json.dumps(tags.tag_dict)},
+                    query_tag=json.dumps(combined_tags),
                 )
             results = conn.execute("SELECT CURRENT_SESSION()")
             sessions = []
@@ -201,10 +215,13 @@ class SnowflakeSqlClient(SqlAlchemySqlClient):
         bind_params: SqlBindParameters = SqlBindParameters(),
         isolation_level: Optional[SqlIsolationLevel] = None,
         allow_re_auth: bool = True,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> pd.DataFrame:
         check_isolation_level(self, isolation_level)
-        with self._engine_connection(engine=self._engine, isolation_level=isolation_level, tags=tags) as conn:
+        with self._engine_connection(
+            engine=self._engine, isolation_level=isolation_level, system_tags=system_tags, extra_tags=extra_tags
+        ) as conn:
             try:
                 return pd.read_sql_query(sqlalchemy.text(stmt), conn, params=bind_params.param_dict)
             except ProgrammingError as e:
@@ -226,9 +243,16 @@ class SnowflakeSqlClient(SqlAlchemySqlClient):
         stmt: str,
         bind_params: SqlBindParameters,
         isolation_level: Optional[SqlIsolationLevel] = None,
-        tags: SqlRequestTagSet = SqlRequestTagSet(),
+        system_tags: SqlRequestTagSet = SqlRequestTagSet(),
+        extra_tags: SqlJsonTag = SqlJsonTag(),
     ) -> pd.DataFrame:
-        return self._query(stmt, bind_params=bind_params, isolation_level=isolation_level, tags=tags)
+        return self._query(
+            stmt,
+            bind_params=bind_params,
+            isolation_level=isolation_level,
+            system_tags=system_tags,
+            extra_tags=extra_tags,
+        )
 
     def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D
         df = self.query(

--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -21,7 +21,7 @@ from metricflow.configuration.constants import (
 from metricflow.configuration.yaml_handler import YamlFileHandler
 from metricflow.protocols.async_sql_client import AsyncSqlClient
 from metricflow.protocols.sql_client import SqlClient, SqlIsolationLevel
-from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.protocols.sql_request import SqlJsonTag
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_clients.base_sql_client_implementation import SqlClientException
 from metricflow.sql_clients.big_query import BigQuerySqlClient
@@ -163,13 +163,13 @@ def sync_execute(  # noqa: D
     async_sql_client: AsyncSqlClient,
     statement: str,
     bind_parameters: SqlBindParameters = SqlBindParameters(),
-    sql_tags: SqlRequestTagSet = SqlRequestTagSet(),
+    extra_sql_tags: SqlJsonTag = SqlJsonTag(),
     isolation_level: Optional[SqlIsolationLevel] = None,
 ) -> None:
     request_id = async_sql_client.async_execute(
         statement=statement,
         bind_parameters=bind_parameters,
-        tags=sql_tags,
+        extra_tags=extra_sql_tags,
         isolation_level=isolation_level,
     )
 
@@ -185,13 +185,13 @@ def sync_query(  # noqa: D
     async_sql_client: AsyncSqlClient,
     statement: str,
     bind_parameters: SqlBindParameters = SqlBindParameters(),
-    sql_tags: SqlRequestTagSet = SqlRequestTagSet(),
+    extra_sql_tags: SqlJsonTag = SqlJsonTag(),
     isolation_level: Optional[SqlIsolationLevel] = None,
 ) -> pd.DataFrame:
     request_id = async_sql_client.async_query(
         statement=statement,
         bind_parameters=bind_parameters,
-        tags=sql_tags,
+        extra_tags=extra_sql_tags,
         isolation_level=isolation_level,
     )
 


### PR DESCRIPTION
This PR updates the tag format used for SQL requests to be of the JSON format so that they are easier to consume.