### PR TITLE
Update CI actions cache keys so they are properly versioned

### DIFF
--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   poetry-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: Pypi Publish
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -27,7 +27,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry
@@ -60,7 +60,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry
@@ -93,7 +93,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry
@@ -126,7 +126,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry
@@ -174,7 +174,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
     name: Snowflake Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     name: Redshift Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     name: BigQuery Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     name: Databricks Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -143,7 +143,7 @@ jobs:
   postgres-tests:
     name: PostgreSQL Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -192,7 +192,7 @@ jobs:
     environment: DW_INTEGRATION_TESTS
     needs: [snowflake-tests, redshift-tests, bigquery-tests]
     if: ${{ github.event_name != 'pull_request' && failure() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Slack Failure

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -30,7 +30,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache
-          key: ${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}-ubuntu-latest-22.04
 
       - name: Install deps
         run: pip install pre-commit

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   pre-commit:
     name: Run Pre-Commit Linting Hooks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   metricflow-unit-tests-duckdb:
     name: MetricFlow Unit Tests - DuckDB
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
@@ -42,7 +42,7 @@ jobs:
           METRICFLOW_CLIENT_EMAIL: ci-tester@gmail.com
   metricflow-unit-tests-postgres:
     name: MetricFlow Unit Tests - PostgreSQL
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -88,7 +88,7 @@ jobs:
           MF_SQL_ENGINE_PASSWORD: postgres
   metricflow-unit-tests:
     name: MetricFlow Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: [metricflow-unit-tests-duckdb, metricflow-unit-tests-postgres]
 

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry
@@ -73,7 +73,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('metricflow/poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   json-schema-consistency-check:
     name: Schema Consistency Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -30,7 +30,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache/pypoetry
-          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
 
       - name: Install Poetry
         run: pip install poetry


### PR DESCRIPTION
This undoes the failed attempt to revert our CI ubuntu runtime to the
previous version, and provides what is hopefully a more robust fix
for the problem.

The CI runner was failing to find matching versioned dependencies in
the hosted tools cache. This was likely caused by one of two things:

1. An update to Ubuntu that updated some system packages
2. A mis-configured cache key (pointing at the wrong poetry.lock file location)

The former is fixed by appending the ubuntu version to the cache key
in our actions/cache configurations.

The latter is fixed by providing the hashFiles call in our actions/cache
configuration with the correct file path for the config file we wish to
hash.

This PR moves us back onto ubuntu-latest, and makes both updates
to our actions cache keys, which will hopefully fix the various CI issues
we're seeing at the moment.