### PR TITLE
Add support for `natural` identifier types

### DIFF
--- a/metricflow/dataset/convert_data_source.py
+++ b/metricflow/dataset/convert_data_source.py
@@ -18,7 +18,7 @@ from metricflow.instances import (
 )
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.elements.dimension import Dimension, DimensionType
-from metricflow.model.objects.elements.identifier import Identifier, IdentifierType
+from metricflow.model.objects.elements.identifier import Identifier
 from metricflow.model.objects.elements.measure import Measure
 from metricflow.model.spec_converters import MeasureConverter
 from metricflow.specs import (
@@ -380,7 +380,7 @@ class DataSourceToDataSetConverter:
         # instances in the instance set. We'll create a different instance for each "possible_identifier_links".
         possible_identifier_links: List[Tuple[IdentifierReference, ...]] = [()]
         for identifier in data_source.identifiers:
-            if identifier.type in (IdentifierType.PRIMARY, IdentifierType.UNIQUE):
+            if identifier.is_linkable_identifier_type:
                 possible_identifier_links.append((identifier.reference,))
 
         # Handle dimensions

--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -11,8 +11,9 @@ from metricflow.model.validations.dimension_const import DimensionConsistencyRul
 from metricflow.model.validations.element_const import ElementConsistencyRule
 from metricflow.model.validations.identifiers import (
     IdentifierConfigRule,
-    OnePrimaryIdentifierPerDataSourceRule,
     IdentifierConsistencyRule,
+    NaturalIdentifierConfigurationRule,
+    OnePrimaryIdentifierPerDataSourceRule,
 )
 from metricflow.model.validations.materializations import ValidMaterializationRule
 from metricflow.model.validations.measures import (
@@ -48,6 +49,7 @@ class ModelValidator:
         ElementConsistencyRule(),
         IdentifierConfigRule(),
         IdentifierConsistencyRule(),
+        NaturalIdentifierConfigurationRule(),
         OnePrimaryIdentifierPerDataSourceRule(),
         MeasureConstraintAliasesRule(),
         MetricMeasuresRule(),

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -10,14 +10,11 @@ from metricflow.references import IdentifierReference, CompositeSubIdentifierRef
 
 
 class IdentifierType(ExtendedEnum):
-    """Defines uniqueness and completeness of identifier"""
+    """Defines uniqueness and the extent to which an identifier represents the common entity for a data source"""
 
     FOREIGN = "foreign"
     PRIMARY = "primary"
     UNIQUE = "unique"
-
-    # for identifiers that are only rendered, not joined on (used when rendering composite identifiers)
-    # RENDER_ONLY = "render_only" # DEPRECATED ? we shouldnt need in the new world?
 
 
 class CompositeSubIdentifier(HashableBaseModel):

--- a/metricflow/model/objects/elements/identifier.py
+++ b/metricflow/model/objects/elements/identifier.py
@@ -13,6 +13,7 @@ class IdentifierType(ExtendedEnum):
     """Defines uniqueness and the extent to which an identifier represents the common entity for a data source"""
 
     FOREIGN = "foreign"
+    NATURAL = "natural"
     PRIMARY = "primary"
     UNIQUE = "unique"
 
@@ -73,3 +74,16 @@ class Identifier(HashableBaseModel, ModelWithMetadataParsing):
     @property
     def reference(self) -> IdentifierReference:  # noqa: D
         return IdentifierReference(element_name=self.name)
+
+    @property
+    def is_linkable_identifier_type(self) -> bool:
+        """Indicates whether or not this identifier can be used as a linkable identifier type for joins
+
+        That is, can you use the identifier as a linkable element in multi-hop dundered syntax. For example,
+        the country dimension in the listings data source can be linked via listing__country, because listing
+        is the primary key.
+
+        At the moment, you may only request things accessible via primary, unique, or natural keys, with natural
+        keys reserved for SCD Type II style data sources.
+        """
+        return self.type in (IdentifierType.PRIMARY, IdentifierType.UNIQUE, IdentifierType.NATURAL)

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -20,7 +20,7 @@ metric_types_enum_values += [x.lower() for x in metric_types_enum_values]
 mutability_type_values = ["IMMUTABLE", "APPEND_ONLY", "FULL_MUTATION", "DS_APPEND_ONLY"]
 mutability_type_values += [x.lower() for x in mutability_type_values]
 
-identifier_type_enum_values = ["PRIMARY", "UNIQUE", "FOREIGN", "RENDER_ONLY"]
+identifier_type_enum_values = ["PRIMARY", "UNIQUE", "FOREIGN"]
 identifier_type_enum_values += [x.lower() for x in identifier_type_enum_values]
 
 aggregation_type_values = ["SUM", "MIN", "MAX", "AVERAGE", "COUNT_DISTINCT", "BOOLEAN", "SUM_BOOLEAN", "COUNT"]

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -20,7 +20,7 @@ metric_types_enum_values += [x.lower() for x in metric_types_enum_values]
 mutability_type_values = ["IMMUTABLE", "APPEND_ONLY", "FULL_MUTATION", "DS_APPEND_ONLY"]
 mutability_type_values += [x.lower() for x in mutability_type_values]
 
-identifier_type_enum_values = ["PRIMARY", "UNIQUE", "FOREIGN"]
+identifier_type_enum_values = ["PRIMARY", "UNIQUE", "FOREIGN", "NATURAL"]
 identifier_type_enum_values += [x.lower() for x in identifier_type_enum_values]
 
 aggregation_type_values = ["SUM", "MIN", "MAX", "AVERAGE", "COUNT_DISTINCT", "BOOLEAN", "SUM_BOOLEAN", "COUNT"]

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -274,11 +274,9 @@
                         "PRIMARY",
                         "UNIQUE",
                         "FOREIGN",
-                        "RENDER_ONLY",
                         "primary",
                         "unique",
-                        "foreign",
-                        "render_only"
+                        "foreign"
                     ]
                 }
             },

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -274,9 +274,11 @@
                         "PRIMARY",
                         "UNIQUE",
                         "FOREIGN",
+                        "NATURAL",
                         "primary",
                         "unique",
-                        "foreign"
+                        "foreign",
+                        "natural"
                     ]
                 }
             },

--- a/metricflow/model/semantics/join_validator.py
+++ b/metricflow/model/semantics/join_validator.py
@@ -21,13 +21,19 @@ class DataSourceIdentifierJoinType:
 class DataSourceJoinValidator:
     """Checks to see if a join between two data sources should be allowed."""
 
-    # Valid joins are the non-fanout joines.
+    # Valid joins are the non-fanout joins.
     _VALID_IDENTIFIER_JOINS = (
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.PRIMARY, right_identifier_type=IdentifierType.NATURAL
+        ),
         DataSourceIdentifierJoinType(
             left_identifier_type=IdentifierType.PRIMARY, right_identifier_type=IdentifierType.PRIMARY
         ),
         DataSourceIdentifierJoinType(
             left_identifier_type=IdentifierType.PRIMARY, right_identifier_type=IdentifierType.UNIQUE
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.UNIQUE, right_identifier_type=IdentifierType.NATURAL
         ),
         DataSourceIdentifierJoinType(
             left_identifier_type=IdentifierType.UNIQUE, right_identifier_type=IdentifierType.PRIMARY
@@ -36,10 +42,19 @@ class DataSourceJoinValidator:
             left_identifier_type=IdentifierType.UNIQUE, right_identifier_type=IdentifierType.UNIQUE
         ),
         DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.NATURAL
+        ),
+        DataSourceIdentifierJoinType(
             left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.PRIMARY
         ),
         DataSourceIdentifierJoinType(
             left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.UNIQUE
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.NATURAL, right_identifier_type=IdentifierType.PRIMARY
+        ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.NATURAL, right_identifier_type=IdentifierType.UNIQUE
         ),
     )
 
@@ -53,6 +68,14 @@ class DataSourceJoinValidator:
         DataSourceIdentifierJoinType(
             left_identifier_type=IdentifierType.FOREIGN, right_identifier_type=IdentifierType.FOREIGN
         ),
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.NATURAL, right_identifier_type=IdentifierType.FOREIGN
+        ),
+        # Natural -> Natural joins are not allowed due to hidden fanout or missing value concerns with
+        # multiple validity windows in play
+        DataSourceIdentifierJoinType(
+            left_identifier_type=IdentifierType.NATURAL, right_identifier_type=IdentifierType.NATURAL
+        ),
     )
 
     def __init__(self, data_source_semantics: DataSourceSemanticsAccessor) -> None:  # noqa: D
@@ -64,7 +87,12 @@ class DataSourceJoinValidator:
         right_data_source_reference: DataSourceReference,
         on_identifier_reference: IdentifierReference,
     ) -> bool:
-        """Return true if we should allow a join with the given parameters to resolve a query."""
+        """Return true if we should allow a join with the given parameters to resolve a query.
+
+        This effectively asserts that the join is possible and is either not a fanout join or else can
+        be managed as a non-fanout join. For join targets using natural keys, which do not guarantee a
+        unique value set, this is done by requiring the presence of a validity window in the target data source.
+        """
         left_identifier = self._data_source_semantics.get_identifier_in_data_source(
             DataSourceElementReference.create_from_references(left_data_source_reference, on_identifier_reference)
         )
@@ -76,6 +104,14 @@ class DataSourceJoinValidator:
             return False
         if right_identifier is None:
             return False
+
+        if right_identifier.type is IdentifierType.NATURAL:
+            right_data_source = self._data_source_semantics.get_by_reference(right_data_source_reference)
+            assert right_data_source, "Type refinement. If you see this error something has refactored wrongly"
+            validity_dims = [dim for dim in right_data_source.dimensions if dim.validity_params is not None]
+            if not validity_dims:
+                # There is no way to refine this to a single row per key, so we cannot support this join
+                return False
 
         join_type = DataSourceIdentifierJoinType(left_identifier.type, right_identifier.type)
 

--- a/metricflow/test/fixtures/model_yamls/scd_model/scd_accounts.yaml
+++ b/metricflow/test/fixtures/model_yamls/scd_model/scd_accounts.yaml
@@ -27,5 +27,5 @@ data_source:
 
   identifiers:
     - name: user
-      type: primary
+      type: natural
       expr: user_id

--- a/metricflow/test/fixtures/model_yamls/scd_model/scd_companies.yaml
+++ b/metricflow/test/fixtures/model_yamls/scd_model/scd_companies.yaml
@@ -1,0 +1,23 @@
+---
+data_source:
+  name: companies
+  description: If a user is a company / business, this defines the mapping.
+  owners:
+    - support@transformdata.io
+
+  sql_table: $dim_companies_table
+
+  dimensions:
+    - name: company_name
+      type: categorical
+
+  identifiers:
+    - name: company
+      type: primary
+      expr: company_id
+    - name: user
+      type: unique
+      expr: user_id
+
+  mutability:
+    type: immutable

