### PR TITLE
Update join for output metrics to consolidate NULL dimension values

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -1160,6 +1160,17 @@ class CombineMetricsNode(Generic[SourceDataSetT], ComputedMetricsOutput[SourceDa
         return "Combine Metrics"
 
     @property
+    def displayed_properties(self) -> List[DisplayedProperty]:
+        """Prints details about the join types and how the node will behave"""
+        custom_properties = [DisplayedProperty("join type", self.join_type)]
+        if self.join_type is SqlJoinType.FULL_OUTER:
+            custom_properties.append(
+                DisplayedProperty("de-duplication method", "post-join aggregation across all dimensions")
+            )
+
+        return super().displayed_properties + custom_properties
+
+    @property
     def join_type(self) -> SqlJoinType:
         """The type of join used for combining metrics."""
         return self._join_type

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -113,6 +113,7 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
                 ("u0004114", "l3141592", "2020-01-02", "2020-01-02"),
                 ("u1612112", "l2718281", "2020-01-02", "2020-01-02"),
                 ("u0004114", "", "2020-01-02", "2020-01-02"),
+                ("u0004114", "l7891283-incomplete", "2020-01-02", "2020-01-02"),
             ],
         ),
     )
@@ -130,6 +131,7 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
                 ("l2718281", cote_divoire, 4, False, "u0005432", "2020-01-02"),
                 ("l9658588-incomplete", "us", None, None, "u1004114", "2020-01-02"),
                 ("l8912456-incomplete", None, None, None, "u1004114", "2020-01-02"),
+                ("l7891283-incomplete", "ca", None, False, "u1004114", "2020-01-02"),
             ],
         ),
     )
@@ -153,6 +155,7 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
                 ("l9658588-incomplete", None, None, None, "u1004114", "2020-01-01", "2020-01-02"),
                 ("l9658588-incomplete", "us", None, None, "u1004114", "2020-01-02", None),
                 ("l8912456-incomplete", None, None, None, "u1004114", "2020-01-02", None),
+                ("l7891283-incomplete", "ca", None, False, "u1004114", "2020-01-02", None),
             ],
         ),
     )

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -48,6 +48,8 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
         ("u0004114", "u0003141", "l2718281", 241.14, True, "2020-01-02", "2020-01-02", "2020-01-03", None),
         ("u0004114", "u0003141", "l3141592", 799.99, False, "2020-01-02", "2020-01-02", "2020-01-03", None),
         ("u0005432", "u0003452", "l2718281", 319.85, True, "2020-01-02", "2020-01-02", "2020-01-03", "u0003452"),
+        ("u0004114", "u1004114", "l9658588-incomplete", 0.0, False, "2020-01-02", "2020-01-02", "2020-01-03", None),
+        ("u0004114", "u1004114", "l8912456-incomplete", 0.0, False, "2020-01-02", "2020-01-02", "2020-01-03", None),
         ("u0003452", "u0005432", "l3141592", 519.89, False, "2020-01-02", "2020-01-02", "2020-01-03", "u0003141"),
         ("u0003452", "u0004114", "l5948301", 332.23, False, "2020-01-02", "2020-01-02", "2020-01-03", "u0003141"),
         ("u1003452", "u1004114", "no_such_listing", 0.0, False, "2020-01-02", "2020-01-02", "2020-01-03", None),
@@ -110,6 +112,7 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
                 ("u0004114", "l2718281", "2020-01-02", "2020-01-02"),
                 ("u0004114", "l3141592", "2020-01-02", "2020-01-02"),
                 ("u1612112", "l2718281", "2020-01-02", "2020-01-02"),
+                ("u0004114", "", "2020-01-02", "2020-01-02"),
             ],
         ),
     )
@@ -125,6 +128,8 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
                 ("l3141592", "us", 3, True, "u0004114", "2020-01-01"),
                 ("l5948301", "us", 5, True, "u0004114", "2020-01-02"),
                 ("l2718281", cote_divoire, 4, False, "u0005432", "2020-01-02"),
+                ("l9658588-incomplete", "us", None, None, "u1004114", "2020-01-02"),
+                ("l8912456-incomplete", None, None, None, "u1004114", "2020-01-02"),
             ],
         ),
     )
@@ -145,6 +150,9 @@ def create_simple_model_tables(mf_test_session_state: MetricFlowTestSessionState
                 # This cote_divoire property changed hands to a person from Maryland who considers it not lux
                 ("l2718281", cote_divoire, 4, False, "u0003154", "2020-01-02", None),
                 ("l5948301", "us", 5, True, "u0004114", "2020-01-02", None),
+                ("l9658588-incomplete", None, None, None, "u1004114", "2020-01-01", "2020-01-02"),
+                ("l9658588-incomplete", "us", None, None, "u1004114", "2020-01-02", None),
+                ("l8912456-incomplete", None, None, None, "u1004114", "2020-01-02", None),
             ],
         ),
     )

--- a/metricflow/test/integration/test_cases/itest_composite_identifier.yaml
+++ b/metricflow/test/integration/test_cases/itest_composite_identifier.yaml
@@ -50,7 +50,7 @@ integration_test:
       , m.team_id AS user_team___team_id
       , m.user_id AS user_team___user_id
     FROM {{ source_schema }}.fct_messages m
