### PR TITLE
Validate each derived metric inputs individually

### DIFF
--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -543,4 +543,15 @@ metric:
         alias: instant
       - name: bookings
 ---
-
+metric:
+  name: "trailing_2_months_revenue_sub_10"
+  description: |
+    Test derived metric with a cumulative metric
+  owners:
+    - support@transformdata.io
+  type: derived
+  type_params:
+    expr: t2mr - 10
+    metrics:
+      - name: trailing_2_months_revenue
+        alias: t2mr

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -157,3 +157,19 @@ def test_parse_and_validate_metric_constraint_dims(query_parser: MetricFlowQuery
             time_constraint_start=as_datetime("2020-01-15"),
             time_constraint_end=as_datetime("2020-02-15"),
         )
+
+
+def test_derived_metric_query_parsing(query_parser: MetricFlowQueryParser) -> None:
+    """Test derived metric inputs are properly validated."""
+
+    # check that no dimension query raises UnableToSatisfyQueryError
+    with pytest.raises(UnableToSatisfyQueryError):
+        query_parser.parse_and_validate_query(
+            metric_names=["trailing_2_months_revenue_sub_10"],
+            group_by_names=[],
+        )
+
+    query_parser.parse_and_validate_query(
+        metric_names=["trailing_2_months_revenue_sub_10"],
+        group_by_names=[MTD],
+    )


### PR DESCRIPTION
## Context
Currently, we don't validate derived metrics correctly. So realistically, one could query for something incorrectly when using derived metric and pass the query parser as there are no query validations against the input metrics.

## Example
we could have a derived metric of a cumulative metric
```yaml
metric:
  name: cumulative_metric
  description: some cumulative metric
  type: cumulative
  type_params:
    measures:
      - some_measure
    window: 7 days
---
metric:
  name: derived_metric
  description: cumulative_metric - 10
  type: derived
  type_params:
    expr: cumulative_metric - 10
    metrics:
      - name: cumulative_metric
```
Now if we query, we would get thrown an error 
```
mf query --metrics cumulative_metric
Unable To Satisfy Query Error: Metric cumulative is a cumulative metric specified with a window/grain_to_date which must be queried with the dimension 'metric_time'.
```
However, if we did
```
mf query --metrics derived_metric
```
the query would go through even though we are effectively querying the same cumulative metric.

## Changes
This PR ensures that we validate each input metric in a derived metric as if we were querying for each input metric individually.