--- a/metricflow/test/fixtures/model_yamls/scd_model/scd_listings.yaml
+++ b/metricflow/test/fixtures/model_yamls/scd_model/scd_listings.yaml
@@ -31,7 +31,7 @@ data_source:
 
   identifiers:
     - name: listing
-      type: primary
+      type: natural
       expr: listing_id
     - name: user
       type: foreign

--- a/metricflow/test/fixtures/model_yamls/scd_model/scd_lux_listings.yaml
+++ b/metricflow/test/fixtures/model_yamls/scd_model/scd_lux_listings.yaml
@@ -43,5 +43,5 @@ data_source:
 
   identifiers:
     - name: lux_listing
-      type: primary
+      type: natural
       expr: lux_listing_id

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0.sql
@@ -117,36 +117,36 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'listings'
               SELECT
-                listings_src_10019.active_from AS window_start
-                , DATE_TRUNC(listings_src_10019.active_from, isoweek) AS window_start__week
-                , DATE_TRUNC(listings_src_10019.active_from, month) AS window_start__month
-                , DATE_TRUNC(listings_src_10019.active_from, quarter) AS window_start__quarter
-                , DATE_TRUNC(listings_src_10019.active_from, isoyear) AS window_start__year
-                , listings_src_10019.active_to AS window_end
-                , DATE_TRUNC(listings_src_10019.active_to, isoweek) AS window_end__week
-                , DATE_TRUNC(listings_src_10019.active_to, month) AS window_end__month
-                , DATE_TRUNC(listings_src_10019.active_to, quarter) AS window_end__quarter
-                , DATE_TRUNC(listings_src_10019.active_to, isoyear) AS window_end__year
-                , listings_src_10019.country
-                , listings_src_10019.is_lux
-                , listings_src_10019.capacity
-                , listings_src_10019.active_from AS listing__window_start
-                , DATE_TRUNC(listings_src_10019.active_from, isoweek) AS listing__window_start__week
-                , DATE_TRUNC(listings_src_10019.active_from, month) AS listing__window_start__month
-                , DATE_TRUNC(listings_src_10019.active_from, quarter) AS listing__window_start__quarter
-                , DATE_TRUNC(listings_src_10019.active_from, isoyear) AS listing__window_start__year
-                , listings_src_10019.active_to AS listing__window_end
-                , DATE_TRUNC(listings_src_10019.active_to, isoweek) AS listing__window_end__week
-                , DATE_TRUNC(listings_src_10019.active_to, month) AS listing__window_end__month
-                , DATE_TRUNC(listings_src_10019.active_to, quarter) AS listing__window_end__quarter
-                , DATE_TRUNC(listings_src_10019.active_to, isoyear) AS listing__window_end__year
-                , listings_src_10019.country AS listing__country
-                , listings_src_10019.is_lux AS listing__is_lux
-                , listings_src_10019.capacity AS listing__capacity
-                , listings_src_10019.listing_id AS listing
-                , listings_src_10019.user_id AS user
-                , listings_src_10019.user_id AS listing__user
-              FROM ***************************.dim_listings listings_src_10019
+                listings_src_10020.active_from AS window_start
+                , DATE_TRUNC(listings_src_10020.active_from, isoweek) AS window_start__week
+                , DATE_TRUNC(listings_src_10020.active_from, month) AS window_start__month
+                , DATE_TRUNC(listings_src_10020.active_from, quarter) AS window_start__quarter
+                , DATE_TRUNC(listings_src_10020.active_from, isoyear) AS window_start__year
+                , listings_src_10020.active_to AS window_end
+                , DATE_TRUNC(listings_src_10020.active_to, isoweek) AS window_end__week
+                , DATE_TRUNC(listings_src_10020.active_to, month) AS window_end__month
+                , DATE_TRUNC(listings_src_10020.active_to, quarter) AS window_end__quarter
+                , DATE_TRUNC(listings_src_10020.active_to, isoyear) AS window_end__year
+                , listings_src_10020.country
+                , listings_src_10020.is_lux
+                , listings_src_10020.capacity
+                , listings_src_10020.active_from AS listing__window_start
+                , DATE_TRUNC(listings_src_10020.active_from, isoweek) AS listing__window_start__week
+                , DATE_TRUNC(listings_src_10020.active_from, month) AS listing__window_start__month
+                , DATE_TRUNC(listings_src_10020.active_from, quarter) AS listing__window_start__quarter
+                , DATE_TRUNC(listings_src_10020.active_from, isoyear) AS listing__window_start__year
+                , listings_src_10020.active_to AS listing__window_end
+                , DATE_TRUNC(listings_src_10020.active_to, isoweek) AS listing__window_end__week
+                , DATE_TRUNC(listings_src_10020.active_to, month) AS listing__window_end__month
+                , DATE_TRUNC(listings_src_10020.active_to, quarter) AS listing__window_end__quarter
+                , DATE_TRUNC(listings_src_10020.active_to, isoyear) AS listing__window_end__year
+                , listings_src_10020.country AS listing__country
+                , listings_src_10020.is_lux AS listing__is_lux
+                , listings_src_10020.capacity AS listing__capacity
+                , listings_src_10020.listing_id AS listing
+                , listings_src_10020.user_id AS user
+                , listings_src_10020.user_id AS listing__user
+              FROM ***************************.dim_listings listings_src_10020
             ) subq_3
           ) subq_4
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   --   ['bookings', 'listing__capacity', 'metric_time']
   SELECT
     subq_12.metric_time AS metric_time
-    , listings_src_10019.capacity AS listing__capacity
+    , listings_src_10020.capacity AS listing__capacity
     , subq_12.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
@@ -26,18 +26,18 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_10018
   ) subq_12
   LEFT OUTER JOIN
-    ***************************.dim_listings listings_src_10019
+    ***************************.dim_listings listings_src_10020
   ON
     (
-      subq_12.listing = listings_src_10019.listing_id
+      subq_12.listing = listings_src_10020.listing_id
     ) AND (
       (
-        subq_12.metric_time >= listings_src_10019.active_from
+        subq_12.metric_time >= listings_src_10020.active_from
       ) AND (
         (
-          subq_12.metric_time < listings_src_10019.active_to
+          subq_12.metric_time < listings_src_10020.active_to
         ) OR (
-          listings_src_10019.active_to IS NULL
+          listings_src_10020.active_to IS NULL
         )
       )
     )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -145,36 +145,36 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'listings'
             SELECT
-              listings_src_10019.active_from AS window_start
-              , DATE_TRUNC(listings_src_10019.active_from, isoweek) AS window_start__week
-              , DATE_TRUNC(listings_src_10019.active_from, month) AS window_start__month
-              , DATE_TRUNC(listings_src_10019.active_from, quarter) AS window_start__quarter
-              , DATE_TRUNC(listings_src_10019.active_from, isoyear) AS window_start__year
-              , listings_src_10019.active_to AS window_end
-              , DATE_TRUNC(listings_src_10019.active_to, isoweek) AS window_end__week
-              , DATE_TRUNC(listings_src_10019.active_to, month) AS window_end__month
-              , DATE_TRUNC(listings_src_10019.active_to, quarter) AS window_end__quarter
-              , DATE_TRUNC(listings_src_10019.active_to, isoyear) AS window_end__year
-              , listings_src_10019.country
-              , listings_src_10019.is_lux
-              , listings_src_10019.capacity
-              , listings_src_10019.active_from AS listing__window_start
-              , DATE_TRUNC(listings_src_10019.active_from, isoweek) AS listing__window_start__week
-              , DATE_TRUNC(listings_src_10019.active_from, month) AS listing__window_start__month
-              , DATE_TRUNC(listings_src_10019.active_from, quarter) AS listing__window_start__quarter
-              , DATE_TRUNC(listings_src_10019.active_from, isoyear) AS listing__window_start__year
-              , listings_src_10019.active_to AS listing__window_end
-              , DATE_TRUNC(listings_src_10019.active_to, isoweek) AS listing__window_end__week
-              , DATE_TRUNC(listings_src_10019.active_to, month) AS listing__window_end__month
-              , DATE_TRUNC(listings_src_10019.active_to, quarter) AS listing__window_end__quarter
-              , DATE_TRUNC(listings_src_10019.active_to, isoyear) AS listing__window_end__year
-              , listings_src_10019.country AS listing__country
-              , listings_src_10019.is_lux AS listing__is_lux
-              , listings_src_10019.capacity AS listing__capacity
-              , listings_src_10019.listing_id AS listing
-              , listings_src_10019.user_id AS user
-              , listings_src_10019.user_id AS listing__user
-            FROM ***************************.dim_listings listings_src_10019
+              listings_src_10020.active_from AS window_start
+              , DATE_TRUNC(listings_src_10020.active_from, isoweek) AS window_start__week
+              , DATE_TRUNC(listings_src_10020.active_from, month) AS window_start__month
+              , DATE_TRUNC(listings_src_10020.active_from, quarter) AS window_start__quarter
+              , DATE_TRUNC(listings_src_10020.active_from, isoyear) AS window_start__year
+              , listings_src_10020.active_to AS window_end
+              , DATE_TRUNC(listings_src_10020.active_to, isoweek) AS window_end__week
+              , DATE_TRUNC(listings_src_10020.active_to, month) AS window_end__month
+              , DATE_TRUNC(listings_src_10020.active_to, quarter) AS window_end__quarter
+              , DATE_TRUNC(listings_src_10020.active_to, isoyear) AS window_end__year
+              , listings_src_10020.country
+              , listings_src_10020.is_lux
+              , listings_src_10020.capacity
+              , listings_src_10020.active_from AS listing__window_start
+              , DATE_TRUNC(listings_src_10020.active_from, isoweek) AS listing__window_start__week
+              , DATE_TRUNC(listings_src_10020.active_from, month) AS listing__window_start__month
+              , DATE_TRUNC(listings_src_10020.active_from, quarter) AS listing__window_start__quarter
+              , DATE_TRUNC(listings_src_10020.active_from, isoyear) AS listing__window_start__year
+              , listings_src_10020.active_to AS listing__window_end
+              , DATE_TRUNC(listings_src_10020.active_to, isoweek) AS listing__window_end__week
+              , DATE_TRUNC(listings_src_10020.active_to, month) AS listing__window_end__month
+              , DATE_TRUNC(listings_src_10020.active_to, quarter) AS listing__window_end__quarter
+              , DATE_TRUNC(listings_src_10020.active_to, isoyear) AS listing__window_end__year
+              , listings_src_10020.country AS listing__country
+              , listings_src_10020.is_lux AS listing__is_lux
+              , listings_src_10020.capacity AS listing__capacity
+              , listings_src_10020.listing_id AS listing
+              , listings_src_10020.user_id AS user
+              , listings_src_10020.user_id AS listing__user
+            FROM ***************************.dim_listings listings_src_10020
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -208,20 +208,20 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'users_latest'
               SELECT