-    JOIN {{ source_schema }}.fct_users u
+    LEFT OUTER JOIN {{ source_schema }}.fct_users u
       ON m.team_id = u.team_id
       AND m.user_id = u.id
     GROUP BY
@@ -72,7 +72,7 @@ integration_test:
       , m.team_id AS user_team___team_id
       , m.user_id AS user_team___user_id
     FROM {{ source_schema }}.fct_messages m
-    JOIN {{ source_schema }}.fct_users u
+    LEFT OUTER JOIN {{ source_schema }}.fct_users u
       ON m.team_id = u.team_id
       AND m.user_id = u.id
     GROUP BY
@@ -94,7 +94,7 @@ integration_test:
       , m.team_id AS user_team___team_id
       , m.user_id AS user_team___user_id
     FROM {{ source_schema }}.fct_messages m
-    JOIN {{ source_schema }}.fct_users u
+    LEFT OUTER JOIN {{ source_schema }}.fct_users u
       ON m.team_id = u.team_id
       AND m.user_id = u.id
     GROUP BY
@@ -113,10 +113,10 @@ integration_test:
       SUM(1) AS messages
       , fum.user_element as user_team__user_id__user_element
     FROM {{ source_schema }}.fct_messages m
-    JOIN {{ source_schema }}.fct_users fu
+    LEFT OUTER JOIN {{ source_schema }}.fct_users fu
       ON m.team_id = fu.team_id
       AND m.user_id = fu.id
-    JOIN {{ source_schema }}.fct_users_more fum
+    LEFT OUTER JOIN {{ source_schema }}.fct_users_more fum
       ON fum.id = fu.id
     GROUP BY
       fum.user_element
@@ -132,10 +132,10 @@ integration_test:
       SUM(1) AS messages
       , fum.user_element as user_team__user_composite_ident_2__user_element
     FROM {{ source_schema }}.fct_messages m
-    JOIN {{ source_schema }}.fct_users fu
+    LEFT OUTER JOIN {{ source_schema }}.fct_users fu
       ON m.team_id = fu.team_id
       AND m.user_id = fu.id
-    JOIN {{ source_schema }}.fct_users_more fum
+    LEFT OUTER JOIN {{ source_schema }}.fct_users_more fum
       ON fum.id = fu.id
     GROUP BY
       fum.user_element

--- a/metricflow/test/integration/test_cases/itest_constraints.yaml
+++ b/metricflow/test/integration/test_cases/itest_constraints.yaml
@@ -4,7 +4,7 @@ integration_test:
   description: Query a metric with a constraint that was requested as a dimension
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
-  group_bys: ["metric_time","is_instant"]
+  group_bys: ["metric_time", "is_instant"]
   where_constraint: "is_instant"
   check_query: |
     SELECT  SUM(booking_value) AS booking_value
@@ -42,7 +42,7 @@ integration_test:
     SELECT SUM(booking_value) AS booking_value
       , is_instant
     FROM  {{ source_schema }}.fct_bookings b
-    JOIN  {{ source_schema }}.dim_listings_latest l ON b.listing_id = l.listing_id
+    LEFT OUTER JOIN  {{ source_schema }}.dim_listings_latest l ON b.listing_id = l.listing_id
     WHERE l.country = 'us'
     GROUP BY  is_instant
 ---
@@ -58,9 +58,8 @@ integration_test:
       , ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
     WHERE ds = '2020-01-01'
-    GROUP BY 
+    GROUP BY
       ds
-
 ---
 integration_test:
   name: test_time_constraint_with_addition_dimension
@@ -74,7 +73,7 @@ integration_test:
     SELECT  SUM(booking_value) AS booking_value
       , ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
-    WHERE is_instant 
+    WHERE is_instant
       and ds = '2020-01-01'
     GROUP BY ds
 ---
@@ -83,14 +82,14 @@ integration_test:
   description: Test a time constraint with a boolean
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
-  group_bys: ["metric_time","is_instant"]
+  group_bys: ["metric_time", "is_instant"]
   where_constraint: "is_instant"
   check_query: |
     SELECT  SUM(booking_value) AS booking_value
       , is_instant
       , ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
-    WHERE is_instant 
+    WHERE is_instant
     GROUP BY ds
       ,is_instant
 ---
@@ -105,10 +104,9 @@ integration_test:
     SELECT  SUM(b.booking_value) AS booking_value
       , b.ds AS metric_time
     FROM  {{ source_schema }}.fct_bookings b
-    JOIN  {{ source_schema }}.dim_listings_latest l ON b.listing_id = l.listing_id
+    LEFT OUTER JOIN  {{ source_schema }}.dim_listings_latest l ON b.listing_id = l.listing_id
     WHERE l.capacity >= 4
     GROUP BY  b.ds
-
 ---
 integration_test:
   name: test_time_constraint_on_time_dimension_with_an_expression
@@ -123,7 +121,6 @@ integration_test:
     FROM  {{source_schema}}.dim_listings_latest l
     WHERE {{ render_time_constraint("created_at", "2020-01-01", "2021-01-01") }}
     GROUP BY  created_at
-
 ---
 integration_test:
   name: test_metric_time_in_where

--- a/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
+++ b/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
@@ -26,7 +26,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: windowed_cumulative_metric_with_joined_dim
@@ -53,14 +52,13 @@ integration_test:
         , u.home_state_latest as user__home_state_latest
         , m.created_at AS ds
       FROM {{ source_schema }}.fct_revenue m
