### PR TITLE
Change SqlBindParameters To Be Immutable / Serializable

### DIFF
--- a/metricflow/dataclass_serialization.py
+++ b/metricflow/dataclass_serialization.py
@@ -90,6 +90,7 @@ def _is_supported_field_type_in_serializable_dataclass(field_type: Type) -> bool
         or issubclass(field_type, float)
         or issubclass(field_type, str)
         or issubclass(field_type, datetime.datetime)
+        or issubclass(field_type, datetime.date)
         or issubclass(field_type, datetime.timedelta)
         or issubclass(field_type, BaseModel)
     )

--- a/metricflow/sql/render/expr_renderer.py
+++ b/metricflow/sql/render/expr_renderer.py
@@ -92,10 +92,10 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         combined_params = SqlBindParameters()
 
         left_expr_rendered = self.render_sql_expr(node.left_expr)
-        combined_params.update(left_expr_rendered.execution_parameters)
+        combined_params = combined_params.combine(left_expr_rendered.execution_parameters)
 
         right_expr_rendered = self.render_sql_expr(node.right_expr)
-        combined_params.update(right_expr_rendered.execution_parameters)
+        combined_params = combined_params.combine(right_expr_rendered.execution_parameters)
 
         # To avoid issues with operator precedence, use parenthesis to group the left / right expressions if they
         # contain operators.
@@ -114,7 +114,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         args_rendered = [self.render_sql_expr(x) for x in node.sql_function_args]
         combined_params = SqlBindParameters()
         for arg_rendered in args_rendered:
-            combined_params.update(arg_rendered.execution_parameters)
+            combined_params = combined_params.combine(arg_rendered.execution_parameters)
 
         distinct_prefix = "DISTINCT " if SqlFunction.is_distinct_aggregation(node.sql_function) else ""
         args_string = ", ".join([x.sql for x in args_rendered])
@@ -145,7 +145,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         can_be_rendered_in_one_line = sum(len(x.expr.sql) for x in args_rendered) < 60
 
         for arg_rendered in args_rendered:
-            combined_parameters.update(arg_rendered.expr.execution_parameters)
+            combined_parameters.combine(arg_rendered.expr.execution_parameters)
             arg_sql = self._render_logical_arg(
                 arg_rendered.expr, arg_rendered.requires_parenthesis, render_in_one_line=can_be_rendered_in_one_line
             )
@@ -251,8 +251,8 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         denominator_sql = f"CAST(NULLIF({rendered_denominator.sql}, 0) AS {self.double_data_type})"
 
         execution_parameters = SqlBindParameters()