-                users_latest_src_10023.ds
-                , DATE_TRUNC(users_latest_src_10023.ds, isoweek) AS ds__week
-                , DATE_TRUNC(users_latest_src_10023.ds, month) AS ds__month
-                , DATE_TRUNC(users_latest_src_10023.ds, quarter) AS ds__quarter
-                , DATE_TRUNC(users_latest_src_10023.ds, isoyear) AS ds__year
-                , users_latest_src_10023.home_state_latest
-                , users_latest_src_10023.ds AS user__ds
-                , DATE_TRUNC(users_latest_src_10023.ds, isoweek) AS user__ds__week
-                , DATE_TRUNC(users_latest_src_10023.ds, month) AS user__ds__month
-                , DATE_TRUNC(users_latest_src_10023.ds, quarter) AS user__ds__quarter
-                , DATE_TRUNC(users_latest_src_10023.ds, isoyear) AS user__ds__year
-                , users_latest_src_10023.home_state_latest AS user__home_state_latest
-                , users_latest_src_10023.user_id AS user
-              FROM ***************************.dim_users_latest users_latest_src_10023
+                users_latest_src_10024.ds
+                , DATE_TRUNC(users_latest_src_10024.ds, isoweek) AS ds__week
+                , DATE_TRUNC(users_latest_src_10024.ds, month) AS ds__month
+                , DATE_TRUNC(users_latest_src_10024.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(users_latest_src_10024.ds, isoyear) AS ds__year
+                , users_latest_src_10024.home_state_latest
+                , users_latest_src_10024.ds AS user__ds
+                , DATE_TRUNC(users_latest_src_10024.ds, isoweek) AS user__ds__week
+                , DATE_TRUNC(users_latest_src_10024.ds, month) AS user__ds__month
+                , DATE_TRUNC(users_latest_src_10024.ds, quarter) AS user__ds__quarter
+                , DATE_TRUNC(users_latest_src_10024.ds, isoyear) AS user__ds__year
+                , users_latest_src_10024.home_state_latest AS user__home_state_latest
+                , users_latest_src_10024.user_id AS user
+              FROM ***************************.dim_users_latest users_latest_src_10024
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -23,15 +23,15 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['user__home_state_latest', 'window_start', 'window_end', 'listing']
   SELECT
-    listings_src_10019.active_from AS window_start
-    , listings_src_10019.active_to AS window_end
-    , listings_src_10019.listing_id AS listing
-    , users_latest_src_10023.home_state_latest AS user__home_state_latest
-  FROM ***************************.dim_listings listings_src_10019
+    listings_src_10020.active_from AS window_start
+    , listings_src_10020.active_to AS window_end
+    , listings_src_10020.listing_id AS listing
+    , users_latest_src_10024.home_state_latest AS user__home_state_latest
+  FROM ***************************.dim_listings listings_src_10020
   LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_10023
+    ***************************.dim_users_latest users_latest_src_10024
   ON
-    listings_src_10019.user_id = users_latest_src_10023.user_id
+    listings_src_10020.user_id = users_latest_src_10024.user_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -127,10 +127,10 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'lux_listing_mapping'
             SELECT
-              lux_listing_mapping_src_10020.listing_id AS listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS lux_listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS listing__lux_listing
-            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+              lux_listing_mapping_src_10021.listing_id AS listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS lux_listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS listing__lux_listing
+            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -184,30 +184,30 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'lux_listings'
               SELECT
-                lux_listings_src_10021.valid_from AS window_start
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, isoweek) AS window_start__week
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, month) AS window_start__month
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, quarter) AS window_start__quarter
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, isoyear) AS window_start__year
-                , lux_listings_src_10021.valid_to AS window_end
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, isoweek) AS window_end__week
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, month) AS window_end__month
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, quarter) AS window_end__quarter
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, isoyear) AS window_end__year
-                , lux_listings_src_10021.is_confirmed_lux
-                , lux_listings_src_10021.valid_from AS lux_listing__window_start
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, isoweek) AS lux_listing__window_start__week
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, month) AS lux_listing__window_start__month
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, quarter) AS lux_listing__window_start__quarter
-                , DATE_TRUNC(lux_listings_src_10021.valid_from, isoyear) AS lux_listing__window_start__year
-                , lux_listings_src_10021.valid_to AS lux_listing__window_end
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, isoweek) AS lux_listing__window_end__week
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, month) AS lux_listing__window_end__month
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, quarter) AS lux_listing__window_end__quarter
-                , DATE_TRUNC(lux_listings_src_10021.valid_to, isoyear) AS lux_listing__window_end__year
-                , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-                , lux_listings_src_10021.lux_listing_id AS lux_listing
-              FROM ***************************.dim_lux_listings lux_listings_src_10021
+                lux_listings_src_10022.valid_from AS window_start
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, isoweek) AS window_start__week
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, month) AS window_start__month
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, quarter) AS window_start__quarter
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, isoyear) AS window_start__year
+                , lux_listings_src_10022.valid_to AS window_end
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, isoweek) AS window_end__week
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, month) AS window_end__month
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, quarter) AS window_end__quarter
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, isoyear) AS window_end__year
+                , lux_listings_src_10022.is_confirmed_lux
+                , lux_listings_src_10022.valid_from AS lux_listing__window_start
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, isoweek) AS lux_listing__window_start__week
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, month) AS lux_listing__window_start__month
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, quarter) AS lux_listing__window_start__quarter
+                , DATE_TRUNC(lux_listings_src_10022.valid_from, isoyear) AS lux_listing__window_start__year
+                , lux_listings_src_10022.valid_to AS lux_listing__window_end
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, isoweek) AS lux_listing__window_end__week
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, month) AS lux_listing__window_end__month
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, quarter) AS lux_listing__window_end__quarter
+                , DATE_TRUNC(lux_listings_src_10022.valid_to, isoyear) AS lux_listing__window_end__year
+                , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+                , lux_listings_src_10022.lux_listing_id AS lux_listing
+              FROM ***************************.dim_lux_listings lux_listings_src_10022
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -26,15 +26,15 @@ LEFT OUTER JOIN (
   --    'lux_listing__window_end',
   --    'listing']
   SELECT
-    lux_listings_src_10021.valid_from AS lux_listing__window_start
-    , lux_listings_src_10021.valid_to AS lux_listing__window_end
-    , lux_listing_mapping_src_10020.listing_id AS listing
-    , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+    lux_listings_src_10022.valid_from AS lux_listing__window_start
+    , lux_listings_src_10022.valid_to AS lux_listing__window_end
+    , lux_listing_mapping_src_10021.listing_id AS listing
+    , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
   LEFT OUTER JOIN
-    ***************************.dim_lux_listings lux_listings_src_10021
+    ***************************.dim_lux_listings lux_listings_src_10022
   ON
-    lux_listing_mapping_src_10020.lux_listing_id = lux_listings_src_10021.lux_listing_id
+    lux_listing_mapping_src_10021.lux_listing_id = lux_listings_src_10022.lux_listing_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -117,36 +117,36 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'listings'
               SELECT
-                listings_src_10019.active_from AS window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-                , listings_src_10019.active_to AS window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-                , listings_src_10019.country
-                , listings_src_10019.is_lux
-                , listings_src_10019.capacity
-                , listings_src_10019.active_from AS listing__window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-                , listings_src_10019.active_to AS listing__window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-                , listings_src_10019.country AS listing__country
-                , listings_src_10019.is_lux AS listing__is_lux
-                , listings_src_10019.capacity AS listing__capacity
-                , listings_src_10019.listing_id AS listing
-                , listings_src_10019.user_id AS user
-                , listings_src_10019.user_id AS listing__user
-              FROM ***************************.dim_listings listings_src_10019
+                listings_src_10020.active_from AS window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+                , listings_src_10020.active_to AS window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+                , listings_src_10020.country
+                , listings_src_10020.is_lux
+                , listings_src_10020.capacity
+                , listings_src_10020.active_from AS listing__window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+                , listings_src_10020.active_to AS listing__window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+                , listings_src_10020.country AS listing__country
+                , listings_src_10020.is_lux AS listing__is_lux
+                , listings_src_10020.capacity AS listing__capacity
+                , listings_src_10020.listing_id AS listing
+                , listings_src_10020.user_id AS user
+                , listings_src_10020.user_id AS listing__user
+              FROM ***************************.dim_listings listings_src_10020
             ) subq_3
           ) subq_4
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   --   ['bookings', 'listing__capacity', 'metric_time']
   SELECT
     subq_12.metric_time AS metric_time
-    , listings_src_10019.capacity AS listing__capacity
+    , listings_src_10020.capacity AS listing__capacity
     , subq_12.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
@@ -26,18 +26,18 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_10018
   ) subq_12
   LEFT OUTER JOIN
-    ***************************.dim_listings listings_src_10019
+    ***************************.dim_listings listings_src_10020
   ON
     (
-      subq_12.listing = listings_src_10019.listing_id
+      subq_12.listing = listings_src_10020.listing_id
     ) AND (
       (
-        subq_12.metric_time >= listings_src_10019.active_from
+        subq_12.metric_time >= listings_src_10020.active_from
       ) AND (
         (
-          subq_12.metric_time < listings_src_10019.active_to
+          subq_12.metric_time < listings_src_10020.active_to
         ) OR (
-          listings_src_10019.active_to IS NULL
+          listings_src_10020.active_to IS NULL
         )
       )
     )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -145,36 +145,36 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'listings'
             SELECT
-              listings_src_10019.active_from AS window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-              , listings_src_10019.active_to AS window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-              , listings_src_10019.country
-              , listings_src_10019.is_lux
-              , listings_src_10019.capacity
-              , listings_src_10019.active_from AS listing__window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-              , listings_src_10019.active_to AS listing__window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-              , listings_src_10019.country AS listing__country
-              , listings_src_10019.is_lux AS listing__is_lux
-              , listings_src_10019.capacity AS listing__capacity
-              , listings_src_10019.listing_id AS listing
-              , listings_src_10019.user_id AS user
-              , listings_src_10019.user_id AS listing__user
-            FROM ***************************.dim_listings listings_src_10019
+              listings_src_10020.active_from AS window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+              , listings_src_10020.active_to AS window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+              , listings_src_10020.country
+              , listings_src_10020.is_lux
+              , listings_src_10020.capacity
+              , listings_src_10020.active_from AS listing__window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+              , listings_src_10020.active_to AS listing__window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+              , listings_src_10020.country AS listing__country
+              , listings_src_10020.is_lux AS listing__is_lux
+              , listings_src_10020.capacity AS listing__capacity
+              , listings_src_10020.listing_id AS listing
+              , listings_src_10020.user_id AS user
+              , listings_src_10020.user_id AS listing__user
+            FROM ***************************.dim_listings listings_src_10020
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -208,20 +208,20 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'users_latest'
               SELECT
