### PR TITLE
Pin CI actions to ubuntu 20.04

### DIFF
--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   poetry-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: Pypi Publish
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
     name: Snowflake Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     name: Redshift Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     name: BigQuery Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     name: Databricks Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -143,7 +143,7 @@ jobs:
   postgres-tests:
     name: PostgreSQL Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:
@@ -192,7 +192,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     needs: [snowflake-tests, redshift-tests, bigquery-tests]
     if: ${{ github.event_name != 'pull_request' && failure() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Slack Failure

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   pre-commit:
     name: Run Pre-Commit Linting Hooks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   metricflow-unit-tests-duckdb:
     name: MetricFlow Unit Tests - DuckDB
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
@@ -42,7 +42,7 @@ jobs:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
   metricflow-unit-tests-postgres:
     name: MetricFlow Unit Tests - PostgreSQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:
@@ -88,7 +88,7 @@ jobs:
           MF_SQL_ENGINE_PASSWORD: postgres
   metricflow-unit-tests:
     name: MetricFlow Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ always() }}
     needs: [metricflow-unit-tests-duckdb, metricflow-unit-tests-postgres]
 

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   json-schema-consistency-check:
     name: Schema Consistency Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
The recent update to ubunutu 22.04 seems to have broken a bunch of
stuff with python installs. In all likelihood the fix is going to
involve hacky environment variable overrides or continuous
reinstallation of python-distutils.

Rather than deal with testing all of those things at this time, we
simply pin the ubuntu version back to 20.04 in CI and hope for the
best.
