### PR TITLE
Update cancel_request to filter by function

### DIFF
--- a/metricflow/protocols/async_sql_client.py
+++ b/metricflow/protocols/async_sql_client.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Protocol, Sequence, Optional
+from typing import Protocol, Sequence, Optional, Callable
 
 from metricflow.protocols.sql_client import SqlClient, SqlIsolationLevel
-from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlRequestTagSet, SqlJsonTag
+from metricflow.protocols.sql_request import SqlRequestId, SqlRequestResult, SqlJsonTag
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
+from metricflow.sql_clients.async_request import CombinedSqlTags
 
 
 class AsyncSqlClient(SqlClient, Protocol):
@@ -38,10 +39,11 @@ class AsyncSqlClient(SqlClient, Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:
-        """Make a best-effort at canceling requests that have a superset of the given tags.
+    def cancel_request(self, match_function: Callable[[CombinedSqlTags], bool]) -> int:
+        """Make a best-effort at canceling requests with tags that match the supplied function.
 
-        Returns the number of cancellation commands sent.
+        The function arguments are the tags associated with the query, and should return a bool indicating whether
+        the given query should be cancelled. Returns the number of cancellation commands sent.
         """
         raise NotImplementedError
 

--- a/metricflow/protocols/sql_request.py
+++ b/metricflow/protocols/sql_request.py
@@ -134,3 +134,6 @@ class SqlJsonTag:
                 )
             new_json_dict[k] = v
         return SqlJsonTag(new_json_dict)
+
+    def __repr__(self) -> str:  # noqa: D
+        return f"{self.__class__.__name__}(json_dict={self._json_dict})"

--- a/metricflow/sql_clients/async_request.py
+++ b/metricflow/sql_clients/async_request.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
+import json
 import logging
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, List
 
 from pydantic import ValidationError
 
 from metricflow.object_utils import pformat_big_objects
-from metricflow.protocols.sql_request import SqlRequestTagSet
+from metricflow.protocols.sql_request import SqlRequestTagSet, SqlJsonTag
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CombinedSqlTags:
+    """Groups system and extra tags for simplicity."""
+
+    system_tags: SqlRequestTagSet = field(default_factory=SqlRequestTagSet)
+    extra_tag: SqlJsonTag = field(default_factory=SqlJsonTag)
 
 
 class SqlStatementCommentMetadata:
@@ -25,17 +35,31 @@ class SqlStatementCommentMetadata:
     """
 
     _TAG_PREFIX = "-- MF_REQUEST_METADATA: "
+    _EXTRA_TAG_PREFIX = "-- MF_EXTRA_TAGS: "
 
     @staticmethod
-    def add_tag_metadata_as_comment(sql_statement: str, tag_set: SqlRequestTagSet) -> str:  # noqa: D
-        if tag_set.tags:
-            return sql_statement + "\n" + SqlStatementCommentMetadata._TAG_PREFIX + tag_set.json()
-        else:
-            return sql_statement
+    def add_tag_metadata_as_comment(sql_statement: str, combined_tags: CombinedSqlTags) -> str:  # noqa: D
+        if combined_tags.system_tags.tags:
+            sql_statement = (
+                sql_statement + "\n" + SqlStatementCommentMetadata._TAG_PREFIX + combined_tags.system_tags.json()
+            )
+
+        if combined_tags.extra_tag.json_dict:
+            serialized_json: Optional[str] = None
+            try:
+                serialized_json = json.dumps(combined_tags.extra_tag.json_dict)
+            except Exception:
+                logger.exception(f"Not including extra tag that couldn't be serialized: {combined_tags.extra_tag}\n")
+
+            if serialized_json:
+                sql_statement = sql_statement + "\n" + SqlStatementCommentMetadata._EXTRA_TAG_PREFIX + serialized_json
+
+        return sql_statement
 
     @staticmethod
-    def parse_tag_metadata_in_comments(sql_statement: str) -> Optional[SqlRequestTagSet]:  # noqa: D
-        tag_sets = []
+    def parse_tag_metadata_in_comments(sql_statement: str) -> CombinedSqlTags:  # noqa: D
+        tag_sets: List[SqlRequestTagSet] = []
+        extra_tags: List[SqlJsonTag] = []
         for line in sql_statement.split("\n"):
             if line.startswith(SqlStatementCommentMetadata._TAG_PREFIX):
                 try:
@@ -43,6 +67,14 @@ class SqlStatementCommentMetadata:
                     tag_sets.append(SqlRequestTagSet.parse_raw(json_str))
                 except ValidationError:
                     logger.exception(f"Unable to parse tag metadata from line: {line}")
+
+            if line.startswith(SqlStatementCommentMetadata._EXTRA_TAG_PREFIX):
+                try:
+                    json_str = line[len(SqlStatementCommentMetadata._EXTRA_TAG_PREFIX) :]
+                    extra_tags.append(SqlJsonTag(json.loads(json_str)))
+                except ValidationError:
+                    logger.exception(f"Unable to parse extra tag metadata from line: {line}")
+
         if len(tag_sets) > 1:
             logger.error(
                 f"Got multiple tag sets from parsing comments:\n"
@@ -50,4 +82,14 @@ class SqlStatementCommentMetadata:
                 f"Using the first one."
             )
 
-        return tag_sets[0] if len(tag_sets) > 0 else None
+        if len(extra_tags) > 1:
+            logger.error(
+                f"Got multiple extra tags from parsing comments:\n"
+                f"{pformat_big_objects(extra_tags)}\n"
+                f"Using the first one."
+            )
+
+        return CombinedSqlTags(
+            system_tags=tag_sets[0] if len(tag_sets) > 0 else SqlRequestTagSet(),
+            extra_tag=extra_tags[0] if len(extra_tags) > 0 else SqlJsonTag(),
+        )

--- a/metricflow/sql_clients/databricks.py
+++ b/metricflow/sql_clients/databricks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Optional, ClassVar, Dict, Sequence
+from typing import Optional, ClassVar, Dict, Sequence, Callable
 
 import pandas as pd
 import sqlalchemy
@@ -14,6 +14,7 @@ from metricflow.protocols.sql_request import SqlRequestTagSet, SqlJsonTag
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql.sql_bind_parameters import SqlColumnType
+from metricflow.sql_clients.async_request import CombinedSqlTags
 from metricflow.sql_clients.base_sql_client_implementation import BaseSqlClientImplementation
 from metricflow.sql_clients.common_client import SqlDialect, check_isolation_level
 
@@ -269,5 +270,5 @@ class DatabricksSqlClient(BaseSqlClientImplementation):
         stmt_uppercased = stmt.upper()
         return SQL_RENAME in stmt_uppercased and SQL_ALTER_TABLE in stmt_uppercased
 
-    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+    def cancel_request(self, match_function: Callable[[CombinedSqlTags], bool]) -> int:  # noqa: D
         raise NotImplementedError

--- a/metricflow/sql_clients/duckdb.py
+++ b/metricflow/sql_clients/duckdb.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from typing import ClassVar, Optional, Sequence
+from typing import ClassVar, Optional, Sequence, Callable
 
 import pandas as pd
 import sqlalchemy
@@ -13,6 +13,7 @@ from metricflow.protocols.sql_request import SqlRequestTagSet, SqlJsonTag
 from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
+from metricflow.sql_clients.async_request import CombinedSqlTags
 from metricflow.sql_clients.common_client import SqlDialect
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
@@ -119,7 +120,7 @@ class DuckDbSqlClient(SqlAlchemySqlClient):
                 chunk_size=chunk_size,
             )
 