-                users_latest_src_10023.ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS ds__year
-                , users_latest_src_10023.home_state_latest
-                , users_latest_src_10023.ds AS user__ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS user__ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS user__ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS user__ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS user__ds__year
-                , users_latest_src_10023.home_state_latest AS user__home_state_latest
-                , users_latest_src_10023.user_id AS user
-              FROM ***************************.dim_users_latest users_latest_src_10023
+                users_latest_src_10024.ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS ds__year
+                , users_latest_src_10024.home_state_latest
+                , users_latest_src_10024.ds AS user__ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS user__ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS user__ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS user__ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS user__ds__year
+                , users_latest_src_10024.home_state_latest AS user__home_state_latest
+                , users_latest_src_10024.user_id AS user
+              FROM ***************************.dim_users_latest users_latest_src_10024
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -23,15 +23,15 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['user__home_state_latest', 'window_start', 'window_end', 'listing']
   SELECT
-    listings_src_10019.active_from AS window_start
-    , listings_src_10019.active_to AS window_end
-    , listings_src_10019.listing_id AS listing
-    , users_latest_src_10023.home_state_latest AS user__home_state_latest
-  FROM ***************************.dim_listings listings_src_10019
+    listings_src_10020.active_from AS window_start
+    , listings_src_10020.active_to AS window_end
+    , listings_src_10020.listing_id AS listing
+    , users_latest_src_10024.home_state_latest AS user__home_state_latest
+  FROM ***************************.dim_listings listings_src_10020
   LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_10023
+    ***************************.dim_users_latest users_latest_src_10024
   ON
-    listings_src_10019.user_id = users_latest_src_10023.user_id
+    listings_src_10020.user_id = users_latest_src_10024.user_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -127,10 +127,10 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'lux_listing_mapping'
             SELECT
-              lux_listing_mapping_src_10020.listing_id AS listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS lux_listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS listing__lux_listing
-            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+              lux_listing_mapping_src_10021.listing_id AS listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS lux_listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS listing__lux_listing
+            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -184,30 +184,30 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'lux_listings'
               SELECT
-                lux_listings_src_10021.valid_from AS window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS window_start__year
-                , lux_listings_src_10021.valid_to AS window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS window_end__year
-                , lux_listings_src_10021.is_confirmed_lux
-                , lux_listings_src_10021.valid_from AS lux_listing__window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS lux_listing__window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS lux_listing__window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS lux_listing__window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS lux_listing__window_start__year
-                , lux_listings_src_10021.valid_to AS lux_listing__window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS lux_listing__window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS lux_listing__window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS lux_listing__window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS lux_listing__window_end__year
-                , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-                , lux_listings_src_10021.lux_listing_id AS lux_listing
-              FROM ***************************.dim_lux_listings lux_listings_src_10021
+                lux_listings_src_10022.valid_from AS window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS window_start__year
+                , lux_listings_src_10022.valid_to AS window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS window_end__year
+                , lux_listings_src_10022.is_confirmed_lux
+                , lux_listings_src_10022.valid_from AS lux_listing__window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS lux_listing__window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS lux_listing__window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS lux_listing__window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS lux_listing__window_start__year
+                , lux_listings_src_10022.valid_to AS lux_listing__window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS lux_listing__window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS lux_listing__window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS lux_listing__window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS lux_listing__window_end__year
+                , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+                , lux_listings_src_10022.lux_listing_id AS lux_listing
+              FROM ***************************.dim_lux_listings lux_listings_src_10022
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -26,15 +26,15 @@ LEFT OUTER JOIN (
   --    'lux_listing__window_end',
   --    'listing']
   SELECT
-    lux_listings_src_10021.valid_from AS lux_listing__window_start
-    , lux_listings_src_10021.valid_to AS lux_listing__window_end
-    , lux_listing_mapping_src_10020.listing_id AS listing
-    , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+    lux_listings_src_10022.valid_from AS lux_listing__window_start
+    , lux_listings_src_10022.valid_to AS lux_listing__window_end
+    , lux_listing_mapping_src_10021.listing_id AS listing
+    , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
   LEFT OUTER JOIN
-    ***************************.dim_lux_listings lux_listings_src_10021
+    ***************************.dim_lux_listings lux_listings_src_10022
   ON
-    lux_listing_mapping_src_10020.lux_listing_id = lux_listings_src_10021.lux_listing_id
+    lux_listing_mapping_src_10021.lux_listing_id = lux_listings_src_10022.lux_listing_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -117,36 +117,36 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'listings'
               SELECT
-                listings_src_10019.active_from AS window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-                , listings_src_10019.active_to AS window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-                , listings_src_10019.country
-                , listings_src_10019.is_lux
-                , listings_src_10019.capacity
-                , listings_src_10019.active_from AS listing__window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-                , listings_src_10019.active_to AS listing__window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-                , listings_src_10019.country AS listing__country
-                , listings_src_10019.is_lux AS listing__is_lux
-                , listings_src_10019.capacity AS listing__capacity
-                , listings_src_10019.listing_id AS listing
-                , listings_src_10019.user_id AS user
-                , listings_src_10019.user_id AS listing__user
-              FROM ***************************.dim_listings listings_src_10019
+                listings_src_10020.active_from AS window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+                , listings_src_10020.active_to AS window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+                , listings_src_10020.country
+                , listings_src_10020.is_lux
+                , listings_src_10020.capacity
+                , listings_src_10020.active_from AS listing__window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+                , listings_src_10020.active_to AS listing__window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+                , listings_src_10020.country AS listing__country
+                , listings_src_10020.is_lux AS listing__is_lux
+                , listings_src_10020.capacity AS listing__capacity
+                , listings_src_10020.listing_id AS listing
+                , listings_src_10020.user_id AS user
+                , listings_src_10020.user_id AS listing__user
+              FROM ***************************.dim_listings listings_src_10020
             ) subq_3
           ) subq_4
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   --   ['bookings', 'listing__capacity', 'metric_time']
   SELECT
     subq_12.metric_time AS metric_time
-    , listings_src_10019.capacity AS listing__capacity
+    , listings_src_10020.capacity AS listing__capacity
     , subq_12.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
@@ -26,18 +26,18 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_10018
   ) subq_12
   LEFT OUTER JOIN
-    ***************************.dim_listings listings_src_10019
+    ***************************.dim_listings listings_src_10020
   ON
     (
-      subq_12.listing = listings_src_10019.listing_id
+      subq_12.listing = listings_src_10020.listing_id
     ) AND (
       (
-        subq_12.metric_time >= listings_src_10019.active_from
+        subq_12.metric_time >= listings_src_10020.active_from
       ) AND (
         (
-          subq_12.metric_time < listings_src_10019.active_to
+          subq_12.metric_time < listings_src_10020.active_to
         ) OR (
-          listings_src_10019.active_to IS NULL
+          listings_src_10020.active_to IS NULL
         )
       )
     )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -145,36 +145,36 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'listings'
             SELECT
-              listings_src_10019.active_from AS window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-              , listings_src_10019.active_to AS window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-              , listings_src_10019.country
-              , listings_src_10019.is_lux
-              , listings_src_10019.capacity
-              , listings_src_10019.active_from AS listing__window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-              , listings_src_10019.active_to AS listing__window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-              , listings_src_10019.country AS listing__country
-              , listings_src_10019.is_lux AS listing__is_lux
-              , listings_src_10019.capacity AS listing__capacity
-              , listings_src_10019.listing_id AS listing
-              , listings_src_10019.user_id AS user
-              , listings_src_10019.user_id AS listing__user
-            FROM ***************************.dim_listings listings_src_10019
+              listings_src_10020.active_from AS window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+              , listings_src_10020.active_to AS window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+              , listings_src_10020.country
+              , listings_src_10020.is_lux
+              , listings_src_10020.capacity
+              , listings_src_10020.active_from AS listing__window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+              , listings_src_10020.active_to AS listing__window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+              , listings_src_10020.country AS listing__country
+              , listings_src_10020.is_lux AS listing__is_lux
+              , listings_src_10020.capacity AS listing__capacity
+              , listings_src_10020.listing_id AS listing
+              , listings_src_10020.user_id AS user
+              , listings_src_10020.user_id AS listing__user
+            FROM ***************************.dim_listings listings_src_10020
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -208,20 +208,20 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'users_latest'
               SELECT
-                users_latest_src_10023.ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS ds__year
-                , users_latest_src_10023.home_state_latest
-                , users_latest_src_10023.ds AS user__ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS user__ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS user__ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS user__ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS user__ds__year
-                , users_latest_src_10023.home_state_latest AS user__home_state_latest
-                , users_latest_src_10023.user_id AS user
-              FROM ***************************.dim_users_latest users_latest_src_10023
+                users_latest_src_10024.ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS ds__year
+                , users_latest_src_10024.home_state_latest
+                , users_latest_src_10024.ds AS user__ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS user__ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS user__ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS user__ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS user__ds__year
+                , users_latest_src_10024.home_state_latest AS user__home_state_latest
+                , users_latest_src_10024.user_id AS user
+              FROM ***************************.dim_users_latest users_latest_src_10024
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -23,15 +23,15 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['user__home_state_latest', 'window_start', 'window_end', 'listing']
   SELECT
-    listings_src_10019.active_from AS window_start
-    , listings_src_10019.active_to AS window_end
-    , listings_src_10019.listing_id AS listing
-    , users_latest_src_10023.home_state_latest AS user__home_state_latest
-  FROM ***************************.dim_listings listings_src_10019
+    listings_src_10020.active_from AS window_start
+    , listings_src_10020.active_to AS window_end
+    , listings_src_10020.listing_id AS listing
+    , users_latest_src_10024.home_state_latest AS user__home_state_latest
+  FROM ***************************.dim_listings listings_src_10020
   LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_10023
+    ***************************.dim_users_latest users_latest_src_10024
   ON
-    listings_src_10019.user_id = users_latest_src_10023.user_id
+    listings_src_10020.user_id = users_latest_src_10024.user_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -127,10 +127,10 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'lux_listing_mapping'
             SELECT
-              lux_listing_mapping_src_10020.listing_id AS listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS lux_listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS listing__lux_listing
-            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+              lux_listing_mapping_src_10021.listing_id AS listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS lux_listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS listing__lux_listing
+            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -184,30 +184,30 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'lux_listings'
               SELECT