-      INNER JOIN {{ source_schema }}.dim_users_latest u
+      LEFT OUTER JOIN {{ source_schema }}.dim_users_latest u
       ON m.user_id = u.user_id
       GROUP BY m.created_at, m.revenue, u.home_state_latest
     ) b
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
     GROUP BY a.ds, user__home_state_latest
     ORDER by a.ds, user__home_state_latest
-
 ---
 integration_test:
   name: cumulative_metric_by_ds
@@ -88,7 +86,6 @@ integration_test:
     ON b.created_at <= a.ds
     GROUP BY a.ds
     ORDER by a.ds
-
 ---
 integration_test:
   name: cumulative_metric_without_ds
@@ -99,7 +96,6 @@ integration_test:
     SELECT
       SUM(revenue) AS revenue_all_time
     FROM {{ source_schema }}.fct_revenue
-
 ---
 integration_test:
   name: multiple_cumulative_metrics
@@ -155,7 +151,6 @@ integration_test:
     ) b
     ON a.ds = b.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: windowed_cumulative_metric_by_time_dimension_with_granularity
@@ -184,7 +179,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: cumulative_metric_by_ds_and_limited_time
@@ -212,7 +206,6 @@ integration_test:
     ON b.created_at <= a.ds
     GROUP BY a.ds
     ORDER by a.ds
-
 ---
 integration_test:
   name: non_additive_cumulative_metric_by_ds
@@ -240,9 +233,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.DAY) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
-
-
 ---
 integration_test:
   name: non_additive_cumulative_metric_by_ds_and_limited_time
@@ -270,7 +260,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.DAY) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
 ---
 integration_test:
   name: grain_to_date_cumulative_metric
@@ -299,8 +288,6 @@ integration_test:
     ON b.ds <= a.ds AND b.ds >= {{ render_date_trunc("a.ds", TimeGranularity.MONTH) }}
     GROUP BY a.ds
     ORDER BY a.ds
-
-
 ---
 integration_test:
   name: cumulative_metric_by_ds_with_granularity

--- a/metricflow/test/integration/test_cases/itest_dimensions.yaml
+++ b/metricflow/test/integration/test_cases/itest_dimensions.yaml
@@ -11,9 +11,9 @@ integration_test:
       , u.home_state_latest AS user__home_state_latest
       , l.is_lux AS listing__is_lux_latest
     FROM {{ source_schema }}.fct_views v
-    JOIN {{ source_schema }}.dim_listings_latest l
+    LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest l
       ON l.listing_id = v.listing_id
-    JOIN {{ source_schema }}.dim_users_latest u
+    LEFT OUTER JOIN {{ source_schema }}.dim_users_latest u
       ON u.user_id = v.user_id
     GROUP BY
       u.home_state_latest
@@ -61,9 +61,9 @@ integration_test:
       , u.home_state_latest AS user__home_state_latest
       , v.listing_id AS listing
     FROM {{ source_schema }}.fct_views v
-    JOIN {{ source_schema }}.dim_listings_latest l
+    LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest l
       ON l.listing_id = v.listing_id
-    JOIN {{ source_schema }}.dim_users_latest u
+    LEFT OUTER JOIN {{ source_schema }}.dim_users_latest u
       ON u.user_id = v.user_id
     GROUP BY
       v.listing_id
@@ -96,10 +96,9 @@ integration_test:
       , u.home_state AS user__home_state
       , v.ds AS metric_time
     FROM {{ source_schema }}.fct_id_verifications v
-    JOIN {{ source_schema }}.dim_users u
+    LEFT OUTER JOIN {{ source_schema }}.dim_users u
       ON u.user_id = v.user_id
       AND u.ds = v.ds
     GROUP BY
       v.ds
       , u.home_state
-