-    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+    def cancel_request(self, match_function: Callable[[CombinedSqlTags], bool]) -> int:  # noqa: D
         raise NotImplementedError
 
     def list_tables(self, schema_name: str) -> Sequence[str]:  # noqa: D

--- a/metricflow/sql_clients/redshift.py
+++ b/metricflow/sql_clients/redshift.py
@@ -1,6 +1,6 @@
 import logging
 import textwrap
-from typing import ClassVar, Optional, Mapping, Union, Sequence
+from typing import ClassVar, Optional, Mapping, Union, Sequence, Callable
 
 import sqlalchemy
 
@@ -9,7 +9,7 @@ from metricflow.protocols.sql_client import SqlEngineAttributes
 from metricflow.protocols.sql_request import SqlRequestTagSet
 from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
-from metricflow.sql_clients.async_request import SqlStatementCommentMetadata
+from metricflow.sql_clients.async_request import SqlStatementCommentMetadata, CombinedSqlTags
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
 from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
 
@@ -101,7 +101,7 @@ class RedshiftSqlClient(SqlAlchemySqlClient):
         for request_id in self.active_requests():
             self.cancel_request(SqlRequestTagSet.create_from_request_id(request_id))
 
-    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+    def cancel_request(self, match_function: Callable[[CombinedSqlTags], bool]) -> int:  # noqa: D
         result = self.query(
             textwrap.dedent(
                 """\
@@ -115,10 +115,10 @@ class RedshiftSqlClient(SqlAlchemySqlClient):
         num_cancelled_queries = 0
 
         for query_id, query_text in result.values:
-            tag_set = SqlStatementCommentMetadata.parse_tag_metadata_in_comments(query_text)
+            parsed_tags = SqlStatementCommentMetadata.parse_tag_metadata_in_comments(query_text)
 
             # Check for a match where the query's tag
-            if tag_set and pattern_tag_set.is_subset_of(tag_set):
+            if match_function(parsed_tags):
                 logger.info(f"Cancelling query ID: {query_id}")
                 self.execute(f"CANCEL {query_id}")
                 num_cancelled_queries += 1

--- a/metricflow/sql_clients/sqlalchemy_dialect.py
+++ b/metricflow/sql_clients/sqlalchemy_dialect.py
@@ -4,7 +4,7 @@ import logging
 import time
 from abc import ABC
 from contextlib import contextmanager
-from typing import Iterator, Optional, Mapping, Union, Sequence, Set
+from typing import Iterator, Optional, Mapping, Union, Sequence, Set, Callable
 
 import pandas as pd
 import sqlalchemy
@@ -13,6 +13,7 @@ from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlIsolationLevel
 from metricflow.protocols.sql_request import SqlRequestTagSet, SqlJsonTag
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
+from metricflow.sql_clients.async_request import CombinedSqlTags
 from metricflow.sql_clients.base_sql_client_implementation import BaseSqlClientImplementation
 from metricflow.sql_clients.common_client import check_isolation_level
 
@@ -168,5 +169,5 @@ class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
         if errors:
             raise ValueError(f"Found errors in the URL: {url}\n" + "\n".join(errors))
 
-    def cancel_request(self, pattern_tag_set: SqlRequestTagSet) -> int:  # noqa: D
+    def cancel_request(self, match_function: Callable[[CombinedSqlTags], bool]) -> int:  # noqa: D
         raise NotImplementedError


### PR DESCRIPTION
This PR updates `AsyncSqlClient.cancel_request` so that a filtering / matching function can be used to select which queries to cancel.