-                lux_listings_src_10021.valid_from AS window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS window_start__year
-                , lux_listings_src_10021.valid_to AS window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS window_end__year
-                , lux_listings_src_10021.is_confirmed_lux
-                , lux_listings_src_10021.valid_from AS lux_listing__window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS lux_listing__window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS lux_listing__window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS lux_listing__window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS lux_listing__window_start__year
-                , lux_listings_src_10021.valid_to AS lux_listing__window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS lux_listing__window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS lux_listing__window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS lux_listing__window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS lux_listing__window_end__year
-                , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-                , lux_listings_src_10021.lux_listing_id AS lux_listing
-              FROM ***************************.dim_lux_listings lux_listings_src_10021
+                lux_listings_src_10022.valid_from AS window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS window_start__year
+                , lux_listings_src_10022.valid_to AS window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS window_end__year
+                , lux_listings_src_10022.is_confirmed_lux
+                , lux_listings_src_10022.valid_from AS lux_listing__window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS lux_listing__window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS lux_listing__window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS lux_listing__window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS lux_listing__window_start__year
+                , lux_listings_src_10022.valid_to AS lux_listing__window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS lux_listing__window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS lux_listing__window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS lux_listing__window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS lux_listing__window_end__year
+                , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+                , lux_listings_src_10022.lux_listing_id AS lux_listing
+              FROM ***************************.dim_lux_listings lux_listings_src_10022
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -26,15 +26,15 @@ LEFT OUTER JOIN (
   --    'lux_listing__window_end',
   --    'listing']
   SELECT
-    lux_listings_src_10021.valid_from AS lux_listing__window_start
-    , lux_listings_src_10021.valid_to AS lux_listing__window_end
-    , lux_listing_mapping_src_10020.listing_id AS listing
-    , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+    lux_listings_src_10022.valid_from AS lux_listing__window_start
+    , lux_listings_src_10022.valid_to AS lux_listing__window_end
+    , lux_listing_mapping_src_10021.listing_id AS listing
+    , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
   LEFT OUTER JOIN
-    ***************************.dim_lux_listings lux_listings_src_10021
+    ***************************.dim_lux_listings lux_listings_src_10022
   ON
-    lux_listing_mapping_src_10020.lux_listing_id = lux_listings_src_10021.lux_listing_id
+    lux_listing_mapping_src_10021.lux_listing_id = lux_listings_src_10022.lux_listing_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -117,36 +117,36 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'listings'
               SELECT
-                listings_src_10019.active_from AS window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-                , listings_src_10019.active_to AS window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-                , listings_src_10019.country
-                , listings_src_10019.is_lux
-                , listings_src_10019.capacity
-                , listings_src_10019.active_from AS listing__window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-                , listings_src_10019.active_to AS listing__window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-                , listings_src_10019.country AS listing__country
-                , listings_src_10019.is_lux AS listing__is_lux
-                , listings_src_10019.capacity AS listing__capacity
-                , listings_src_10019.listing_id AS listing
-                , listings_src_10019.user_id AS user
-                , listings_src_10019.user_id AS listing__user
-              FROM ***************************.dim_listings listings_src_10019
+                listings_src_10020.active_from AS window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+                , listings_src_10020.active_to AS window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+                , listings_src_10020.country
+                , listings_src_10020.is_lux
+                , listings_src_10020.capacity
+                , listings_src_10020.active_from AS listing__window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+                , listings_src_10020.active_to AS listing__window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+                , listings_src_10020.country AS listing__country
+                , listings_src_10020.is_lux AS listing__is_lux
+                , listings_src_10020.capacity AS listing__capacity
+                , listings_src_10020.listing_id AS listing
+                , listings_src_10020.user_id AS user
+                , listings_src_10020.user_id AS listing__user
+              FROM ***************************.dim_listings listings_src_10020
             ) subq_3
           ) subq_4
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   --   ['bookings', 'listing__capacity', 'metric_time']
   SELECT
     subq_12.metric_time AS metric_time
-    , listings_src_10019.capacity AS listing__capacity
+    , listings_src_10020.capacity AS listing__capacity
     , subq_12.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
@@ -26,18 +26,18 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_10018
   ) subq_12
   LEFT OUTER JOIN
-    ***************************.dim_listings listings_src_10019
+    ***************************.dim_listings listings_src_10020
   ON
     (
-      subq_12.listing = listings_src_10019.listing_id
+      subq_12.listing = listings_src_10020.listing_id
     ) AND (
       (
-        subq_12.metric_time >= listings_src_10019.active_from
+        subq_12.metric_time >= listings_src_10020.active_from
       ) AND (
         (
-          subq_12.metric_time < listings_src_10019.active_to
+          subq_12.metric_time < listings_src_10020.active_to
         ) OR (
-          listings_src_10019.active_to IS NULL
+          listings_src_10020.active_to IS NULL
         )
       )
     )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -145,36 +145,36 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'listings'
             SELECT
-              listings_src_10019.active_from AS window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-              , listings_src_10019.active_to AS window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-              , listings_src_10019.country
-              , listings_src_10019.is_lux
-              , listings_src_10019.capacity
-              , listings_src_10019.active_from AS listing__window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-              , listings_src_10019.active_to AS listing__window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-              , listings_src_10019.country AS listing__country
-              , listings_src_10019.is_lux AS listing__is_lux
-              , listings_src_10019.capacity AS listing__capacity
-              , listings_src_10019.listing_id AS listing
-              , listings_src_10019.user_id AS user
-              , listings_src_10019.user_id AS listing__user
-            FROM ***************************.dim_listings listings_src_10019
+              listings_src_10020.active_from AS window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+              , listings_src_10020.active_to AS window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+              , listings_src_10020.country
+              , listings_src_10020.is_lux
+              , listings_src_10020.capacity
+              , listings_src_10020.active_from AS listing__window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+              , listings_src_10020.active_to AS listing__window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+              , listings_src_10020.country AS listing__country
+              , listings_src_10020.is_lux AS listing__is_lux
+              , listings_src_10020.capacity AS listing__capacity
+              , listings_src_10020.listing_id AS listing
+              , listings_src_10020.user_id AS user
+              , listings_src_10020.user_id AS listing__user
+            FROM ***************************.dim_listings listings_src_10020
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -208,20 +208,20 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'users_latest'
               SELECT
-                users_latest_src_10023.ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS ds__year
-                , users_latest_src_10023.home_state_latest
-                , users_latest_src_10023.ds AS user__ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS user__ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS user__ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS user__ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS user__ds__year
-                , users_latest_src_10023.home_state_latest AS user__home_state_latest
-                , users_latest_src_10023.user_id AS user
-              FROM ***************************.dim_users_latest users_latest_src_10023
+                users_latest_src_10024.ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS ds__year
+                , users_latest_src_10024.home_state_latest
+                , users_latest_src_10024.ds AS user__ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS user__ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS user__ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS user__ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS user__ds__year
+                , users_latest_src_10024.home_state_latest AS user__home_state_latest
+                , users_latest_src_10024.user_id AS user
+              FROM ***************************.dim_users_latest users_latest_src_10024
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -23,15 +23,15 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['user__home_state_latest', 'window_start', 'window_end', 'listing']
   SELECT
-    listings_src_10019.active_from AS window_start
-    , listings_src_10019.active_to AS window_end
-    , listings_src_10019.listing_id AS listing
-    , users_latest_src_10023.home_state_latest AS user__home_state_latest
-  FROM ***************************.dim_listings listings_src_10019
+    listings_src_10020.active_from AS window_start
+    , listings_src_10020.active_to AS window_end
+    , listings_src_10020.listing_id AS listing
+    , users_latest_src_10024.home_state_latest AS user__home_state_latest
+  FROM ***************************.dim_listings listings_src_10020
   LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_10023
+    ***************************.dim_users_latest users_latest_src_10024
   ON
-    listings_src_10019.user_id = users_latest_src_10023.user_id
+    listings_src_10020.user_id = users_latest_src_10024.user_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -127,10 +127,10 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'lux_listing_mapping'
             SELECT
-              lux_listing_mapping_src_10020.listing_id AS listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS lux_listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS listing__lux_listing
-            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+              lux_listing_mapping_src_10021.listing_id AS listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS lux_listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS listing__lux_listing
+            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -184,30 +184,30 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'lux_listings'
               SELECT
-                lux_listings_src_10021.valid_from AS window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS window_start__year
-                , lux_listings_src_10021.valid_to AS window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS window_end__year
-                , lux_listings_src_10021.is_confirmed_lux
-                , lux_listings_src_10021.valid_from AS lux_listing__window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS lux_listing__window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS lux_listing__window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS lux_listing__window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS lux_listing__window_start__year
-                , lux_listings_src_10021.valid_to AS lux_listing__window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS lux_listing__window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS lux_listing__window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS lux_listing__window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS lux_listing__window_end__year
-                , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-                , lux_listings_src_10021.lux_listing_id AS lux_listing
-              FROM ***************************.dim_lux_listings lux_listings_src_10021
+                lux_listings_src_10022.valid_from AS window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS window_start__year
+                , lux_listings_src_10022.valid_to AS window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS window_end__year
+                , lux_listings_src_10022.is_confirmed_lux
+                , lux_listings_src_10022.valid_from AS lux_listing__window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS lux_listing__window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS lux_listing__window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS lux_listing__window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS lux_listing__window_start__year
+                , lux_listings_src_10022.valid_to AS lux_listing__window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS lux_listing__window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS lux_listing__window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS lux_listing__window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS lux_listing__window_end__year
+                , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+                , lux_listings_src_10022.lux_listing_id AS lux_listing
+              FROM ***************************.dim_lux_listings lux_listings_src_10022
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -26,15 +26,15 @@ LEFT OUTER JOIN (
   --    'lux_listing__window_end',
   --    'listing']
   SELECT
-    lux_listings_src_10021.valid_from AS lux_listing__window_start
-    , lux_listings_src_10021.valid_to AS lux_listing__window_end
-    , lux_listing_mapping_src_10020.listing_id AS listing
-    , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+    lux_listings_src_10022.valid_from AS lux_listing__window_start
+    , lux_listings_src_10022.valid_to AS lux_listing__window_end
+    , lux_listing_mapping_src_10021.listing_id AS listing
+    , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
   LEFT OUTER JOIN
-    ***************************.dim_lux_listings lux_listings_src_10021
+    ***************************.dim_lux_listings lux_listings_src_10022
   ON
-    lux_listing_mapping_src_10020.lux_listing_id = lux_listings_src_10021.lux_listing_id
+    lux_listing_mapping_src_10021.lux_listing_id = lux_listings_src_10022.lux_listing_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -117,36 +117,36 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'listings'
               SELECT