--- a/metricflow/test/integration/test_cases/itest_granularity.yaml
+++ b/metricflow/test/integration/test_cases/itest_granularity.yaml
@@ -161,7 +161,7 @@ integration_test:
       SUM(booking) AS bookings
       , {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS listing_id__listing_creation_ds
     FROM {{ source_schema }}.fct_bookings_extended b
-    JOIN {{ source_schema }}.dim_listings_extended l
+    LEFT OUTER JOIN {{ source_schema }}.dim_listings_extended l
     ON b.listing_id = l.listing_id
     GROUP BY
       listing_id__listing_creation_ds
@@ -178,7 +178,7 @@ integration_test:
       SUM(booking) AS bookings
       , {{ render_date_trunc("l.listing_creation_ds", TimeGranularity.MONTH) }} AS listing_id__listing_creation_ds__month
     FROM {{ source_schema }}.fct_bookings_extended b
-    JOIN {{ source_schema }}.dim_listings_extended l
+    LEFT OUTER JOIN {{ source_schema }}.dim_listings_extended l
     ON b.listing_id = l.listing_id
     GROUP BY
       listing_id__listing_creation_ds__month

--- a/metricflow/test/integration/test_cases/itest_measure_constraints.yaml
+++ b/metricflow/test/integration/test_cases/itest_measure_constraints.yaml
@@ -137,7 +137,7 @@ integration_test:
         CAST(SUM(account_balance) AS {{ double_data_type_name }}) AS total_account_balance_first_day
         , fa_west_filtered.ds
       FROM (
-        SELECT 
+        SELECT
           fa_west.ds
           , fa_west.ds AS metric_time
           , user_id AS user
@@ -163,7 +163,7 @@ integration_test:
         CAST(SUM(account_balance) AS {{ double_data_type_name }}) AS total_account_balance_first_day
         , fa_east_filtered.ds
       FROM (
-        SELECT 
+        SELECT
           fa_east.ds
           , fa_east.ds AS metric_time
           , user_id AS user

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -598,7 +598,7 @@ integration_test:
 ---
 integration_test:
   name: three_metrics_with_null_dimension_values
-  description: Tests querying three metrics with a dimension having NULL values
+  description: Tests querying three metrics with a dimension having NULL values and the on clause COALESCE behavior
   model: SIMPLE_MODEL
   metrics: ["bookings", "views", "listings"]
   group_bys: ["listing__is_lux_latest", "listing__country_latest"]
@@ -638,4 +638,4 @@ integration_test:
       FROM {{ source_schema }}.dim_listings_latest
       GROUP BY 1,2
     ) li
-    ON bk.is_lux = li.is_lux AND bk.country = li.country
+    ON COALESCE(bk.is_lux, vw.is_lux) = li.is_lux AND COALESCE(bk.country, vw.country) = li.country

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -567,8 +567,8 @@ integration_test:
     ["metric_time", "listing__is_lux_latest", "listing__country_latest"]
   check_query: |
     SELECT
-      bk.bookings
-      ,vw.views
+      MAX(bk.bookings) AS bookings
+      ,MAX(vw.views) AS views
       ,COALESCE(bk.metric_time, vw.metric_time) AS metric_time
       ,COALESCE(bk.is_lux, vw.is_lux) AS listing__is_lux_latest
       ,COALESCE(bk.country, vw.country) AS listing__country_latest
@@ -595,6 +595,7 @@ integration_test:
         GROUP BY 1,2,3
     ) vw
     ON bk.metric_time = vw.metric_time AND bk.is_lux = vw.is_lux AND bk.country = vw.country
+    GROUP BY 3,4,5
 ---
 integration_test:
   name: three_metrics_with_null_dimension_values
@@ -604,9 +605,9 @@ integration_test:
   group_bys: ["listing__is_lux_latest", "listing__country_latest"]
   check_query: |
     SELECT
-      bk.bookings
-      ,vw.views
-      ,li.listings
+      MAX(bk.bookings) AS bookings
+      ,MAX(vw.views) AS views
+      ,MAX(li.listings) AS listings
       ,COALESCE(bk.is_lux, vw.is_lux, li.is_lux) AS listing__is_lux_latest
       ,COALESCE(bk.country, vw.country, li.country) AS listing__country_latest
     FROM (
@@ -639,3 +640,4 @@ integration_test:
       GROUP BY 1,2
     ) li
     ON COALESCE(bk.is_lux, vw.is_lux) = li.is_lux AND COALESCE(bk.country, vw.country) = li.country
+    GROUP BY 4,5

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -164,7 +164,7 @@ integration_test:
       SUM(b.booking_value) AS instant_booking_value
       , b.ds AS metric_time
     FROM {{ source_schema }}.fct_bookings b
-    JOIN {{ source_schema }}.dim_listings_latest l
+    LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest l
       ON l.listing_id = b.listing_id
     WHERE
       b.is_instant
@@ -337,7 +337,7 @@ integration_test:
 ---
 integration_test:
   name: ratio_primary_ident
-  description: Test ratio metric from a single data source.
+  description: Test ratio metric joined on primary identifier.
   model: SIMPLE_MODEL
   metrics: ["bookings_per_listing"]
   group_bys: ["metric_time"]

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -557,3 +557,85 @@ integration_test:
       GROUP BY
         ds
     ) a
+---
+integration_test:
+  name: two_metrics_with_null_dimension_values
+  description: Tests querying two metrics with a dimension having a NULL values
+  model: SIMPLE_MODEL
+  metrics: ["bookings", "views"]
+  group_bys:
+    ["metric_time", "listing__is_lux_latest", "listing__country_latest"]
+  check_query: |
+    SELECT
+      bk.bookings
+      ,vw.views
+      ,COALESCE(bk.metric_time, vw.metric_time) AS metric_time
+      ,COALESCE(bk.is_lux, vw.is_lux) AS listing__is_lux_latest
+      ,COALESCE(bk.country, vw.country) AS listing__country_latest
+    FROM (
+      SELECT
+        a.ds AS metric_time
+        ,b.is_lux
+        ,b.country
+        ,SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings a
+      LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest b
+      ON a.listing_id = b.listing_id
+      GROUP BY 1,2,3
+    ) bk
+    FULL OUTER JOIN (
+      SELECT
+        c.ds AS metric_time
+        ,d.is_lux
+        ,d.country
+        ,SUM(1) AS views
+        FROM {{ source_schema }}.fct_views c
+        LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest d
+        ON c.listing_id = d.listing_id
+        GROUP BY 1,2,3
+    ) vw
+    ON bk.metric_time = vw.metric_time AND bk.is_lux = vw.is_lux AND bk.country = vw.country
+---
+integration_test:
+  name: three_metrics_with_null_dimension_values
+  description: Tests querying three metrics with a dimension having NULL values
+  model: SIMPLE_MODEL
+  metrics: ["bookings", "views", "listings"]
+  group_bys: ["listing__is_lux_latest", "listing__country_latest"]
+  check_query: |
+    SELECT
+      bk.bookings
+      ,vw.views
+      ,li.listings
+      ,COALESCE(bk.is_lux, vw.is_lux, li.is_lux) AS listing__is_lux_latest
+      ,COALESCE(bk.country, vw.country, li.country) AS listing__country_latest
+    FROM (
+      SELECT
+        b.is_lux
+        ,b.country
+        ,SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings a
+      LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest b
+      ON a.listing_id = b.listing_id
+      GROUP BY 1,2
+    ) bk
+    FULL OUTER JOIN (
+      SELECT
+        d.is_lux
+        ,d.country
+        ,SUM(1) AS views
+        FROM {{ source_schema }}.fct_views c
+        LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest d
+        ON c.listing_id = d.listing_id
+        GROUP BY 1,2
+    ) vw
+    ON bk.is_lux = vw.is_lux AND bk.country = vw.country
+    FULL OUTER JOIN (
+      SELECT
+        is_lux
+        ,country
+        ,SUM(1) AS listings
+      FROM {{ source_schema }}.dim_listings_latest
+      GROUP BY 1,2
+    ) li
+    ON bk.is_lux = li.is_lux AND bk.country = li.country

