### PR TITLE
BUG: Aggregate functions gets mixed with other exprs when optimized

### DIFF
--- a/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_left_node_statement__after_reducing.sql
+++ b/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_left_node_statement__after_reducing.sql
@@ -1,0 +1,17 @@
+-- query
+SELECT
+  src2.bookings AS bookings
+  , src3.listings AS listings
+FROM (
+  -- src4
+  SELECT
+    SUM(src4.listings) AS listings
+  FROM demo.fct_listings src4
+) src2
+CROSS JOIN (
+  -- src1
+  -- src2
+  SELECT
+    SUM(1) AS bookings
+  FROM demo.fct_bookings src0
+) src3

--- a/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_left_node_statement__before_reducing.sql
+++ b/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_left_node_statement__before_reducing.sql
@@ -1,0 +1,21 @@
+-- query
+SELECT
+  src2.bookings AS bookings
+  , src3.listings AS listings
+FROM (
+  -- src4
+  SELECT
+    SUM(src4.listings) AS listings
+  FROM demo.fct_listings src4
+) src2
+CROSS JOIN (
+  -- src2
+  SELECT
+    SUM(src1.bookings) AS bookings
+  FROM (
+    -- src1
+    SELECT
+      1 AS bookings
+    FROM demo.fct_bookings src0
+  ) src1
+) src3

--- a/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__after_reducing.sql
+++ b/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__after_reducing.sql
@@ -1,0 +1,17 @@
+-- query
+SELECT
+  src2.bookings AS bookings
+  , src3.listings AS listings
+FROM (
+  -- src1
+  -- src2
+  SELECT
+    SUM(1) AS bookings
+  FROM demo.fct_bookings src0
+) src2
+CROSS JOIN (
+  -- src4
+  SELECT
+    SUM(src4.listings) AS listings
+  FROM demo.fct_listings src4
+) src3

--- a/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__before_reducing.sql
+++ b/metricflow/test/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__before_reducing.sql
@@ -1,0 +1,21 @@
+-- query
+SELECT
+  src2.bookings AS bookings
+  , src3.listings AS listings
+FROM (
+  -- src2
+  SELECT
+    SUM(src1.bookings) AS bookings
+  FROM (
+    -- src1
+    SELECT
+      1 AS bookings
+    FROM demo.fct_bookings src0
+  ) src1
+) src2
+CROSS JOIN (
+  -- src4
+  SELECT
+    SUM(src4.listings) AS listings
+  FROM demo.fct_listings src4
+) src3

--- a/metricflow/test/sql/optimizer/test_rewriting_sub_query_reducer.py
+++ b/metricflow/test/sql/optimizer/test_rewriting_sub_query_reducer.py
@@ -768,3 +768,289 @@ def test_reduce_all_join_sources(
         sql_plan_node=sub_query_reducer.optimize(reduce_all_join_select_statement),
         plan_id="after_reducing",
     )