-                listings_src_10019.active_from AS window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-                , listings_src_10019.active_to AS window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-                , listings_src_10019.country
-                , listings_src_10019.is_lux
-                , listings_src_10019.capacity
-                , listings_src_10019.active_from AS listing__window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-                , listings_src_10019.active_to AS listing__window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-                , listings_src_10019.country AS listing__country
-                , listings_src_10019.is_lux AS listing__is_lux
-                , listings_src_10019.capacity AS listing__capacity
-                , listings_src_10019.listing_id AS listing
-                , listings_src_10019.user_id AS user
-                , listings_src_10019.user_id AS listing__user
-              FROM ***************************.dim_listings listings_src_10019
+                listings_src_10020.active_from AS window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+                , listings_src_10020.active_to AS window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+                , listings_src_10020.country
+                , listings_src_10020.is_lux
+                , listings_src_10020.capacity
+                , listings_src_10020.active_from AS listing__window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+                , listings_src_10020.active_to AS listing__window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+                , listings_src_10020.country AS listing__country
+                , listings_src_10020.is_lux AS listing__is_lux
+                , listings_src_10020.capacity AS listing__capacity
+                , listings_src_10020.listing_id AS listing
+                , listings_src_10020.user_id AS user
+                , listings_src_10020.user_id AS listing__user
+              FROM ***************************.dim_listings listings_src_10020
             ) subq_3
           ) subq_4
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   --   ['bookings', 'listing__capacity', 'metric_time']
   SELECT
     subq_12.metric_time AS metric_time
-    , listings_src_10019.capacity AS listing__capacity
+    , listings_src_10020.capacity AS listing__capacity
     , subq_12.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
@@ -26,18 +26,18 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_10018
   ) subq_12
   LEFT OUTER JOIN
-    ***************************.dim_listings listings_src_10019
+    ***************************.dim_listings listings_src_10020
   ON
     (
-      subq_12.listing = listings_src_10019.listing_id
+      subq_12.listing = listings_src_10020.listing_id
     ) AND (
       (
-        subq_12.metric_time >= listings_src_10019.active_from
+        subq_12.metric_time >= listings_src_10020.active_from
       ) AND (
         (
-          subq_12.metric_time < listings_src_10019.active_to
+          subq_12.metric_time < listings_src_10020.active_to
         ) OR (
-          listings_src_10019.active_to IS NULL
+          listings_src_10020.active_to IS NULL
         )
       )
     )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -145,36 +145,36 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'listings'
             SELECT
-              listings_src_10019.active_from AS window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-              , listings_src_10019.active_to AS window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-              , listings_src_10019.country
-              , listings_src_10019.is_lux
-              , listings_src_10019.capacity
-              , listings_src_10019.active_from AS listing__window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-              , listings_src_10019.active_to AS listing__window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-              , listings_src_10019.country AS listing__country
-              , listings_src_10019.is_lux AS listing__is_lux
-              , listings_src_10019.capacity AS listing__capacity
-              , listings_src_10019.listing_id AS listing
-              , listings_src_10019.user_id AS user
-              , listings_src_10019.user_id AS listing__user
-            FROM ***************************.dim_listings listings_src_10019
+              listings_src_10020.active_from AS window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+              , listings_src_10020.active_to AS window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+              , listings_src_10020.country
+              , listings_src_10020.is_lux
+              , listings_src_10020.capacity
+              , listings_src_10020.active_from AS listing__window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+              , listings_src_10020.active_to AS listing__window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+              , listings_src_10020.country AS listing__country
+              , listings_src_10020.is_lux AS listing__is_lux
+              , listings_src_10020.capacity AS listing__capacity
+              , listings_src_10020.listing_id AS listing
+              , listings_src_10020.user_id AS user
+              , listings_src_10020.user_id AS listing__user
+            FROM ***************************.dim_listings listings_src_10020
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -208,20 +208,20 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'users_latest'
               SELECT
-                users_latest_src_10023.ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS ds__year
-                , users_latest_src_10023.home_state_latest
-                , users_latest_src_10023.ds AS user__ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS user__ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS user__ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS user__ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS user__ds__year
-                , users_latest_src_10023.home_state_latest AS user__home_state_latest
-                , users_latest_src_10023.user_id AS user
-              FROM ***************************.dim_users_latest users_latest_src_10023
+                users_latest_src_10024.ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS ds__year
+                , users_latest_src_10024.home_state_latest
+                , users_latest_src_10024.ds AS user__ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS user__ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS user__ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS user__ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS user__ds__year
+                , users_latest_src_10024.home_state_latest AS user__home_state_latest
+                , users_latest_src_10024.user_id AS user
+              FROM ***************************.dim_users_latest users_latest_src_10024
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -23,15 +23,15 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['user__home_state_latest', 'window_start', 'window_end', 'listing']
   SELECT
-    listings_src_10019.active_from AS window_start
-    , listings_src_10019.active_to AS window_end
-    , listings_src_10019.listing_id AS listing
-    , users_latest_src_10023.home_state_latest AS user__home_state_latest
-  FROM ***************************.dim_listings listings_src_10019
+    listings_src_10020.active_from AS window_start
+    , listings_src_10020.active_to AS window_end
+    , listings_src_10020.listing_id AS listing
+    , users_latest_src_10024.home_state_latest AS user__home_state_latest
+  FROM ***************************.dim_listings listings_src_10020
   LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_10023
+    ***************************.dim_users_latest users_latest_src_10024
   ON
-    listings_src_10019.user_id = users_latest_src_10023.user_id
+    listings_src_10020.user_id = users_latest_src_10024.user_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -127,10 +127,10 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'lux_listing_mapping'
             SELECT
-              lux_listing_mapping_src_10020.listing_id AS listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS lux_listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS listing__lux_listing
-            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+              lux_listing_mapping_src_10021.listing_id AS listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS lux_listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS listing__lux_listing
+            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -184,30 +184,30 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'lux_listings'
               SELECT
-                lux_listings_src_10021.valid_from AS window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS window_start__year
-                , lux_listings_src_10021.valid_to AS window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS window_end__year
-                , lux_listings_src_10021.is_confirmed_lux
-                , lux_listings_src_10021.valid_from AS lux_listing__window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS lux_listing__window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS lux_listing__window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS lux_listing__window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS lux_listing__window_start__year
-                , lux_listings_src_10021.valid_to AS lux_listing__window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS lux_listing__window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS lux_listing__window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS lux_listing__window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS lux_listing__window_end__year
-                , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-                , lux_listings_src_10021.lux_listing_id AS lux_listing
-              FROM ***************************.dim_lux_listings lux_listings_src_10021
+                lux_listings_src_10022.valid_from AS window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS window_start__year
+                , lux_listings_src_10022.valid_to AS window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS window_end__year
+                , lux_listings_src_10022.is_confirmed_lux
+                , lux_listings_src_10022.valid_from AS lux_listing__window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS lux_listing__window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS lux_listing__window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS lux_listing__window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS lux_listing__window_start__year
+                , lux_listings_src_10022.valid_to AS lux_listing__window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS lux_listing__window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS lux_listing__window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS lux_listing__window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS lux_listing__window_end__year
+                , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+                , lux_listings_src_10022.lux_listing_id AS lux_listing
+              FROM ***************************.dim_lux_listings lux_listings_src_10022
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -26,15 +26,15 @@ LEFT OUTER JOIN (
   --    'lux_listing__window_end',
   --    'listing']
   SELECT
-    lux_listings_src_10021.valid_from AS lux_listing__window_start
-    , lux_listings_src_10021.valid_to AS lux_listing__window_end
-    , lux_listing_mapping_src_10020.listing_id AS listing
-    , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+    lux_listings_src_10022.valid_from AS lux_listing__window_start
+    , lux_listings_src_10022.valid_to AS lux_listing__window_end
+    , lux_listing_mapping_src_10021.listing_id AS listing
+    , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
   LEFT OUTER JOIN
-    ***************************.dim_lux_listings lux_listings_src_10021
+    ***************************.dim_lux_listings lux_listings_src_10022
   ON
-    lux_listing_mapping_src_10020.lux_listing_id = lux_listings_src_10021.lux_listing_id
+    lux_listing_mapping_src_10021.lux_listing_id = lux_listings_src_10022.lux_listing_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0.sql
@@ -117,36 +117,36 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'listings'
               SELECT
-                listings_src_10019.active_from AS window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-                , listings_src_10019.active_to AS window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-                , listings_src_10019.country
-                , listings_src_10019.is_lux
-                , listings_src_10019.capacity
-                , listings_src_10019.active_from AS listing__window_start
-                , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-                , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-                , listings_src_10019.active_to AS listing__window_end
-                , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-                , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-                , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-                , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-                , listings_src_10019.country AS listing__country
-                , listings_src_10019.is_lux AS listing__is_lux
-                , listings_src_10019.capacity AS listing__capacity
-                , listings_src_10019.listing_id AS listing
-                , listings_src_10019.user_id AS user
-                , listings_src_10019.user_id AS listing__user
-              FROM ***************************.dim_listings listings_src_10019
+                listings_src_10020.active_from AS window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+                , listings_src_10020.active_to AS window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+                , listings_src_10020.country
+                , listings_src_10020.is_lux
+                , listings_src_10020.capacity
+                , listings_src_10020.active_from AS listing__window_start
+                , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+                , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+                , listings_src_10020.active_to AS listing__window_end
+                , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+                , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+                , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+                , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+                , listings_src_10020.country AS listing__country
+                , listings_src_10020.is_lux AS listing__is_lux
+                , listings_src_10020.capacity AS listing__capacity
+                , listings_src_10020.listing_id AS listing
+                , listings_src_10020.user_id AS user
+                , listings_src_10020.user_id AS listing__user
+              FROM ***************************.dim_listings listings_src_10020
             ) subq_3
           ) subq_4
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_join_to_scd_dimension__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   --   ['bookings', 'listing__capacity', 'metric_time']
   SELECT
     subq_12.metric_time AS metric_time
-    , listings_src_10019.capacity AS listing__capacity
+    , listings_src_10020.capacity AS listing__capacity
     , subq_12.bookings AS bookings
   FROM (
     -- Read Elements From Data Source 'bookings_source'
@@ -26,18 +26,18 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_10018
   ) subq_12
   LEFT OUTER JOIN
-    ***************************.dim_listings listings_src_10019
+    ***************************.dim_listings listings_src_10020
   ON
     (
-      subq_12.listing = listings_src_10019.listing_id
+      subq_12.listing = listings_src_10020.listing_id
     ) AND (
       (
-        subq_12.metric_time >= listings_src_10019.active_from
+        subq_12.metric_time >= listings_src_10020.active_from
       ) AND (
         (
-          subq_12.metric_time < listings_src_10019.active_to
+          subq_12.metric_time < listings_src_10020.active_to
         ) OR (
-          listings_src_10019.active_to IS NULL
+          listings_src_10020.active_to IS NULL
         )
       )
     )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -145,36 +145,36 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'listings'
             SELECT