--- a/metricflow/test/integration/test_cases/itest_multi_hop_join.yaml
+++ b/metricflow/test/integration/test_cases/itest_multi_hop_join.yaml
@@ -10,9 +10,9 @@ integration_test:
         ct.customer_name as account_id__customer_id__customer_name
         , SUM(am.txn_count) as txn_count
     FROM {{ source_schema }}.bridge_table bt
-    JOIN {{ source_schema }}.customer_table ct
+    LEFT OUTER JOIN {{ source_schema }}.customer_table ct
       ON ct.customer_id = bt.customer_id
-    JOIN {{ source_schema }}.account_month_txns am
+    LEFT OUTER JOIN {{ source_schema }}.account_month_txns am
       ON bt.account_id = am.account_id
     GROUP BY
       ct.customer_name
@@ -22,7 +22,11 @@ integration_test:
   description: Tests a query requesting mulitple multi-hop join dims that dont come from the same data source
   model: UNPARTITIONED_MULTI_HOP_JOIN_MODEL
   metrics: ["txn_count"]
-  group_bys: ["account_id__customer_id__customer_name", "account_id__customer_id__country"]
+  group_bys:
+    [
+      "account_id__customer_id__customer_name",
+      "account_id__customer_id__country",
+    ]
   check_query: |
     SELECT
       dim_src0.customer_name as account_id__customer_id__customer_name
@@ -52,16 +56,20 @@ integration_test:
   description: Tests a query requesting mulitple multi-hop join dims from the same source
   model: UNPARTITIONED_MULTI_HOP_JOIN_MODEL
   metrics: ["txn_count"]
-  group_bys: ["account_id__customer_id__customer_name", "account_id__customer_id__customer_atomic_weight"]
+  group_bys:
+    [
+      "account_id__customer_id__customer_name",
+      "account_id__customer_id__customer_atomic_weight",
+    ]
   check_query: |
     SELECT
       ct.customer_name as account_id__customer_id__customer_name
       , ct.customer_atomic_weight as account_id__customer_id__customer_atomic_weight
       , SUM(am.txn_count) as txn_count
     FROM {{ source_schema }}.bridge_table bt
-    JOIN {{ source_schema }}.customer_table ct
+    LEFT OUTER JOIN {{ source_schema }}.customer_table ct
       ON ct.customer_id = bt.customer_id
-    JOIN {{ source_schema }}.account_month_txns am
+    LEFT OUTER JOIN {{ source_schema }}.account_month_txns am
       ON bt.account_id = am.account_id
     GROUP BY
       ct.customer_name
@@ -72,7 +80,12 @@ integration_test:
   description: Tests a query with multihop and single hop join dimensions
   model: UNPARTITIONED_MULTI_HOP_JOIN_MODEL
   metrics: ["txn_count"]
-  group_bys: ["account_id__customer_id__customer_name", "account_id__customer_id__country", "account_id__extra_dim"]
+  group_bys:
+    [
+      "account_id__customer_id__customer_name",
+      "account_id__customer_id__country",
+      "account_id__extra_dim",
+    ]
   check_query: |
     SELECT
       dim_src0.customer_name as account_id__customer_id__customer_name

--- a/metricflow/test/integration/test_cases/itest_partitions.yaml
+++ b/metricflow/test/integration/test_cases/itest_partitions.yaml
@@ -26,7 +26,7 @@ integration_test:
       SUM(1) AS identity_verifications
       , dim.home_state AS user__home_state
     FROM {{ source_schema }}.fct_id_verifications fct
-    JOIN {{ source_schema }}.dim_users dim
+    LEFT OUTER JOIN {{ source_schema }}.dim_users dim
       ON fct.user_id = dim.user_id
         AND fct.ds_partitioned = dim.ds_partitioned
     GROUP BY
@@ -44,7 +44,7 @@ integration_test:
       , fct.ds_partitioned AS ds_partitioned
       , dim.home_state AS user__home_state
     FROM {{ source_schema }}.fct_id_verifications fct