+
+
+@pytest.fixture
+def reducing_join_statement() -> SqlSelectStatementNode:
+    """SELECT statement used to build test cases.
+
+    -- query
+    SELECT
+      src2.bookings AS bookings
+      , src3.listings AS listings
+    FROM (
+      -- src2
+      SELECT
+        SUM(src1.bookings) AS bookings
+      FROM (
+        -- src1
+        SELECT
+          1 AS bookings
+        FROM demo.fct_bookings src0
+      ) src1
+    ) src2
+    CROSS JOIN (
+      -- src4
+      SELECT
+        SUM(src4.listings) AS listings
+      FROM demo.fct_listings src4
+    ) src3
+    """
+    return SqlSelectStatementNode(
+        description="query",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="bookings")
+                ),
+                column_alias="bookings",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression(
+                    col_ref=SqlColumnReference(table_alias="src3", column_name="listings")
+                ),
+                column_alias="listings",
+            ),
+        ),
+        from_source=SqlSelectStatementNode(
+            description="src2",
+            select_columns=(
+                SqlSelectColumn(
+                    expr=SqlAggregateFunctionExpression(
+                        sql_function=SqlFunction.SUM,
+                        sql_function_args=[
+                            SqlColumnReferenceExpression(
+                                col_ref=SqlColumnReference(table_alias="src1", column_name="bookings")
+                            )
+                        ],
+                    ),
+                    column_alias="bookings",
+                ),
+            ),
+            from_source=SqlSelectStatementNode(
+                description="src1",
+                select_columns=(
+                    SqlSelectColumn(
+                        expr=SqlStringExpression(sql_expr="1", requires_parenthesis=False, used_columns=()),
+                        column_alias="bookings",
+                    ),
+                ),
+                from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+                from_source_alias="src0",
+                joins_descs=(),
+                where=None,
+                group_bys=(),
+                order_bys=(),
+                limit=None,
+            ),
+            from_source_alias="src1",
+            joins_descs=(),
+            where=None,
+            group_bys=(),
+            order_bys=(),
+            limit=None,
+        ),
+        from_source_alias="src2",
+        joins_descs=(
+            SqlJoinDescription(
+                right_source=SqlSelectStatementNode(
+                    description="src4",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlAggregateFunctionExpression(
+                                sql_function=SqlFunction.SUM,
+                                sql_function_args=[
+                                    SqlColumnReferenceExpression(
+                                        col_ref=SqlColumnReference(table_alias="src4", column_name="listings")
+                                    )
+                                ],
+                            ),
+                            column_alias="listings",
+                        ),
+                    ),
+                    from_source=SqlTableFromClauseNode(
+                        sql_table=SqlTable(schema_name="demo", table_name="fct_listings")
+                    ),
+                    from_source_alias="src4",
+                    joins_descs=(),
+                    where=None,
+                    group_bys=(),
+                    order_bys=(),
+                    limit=None,
+                ),
+                right_source_alias="src3",
+                on_condition=None,
+                join_type=SqlJoinType.CROSS_JOIN,
+            ),
+        ),
+        group_bys=(),
+        where=None,
+        order_bys=(),
+        limit=None,
+    )
+
+
+def test_reducing_join_statement(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    reducing_join_statement: SqlSelectStatementNode,
+) -> None:
+    """Tests a case where a join query should not reduced an aggregate"""
+    assert_default_rendered_sql_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        sql_plan_node=reducing_join_statement,
+        plan_id="before_reducing",
+    )
+
+    sub_query_reducer = SqlRewritingSubQueryReducer()
+
+    assert_default_rendered_sql_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        sql_plan_node=sub_query_reducer.optimize(reducing_join_statement),
+        plan_id="after_reducing",
+    )
+
+
+@pytest.fixture
+def reducing_join_left_node_statement() -> SqlSelectStatementNode:
+    """SELECT statement used to build test cases.
+
+    -- query
+    SELECT
+      src2.bookings AS bookings
+      , src3.listings AS listings
+    FROM (
+      -- src2
+      SELECT
+        SUM(src1.bookings) AS bookings
+      FROM (
+        -- src1
+        SELECT
+          1 AS bookings
+        FROM demo.fct_bookings src0
+      ) src1
+    ) src2
+    CROSS JOIN (
+      -- src4
+      SELECT
+        SUM(src4.listings) AS listings
+      FROM demo.fct_listings src4
+    ) src3
+    """
+    return SqlSelectStatementNode(
+        description="query",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="bookings")
+                ),
+                column_alias="bookings",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression(
+                    col_ref=SqlColumnReference(table_alias="src3", column_name="listings")
+                ),
+                column_alias="listings",
+            ),
+        ),
+        from_source=SqlSelectStatementNode(
+            description="src4",
+            select_columns=(
+                SqlSelectColumn(
+                    expr=SqlAggregateFunctionExpression(
+                        sql_function=SqlFunction.SUM,
+                        sql_function_args=[
+                            SqlColumnReferenceExpression(
+                                col_ref=SqlColumnReference(table_alias="src4", column_name="listings")
+                            )
+                        ],
+                    ),
+                    column_alias="listings",
+                ),
+            ),
+            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_listings")),
+            from_source_alias="src4",
+            joins_descs=(),
+            where=None,
+            group_bys=(),
+            order_bys=(),
+            limit=None,
+        ),
+        from_source_alias="src2",
+        joins_descs=(
+            SqlJoinDescription(
+                right_source=SqlSelectStatementNode(
+                    description="src2",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlAggregateFunctionExpression(
+                                sql_function=SqlFunction.SUM,
+                                sql_function_args=[
+                                    SqlColumnReferenceExpression(
+                                        col_ref=SqlColumnReference(table_alias="src1", column_name="bookings")
+                                    )
+                                ],
+                            ),
+                            column_alias="bookings",
+                        ),
+                    ),
+                    from_source=SqlSelectStatementNode(
+                        description="src1",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlStringExpression(sql_expr="1", requires_parenthesis=False, used_columns=()),
+                                column_alias="bookings",
+                            ),
+                        ),
+                        from_source=SqlTableFromClauseNode(
+                            sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+                        ),
+                        from_source_alias="src0",
+                        joins_descs=(),
+                        where=None,
+                        group_bys=(),
+                        order_bys=(),
+                        limit=None,
+                    ),
+                    from_source_alias="src1",
+                    joins_descs=(),
+                    where=None,
+                    group_bys=(),
+                    order_bys=(),
+                    limit=None,
+                ),
+                right_source_alias="src3",
+                on_condition=None,
+                join_type=SqlJoinType.CROSS_JOIN,
+            ),
+        ),
+        group_bys=(),
+        where=None,
+        order_bys=(),
+        limit=None,
+    )
+
+
+def test_reducing_join_left_node_statement(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    reducing_join_left_node_statement: SqlSelectStatementNode,
+) -> None:
+    """Tests a case where a join query should not reduced an aggregate"""
+    assert_default_rendered_sql_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        sql_plan_node=reducing_join_left_node_statement,
+        plan_id="before_reducing",
+    )
+
+    sub_query_reducer = SqlRewritingSubQueryReducer()
+
+    assert_default_rendered_sql_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        sql_plan_node=sub_query_reducer.optimize(reducing_join_left_node_statement),
+        plan_id="after_reducing",
+    )