-              listings_src_10019.active_from AS window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS window_start__year
-              , listings_src_10019.active_to AS window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS window_end__year
-              , listings_src_10019.country
-              , listings_src_10019.is_lux
-              , listings_src_10019.capacity
-              , listings_src_10019.active_from AS listing__window_start
-              , DATE_TRUNC('week', listings_src_10019.active_from) AS listing__window_start__week
-              , DATE_TRUNC('month', listings_src_10019.active_from) AS listing__window_start__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_from) AS listing__window_start__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_from) AS listing__window_start__year
-              , listings_src_10019.active_to AS listing__window_end
-              , DATE_TRUNC('week', listings_src_10019.active_to) AS listing__window_end__week
-              , DATE_TRUNC('month', listings_src_10019.active_to) AS listing__window_end__month
-              , DATE_TRUNC('quarter', listings_src_10019.active_to) AS listing__window_end__quarter
-              , DATE_TRUNC('year', listings_src_10019.active_to) AS listing__window_end__year
-              , listings_src_10019.country AS listing__country
-              , listings_src_10019.is_lux AS listing__is_lux
-              , listings_src_10019.capacity AS listing__capacity
-              , listings_src_10019.listing_id AS listing
-              , listings_src_10019.user_id AS user
-              , listings_src_10019.user_id AS listing__user
-            FROM ***************************.dim_listings listings_src_10019
+              listings_src_10020.active_from AS window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS window_start__year
+              , listings_src_10020.active_to AS window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS window_end__year
+              , listings_src_10020.country
+              , listings_src_10020.is_lux
+              , listings_src_10020.capacity
+              , listings_src_10020.active_from AS listing__window_start
+              , DATE_TRUNC('week', listings_src_10020.active_from) AS listing__window_start__week
+              , DATE_TRUNC('month', listings_src_10020.active_from) AS listing__window_start__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_from) AS listing__window_start__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_from) AS listing__window_start__year
+              , listings_src_10020.active_to AS listing__window_end
+              , DATE_TRUNC('week', listings_src_10020.active_to) AS listing__window_end__week
+              , DATE_TRUNC('month', listings_src_10020.active_to) AS listing__window_end__month
+              , DATE_TRUNC('quarter', listings_src_10020.active_to) AS listing__window_end__quarter
+              , DATE_TRUNC('year', listings_src_10020.active_to) AS listing__window_end__year
+              , listings_src_10020.country AS listing__country
+              , listings_src_10020.is_lux AS listing__is_lux
+              , listings_src_10020.capacity AS listing__capacity
+              , listings_src_10020.listing_id AS listing
+              , listings_src_10020.user_id AS user
+              , listings_src_10020.user_id AS listing__user
+            FROM ***************************.dim_listings listings_src_10020
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -208,20 +208,20 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'users_latest'
               SELECT
-                users_latest_src_10023.ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS ds__year
-                , users_latest_src_10023.home_state_latest
-                , users_latest_src_10023.ds AS user__ds
-                , DATE_TRUNC('week', users_latest_src_10023.ds) AS user__ds__week
-                , DATE_TRUNC('month', users_latest_src_10023.ds) AS user__ds__month
-                , DATE_TRUNC('quarter', users_latest_src_10023.ds) AS user__ds__quarter
-                , DATE_TRUNC('year', users_latest_src_10023.ds) AS user__ds__year
-                , users_latest_src_10023.home_state_latest AS user__home_state_latest
-                , users_latest_src_10023.user_id AS user
-              FROM ***************************.dim_users_latest users_latest_src_10023
+                users_latest_src_10024.ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS ds__year
+                , users_latest_src_10024.home_state_latest
+                , users_latest_src_10024.ds AS user__ds
+                , DATE_TRUNC('week', users_latest_src_10024.ds) AS user__ds__week
+                , DATE_TRUNC('month', users_latest_src_10024.ds) AS user__ds__month
+                , DATE_TRUNC('quarter', users_latest_src_10024.ds) AS user__ds__quarter
+                , DATE_TRUNC('year', users_latest_src_10024.ds) AS user__ds__year
+                , users_latest_src_10024.home_state_latest AS user__home_state_latest
+                , users_latest_src_10024.user_id AS user
+              FROM ***************************.dim_users_latest users_latest_src_10024
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -23,15 +23,15 @@ LEFT OUTER JOIN (
   -- Pass Only Elements:
   --   ['user__home_state_latest', 'window_start', 'window_end', 'listing']
   SELECT
-    listings_src_10019.active_from AS window_start
-    , listings_src_10019.active_to AS window_end
-    , listings_src_10019.listing_id AS listing
-    , users_latest_src_10023.home_state_latest AS user__home_state_latest
-  FROM ***************************.dim_listings listings_src_10019
+    listings_src_10020.active_from AS window_start
+    , listings_src_10020.active_to AS window_end
+    , listings_src_10020.listing_id AS listing
+    , users_latest_src_10024.home_state_latest AS user__home_state_latest
+  FROM ***************************.dim_listings listings_src_10020
   LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_10023
+    ***************************.dim_users_latest users_latest_src_10024
   ON
-    listings_src_10019.user_id = users_latest_src_10023.user_id
+    listings_src_10020.user_id = users_latest_src_10024.user_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -127,10 +127,10 @@ FROM (
           FROM (
             -- Read Elements From Data Source 'lux_listing_mapping'
             SELECT
-              lux_listing_mapping_src_10020.listing_id AS listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS lux_listing
-              , lux_listing_mapping_src_10020.lux_listing_id AS listing__lux_listing
-            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+              lux_listing_mapping_src_10021.listing_id AS listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS lux_listing
+              , lux_listing_mapping_src_10021.lux_listing_id AS listing__lux_listing
+            FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
           ) subq_3
           LEFT OUTER JOIN (
             -- Pass Only Elements:
@@ -184,30 +184,30 @@ FROM (
             FROM (
               -- Read Elements From Data Source 'lux_listings'
               SELECT
-                lux_listings_src_10021.valid_from AS window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS window_start__year
-                , lux_listings_src_10021.valid_to AS window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS window_end__year
-                , lux_listings_src_10021.is_confirmed_lux
-                , lux_listings_src_10021.valid_from AS lux_listing__window_start
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_from) AS lux_listing__window_start__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_from) AS lux_listing__window_start__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_from) AS lux_listing__window_start__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_from) AS lux_listing__window_start__year
-                , lux_listings_src_10021.valid_to AS lux_listing__window_end
-                , DATE_TRUNC('week', lux_listings_src_10021.valid_to) AS lux_listing__window_end__week
-                , DATE_TRUNC('month', lux_listings_src_10021.valid_to) AS lux_listing__window_end__month
-                , DATE_TRUNC('quarter', lux_listings_src_10021.valid_to) AS lux_listing__window_end__quarter
-                , DATE_TRUNC('year', lux_listings_src_10021.valid_to) AS lux_listing__window_end__year
-                , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-                , lux_listings_src_10021.lux_listing_id AS lux_listing
-              FROM ***************************.dim_lux_listings lux_listings_src_10021
+                lux_listings_src_10022.valid_from AS window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS window_start__year
+                , lux_listings_src_10022.valid_to AS window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS window_end__year
+                , lux_listings_src_10022.is_confirmed_lux
+                , lux_listings_src_10022.valid_from AS lux_listing__window_start
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_from) AS lux_listing__window_start__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_from) AS lux_listing__window_start__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_from) AS lux_listing__window_start__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_from) AS lux_listing__window_start__year
+                , lux_listings_src_10022.valid_to AS lux_listing__window_end
+                , DATE_TRUNC('week', lux_listings_src_10022.valid_to) AS lux_listing__window_end__week
+                , DATE_TRUNC('month', lux_listings_src_10022.valid_to) AS lux_listing__window_end__month
+                , DATE_TRUNC('quarter', lux_listings_src_10022.valid_to) AS lux_listing__window_end__quarter
+                , DATE_TRUNC('year', lux_listings_src_10022.valid_to) AS lux_listing__window_end__year
+                , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+                , lux_listings_src_10022.lux_listing_id AS lux_listing
+              FROM ***************************.dim_lux_listings lux_listings_src_10022
             ) subq_4
           ) subq_5
           ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -26,15 +26,15 @@ LEFT OUTER JOIN (
   --    'lux_listing__window_end',
   --    'listing']
   SELECT
-    lux_listings_src_10021.valid_from AS lux_listing__window_start
-    , lux_listings_src_10021.valid_to AS lux_listing__window_end
-    , lux_listing_mapping_src_10020.listing_id AS listing
-    , lux_listings_src_10021.is_confirmed_lux AS lux_listing__is_confirmed_lux
-  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10020
+    lux_listings_src_10022.valid_from AS lux_listing__window_start
+    , lux_listings_src_10022.valid_to AS lux_listing__window_end
+    , lux_listing_mapping_src_10021.listing_id AS listing
+    , lux_listings_src_10022.is_confirmed_lux AS lux_listing__is_confirmed_lux
+  FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_10021
   LEFT OUTER JOIN
-    ***************************.dim_lux_listings lux_listings_src_10021
+    ***************************.dim_lux_listings lux_listings_src_10022
   ON
-    lux_listing_mapping_src_10020.lux_listing_id = lux_listings_src_10021.lux_listing_id
+    lux_listing_mapping_src_10021.lux_listing_id = lux_listings_src_10022.lux_listing_id
 ) subq_18
 ON
   (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_scd_dimension__plan0.xml
@@ -390,14 +390,14 @@
                                 <!--   {'class': 'SqlSelectColumn',                           -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_86),  -->
                                 <!--    'column_alias': 'capacity'}                           -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10019) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10020) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Read Elements From Data Source 'listings' -->
-                                    <!-- node_id = ss_10019 -->
+                                    <!-- node_id = ss_10020 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10355),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10362),  -->
                                     <!--    'column_alias': 'window_start'}                          -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -417,7 +417,7 @@
                                     <!--    'column_alias': 'window_start__year'}              -->
                                     <!-- col5 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10360),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10367),  -->
                                     <!--    'column_alias': 'window_end'}                            -->
                                     <!-- col6 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -437,19 +437,19 @@
                                     <!--    'column_alias': 'window_end__year'}                -->
                                     <!-- col10 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10365),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10372),  -->
                                     <!--    'column_alias': 'country'}                               -->
                                     <!-- col11 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10366),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10373),  -->
                                     <!--    'column_alias': 'is_lux'}                                -->
                                     <!-- col12 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10367),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10374),  -->
                                     <!--    'column_alias': 'capacity'}                              -->
                                     <!-- col13 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10368),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10375),  -->
                                     <!--    'column_alias': 'listing__window_start'}                 -->
                                     <!-- col14 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -469,7 +469,7 @@
                                     <!--    'column_alias': 'listing__window_start__year'}     -->
                                     <!-- col18 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10373),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10380),  -->
                                     <!--    'column_alias': 'listing__window_end'}                   -->
                                     <!-- col19 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -489,33 +489,33 @@
                                     <!--    'column_alias': 'listing__window_end__year'}       -->
                                     <!-- col23 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10378),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10385),  -->
                                     <!--    'column_alias': 'listing__country'}                      -->
                                     <!-- col24 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10379),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10386),  -->
                                     <!--    'column_alias': 'listing__is_lux'}                       -->
                                     <!-- col25 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10380),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10387),  -->
                                     <!--    'column_alias': 'listing__capacity'}                     -->
                                     <!-- col26 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10381),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10388),  -->
                                     <!--    'column_alias': 'listing'}                               -->
                                     <!-- col27 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10382),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10389),  -->
                                     <!--    'column_alias': 'user'}                                  -->
                                     <!-- col28 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10383),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10390),  -->
                                     <!--    'column_alias': 'listing__user'}                         -->