-    JOIN {{ source_schema }}.dim_users dim
+    LEFT OUTER JOIN {{ source_schema }}.dim_users dim
       ON fct.user_id = dim.user_id
         AND fct.ds_partitioned = dim.ds_partitioned
     GROUP BY
@@ -62,7 +62,7 @@ integration_test:
       SUM(1) AS identity_verifications
       , dim.home_state_latest AS user__home_state_latest
     FROM {{ source_schema }}.fct_id_verifications fct
-    JOIN {{ source_schema }}.dim_users_latest dim
+    LEFT OUTER JOIN {{ source_schema }}.dim_users_latest dim
       ON fct.user_id = dim.user_id
     GROUP BY
       dim.home_state_latest
@@ -80,7 +80,7 @@ integration_test:
       , fct.ds_partitioned AS ds_partitioned
       , dim.home_state AS user__home_state
     FROM {{ source_schema }}.fct_id_verifications fct
-    JOIN {{ source_schema }}.dim_users dim
+    LEFT OUTER JOIN {{ source_schema }}.dim_users dim
       ON fct.user_id = dim.user_id
         AND fct.ds_partitioned = dim.ds_partitioned
         WHERE {{ render_time_constraint("fct.ds_partitioned", "2020-01-01", "2020-01-01") }}

--- a/metricflow/test/integration/test_cases/itest_simple_non_ds.yaml
+++ b/metricflow/test/integration/test_cases/itest_simple_non_ds.yaml
@@ -13,7 +13,7 @@ integration_test:
       , l.country AS listing__country_latest
       , b.dt AS dt
     FROM {{ source_schema }}.fct_bookings_dt b
-    JOIN {{ source_schema }}.dim_listings_latest l
+    LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest l
       ON b.listing_id = l.listing_id
     WHERE {{ render_time_constraint("dt", "2020-01-01", "2020-01-01") }}
     GROUP BY

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_data_source__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_data_source__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
@@ -7,9 +7,9 @@
         <!--   SELECT                                                                                  -->
         <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
         <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , subq_12.bookings AS bookings                                                        -->