-        execution_parameters.update(rendered_numerator.execution_parameters)
-        execution_parameters.update(rendered_denominator.execution_parameters)
+        execution_parameters = execution_parameters.combine(rendered_numerator.execution_parameters)
+        execution_parameters = execution_parameters.combine(rendered_denominator.execution_parameters)
 
         return SqlExpressionRenderResult(
             sql=f"{numerator_sql} / {denominator_sql}",
@@ -264,14 +264,14 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         rendered_start_expr = self.render_sql_expr(node.start_expr)
         rendered_end_expr = self.render_sql_expr(node.end_expr)
 
-        execution_parameters = SqlBindParameters()
-        execution_parameters.update(rendered_column_arg.execution_parameters)
-        execution_parameters.update(rendered_start_expr.execution_parameters)
-        execution_parameters.update(rendered_end_expr.execution_parameters)
+        bind_parameters = SqlBindParameters()
+        bind_parameters = bind_parameters.combine(rendered_column_arg.execution_parameters)
+        bind_parameters = bind_parameters.combine(rendered_start_expr.execution_parameters)
+        bind_parameters = bind_parameters.combine(rendered_end_expr.execution_parameters)
 
         return SqlExpressionRenderResult(
             sql=f"{rendered_column_arg.sql} BETWEEN {rendered_start_expr.sql} AND {rendered_end_expr.sql}",
-            execution_parameters=execution_parameters,
+            execution_parameters=bind_parameters,
         )
 
     def visit_window_function_expr(self, node: SqlWindowFunctionExpression) -> SqlExpressionRenderResult:  # noqa: D
@@ -288,7 +288,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         if order_by_args_rendered:
             args_rendered.extend(list(order_by_args_rendered.keys()))
         for arg_rendered in args_rendered:
-            combined_params.update(arg_rendered.execution_parameters)
+            combined_params = combined_params.combine(arg_rendered.execution_parameters)
 
         sql_function_args_string = ", ".join([x.sql for x in sql_function_args_rendered])
         partition_by_args_string = (

--- a/metricflow/sql/sql_bind_parameters.py
+++ b/metricflow/sql/sql_bind_parameters.py
@@ -1,37 +1,130 @@
 from __future__ import annotations
 
+import datetime
 from collections import OrderedDict
-from typing import Dict, Any
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple, Mapping
 
-from metricflow.model.objects.base import HashableBaseModel
-from metricflow.object_utils import SqlColumnType
+from metricflow.dataclass_serialization import SerializableDataclass
+from metricflow.object_utils import SqlColumnType, assert_exactly_one_arg_set
 
 
-class SqlBindParameters(HashableBaseModel):
+@dataclass(frozen=True)
+class SqlBindParameterValue(SerializableDataclass):
+    """SqlColumnType has issues with serialization, so using this union-style type."""
+
+    str_value: Optional[str] = None
+    int_value: Optional[int] = None
+    float_value: Optional[float] = None
+    datetime_value: Optional[datetime.datetime] = None
+    date_value: Optional[datetime.date] = None
+    bool_value: Optional[bool] = None
+
+    def __post_init__(self) -> None:  # noqa: D
+        assert_exactly_one_arg_set(
+            str_value=self.str_value,
+            int_value=self.int_value,
+            float_value=self.float_value,
+            datetime_value=self.datetime_value,
+            date_value=self.date_value,
+            bool_value=self.bool_value,
+        )
+
+    @property
+    def union_value(self) -> SqlColumnType:  # noqa: D
+        if self.str_value is not None:
+            return self.str_value
+        elif self.int_value is not None:
+            return self.int_value
+        elif self.float_value is not None:
+            return self.float_value
+        elif self.datetime_value is not None:
+            return self.datetime_value
+        elif self.date_value is not None:
+            return self.date_value
+        elif self.bool_value is not None:
+            return self.bool_value
+        raise RuntimeError("No values are set - this should have been prevented by the post init")
+
+    @staticmethod
+    def create_from_sql_column_type(value: SqlColumnType) -> SqlBindParameterValue:
+        """Convenience method for creating these values. Frowning on the use of isinstance()."""
+
+        if isinstance(value, str):
+            return SqlBindParameterValue(str_value=value)
+        elif isinstance(value, int):
+            return SqlBindParameterValue(int_value=value)
+        elif isinstance(value, float):
+            return SqlBindParameterValue(float_value=value)
+        elif isinstance(value, datetime.datetime):
+            return SqlBindParameterValue(datetime_value=value)
+        elif isinstance(value, datetime.date):
+            return SqlBindParameterValue(date_value=value)
+        elif isinstance(value, bool):
+            return SqlBindParameterValue(bool_value=value)
+
+        raise RuntimeError(f"Unhandled type: {type(value)}")
+
+
+@dataclass(frozen=True)
+class SqlBindParameter(SerializableDataclass):  # noqa: D
+    key: str
+    value: SqlBindParameterValue
+
+
+@dataclass(frozen=True)
+class SqlBindParameters(SerializableDataclass):
     """Helps to build execution parameters during SQL query rendering.
 
     These can be used as per https://docs.sqlalchemy.org/en/14/core/tutorial.html#using-textual-sql
     """
 
-    param_dict: Dict[str, SqlColumnType] = OrderedDict()
+    # Using tuples for immutability as dicts are not.
+    param_items: Tuple[SqlBindParameter, ...] = ()
 
-    class Config:
-        """Pydantic config: smart_union prevents unexpected type coercion.
+    def combine(self, additional_params: SqlBindParameters) -> SqlBindParameters:
+        """Create a new set of bind parameters that includes parameters from this and additional_params"""
+        if len(self.param_items) == 0:
+            return additional_params
 
-        https://pydantic-docs.helpmanual.io/usage/model_config/#smart-union
-        """
+        if len(additional_params.param_items) == 0:
+            return self
 
-        smart_union = True
+        self_dict = {item.key: item.value for item in self.param_items}
+        other_dict = {item.key: item.value for item in additional_params.param_items}
 
-    def update(self, additional_params: SqlBindParameters) -> None:
-        """Add the parameters to this set, mutating it."""
-        for key, value in additional_params.param_dict.items():
-            if key in self.param_dict and self.param_dict[key] != value:
+        for key, value in other_dict.items():
+            if key in self_dict and self_dict[key] != value:
                 raise RuntimeError(
-                    f"Conflict with key {key} in merging parameters. "
-                    f"Existing params: {self.param_dict} Additional params: {additional_params}"
+                    f"Conflict with key {key} in combining parameters. "
+                    f"Existing params: {self_dict} Additional params: {other_dict}"
                 )
-        self.param_dict.update(additional_params.param_dict)
+        new_items = list(self.param_items)
+        included_keys = set(item.key for item in new_items)
+        for item in additional_params.param_items:
+            if item.key in included_keys:
+                continue
+            new_items.append(item)
+            included_keys.add(item.key)
+
+        return SqlBindParameters(param_items=tuple(new_items))
+
+    @property
+    def param_dict(self) -> OrderedDict[str, SqlColumnType]:
+        """Useful for passing into SQLAlchemy / DB-API methods."""
+        param_dict: OrderedDict[str, SqlColumnType] = OrderedDict()
+        for item in self.param_items:
+            param_dict[item.key] = item.value.union_value
+        return param_dict
+
+    @staticmethod
+    def create_from_dict(param_dict: Mapping[str, SqlColumnType]) -> SqlBindParameters:  # noqa: D
+        return SqlBindParameters(
+            tuple(
+                SqlBindParameter(key=key, value=SqlBindParameterValue.create_from_sql_column_type(value))
+                for key, value in param_dict.items()
+            )
+        )
 
     def __eq__(self, other: Any) -> bool:  # type: ignore  # noqa: D
         return isinstance(other, SqlBindParameters) and self.param_dict == other.param_dict

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -71,7 +71,7 @@
                                 <!--                                                                     'element_name': 'listing'},)},),  -->
                                 <!--                          'time_dimension_specs': (),                                                  -->
                                 <!--                          'identifier_specs': ()},                                                     -->