### PR DESCRIPTION
## Context
There are certain cases where the sub query reducer collapses cross joins, it potentially leads to a final select node containing a mix of aggregate functions and other exprs (ie., column references). This ends up throwing an invalid GROUP BY error.

## Example
### Before optimizer
```sql
-- query
SELECT
  src2.bookings AS bookings
  , src3.listings AS listings
FROM (
  -- src2
  SELECT
    SUM(src1.bookings) AS bookings
  FROM (
    -- src1
    SELECT
      1 AS bookings
    FROM demo.fct_bookings src0
  ) src1
) src2
CROSS JOIN (
  -- src4
  SELECT
    SUM(src4.listings) AS listings
  FROM demo.fct_listings src4
) src3
```
### Current optmizer
```sql
-- query
SELECT
  src2.bookings AS bookings
  , SUM(src4.listings) AS listings
FROM (
  -- src2
  SELECT
    SUM(1) AS bookings
  FROM demo.fct_bookings src1
) src2
CROSS JOIN
  demo.fct_listings src4
```
This would throw an error similar to this
```
SQL compilation error: [src2.bookings] is not a valid group by expression
```

### Optimizer with this PR
```sql
-- query
SELECT
  src2.bookings AS bookings
  , src3.listings AS listings
FROM (
  -- src1
  -- src2
  SELECT
    SUM(1) AS bookings
  FROM demo.fct_bookings src0
) src2
CROSS JOIN (
  -- src4
  SELECT
    SUM(src4.listings) AS listings
  FROM demo.fct_listings src4
) src3
```