-                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10015) -->
+                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10016) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>
                                         <!-- description = Read from ***************************.dim_listings -->
-                                        <!-- node_id = tfc_10015 -->
+                                        <!-- node_id = tfc_10016 -->
                                         <!-- table_id = ***************************.dim_listings -->
                                     </SqlTableFromClauseNode>
                                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_through_scd_dimension__plan0.xml
@@ -514,7 +514,7 @@
                             <!--   {'class': 'SqlSelectColumn',                            -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_180),  -->
                             <!--    'column_alias': 'user__home_state_latest'}             -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10019) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10020) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
                             <!--    'right_source': SqlSelectStatementNode(node_id=ss_6),    -->
@@ -524,10 +524,10 @@
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description = Read Elements From Data Source 'listings' -->
-                                <!-- node_id = ss_10019 -->
+                                <!-- node_id = ss_10020 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10355),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10362),  -->
                                 <!--    'column_alias': 'window_start'}                          -->
                                 <!-- col1 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -547,7 +547,7 @@
                                 <!--    'column_alias': 'window_start__year'}              -->
                                 <!-- col5 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10360),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10367),  -->
                                 <!--    'column_alias': 'window_end'}                            -->
                                 <!-- col6 =                                                -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -567,19 +567,19 @@
                                 <!--    'column_alias': 'window_end__year'}                -->
                                 <!-- col10 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10365),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10372),  -->
                                 <!--    'column_alias': 'country'}                               -->
                                 <!-- col11 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10366),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10373),  -->
                                 <!--    'column_alias': 'is_lux'}                                -->
                                 <!-- col12 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10367),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10374),  -->
                                 <!--    'column_alias': 'capacity'}                              -->
                                 <!-- col13 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10368),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10375),  -->
                                 <!--    'column_alias': 'listing__window_start'}                 -->
                                 <!-- col14 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -599,7 +599,7 @@
                                 <!--    'column_alias': 'listing__window_start__year'}     -->
                                 <!-- col18 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10373),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10380),  -->
                                 <!--    'column_alias': 'listing__window_end'}                   -->
                                 <!-- col19 =                                               -->
                                 <!--   {'class': 'SqlSelectColumn',                        -->
@@ -619,33 +619,33 @@
                                 <!--    'column_alias': 'listing__window_end__year'}       -->
                                 <!-- col23 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10378),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10385),  -->
                                 <!--    'column_alias': 'listing__country'}                      -->
                                 <!-- col24 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10379),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10386),  -->
                                 <!--    'column_alias': 'listing__is_lux'}                       -->
                                 <!-- col25 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10380),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10387),  -->
                                 <!--    'column_alias': 'listing__capacity'}                     -->
                                 <!-- col26 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10381),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10388),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col27 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10382),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10389),  -->
                                 <!--    'column_alias': 'user'}                                  -->
                                 <!-- col28 =                                                     -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10383),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10390),  -->
                                 <!--    'column_alias': 'listing__user'}                         -->
-                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10015) -->
+                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10016) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
                                     <!-- description = Read from ***************************.dim_listings -->
-                                    <!-- node_id = tfc_10015 -->
+                                    <!-- node_id = tfc_10016 -->
                                     <!-- table_id = ***************************.dim_listings -->
                                 </SqlTableFromClauseNode>
                             </SqlSelectStatementNode>
@@ -718,14 +718,14 @@
                                 <!--   {'class': 'SqlSelectColumn',                            -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_137),  -->
                                 <!--    'column_alias': 'user__home_state_latest'}             -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10023) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10024) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Read Elements From Data Source 'users_latest' -->
-                                    <!-- node_id = ss_10023 -->
+                                    <!-- node_id = ss_10024 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10433),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10440),  -->
                                     <!--    'column_alias': 'ds'}                                    -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -745,11 +745,11 @@
                                     <!--    'column_alias': 'ds__year'}                        -->
                                     <!-- col5 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10438),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10445),  -->
                                     <!--    'column_alias': 'home_state_latest'}                     -->
                                     <!-- col6 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10439),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10446),  -->
                                     <!--    'column_alias': 'user__ds'}                              -->
                                     <!-- col7 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -769,17 +769,17 @@
                                     <!--    'column_alias': 'user__ds__year'}                  -->
                                     <!-- col11 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10444),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10451),  -->
                                     <!--    'column_alias': 'user__home_state_latest'}               -->
                                     <!-- col12 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10445),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10452),  -->
                                     <!--    'column_alias': 'user'}                                  -->
-                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10019) -->
+                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10020) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>
                                         <!-- description = Read from ***************************.dim_users_latest -->
-                                        <!-- node_id = tfc_10019 -->
+                                        <!-- node_id = tfc_10020 -->
                                         <!-- table_id = ***************************.dim_users_latest -->
                                     </SqlTableFromClauseNode>
                                 </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_hop_to_scd_dimension__plan0.xml
@@ -433,7 +433,7 @@
                             <!--   {'class': 'SqlSelectColumn',                            -->
                             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_153),  -->
                             <!--    'column_alias': 'lux_listing__is_confirmed_lux'}       -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10020) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10021) -->
                             <!-- join_0 =                                                    -->
                             <!--   {'class': 'SqlJoinDescription',                           -->
                             <!--    'right_source': SqlSelectStatementNode(node_id=ss_6),    -->
@@ -443,25 +443,25 @@
                             <!-- where = None -->
                             <SqlSelectStatementNode>
                                 <!-- description = Read Elements From Data Source 'lux_listing_mapping' -->
-                                <!-- node_id = ss_10020 -->
+                                <!-- node_id = ss_10021 -->
                                 <!-- col0 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10384),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10391),  -->
                                 <!--    'column_alias': 'listing'}                               -->
                                 <!-- col1 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10385),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10392),  -->
                                 <!--    'column_alias': 'lux_listing'}                           -->
                                 <!-- col2 =                                                      -->
                                 <!--   {'class': 'SqlSelectColumn',                              -->
-                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10386),  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10393),  -->
                                 <!--    'column_alias': 'listing__lux_listing'}                  -->
-                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10016) -->
+                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10017) -->
                                 <!-- where = None -->
                                 <SqlTableFromClauseNode>
                                     <!-- description =                                                       -->
                                     <!--   Read from ***************************.dim_lux_listing_id_mapping  -->
-                                    <!-- node_id = tfc_10016 -->
+                                    <!-- node_id = tfc_10017 -->
                                     <!-- table_id = ***************************.dim_lux_listing_id_mapping -->
                                 </SqlTableFromClauseNode>
                             </SqlSelectStatementNode>
@@ -584,14 +584,14 @@
                                 <!--   {'class': 'SqlSelectColumn',                            -->
                                 <!--    'expr': SqlColumnReferenceExpression(node_id=cr_126),  -->
                                 <!--    'column_alias': 'lux_listing__is_confirmed_lux'}       -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10021) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10022) -->
                                 <!-- where = None -->
                                 <SqlSelectStatementNode>
                                     <!-- description = Read Elements From Data Source 'lux_listings' -->
-                                    <!-- node_id = ss_10021 -->
+                                    <!-- node_id = ss_10022 -->
                                     <!-- col0 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10387),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10394),  -->
                                     <!--    'column_alias': 'window_start'}                          -->
                                     <!-- col1 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -611,7 +611,7 @@
                                     <!--    'column_alias': 'window_start__year'}              -->
                                     <!-- col5 =                                                      -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10392),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10399),  -->
                                     <!--    'column_alias': 'window_end'}                            -->
                                     <!-- col6 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -631,11 +631,11 @@
                                     <!--    'column_alias': 'window_end__year'}                -->
                                     <!-- col10 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10397),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10404),  -->
                                     <!--    'column_alias': 'is_confirmed_lux'}                      -->
                                     <!-- col11 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10398),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10405),  -->
                                     <!--    'column_alias': 'lux_listing__window_start'}             -->
                                     <!-- col12 =                                                -->
                                     <!--   {'class': 'SqlSelectColumn',                         -->
@@ -655,7 +655,7 @@
                                     <!--    'column_alias': 'lux_listing__window_start__year'}  -->
                                     <!-- col16 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10403),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10410),  -->
                                     <!--    'column_alias': 'lux_listing__window_end'}               -->
                                     <!-- col17 =                                               -->
                                     <!--   {'class': 'SqlSelectColumn',                        -->
@@ -675,17 +675,17 @@
                                     <!--    'column_alias': 'lux_listing__window_end__year'}   -->
                                     <!-- col21 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10408),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10415),  -->
                                     <!--    'column_alias': 'lux_listing__is_confirmed_lux'}         -->
                                     <!-- col22 =                                                     -->
                                     <!--   {'class': 'SqlSelectColumn',                              -->
-                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10409),  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10416),  -->
                                     <!--    'column_alias': 'lux_listing'}                           -->
-                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10017) -->
+                                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_10018) -->
                                     <!-- where = None -->
                                     <SqlTableFromClauseNode>
                                         <!-- description = Read from ***************************.dim_lux_listings -->
-                                        <!-- node_id = tfc_10017 -->
+                                        <!-- node_id = tfc_10018 -->
                                         <!-- table_id = ***************************.dim_lux_listings -->
                                     </SqlTableFromClauseNode>
                                 </SqlSelectStatementNode>


### PR DESCRIPTION
Up to now the way we were specifying the join identifier in data sources
with validity windows was to mark it as `primary`, but this was really
a temporary hack around the lack of a more appropriate identifier type.

The IdentifierType.PRIMARY implies uniqueness, and as such having
SCD-style data sources overload that term can lead to confusion since
the identifier is not unique unless a validity window filter is
applied.

This PR adds a new identifier type - `natural`, representing the
"natural" key - and updates the scd models to use it. It also
adds additional validation around the use of this identifier type,
requiring it for all data sources with validity windows and restricting
its use to such scenarios. To prevent confusion with identifier types
we do not support for joins in SCD-style data sources, we also
update our validation to prevent the use of `primary` and `unique`
identifier types in data sources with validity parameters set.