-                                <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                          -->
+                                <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}                         -->
                                 <FilterElementsNode>
                                     <!-- description =                                                                       -->
                                     <!--   Pass Only Elements:                                                               -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -52,17 +52,17 @@
                             <WhereConstraintNode>
                                 <!-- description = Constrain Output with WHERE -->
                                 <!-- node_id = wcc_0 -->
-                                <!-- where_condition =                                                             -->
-                                <!--   {'class': 'SpecWhereClauseConstraint',                                      -->
-                                <!--    'where_condition': 'is_instant',                                           -->
-                                <!--    'linkable_names': ('is_instant',),                                         -->
-                                <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                          -->
-                                <!--                          'dimension_specs': ({'class': 'DimensionSpec',       -->
-                                <!--                                               'element_name': 'is_instant',   -->
-                                <!--                                               'identifier_links': ()},),      -->
-                                <!--                          'time_dimension_specs': (),                          -->
-                                <!--                          'identifier_specs': ()},                             -->
-                                <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}  -->
+                                <!-- where_condition =                                                              -->
+                                <!--   {'class': 'SpecWhereClauseConstraint',                                       -->
+                                <!--    'where_condition': 'is_instant',                                            -->
+                                <!--    'linkable_names': ('is_instant',),                                          -->
+                                <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                           -->
+                                <!--                          'dimension_specs': ({'class': 'DimensionSpec',        -->
+                                <!--                                               'element_name': 'is_instant',    -->
+                                <!--                                               'identifier_links': ()},),       -->
+                                <!--                          'time_dimension_specs': (),                           -->
+                                <!--                          'identifier_specs': ()},                              -->
+                                <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}  -->
                                 <FilterElementsNode>
                                     <!-- description =                                       -->
                                     <!--   Pass Only Elements:                               -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -38,7 +38,7 @@
                         <!--                                                                     'element_name': 'listing'},)},),  -->
                         <!--                          'time_dimension_specs': (),                                                  -->
                         <!--                          'identifier_specs': ()},                                                     -->
-                        <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                          -->
+                        <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}                         -->
                         <FilterElementsNode>
                             <!-- description =                                              -->
                             <!--   Pass Only Elements:                                      -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -38,7 +38,7 @@
                         <!--                                                    'identifier_links': (),                      -->
                         <!--                                                    'time_granularity': TimeGranularity.DAY},),  -->
                         <!--                          'identifier_specs': ()},                                               -->
-                        <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                    -->
+                        <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}                   -->
                         <FilterElementsNode>
                             <!-- description =                                  -->
                             <!--   Pass Only Elements:                          -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -27,7 +27,7 @@
                     <!--                                                                     'element_name': 'listing'},)},),  -->
                     <!--                          'time_dimension_specs': (),                                                  -->
                     <!--                          'identifier_specs': ()},                                                     -->
-                    <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}                          -->
+                    <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}                         -->
                     <FilterElementsNode>
                         <!-- description =                                -->
                         <!--   Pass Only Elements:                        -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -73,17 +73,17 @@
                         <WhereConstraintNode>
                             <!-- description = Constrain Output with WHERE -->
                             <!-- node_id = wcc_0 -->