-        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_14.booking_value AS booking_value                                              -->
+        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
+        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -91,5 +91,8 @@
         <!--     ) AND (                                                                               -->
         <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
+        <!--   GROUP BY                                                                                -->
+        <!--     ds                                                                                    -->
+        <!--     , is_instant                                                                          -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -6,8 +6,8 @@
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
         <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , subq_8.bookings AS bookings                                 -->
-        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
         <!--     -- Compute Metrics via Expressions                            -->
@@ -49,5 +49,7 @@
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
         <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--   GROUP BY                                                        -->
+        <!--     is_instant                                                    -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -7,9 +7,9 @@
         <!--   SELECT                                                                                  -->
         <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
         <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , subq_12.bookings AS bookings                                                        -->
-        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_14.booking_value AS booking_value                                              -->
+        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
+        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -91,5 +91,8 @@
         <!--     ) AND (                                                                               -->
         <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
+        <!--   GROUP BY                                                                                -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -6,8 +6,8 @@
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
         <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , subq_8.bookings AS bookings                                 -->
-        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
         <!--     -- Compute Metrics via Expressions                            -->
@@ -49,5 +49,7 @@
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
         <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--   GROUP BY                                                        -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -7,9 +7,9 @@
         <!--   SELECT                                                                                  -->
         <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
         <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , subq_12.bookings AS bookings                                                        -->
-        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_14.booking_value AS booking_value                                              -->
+        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
+        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -91,5 +91,8 @@
         <!--     ) AND (                                                                               -->
         <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
+        <!--   GROUP BY                                                                                -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -6,8 +6,8 @@
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
         <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , subq_8.bookings AS bookings                                 -->
-        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
         <!--     -- Compute Metrics via Expressions                            -->
@@ -49,5 +49,7 @@
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
         <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--   GROUP BY                                                        -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -7,9 +7,9 @@
         <!--   SELECT                                                                                  -->
         <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
         <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , subq_12.bookings AS bookings                                                        -->
-        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_14.booking_value AS booking_value                                              -->
+        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
+        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -91,5 +91,8 @@
         <!--     ) AND (                                                                               -->
         <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
+        <!--   GROUP BY                                                                                -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -6,8 +6,8 @@
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
         <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , subq_8.bookings AS bookings                                 -->
-        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
         <!--     -- Compute Metrics via Expressions                            -->
@@ -49,5 +49,7 @@
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
         <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--   GROUP BY                                                        -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -7,9 +7,9 @@
         <!--   SELECT                                                                                  -->
         <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
         <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , subq_12.bookings AS bookings                                                        -->
-        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_14.booking_value AS booking_value                                              -->
+        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
+        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -91,5 +91,8 @@
         <!--     ) AND (                                                                               -->
         <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
+        <!--   GROUP BY                                                                                -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -6,8 +6,8 @@
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
         <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , subq_8.bookings AS bookings                                 -->
-        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
         <!--     -- Compute Metrics via Expressions                            -->
@@ -49,5 +49,7 @@
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
         <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--   GROUP BY                                                        -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -7,9 +7,9 @@
         <!--   SELECT                                                                                  -->
         <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
         <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , subq_12.bookings AS bookings                                                        -->
-        <!--     , subq_13.instant_bookings AS instant_bookings                                        -->
-        <!--     , subq_14.booking_value AS booking_value                                              -->
+        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
+        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
         <!--   FROM (                                                                                  -->
         <!--     -- Aggregate Measures                                                                 -->
         <!--     -- Compute Metrics via Expressions                                                    -->
@@ -91,5 +91,8 @@
         <!--     ) AND (                                                                               -->
         <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
         <!--     )                                                                                     -->
+        <!--   GROUP BY                                                                                -->
+        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -6,8 +6,8 @@
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
         <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , subq_8.bookings AS bookings                                 -->
-        <!--     , subq_9.booking_value AS booking_value                       -->
+        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
         <!--     -- Compute Metrics via Expressions                            -->
@@ -49,5 +49,7 @@
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
         <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--   GROUP BY                                                        -->
+        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_value AS booking_value
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -271,3 +271,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_value AS booking_value
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_10.bookings AS bookings
-  , subq_11.listings AS listings
+  MAX(subq_10.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_22.bookings AS bookings
-  , subq_23.listings AS listings
+  MAX(subq_22.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_value AS booking_value
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -271,3 +271,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_value AS booking_value
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_10.bookings AS bookings
-  , subq_11.listings AS listings
+  MAX(subq_10.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_22.bookings AS bookings
-  , subq_23.listings AS listings
+  MAX(subq_22.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_value AS booking_value
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -271,3 +271,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_value AS booking_value
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_10.bookings AS bookings
-  , subq_11.listings AS listings
+  MAX(subq_10.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_22.bookings AS bookings
-  , subq_23.listings AS listings
+  MAX(subq_22.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_value AS booking_value
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -271,3 +271,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_value AS booking_value
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_10.bookings AS bookings
-  , subq_11.listings AS listings
+  MAX(subq_10.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_22.bookings AS bookings
-  , subq_23.listings AS listings
+  MAX(subq_22.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_value AS booking_value
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -271,3 +271,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_value AS booking_value
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_10.bookings AS bookings
-  , subq_11.listings AS listings
+  MAX(subq_10.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_22.bookings AS bookings
-  , subq_23.listings AS listings
+  MAX(subq_22.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_value AS booking_value
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -271,3 +271,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_value AS booking_value
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_10.bookings AS bookings
-  , subq_11.listings AS listings
+  MAX(subq_10.bookings) AS bookings
+  , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
   SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  subq_22.bookings AS bookings
-  , subq_23.listings AS listings
+  MAX(subq_22.bookings) AS bookings
+  , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_common_data_source__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_common_data_source__plan0.xml
@@ -4,16 +4,16 @@
         <!-- node_id = ss_15 -->
         <!-- col0 =                                                                            -->
         <!--   {'class': 'SqlSelectColumn',                                                    -->
-        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
         <!--    'column_alias': 'metric_time'}                                                 -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
-        <!--    'column_alias': 'bookings'}                            -->
-        <!-- col2 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
-        <!--    'column_alias': 'booking_value'}                       -->
+        <!-- col1 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+        <!--    'column_alias': 'bookings'}                                               -->
+        <!-- col2 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+        <!--    'column_alias': 'booking_value'}                                          -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
         <!-- join_0 =                                                    -->
         <!--   {'class': 'SqlJoinDescription',                           -->
@@ -21,6 +21,10 @@
         <!--    'right_source_alias': 'subq_9',                          -->
         <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
         <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+        <!-- group_by0 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                                    -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+        <!--    'column_alias': 'metric_time'}                                                 -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multiple_metrics_no_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multiple_metrics_no_dimensions__plan0.xml
@@ -2,14 +2,14 @@
     <SqlSelectStatementNode>
         <!-- description = Combine Metrics -->
         <!-- node_id = ss_21 -->
-        <!-- col0 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_589),  -->
-        <!--    'column_alias': 'bookings'}                            -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_590),  -->
-        <!--    'column_alias': 'listings'}                            -->
+        <!-- col0 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+        <!--    'column_alias': 'bookings'}                                               -->
+        <!-- col1 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+        <!--    'column_alias': 'listings'}                                               -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
         <!-- join_0 =                                                   -->
         <!--   {'class': 'SqlJoinDescription',                          -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_payments AS booking_payments
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -264,3 +264,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_payments AS booking_payments
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_payments AS booking_payments
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -264,3 +264,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_payments AS booking_payments
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_payments AS booking_payments
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -264,3 +264,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_payments AS booking_payments
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_payments AS booking_payments
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -264,3 +264,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_payments AS booking_payments
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_payments AS booking_payments
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -264,3 +264,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_payments AS booking_payments
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , subq_8.bookings AS bookings
-  , subq_9.booking_payments AS booking_payments
+  , MAX(subq_8.bookings) AS bookings
+  , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
   SELECT
@@ -264,3 +264,5 @@ FULL OUTER JOIN (
 ) subq_9
 ON
   subq_8.metric_time = subq_9.metric_time
+GROUP BY
+  COALESCE(subq_8.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Combine Metrics
 SELECT
   COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , subq_18.bookings AS bookings
-  , subq_19.booking_payments AS booking_payments
+  , MAX(subq_18.bookings) AS bookings
+  , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -44,3 +44,5 @@ FULL OUTER JOIN (
 ) subq_19
 ON
   subq_18.metric_time = subq_19.metric_time
+GROUP BY
+  COALESCE(subq_18.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -4,16 +4,16 @@
         <!-- node_id = ss_15 -->
         <!-- col0 =                                                                            -->
         <!--   {'class': 'SqlSelectColumn',                                                    -->
-        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
         <!--    'column_alias': 'metric_time'}                                                 -->
-        <!-- col1 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),  -->
-        <!--    'column_alias': 'bookings'}                            -->
-        <!-- col2 =                                                    -->
-        <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),  -->
-        <!--    'column_alias': 'booking_payments'}                    -->
+        <!-- col1 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX),  -->
+        <!--    'column_alias': 'bookings'}                                               -->
+        <!-- col2 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX),  -->
+        <!--    'column_alias': 'booking_payments'}                                       -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
         <!-- join_0 =                                                    -->
         <!--   {'class': 'SqlJoinDescription',                           -->
@@ -21,6 +21,10 @@
         <!--    'right_source_alias': 'subq_9',                          -->
         <!--    'join_type': SqlJoinType.FULL_OUTER,                     -->
         <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+        <!-- group_by0 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                                    -->
+        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE),  -->
+        <!--    'column_alias': 'metric_time'}                                                 -->
         <!-- where = None -->
         <SqlSelectStatementNode>
             <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_data_source__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_data_source__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_data_sources__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_data_sources__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_data_sources__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_data_sources__dfpo_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_1 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_2 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_data_source__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_data_source__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_data_sources__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_data_sources__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_data_sources__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_data_sources__dfpo_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_1 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_6 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_0 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_1 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_2 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