-                            <!-- where_condition =                                                             -->
-                            <!--   {'class': 'SpecWhereClauseConstraint',                                      -->
-                            <!--    'where_condition': 'is_instant',                                           -->
-                            <!--    'linkable_names': ('is_instant',),                                         -->
-                            <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                          -->
-                            <!--                          'dimension_specs': ({'class': 'DimensionSpec',       -->
-                            <!--                                               'element_name': 'is_instant',   -->
-                            <!--                                               'identifier_links': ()},),      -->
-                            <!--                          'time_dimension_specs': (),                          -->
-                            <!--                          'identifier_specs': ()},                             -->
-                            <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}  -->
+                            <!-- where_condition =                                                              -->
+                            <!--   {'class': 'SpecWhereClauseConstraint',                                       -->
+                            <!--    'where_condition': 'is_instant',                                            -->
+                            <!--    'linkable_names': ('is_instant',),                                          -->
+                            <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                           -->
+                            <!--                          'dimension_specs': ({'class': 'DimensionSpec',        -->
+                            <!--                                               'element_name': 'is_instant',    -->
+                            <!--                                               'identifier_links': ()},),       -->
+                            <!--                          'time_dimension_specs': (),                           -->
+                            <!--                          'identifier_specs': ()},                              -->
+                            <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}  -->
                             <FilterElementsNode>
                                 <!-- description =                                       -->
                                 <!--   Pass Only Elements:                               -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -73,17 +73,17 @@
                         <WhereConstraintNode>
                             <!-- description = Constrain Output with WHERE -->
                             <!-- node_id = wcc_1 -->
-                            <!-- where_condition =                                                             -->
-                            <!--   {'class': 'SpecWhereClauseConstraint',                                      -->
-                            <!--    'where_condition': 'is_instant',                                           -->
-                            <!--    'linkable_names': ('is_instant',),                                         -->
-                            <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                          -->
-                            <!--                          'dimension_specs': ({'class': 'DimensionSpec',       -->
-                            <!--                                               'element_name': 'is_instant',   -->
-                            <!--                                               'identifier_links': ()},),      -->
-                            <!--                          'time_dimension_specs': (),                          -->
-                            <!--                          'identifier_specs': ()},                             -->
-                            <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_dict': {}}}  -->
+                            <!-- where_condition =                                                              -->
+                            <!--   {'class': 'SpecWhereClauseConstraint',                                       -->
+                            <!--    'where_condition': 'is_instant',                                            -->
+                            <!--    'linkable_names': ('is_instant',),                                          -->
+                            <!--    'linkable_spec_set': {'class': 'LinkableSpecSet',                           -->
+                            <!--                          'dimension_specs': ({'class': 'DimensionSpec',        -->
+                            <!--                                               'element_name': 'is_instant',    -->
+                            <!--                                               'identifier_links': ()},),       -->
+                            <!--                          'time_dimension_specs': (),                           -->
+                            <!--                          'identifier_specs': ()},                              -->
+                            <!--    'execution_parameters': {'class': 'SqlBindParameters', 'param_items': ()}}  -->
                             <FilterElementsNode>
                                 <!-- description =                                       -->
                                 <!--   Pass Only Elements:                               -->

--- a/metricflow/test/sql/test_bind_parameter_serialization.py
+++ b/metricflow/test/sql/test_bind_parameter_serialization.py
@@ -1,0 +1,31 @@
+import pytest
+
+from metricflow.dataclass_serialization import DataclassSerializer, DataClassDeserializer
+from metricflow.sql.sql_bind_parameters import SqlBindParameters, SqlBindParameter, SqlBindParameterValue
+
+
+@pytest.fixture
+def serializer() -> DataclassSerializer:  # noqa: D
+    return DataclassSerializer()
+
+
+@pytest.fixture
+def deserializer() -> DataClassDeserializer:  # noqa: D
+    return DataClassDeserializer()
+
+
+def test_serialization(  # noqa: D
+    serializer: DataclassSerializer,
+    deserializer: DataClassDeserializer,
+) -> None:
+    bind_parameters = SqlBindParameters(
+        param_items=(
+            SqlBindParameter("key0", SqlBindParameterValue.create_from_sql_column_type("value0")),
+            SqlBindParameter("key1", SqlBindParameterValue.create_from_sql_column_type("value1")),
+        )
+    )
+    serialized_obj = serializer.pydantic_serialize(bind_parameters)
+    deserialized_obj = deserializer.pydantic_deserialize(
+        dataclass_type=SqlBindParameters, serialized_obj=serialized_obj
+    )
+    assert bind_parameters == deserialized_obj


### PR DESCRIPTION
This PR changes `SqlBindParameters` to be immutable and serializable. This is needed as `MetricFlowQuerySpec` (supposed to be immutable / serializable) can include `SqlBindParameters` via a `WhereClauseConstraint`.