@@ -13,6 +13,7 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_0 -->
+                <!-- join type = SqlJoinType.INNER -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_1 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_0 -->
@@ -56,6 +58,7 @@
                 <CombineMetricsNode>
                     <!-- description = Combine Metrics -->
                     <!-- node_id = cbm_0 -->
+                    <!-- join type = SqlJoinType.INNER -->
                     <ComputeMetricsNode>
                         <!-- description = Compute Metrics via Expressions -->
                         <!-- node_id = cm_1 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
@@ -5,6 +5,8 @@
         <CombineMetricsNode>
             <!-- description = Combine Metrics -->
             <!-- node_id = cbm_2 -->
+            <!-- join type = SqlJoinType.FULL_OUTER -->
+            <!-- de-duplication method = post-join aggregation across all dimensions -->
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_4 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
@@ -13,6 +13,7 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_1 -->
+                <!-- join type = SqlJoinType.INNER -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_2 -->
@@ -24,6 +25,7 @@
                     <CombineMetricsNode>
                         <!-- description = Combine Metrics -->
                         <!-- node_id = cbm_0 -->
+                        <!-- join type = SqlJoinType.INNER -->
                         <ComputeMetricsNode>
                             <!-- description = Compute Metrics via Expressions -->
                             <!-- node_id = cm_0 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
@@ -13,6 +13,7 @@
             <CombineMetricsNode>
                 <!-- description = Combine Metrics -->
                 <!-- node_id = cbm_2 -->
+                <!-- join type = SqlJoinType.INNER -->
                 <ComputeMetricsNode>
                     <!-- description = Compute Metrics via Expressions -->
                     <!-- node_id = cm_9 -->


### PR DESCRIPTION
Up until now, the output of a multi-metric query would do a FULL OUTER JOIN
on all dimension elements to link the metric values to the corresponding dimension.
The ON condition was a simple equality between (coalesced) dimension values. This
resulted in SQL NULL semantics for the output, meaning that NULL = NULL would return
NULL, and therefore the join condition would not be met. As a result, any row with NULL
dimension values would be repeated for each metric.

This PR alters that behavior such that NULL = NULL would be considered the same value, and
so our metrics output will always have exactly one row for each set of distinct dimension values.
It's worth noting that this is true whether the missing values are due to a matching NULL value
in a matched row OR a NULL value caused by a missing key. This change in behavior brings
the multi-metric case in line with the single-metric case, as a GROUP BY will do fundamentally
the same thing, consolidating all NULLs into a single row regardless of if they were caused by
a missing join key or a placed NULL value.

By way of illustration of how the output will change, here is the before and after for a query like 
`mf query --metrics bookings,listings,views --dimensions listing__country_latest,listing__is_lux_latest`.

Before:

```
|   bookings | listing__country_latest   | listing__is_lux_latest   |   listings |   views |
|-----------:|:--------------------------|:-------------------------|-----------:|--------:|
|          1 | us                        |                          |        nan |     nan |
|          2 |                           |                          |        nan |     nan |
|          5 | cote d'ivoire             | False                    |          1 |       2 |
|          7 | us                        | True                     |          2 |       3 |
|        nan | ca                        | False                    |          1 |       1 |
|        nan | ca                        | False                    |          1 |     nan |
|        nan | us                        |                          |          1 |     nan |
|        nan |                           |                          |          1 |     nan |
|        nan |                           |                          |        nan |       1 |
```

After:

```
|   bookings | listing__country_latest   | listing__is_lux_latest   |   listings |   views |
|-----------:|:--------------------------|:-------------------------|-----------:|--------:|
|          1 | us                        |                          |          1 |     nan |
|          2 |                           |                          |          1 |       1 |
|          5 | cote d'ivoire             | False                    |          1 |       2 |
|          7 | us                        | True                     |          2 |       3 |
|        nan | ca                        | False                    |          1 |       1 |
```