### PR TITLE
Fix incomplete JOIN condition for combining derived metrics nodes

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -967,7 +967,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                     join_data_set=join_data_set,
                     join_type=join_type,
                     column_names=column_names,
-                    aliases_seen=aliases_seen,
+                    table_aliases_for_coalesce=aliases_seen,
                 )
             )
             aliases_seen.append(join_data_set.alias)

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -57,7 +57,6 @@ from metricflow.plan_conversion.select_column_gen import (
     SelectColumnSet,
 )
 from metricflow.plan_conversion.spec_transforms import (
-    make_coalesced_expr,
     CreateSelectCoalescedColumnsForLinkableSpecs,
     SelectOnlyLinkableSpecs,
 )
@@ -80,10 +79,6 @@ from metricflow.sql.optimizer.optimization_levels import (
     SqlQueryOptimizerConfiguration,
 )
 from metricflow.sql.sql_exprs import (
-    SqlComparison,
-    SqlComparisonExpression,
-    SqlLogicalExpression,
-    SqlLogicalOperator,
     SqlExpressionNode,
     SqlColumnReferenceExpression,
     SqlColumnReference,
@@ -894,52 +889,6 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                 )
         return select_columns
 
-    @staticmethod
-    def _make_equality_expression_for_full_outer_join(
-        table_aliases_in_coalesce: Sequence[str], right_table_alias: str, column_alias: str
-    ) -> SqlExpressionNode:
-        """Creates an expression that can go in the ON condition when coalescing join keys with a FULL OUTER JOIN.
-
-        e.g.
-
-        dimension_specs = ["is_instant", "ds"]
-        table_aliases_in_coalesce = ["a", "b"]
-        table_alias_on_right_equality = ["c"]
-
-        ->
-
-        COALESCE(a.is_instant, b.is_instant) = c.is_instant
-        AND COALESCE(a.ds, b.ds) = c.ds
-
-        This is necessary for cases where 3 or more subqueries will be linked via FULL OUTER JOINs. If that happens,
-        the set of join keys from subquery 3 must be compared to the join keys from both subquery 1 and subquery 2,
-        otherwise duplicate rows might appear in the output.
-
-        For example:
-
-        table1: [('a', 10), ('b', 20)]
-        table2: [('a', 100), ('c', 200)]
-        table3: [('a', 1000), ('c', 2000)]
-
-        ->
-
-        output without COALESCE: [('a', 10, 100, 1000), ('c', NULL, 200, NULL), ('c', NULL, NULL, 2000)]
-        output with COALESCE: [('a', 10, 100, 1000), ('c', NULL, 200, 2000)]
-
-        The latter scenario consolidates the rows keyed by 'c' into a single entry.
-        """
-
-        return SqlComparisonExpression(
-            left_expr=make_coalesced_expr(table_aliases_in_coalesce, column_alias),
-            comparison=SqlComparison.EQUALS,
-            right_expr=SqlColumnReferenceExpression(
-                col_ref=SqlColumnReference(
-                    table_alias=right_table_alias,
-                    column_name=column_alias,
-                )
-            ),
-        )
-
     def visit_combine_metrics_node(self, node: CombineMetricsNode[SqlDataSetT]) -> SqlDataSet:
         """Join computed metric datasets together to return a single dataset containing all metrics
 
@@ -1012,42 +961,15 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         column_names = [associations[0].column_name for associations in column_associations]
         aliases_seen = [from_data_set.alias]
         for join_data_set in join_data_sets:
-            if join_type is SqlJoinType.FULL_OUTER:
-                equality_exprs = [
-                    DataflowToSqlQueryPlanConverter._make_equality_expression_for_full_outer_join(
-                        aliases_seen, join_data_set.alias, colname
-                    )
-                    for colname in column_names
-                ]
-                on_condition = (
-                    SqlLogicalExpression(operator=SqlLogicalOperator.AND, args=tuple(equality_exprs))
-                    if len(equality_exprs) > 1
-                    else equality_exprs[0]
+            joins_descriptions.append(
+                SqlQueryPlanJoinBuilder.make_combine_metrics_join_description(
+                    from_data_set=from_data_set,
+                    join_data_set=join_data_set,
+                    join_type=join_type,
+                    column_names=column_names,
+                    aliases_seen=aliases_seen,
                 )
-                joins_descriptions.append(
-                    SqlJoinDescription(
-                        right_source=join_data_set.data_set.sql_select_node,
-                        right_source_alias=join_data_set.alias,
-                        on_condition=on_condition,
-                        join_type=join_type,
-                    )
-                )
-            else:
-                column_equality_descriptions = [
-                    ColumnEqualityDescription(
-                        left_column_alias=name, right_column_alias=name, treat_nulls_as_equal=True
-                    )
-                    for name in column_names
-                ]
-                joins_descriptions.append(
-                    SqlQueryPlanJoinBuilder.make_sql_join_description(
-                        right_source_node=join_data_set.data_set.sql_select_node,
-                        left_source_alias=from_data_set.alias,
-                        right_source_alias=join_data_set.alias,
-                        column_equality_descriptions=column_equality_descriptions,
-                        join_type=join_type,
-                    )
-                )
+            )
             aliases_seen.append(join_data_set.alias)
 
         # We can merge all parent instances since the common linkable instances will be de-duped.

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -933,7 +933,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
             [set(x.instance_set.spec_set.linkable_specs) == set(linkable_specs) for x in parent_data_sets]
         ), "All parent nodes should have the same set of linkable instances since all values are coalesced."
         linkable_spec_set = parent_data_sets[0].instance_set.spec_set.transform(SelectOnlyLinkableSpecs())
-        use_cross_join = len(linkable_spec_set.all_specs) == 0
+        join_type = SqlJoinType.CROSS_JOIN if len(linkable_spec_set.all_specs) == 0 else node.join_type
 
         joins_descriptions = []
         parent_source_table_aliases = []
@@ -958,9 +958,9 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
                         table_aliases_in_coalesce=parent_source_table_aliases[:i],
                         table_alias_on_right_equality=parent_source_table_aliases[i],
                     ).transform(linkable_spec_set)
-                    if not use_cross_join
+                    if join_type is not SqlJoinType.CROSS_JOIN
                     else None,
-                    join_type=node.join_type if not use_cross_join else SqlJoinType.CROSS_JOIN,
+                    join_type=join_type,
                 )
             )
 

--- a/metricflow/plan_conversion/spec_transforms.py
+++ b/metricflow/plan_conversion/spec_transforms.py
@@ -1,55 +1,13 @@
 from typing import Sequence, List
 
 from metricflow.plan_conversion.select_column_gen import SelectColumnSet
+from metricflow.plan_conversion.sql_expression_builders import make_coalesced_expr
 from metricflow.specs import (
     InstanceSpecSetTransform,
     InstanceSpecSet,
     ColumnAssociationResolver,
 )
-from metricflow.sql.sql_exprs import (
-    SqlExpressionNode,
-    SqlColumnReferenceExpression,
-    SqlColumnReference,
-    SqlAggregateFunctionExpression,
-    SqlFunction,
-)
 from metricflow.sql.sql_plan import SqlSelectColumn
-
-
-def make_coalesced_expr(table_aliases: Sequence[str], column_alias: str) -> SqlExpressionNode:
-    """Makes a coalesced expression of the given column from the given table aliases.
-
-    e.g.
-
-    table_aliases = ["a", "b"]
-    column_alias = "is_instant"
-
-    ->
-
-    COALESCE(a.is_instant, b.is_instant)
-    """
-    if len(table_aliases) == 1:
-        return SqlColumnReferenceExpression(
-            col_ref=SqlColumnReference(
-                table_alias=table_aliases[0],
-                column_name=column_alias,
-            )
-        )
-    else:
-        columns_to_coalesce: List[SqlExpressionNode] = []
-        for table_alias in table_aliases:
-            columns_to_coalesce.append(
-                SqlColumnReferenceExpression(
-                    col_ref=SqlColumnReference(
-                        table_alias=table_alias,
-                        column_name=column_alias,
-                    )
-                )
-            )
-        return SqlAggregateFunctionExpression(
-            sql_function=SqlFunction.COALESCE,
-            sql_function_args=columns_to_coalesce,
-        )
 
 
 class CreateSelectCoalescedColumnsForLinkableSpecs(InstanceSpecSetTransform[SelectColumnSet]):

--- a/metricflow/plan_conversion/sql_expression_builders.py
+++ b/metricflow/plan_conversion/sql_expression_builders.py
@@ -1,0 +1,47 @@
+"""Utility module for building sql expressions from inputs derived from dataflow plan or other nodes."""
+
+from typing import List, Sequence
+
+from metricflow.sql.sql_exprs import (
+    SqlExpressionNode,
+    SqlColumnReferenceExpression,
+    SqlColumnReference,
+    SqlAggregateFunctionExpression,
+    SqlFunction,
+)
+
+
+def make_coalesced_expr(table_aliases: Sequence[str], column_alias: str) -> SqlExpressionNode:
+    """Makes a coalesced expression of the given column from the given table aliases.
+
+    e.g.
+
+    table_aliases = ["a", "b"]
+    column_alias = "is_instant"
+
+    ->
+
+    COALESCE(a.is_instant, b.is_instant)
+    """
+    if len(table_aliases) == 1:
+        return SqlColumnReferenceExpression(
+            col_ref=SqlColumnReference(
+                table_alias=table_aliases[0],
+                column_name=column_alias,
+            )
+        )
+    else:
+        columns_to_coalesce: List[SqlExpressionNode] = []
+        for table_alias in table_aliases:
+            columns_to_coalesce.append(
+                SqlColumnReferenceExpression(
+                    col_ref=SqlColumnReference(
+                        table_alias=table_alias,
+                        column_name=column_alias,
+                    )
+                )
+            )
+        return SqlAggregateFunctionExpression(
+            sql_function=SqlFunction.COALESCE,
+            sql_function_args=columns_to_coalesce,
+        )

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple, TypeVar
 
 from metricflow.dataflow.dataflow_plan import JoinDescription, JoinOverTimeRangeNode
+from metricflow.plan_conversion.spec_transforms import make_coalesced_expr
 from metricflow.plan_conversion.sql_dataset import SqlDataSet
 from metricflow.sql.sql_plan import SqlExpressionNode, SqlJoinDescription, SqlJoinType, SqlSelectStatementNode
 from metricflow.sql.sql_exprs import (
@@ -308,6 +309,102 @@ class SqlQueryPlanJoinBuilder:
 
         return SqlLogicalExpression(
             operator=SqlLogicalOperator.AND, args=(window_start_condition, window_end_condition)
+        )
+
+    @staticmethod
+    def make_combine_metrics_join_description(
+        from_data_set: AnnotatedSqlDataSet,
+        join_data_set: AnnotatedSqlDataSet,
+        join_type: SqlJoinType,
+        column_names: Sequence[str],
+        aliases_seen: Sequence[str],
+    ) -> SqlJoinDescription:
+        """Creates the sql join description for combining two separate metrics output datasets
+
+        These might be combined in service of producing complete output for end user consumption, in which
+        case the join type will be FULL OUTER in order to ensure all rows are included. In this case, the
+        join must account for all past table aliases seen in prior joins in order to produce the final
+        coalesce expression for processing the join correctly.
+
+        Metric data sets might also be combined to serve as inputs to a derived metric, in which case the
+        join type will not be a FULL OUTER, and we should use null-safe column equality comparisons with
+        the relevant join type for
+        """
+        if join_type is SqlJoinType.FULL_OUTER:
+            equality_exprs = [
+                SqlQueryPlanJoinBuilder._make_equality_expression_for_full_outer_join(
+                    aliases_seen, join_data_set.alias, colname
+                )
+                for colname in column_names
+            ]
+            on_condition = (
+                SqlLogicalExpression(operator=SqlLogicalOperator.AND, args=tuple(equality_exprs))
+                if len(equality_exprs) > 1
+                else equality_exprs[0]
+            )
+            return SqlJoinDescription(
+                right_source=join_data_set.data_set.sql_select_node,
+                right_source_alias=join_data_set.alias,
+                on_condition=on_condition,
+                join_type=join_type,
+            )
+        else:
+            column_equality_descriptions = [
+                ColumnEqualityDescription(left_column_alias=name, right_column_alias=name, treat_nulls_as_equal=True)
+                for name in column_names
+            ]
+            return SqlQueryPlanJoinBuilder.make_sql_join_description(
+                right_source_node=join_data_set.data_set.sql_select_node,
+                left_source_alias=from_data_set.alias,
+                right_source_alias=join_data_set.alias,
+                column_equality_descriptions=column_equality_descriptions,
+                join_type=join_type,
+            )
+
+    @staticmethod
+    def _make_equality_expression_for_full_outer_join(
+        table_aliases_in_coalesce: Sequence[str], right_table_alias: str, column_alias: str
+    ) -> SqlExpressionNode:
+        """Creates an expression that can go in the ON condition when coalescing join keys with a FULL OUTER JOIN.
+
+        e.g.
+
+        dimension_specs = ["is_instant", "ds"]
+        table_aliases_in_coalesce = ["a", "b"]
+        table_alias_on_right_equality = ["c"]
+
+        ->
+
+        COALESCE(a.is_instant, b.is_instant) = c.is_instant
+        AND COALESCE(a.ds, b.ds) = c.ds
+
+        This is necessary for cases where 3 or more subqueries will be linked via FULL OUTER JOINs. If that happens,
+        the set of join keys from subquery 3 must be compared to the join keys from both subquery 1 and subquery 2,
+        otherwise duplicate rows might appear in the output.
+
+        For example:
+
+        table1: [('a', 10), ('b', 20)]
+        table2: [('a', 100), ('c', 200)]
+        table3: [('a', 1000), ('c', 2000)]
+
+        ->
+
+        output without COALESCE: [('a', 10, 100, 1000), ('c', NULL, 200, NULL), ('c', NULL, NULL, 2000)]
+        output with COALESCE: [('a', 10, 100, 1000), ('c', NULL, 200, 2000)]
+
+        The latter scenario consolidates the rows keyed by 'c' into a single entry.
+        """
+
+        return SqlComparisonExpression(
+            left_expr=make_coalesced_expr(table_aliases_in_coalesce, column_alias),
+            comparison=SqlComparison.EQUALS,
+            right_expr=SqlColumnReferenceExpression(
+                col_ref=SqlColumnReference(
+                    table_alias=right_table_alias,
+                    column_name=column_alias,
+                )
+            ),
         )
 
     @staticmethod

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -555,3 +555,17 @@ metric:
     metrics:
       - name: trailing_2_months_revenue
         alias: t2mr
+---
+metric:
+  name: booking_value_per_view
+  description: proportion of booking value per view, which allows us to test joins to listings with null values
+  owners:
+    - support@transformdata.io
+  type: derived
+  type_params:
+    expr: booking_value / NULLIF(views, 0)
+    metrics:
+      - name: booking_value
+      - name: views
+---
+

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -670,4 +670,4 @@ integration_test:
       ON c.listing_id = d.listing_id
       GROUP BY 2
     ) vw
-    ON bk.is_lux = vw.is_lux
+    ON bk.is_lux = vw.is_lux OR (bk.is_lux IS NULL AND vw.is_lux IS NULL)

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -641,3 +641,33 @@ integration_test:
     ) li
     ON COALESCE(bk.is_lux, vw.is_lux) = li.is_lux AND COALESCE(bk.country, vw.country) = li.country
     GROUP BY 4,5
+---
+integration_test:
+  name: derived_metrics_with_null_dimension_values
+  description: Tests querying a derived metric with multiple inputs that link to dimension(s) with null values
+  model: SIMPLE_MODEL
+  metrics: [booking_value_per_view]
+  group_bys: [listing__is_lux_latest]
+  check_query: |
+    SELECT
+      bk.booking_value / NULLIF(vw.views, 0) AS booking_value_per_view
+      , bk.is_lux AS listing__is_lux_latest
+    FROM (
+      SELECT
+        SUM(a.booking_value) AS booking_value
+        ,b.is_lux
+      FROM {{ source_schema }}.fct_bookings a
+      LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest b
+      ON a.listing_id = b.listing_id
+      GROUP BY 2
+    ) bk
+    INNER JOIN (
+      SELECT
+        SUM(1) AS views
+        ,d.is_lux
+      FROM {{ source_schema }}.fct_views c
+      LEFT OUTER JOIN {{ source_schema }}.dim_listings_latest d
+      ON c.listing_id = d.listing_id
+      GROUP BY 2
+    ) vw
+    ON bk.is_lux = vw.is_lux

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_combined_metrics_plan__ep_0.xml
@@ -2,97 +2,93 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                               -->
-        <!--   -- Combine Metrics                                                                      -->
-        <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
-        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
-        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
-        <!--   FROM (                                                                                  -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(bookings) AS bookings                                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , 1 AS bookings                                                                   -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_2                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_12                                                                               -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                      -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_6                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_13                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
-        <!--     ) AND (                                                                               -->
-        <!--       subq_12.ds = subq_13.ds                                                             -->
-        <!--     )                                                                                     -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Metric Time Dimension 'ds'                                                         -->
-        <!--     -- Pass Only Elements:                                                                -->
-        <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(booking_value) AS booking_value                                               -->
-        <!--     FROM (                                                                                -->
-        <!--       -- User Defined SQL Query                                                           -->
-        <!--       SELECT * FROM ***************************.fct_bookings                              -->
-        <!--     ) bookings_source_src_10001                                                           -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_14                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
-        <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
-        <!--     )                                                                                     -->
-        <!--   GROUP BY                                                                                -->
-        <!--     ds                                                                                    -->
-        <!--     , is_instant                                                                          -->
+        <!-- sql_query =                                                                             -->
+        <!--   -- Combine Metrics                                                                    -->
+        <!--   SELECT                                                                                -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                                                  -->
+        <!--     , MAX(subq_9.instant_bookings) AS instant_bookings                                  -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                       -->
+        <!--   FROM (                                                                                -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(bookings) AS bookings                                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                             -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , 1 AS bookings                                                                 -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_2                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_4                                                                              -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                     -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_7                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_9                                                                              -->
+        <!--   ON                                                                                    -->
+        <!--     (subq_4.is_instant = subq_9.is_instant) AND (subq_4.ds = subq_9.ds)                 -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                 -->
+        <!--     -- Metric Time Dimension 'ds'                                                       -->
+        <!--     -- Pass Only Elements:                                                              -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                          -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(booking_value) AS booking_value                                             -->
+        <!--     FROM (                                                                              -->
+        <!--       -- User Defined SQL Query                                                         -->
+        <!--       SELECT * FROM ***************************.fct_bookings                            -->
+        <!--     ) bookings_source_src_10001                                                         -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_14                                                                             -->
+        <!--   ON                                                                                    -->
+        <!--     (                                                                                   -->
+        <!--       COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant               -->
+        <!--     ) AND (                                                                             -->
+        <!--       COALESCE(subq_4.ds, subq_9.ds) = subq_14.ds                                       -->
+        <!--     )                                                                                   -->
+        <!--   GROUP BY                                                                              -->
+        <!--     ds                                                                                  -->
+        <!--     , is_instant                                                                        -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuerySqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -5,8 +5,8 @@
         <!-- sql_query =                                                       -->
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                            -->
         <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
@@ -29,7 +29,7 @@
         <!--     ) subq_2                                                      -->
         <!--     GROUP BY                                                      -->
         <!--       is_instant                                                  -->
-        <!--   ) subq_8                                                        -->
+        <!--   ) subq_4                                                        -->
         <!--   FULL OUTER JOIN (                                               -->
         <!--     -- Read Elements From Data Source 'bookings_source'           -->
         <!--     -- Metric Time Dimension 'ds'                                 -->
@@ -48,7 +48,7 @@
         <!--       is_instant                                                  -->
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
-        <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--     subq_4.is_instant = subq_9.is_instant                         -->
         <!--   GROUP BY                                                        -->
         <!--     is_instant                                                    -->
     </SelectSqlQueryToDataFrameTask>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -2,97 +2,93 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                               -->
-        <!--   -- Combine Metrics                                                                      -->
-        <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
-        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
-        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
-        <!--   FROM (                                                                                  -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(bookings) AS bookings                                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , 1 AS bookings                                                                   -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_2                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_12                                                                               -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                      -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_6                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_13                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
-        <!--     ) AND (                                                                               -->
-        <!--       subq_12.ds = subq_13.ds                                                             -->
-        <!--     )                                                                                     -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Metric Time Dimension 'ds'                                                         -->
-        <!--     -- Pass Only Elements:                                                                -->
-        <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(booking_value) AS booking_value                                               -->
-        <!--     FROM (                                                                                -->
-        <!--       -- User Defined SQL Query                                                           -->
-        <!--       SELECT * FROM ***************************.fct_bookings                              -->
-        <!--     ) bookings_source_src_10001                                                           -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_14                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
-        <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
-        <!--     )                                                                                     -->
-        <!--   GROUP BY                                                                                -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
+        <!-- sql_query =                                                                             -->
+        <!--   -- Combine Metrics                                                                    -->
+        <!--   SELECT                                                                                -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                                                  -->
+        <!--     , MAX(subq_9.instant_bookings) AS instant_bookings                                  -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                       -->
+        <!--   FROM (                                                                                -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(bookings) AS bookings                                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                             -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , 1 AS bookings                                                                 -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_2                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_4                                                                              -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                     -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_7                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_9                                                                              -->
+        <!--   ON                                                                                    -->
+        <!--     (subq_4.is_instant = subq_9.is_instant) AND (subq_4.ds = subq_9.ds)                 -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                 -->
+        <!--     -- Metric Time Dimension 'ds'                                                       -->
+        <!--     -- Pass Only Elements:                                                              -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                          -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(booking_value) AS booking_value                                             -->
+        <!--     FROM (                                                                              -->
+        <!--       -- User Defined SQL Query                                                         -->
+        <!--       SELECT * FROM ***************************.fct_bookings                            -->
+        <!--     ) bookings_source_src_10001                                                         -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_14                                                                             -->
+        <!--   ON                                                                                    -->
+        <!--     (                                                                                   -->
+        <!--       COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant               -->
+        <!--     ) AND (                                                                             -->
+        <!--       COALESCE(subq_4.ds, subq_9.ds) = subq_14.ds                                       -->
+        <!--     )                                                                                   -->
+        <!--   GROUP BY                                                                              -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DatabricksSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -5,8 +5,8 @@
         <!-- sql_query =                                                       -->
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                            -->
         <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
@@ -29,7 +29,7 @@
         <!--     ) subq_2                                                      -->
         <!--     GROUP BY                                                      -->
         <!--       is_instant                                                  -->
-        <!--   ) subq_8                                                        -->
+        <!--   ) subq_4                                                        -->
         <!--   FULL OUTER JOIN (                                               -->
         <!--     -- Read Elements From Data Source 'bookings_source'           -->
         <!--     -- Metric Time Dimension 'ds'                                 -->
@@ -48,8 +48,8 @@
         <!--       is_instant                                                  -->
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
-        <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--     subq_4.is_instant = subq_9.is_instant                         -->
         <!--   GROUP BY                                                        -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -2,97 +2,93 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                               -->
-        <!--   -- Combine Metrics                                                                      -->
-        <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
-        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
-        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
-        <!--   FROM (                                                                                  -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(bookings) AS bookings                                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , 1 AS bookings                                                                   -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_2                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_12                                                                               -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                      -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_6                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_13                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
-        <!--     ) AND (                                                                               -->
-        <!--       subq_12.ds = subq_13.ds                                                             -->
-        <!--     )                                                                                     -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Metric Time Dimension 'ds'                                                         -->
-        <!--     -- Pass Only Elements:                                                                -->
-        <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(booking_value) AS booking_value                                               -->
-        <!--     FROM (                                                                                -->
-        <!--       -- User Defined SQL Query                                                           -->
-        <!--       SELECT * FROM ***************************.fct_bookings                              -->
-        <!--     ) bookings_source_src_10001                                                           -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_14                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
-        <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
-        <!--     )                                                                                     -->
-        <!--   GROUP BY                                                                                -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
+        <!-- sql_query =                                                                             -->
+        <!--   -- Combine Metrics                                                                    -->
+        <!--   SELECT                                                                                -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                                                  -->
+        <!--     , MAX(subq_9.instant_bookings) AS instant_bookings                                  -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                       -->
+        <!--   FROM (                                                                                -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(bookings) AS bookings                                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                             -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , 1 AS bookings                                                                 -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_2                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_4                                                                              -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                     -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_7                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_9                                                                              -->
+        <!--   ON                                                                                    -->
+        <!--     (subq_4.is_instant = subq_9.is_instant) AND (subq_4.ds = subq_9.ds)                 -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                 -->
+        <!--     -- Metric Time Dimension 'ds'                                                       -->
+        <!--     -- Pass Only Elements:                                                              -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                          -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(booking_value) AS booking_value                                             -->
+        <!--     FROM (                                                                              -->
+        <!--       -- User Defined SQL Query                                                         -->
+        <!--       SELECT * FROM ***************************.fct_bookings                            -->
+        <!--     ) bookings_source_src_10001                                                         -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_14                                                                             -->
+        <!--   ON                                                                                    -->
+        <!--     (                                                                                   -->
+        <!--       COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant               -->
+        <!--     ) AND (                                                                             -->
+        <!--       COALESCE(subq_4.ds, subq_9.ds) = subq_14.ds                                       -->
+        <!--     )                                                                                   -->
+        <!--   GROUP BY                                                                              -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDbSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -5,8 +5,8 @@
         <!-- sql_query =                                                       -->
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                            -->
         <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
@@ -29,7 +29,7 @@
         <!--     ) subq_2                                                      -->
         <!--     GROUP BY                                                      -->
         <!--       is_instant                                                  -->
-        <!--   ) subq_8                                                        -->
+        <!--   ) subq_4                                                        -->
         <!--   FULL OUTER JOIN (                                               -->
         <!--     -- Read Elements From Data Source 'bookings_source'           -->
         <!--     -- Metric Time Dimension 'ds'                                 -->
@@ -48,8 +48,8 @@
         <!--       is_instant                                                  -->
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
-        <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--     subq_4.is_instant = subq_9.is_instant                         -->
         <!--   GROUP BY                                                        -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -2,97 +2,93 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                               -->
-        <!--   -- Combine Metrics                                                                      -->
-        <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
-        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
-        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
-        <!--   FROM (                                                                                  -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(bookings) AS bookings                                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , 1 AS bookings                                                                   -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_2                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_12                                                                               -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                      -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_6                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_13                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
-        <!--     ) AND (                                                                               -->
-        <!--       subq_12.ds = subq_13.ds                                                             -->
-        <!--     )                                                                                     -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Metric Time Dimension 'ds'                                                         -->
-        <!--     -- Pass Only Elements:                                                                -->
-        <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(booking_value) AS booking_value                                               -->
-        <!--     FROM (                                                                                -->
-        <!--       -- User Defined SQL Query                                                           -->
-        <!--       SELECT * FROM ***************************.fct_bookings                              -->
-        <!--     ) bookings_source_src_10001                                                           -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_14                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
-        <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
-        <!--     )                                                                                     -->
-        <!--   GROUP BY                                                                                -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
+        <!-- sql_query =                                                                             -->
+        <!--   -- Combine Metrics                                                                    -->
+        <!--   SELECT                                                                                -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                                                  -->
+        <!--     , MAX(subq_9.instant_bookings) AS instant_bookings                                  -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                       -->
+        <!--   FROM (                                                                                -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(bookings) AS bookings                                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                             -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , 1 AS bookings                                                                 -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_2                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_4                                                                              -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                     -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_7                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_9                                                                              -->
+        <!--   ON                                                                                    -->
+        <!--     (subq_4.is_instant = subq_9.is_instant) AND (subq_4.ds = subq_9.ds)                 -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                 -->
+        <!--     -- Metric Time Dimension 'ds'                                                       -->
+        <!--     -- Pass Only Elements:                                                              -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                          -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(booking_value) AS booking_value                                             -->
+        <!--     FROM (                                                                              -->
+        <!--       -- User Defined SQL Query                                                         -->
+        <!--       SELECT * FROM ***************************.fct_bookings                            -->
+        <!--     ) bookings_source_src_10001                                                         -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_14                                                                             -->
+        <!--   ON                                                                                    -->
+        <!--     (                                                                                   -->
+        <!--       COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant               -->
+        <!--     ) AND (                                                                             -->
+        <!--       COALESCE(subq_4.ds, subq_9.ds) = subq_14.ds                                       -->
+        <!--     )                                                                                   -->
+        <!--   GROUP BY                                                                              -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/PostgresSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -5,8 +5,8 @@
         <!-- sql_query =                                                       -->
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                            -->
         <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
@@ -29,7 +29,7 @@
         <!--     ) subq_2                                                      -->
         <!--     GROUP BY                                                      -->
         <!--       is_instant                                                  -->
-        <!--   ) subq_8                                                        -->
+        <!--   ) subq_4                                                        -->
         <!--   FULL OUTER JOIN (                                               -->
         <!--     -- Read Elements From Data Source 'bookings_source'           -->
         <!--     -- Metric Time Dimension 'ds'                                 -->
@@ -48,8 +48,8 @@
         <!--       is_instant                                                  -->
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
-        <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--     subq_4.is_instant = subq_9.is_instant                         -->
         <!--   GROUP BY                                                        -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -2,97 +2,93 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                               -->
-        <!--   -- Combine Metrics                                                                      -->
-        <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
-        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
-        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
-        <!--   FROM (                                                                                  -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(bookings) AS bookings                                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , 1 AS bookings                                                                   -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_2                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_12                                                                               -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                      -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_6                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_13                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
-        <!--     ) AND (                                                                               -->
-        <!--       subq_12.ds = subq_13.ds                                                             -->
-        <!--     )                                                                                     -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Metric Time Dimension 'ds'                                                         -->
-        <!--     -- Pass Only Elements:                                                                -->
-        <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(booking_value) AS booking_value                                               -->
-        <!--     FROM (                                                                                -->
-        <!--       -- User Defined SQL Query                                                           -->
-        <!--       SELECT * FROM ***************************.fct_bookings                              -->
-        <!--     ) bookings_source_src_10001                                                           -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_14                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
-        <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
-        <!--     )                                                                                     -->
-        <!--   GROUP BY                                                                                -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
+        <!-- sql_query =                                                                             -->
+        <!--   -- Combine Metrics                                                                    -->
+        <!--   SELECT                                                                                -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                                                  -->
+        <!--     , MAX(subq_9.instant_bookings) AS instant_bookings                                  -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                       -->
+        <!--   FROM (                                                                                -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(bookings) AS bookings                                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                             -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , 1 AS bookings                                                                 -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_2                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_4                                                                              -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                     -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_7                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_9                                                                              -->
+        <!--   ON                                                                                    -->
+        <!--     (subq_4.is_instant = subq_9.is_instant) AND (subq_4.ds = subq_9.ds)                 -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                 -->
+        <!--     -- Metric Time Dimension 'ds'                                                       -->
+        <!--     -- Pass Only Elements:                                                              -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                          -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(booking_value) AS booking_value                                             -->
+        <!--     FROM (                                                                              -->
+        <!--       -- User Defined SQL Query                                                         -->
+        <!--       SELECT * FROM ***************************.fct_bookings                            -->
+        <!--     ) bookings_source_src_10001                                                         -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_14                                                                             -->
+        <!--   ON                                                                                    -->
+        <!--     (                                                                                   -->
+        <!--       COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant               -->
+        <!--     ) AND (                                                                             -->
+        <!--       COALESCE(subq_4.ds, subq_9.ds) = subq_14.ds                                       -->
+        <!--     )                                                                                   -->
+        <!--   GROUP BY                                                                              -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/RedshiftSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -5,8 +5,8 @@
         <!-- sql_query =                                                       -->
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                            -->
         <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
@@ -29,7 +29,7 @@
         <!--     ) subq_2                                                      -->
         <!--     GROUP BY                                                      -->
         <!--       is_instant                                                  -->
-        <!--   ) subq_8                                                        -->
+        <!--   ) subq_4                                                        -->
         <!--   FULL OUTER JOIN (                                               -->
         <!--     -- Read Elements From Data Source 'bookings_source'           -->
         <!--     -- Metric Time Dimension 'ds'                                 -->
@@ -48,8 +48,8 @@
         <!--       is_instant                                                  -->
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
-        <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--     subq_4.is_instant = subq_9.is_instant                         -->
         <!--   GROUP BY                                                        -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_combined_metrics_plan__ep_0.xml
@@ -2,97 +2,93 @@
     <SelectSqlQueryToDataFrameTask>
         <!-- description = Run a query and write the results to a data frame -->
         <!-- node_id = rsq_0 -->
-        <!-- sql_query =                                                                               -->
-        <!--   -- Combine Metrics                                                                      -->
-        <!--   SELECT                                                                                  -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds) AS ds                                    -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_12.bookings) AS bookings                                                   -->
-        <!--     , MAX(subq_13.instant_bookings) AS instant_bookings                                   -->
-        <!--     , MAX(subq_14.booking_value) AS booking_value                                         -->
-        <!--   FROM (                                                                                  -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(bookings) AS bookings                                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['bookings', 'is_instant', 'ds']                                               -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , 1 AS bookings                                                                   -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_2                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_12                                                                               -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(instant_bookings) AS instant_bookings                                         -->
-        <!--     FROM (                                                                                -->
-        <!--       -- Read Elements From Data Source 'bookings_source'                                 -->
-        <!--       -- Metric Time Dimension 'ds'                                                       -->
-        <!--       -- Pass Only Elements:                                                              -->
-        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                       -->
-        <!--       SELECT                                                                              -->
-        <!--         ds                                                                                -->
-        <!--         , is_instant                                                                      -->
-        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                      -->
-        <!--       FROM (                                                                              -->
-        <!--         -- User Defined SQL Query                                                         -->
-        <!--         SELECT * FROM ***************************.fct_bookings                            -->
-        <!--       ) bookings_source_src_10001                                                         -->
-        <!--     ) subq_6                                                                              -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_13                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       subq_12.is_instant = subq_13.is_instant                                             -->
-        <!--     ) AND (                                                                               -->
-        <!--       subq_12.ds = subq_13.ds                                                             -->
-        <!--     )                                                                                     -->
-        <!--   FULL OUTER JOIN (                                                                       -->
-        <!--     -- Read Elements From Data Source 'bookings_source'                                   -->
-        <!--     -- Metric Time Dimension 'ds'                                                         -->
-        <!--     -- Pass Only Elements:                                                                -->
-        <!--     --   ['booking_value', 'is_instant', 'ds']                                            -->
-        <!--     -- Aggregate Measures                                                                 -->
-        <!--     -- Compute Metrics via Expressions                                                    -->
-        <!--     SELECT                                                                                -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--       , SUM(booking_value) AS booking_value                                               -->
-        <!--     FROM (                                                                                -->
-        <!--       -- User Defined SQL Query                                                           -->
-        <!--       SELECT * FROM ***************************.fct_bookings                              -->
-        <!--     ) bookings_source_src_10001                                                           -->
-        <!--     GROUP BY                                                                              -->
-        <!--       ds                                                                                  -->
-        <!--       , is_instant                                                                        -->
-        <!--   ) subq_14                                                                               -->
-        <!--   ON                                                                                      -->
-        <!--     (                                                                                     -->
-        <!--       COALESCE(subq_12.is_instant, subq_13.is_instant) = subq_14.is_instant               -->
-        <!--     ) AND (                                                                               -->
-        <!--       COALESCE(subq_12.ds, subq_13.ds) = subq_14.ds                                       -->
-        <!--     )                                                                                     -->
-        <!--   GROUP BY                                                                                -->
-        <!--     COALESCE(subq_12.ds, subq_13.ds, subq_14.ds)                                          -->
-        <!--     , COALESCE(subq_12.is_instant, subq_13.is_instant, subq_14.is_instant)                -->
+        <!-- sql_query =                                                                             -->
+        <!--   -- Combine Metrics                                                                    -->
+        <!--   SELECT                                                                                -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds) AS ds                                    -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                                                  -->
+        <!--     , MAX(subq_9.instant_bookings) AS instant_bookings                                  -->
+        <!--     , MAX(subq_14.booking_value) AS booking_value                                       -->
+        <!--   FROM (                                                                                -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(bookings) AS bookings                                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['bookings', 'is_instant', 'ds']                                             -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , 1 AS bookings                                                                 -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_2                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_4                                                                              -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(instant_bookings) AS instant_bookings                                       -->
+        <!--     FROM (                                                                              -->
+        <!--       -- Read Elements From Data Source 'bookings_source'                               -->
+        <!--       -- Metric Time Dimension 'ds'                                                     -->
+        <!--       -- Pass Only Elements:                                                            -->
+        <!--       --   ['instant_bookings', 'is_instant', 'ds']                                     -->
+        <!--       SELECT                                                                            -->
+        <!--         ds                                                                              -->
+        <!--         , is_instant                                                                    -->
+        <!--         , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings                    -->
+        <!--       FROM (                                                                            -->
+        <!--         -- User Defined SQL Query                                                       -->
+        <!--         SELECT * FROM ***************************.fct_bookings                          -->
+        <!--       ) bookings_source_src_10001                                                       -->
+        <!--     ) subq_7                                                                            -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_9                                                                              -->
+        <!--   ON                                                                                    -->
+        <!--     (subq_4.is_instant = subq_9.is_instant) AND (subq_4.ds = subq_9.ds)                 -->
+        <!--   FULL OUTER JOIN (                                                                     -->
+        <!--     -- Read Elements From Data Source 'bookings_source'                                 -->
+        <!--     -- Metric Time Dimension 'ds'                                                       -->
+        <!--     -- Pass Only Elements:                                                              -->
+        <!--     --   ['booking_value', 'is_instant', 'ds']                                          -->
+        <!--     -- Aggregate Measures                                                               -->
+        <!--     -- Compute Metrics via Expressions                                                  -->
+        <!--     SELECT                                                                              -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--       , SUM(booking_value) AS booking_value                                             -->
+        <!--     FROM (                                                                              -->
+        <!--       -- User Defined SQL Query                                                         -->
+        <!--       SELECT * FROM ***************************.fct_bookings                            -->
+        <!--     ) bookings_source_src_10001                                                         -->
+        <!--     GROUP BY                                                                            -->
+        <!--       ds                                                                                -->
+        <!--       , is_instant                                                                      -->
+        <!--   ) subq_14                                                                             -->
+        <!--   ON                                                                                    -->
+        <!--     (                                                                                   -->
+        <!--       COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant               -->
+        <!--     ) AND (                                                                             -->
+        <!--       COALESCE(subq_4.ds, subq_9.ds) = subq_14.ds                                       -->
+        <!--     )                                                                                   -->
+        <!--   GROUP BY                                                                              -->
+        <!--     COALESCE(subq_4.ds, subq_9.ds, subq_14.ds)                                          -->
+        <!--     , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_execution.py/ExecutionPlan/SnowflakeSqlClient/test_small_combined_metrics_plan__ep_0.xml
@@ -5,8 +5,8 @@
         <!-- sql_query =                                                       -->
         <!--   -- Combine Metrics                                              -->
         <!--   SELECT                                                          -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant) AS is_instant  -->
-        <!--     , MAX(subq_8.bookings) AS bookings                            -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant  -->
+        <!--     , MAX(subq_4.bookings) AS bookings                            -->
         <!--     , MAX(subq_9.booking_value) AS booking_value                  -->
         <!--   FROM (                                                          -->
         <!--     -- Aggregate Measures                                         -->
@@ -29,7 +29,7 @@
         <!--     ) subq_2                                                      -->
         <!--     GROUP BY                                                      -->
         <!--       is_instant                                                  -->
-        <!--   ) subq_8                                                        -->
+        <!--   ) subq_4                                                        -->
         <!--   FULL OUTER JOIN (                                               -->
         <!--     -- Read Elements From Data Source 'bookings_source'           -->
         <!--     -- Metric Time Dimension 'ds'                                 -->
@@ -48,8 +48,8 @@
         <!--       is_instant                                                  -->
         <!--   ) subq_9                                                        -->
         <!--   ON                                                              -->
-        <!--     subq_8.is_instant = subq_9.is_instant                         -->
+        <!--     subq_4.is_instant = subq_9.is_instant                         -->
         <!--   GROUP BY                                                        -->
-        <!--     COALESCE(subq_8.is_instant, subq_9.is_instant)                -->
+        <!--     COALESCE(subq_4.is_instant, subq_9.is_instant)                -->
     </SelectSqlQueryToDataFrameTask>
 </ExecutionPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
@@ -135,78 +135,78 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_value
+    subq_8.metric_time
+    , subq_8.booking_value
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_value) AS booking_value
+      subq_7.metric_time
+      , SUM(subq_7.booking_value) AS booking_value
     FROM (
       -- Pass Only Elements:
       --   ['booking_value', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_value
+        subq_6.metric_time
+        , subq_6.booking_value
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.ds AS metric_time
-          , subq_4.ds__week AS metric_time__week
-          , subq_4.ds__month AS metric_time__month
-          , subq_4.ds__quarter AS metric_time__quarter
-          , subq_4.ds__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.bookings
-          , subq_4.instant_bookings
-          , subq_4.booking_value
-          , subq_4.max_booking_value
-          , subq_4.min_booking_value
-          , subq_4.bookers
-          , subq_4.average_booking_value
-          , subq_4.referred_bookings
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.ds AS metric_time
+          , subq_5.ds__week AS metric_time__week
+          , subq_5.ds__month AS metric_time__month
+          , subq_5.ds__quarter AS metric_time__quarter
+          , subq_5.ds__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.bookings
+          , subq_5.instant_bookings
+          , subq_5.booking_value
+          , subq_5.max_booking_value
+          , subq_5.min_booking_value
+          , subq_5.bookers
+          , subq_5.average_booking_value
+          , subq_5.referred_bookings
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -262,14 +262,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     metric_time
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
@@ -275,5 +275,9 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    subq_4.metric_time = subq_9.metric_time
+    (
+      subq_4.metric_time = subq_9.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+    )
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-    , subq_8.ref_bookings AS ref_bookings
+    COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+    , subq_4.ref_bookings AS ref_bookings
     , subq_9.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -140,78 +140,78 @@ FROM (
       GROUP BY
         subq_2.metric_time
     ) subq_3
-  ) subq_8
+  ) subq_4
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_7.metric_time
-      , subq_7.bookings
+      subq_8.metric_time
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time
-        , SUM(subq_6.bookings) AS bookings
+        subq_7.metric_time
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_5.metric_time
-          , subq_5.bookings
+          subq_6.metric_time
+          , subq_6.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds_partitioned
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.booking_paid_at
-            , subq_4.booking_paid_at__week
-            , subq_4.booking_paid_at__month
-            , subq_4.booking_paid_at__quarter
-            , subq_4.booking_paid_at__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds
-            , subq_4.create_a_cycle_in_the_join_graph__ds__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.create_a_cycle_in_the_join_graph
-            , subq_4.create_a_cycle_in_the_join_graph__listing
-            , subq_4.create_a_cycle_in_the_join_graph__guest
-            , subq_4.create_a_cycle_in_the_join_graph__host
-            , subq_4.is_instant
-            , subq_4.create_a_cycle_in_the_join_graph__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.ds_partitioned
+            , subq_5.ds_partitioned__week
+            , subq_5.ds_partitioned__month
+            , subq_5.ds_partitioned__quarter
+            , subq_5.ds_partitioned__year
+            , subq_5.booking_paid_at
+            , subq_5.booking_paid_at__week
+            , subq_5.booking_paid_at__month
+            , subq_5.booking_paid_at__quarter
+            , subq_5.booking_paid_at__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds
+            , subq_5.create_a_cycle_in_the_join_graph__ds__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.guest
+            , subq_5.host
+            , subq_5.create_a_cycle_in_the_join_graph
+            , subq_5.create_a_cycle_in_the_join_graph__listing
+            , subq_5.create_a_cycle_in_the_join_graph__guest
+            , subq_5.create_a_cycle_in_the_join_graph__host
+            , subq_5.is_instant
+            , subq_5.create_a_cycle_in_the_join_graph__is_instant
+            , subq_5.bookings
+            , subq_5.instant_bookings
+            , subq_5.booking_value
+            , subq_5.max_booking_value
+            , subq_5.min_booking_value
+            , subq_5.bookers
+            , subq_5.average_booking_value
+            , subq_5.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -267,13 +267,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_4
-        ) subq_5
-      ) subq_6
+          ) subq_5
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_6.metric_time
-    ) subq_7
+        subq_7.metric_time
+    ) subq_8
   ) subq_9
   ON
-    subq_8.metric_time = subq_9.metric_time
+    subq_4.metric_time = subq_9.metric_time
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
@@ -53,5 +53,9 @@ FROM (
       metric_time
   ) subq_20
   ON
-    subq_15.metric_time = subq_20.metric_time
+    (
+      subq_15.metric_time = subq_20.metric_time
+    ) OR (
+      (subq_15.metric_time IS NULL) AND (subq_20.metric_time IS NULL)
+    )
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time) AS metric_time
-    , subq_19.ref_bookings AS ref_bookings
+    COALESCE(subq_15.metric_time, subq_20.metric_time) AS metric_time
+    , subq_15.ref_bookings AS ref_bookings
     , subq_20.bookings AS bookings
   FROM (
     -- Aggregate Measures
@@ -29,7 +29,7 @@ FROM (
     ) subq_13
     GROUP BY
       metric_time
-  ) subq_19
+  ) subq_15
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -48,10 +48,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_17
+    ) subq_18
     GROUP BY
       metric_time
   ) subq_20
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_15.metric_time = subq_20.metric_time
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_10.bookings) AS bookings
+  MAX(subq_5.bookings) AS bookings
   , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
@@ -186,100 +186,100 @@ FROM (
       ) subq_2
     ) subq_3
   ) subq_4
-) subq_10
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_8.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements:
       --   ['listings']
       SELECT
-        subq_7.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.created_at
-          , subq_6.created_at__week
-          , subq_6.created_at__month
-          , subq_6.created_at__quarter
-          , subq_6.created_at__year
-          , subq_6.listing__ds
-          , subq_6.listing__ds__week
-          , subq_6.listing__ds__month
-          , subq_6.listing__ds__quarter
-          , subq_6.listing__ds__year
-          , subq_6.listing__created_at
-          , subq_6.listing__created_at__week
-          , subq_6.listing__created_at__month
-          , subq_6.listing__created_at__quarter
-          , subq_6.listing__created_at__year
-          , subq_6.metric_time
-          , subq_6.metric_time__week
-          , subq_6.metric_time__month
-          , subq_6.metric_time__quarter
-          , subq_6.metric_time__year
-          , subq_6.listing
-          , subq_6.user
-          , subq_6.listing__user
-          , subq_6.country_latest
-          , subq_6.is_lux_latest
-          , subq_6.capacity_latest
-          , subq_6.listing__country_latest
-          , subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.listings
-          , subq_6.largest_listing
-          , subq_6.smallest_listing
+          subq_7.ds
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.created_at
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.listing__ds
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__created_at
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.metric_time
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.created_at
-            , subq_5.created_at__week
-            , subq_5.created_at__month
-            , subq_5.created_at__quarter
-            , subq_5.created_at__year
-            , subq_5.listing__ds
-            , subq_5.listing__ds__week
-            , subq_5.listing__ds__month
-            , subq_5.listing__ds__quarter
-            , subq_5.listing__ds__year
-            , subq_5.listing__created_at
-            , subq_5.listing__created_at__week
-            , subq_5.listing__created_at__month
-            , subq_5.listing__created_at__quarter
-            , subq_5.listing__created_at__year
-            , subq_5.ds AS metric_time
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.listing
-            , subq_5.user
-            , subq_5.listing__user
-            , subq_5.country_latest
-            , subq_5.is_lux_latest
-            , subq_5.capacity_latest
-            , subq_5.listing__country_latest
-            , subq_5.listing__is_lux_latest
-            , subq_5.listing__capacity_latest
-            , subq_5.listings
-            , subq_5.largest_listing
-            , subq_5.smallest_listing
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.created_at
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.listing__ds
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__created_at
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Data Source 'listings_latest'
             SELECT
@@ -316,10 +316,10 @@ CROSS JOIN (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_5
-        ) subq_6
-        WHERE subq_6.metric_time BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
-      ) subq_7
-    ) subq_8
-  ) subq_9
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
+      ) subq_8
+    ) subq_9
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_22.bookings) AS bookings
+  MAX(subq_17.bookings) AS bookings
   , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
@@ -17,7 +17,7 @@ FROM (
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
   WHERE ds BETWEEN CAST('2020-01-01' AS DATETIME) AND CAST('2020-01-01' AS DATETIME)
-) subq_22
+) subq_17
 CROSS JOIN (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
@@ -287,7 +287,11 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        subq_4.metric_time = subq_9.metric_time
+        (
+          subq_4.metric_time = subq_9.metric_time
+        ) OR (
+          (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+        )
     ) subq_10
   ) subq_11
   INNER JOIN (
@@ -424,7 +428,11 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    subq_11.metric_time = subq_16.metric_time
+    (
+      subq_11.metric_time = subq_16.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_16.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -559,5 +567,9 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
+    (
+      subq_11.metric_time = subq_21.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    )
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time, subq_21.metric_time) AS metric_time
-    , subq_19.non_referred AS non_referred
-    , subq_20.instant AS instant
+    COALESCE(subq_11.metric_time, subq_16.metric_time, subq_21.metric_time) AS metric_time
+    , subq_11.non_referred AS non_referred
+    , subq_16.instant AS instant
     , subq_21.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-        , subq_8.ref_bookings AS ref_bookings
+        COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+        , subq_4.ref_bookings AS ref_bookings
         , subq_9.bookings AS bookings
       FROM (
         -- Compute Metrics via Expressions
@@ -152,78 +152,78 @@ FROM (
           GROUP BY
             subq_2.metric_time
         ) subq_3
-      ) subq_8
+      ) subq_4
       INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
-          subq_7.metric_time
-          , subq_7.bookings
+          subq_8.metric_time
+          , subq_8.bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_6.metric_time
-            , SUM(subq_6.bookings) AS bookings
+            subq_7.metric_time
+            , SUM(subq_7.bookings) AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'metric_time']
             SELECT
-              subq_5.metric_time
-              , subq_5.bookings
+              subq_6.metric_time
+              , subq_6.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds_partitioned
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.booking_paid_at
-                , subq_4.booking_paid_at__week
-                , subq_4.booking_paid_at__month
-                , subq_4.booking_paid_at__quarter
-                , subq_4.booking_paid_at__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds
-                , subq_4.create_a_cycle_in_the_join_graph__ds__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_4.ds AS metric_time
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.create_a_cycle_in_the_join_graph
-                , subq_4.create_a_cycle_in_the_join_graph__listing
-                , subq_4.create_a_cycle_in_the_join_graph__guest
-                , subq_4.create_a_cycle_in_the_join_graph__host
-                , subq_4.is_instant
-                , subq_4.create_a_cycle_in_the_join_graph__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
+                subq_5.ds
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds_partitioned
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.booking_paid_at
+                , subq_5.booking_paid_at__week
+                , subq_5.booking_paid_at__month
+                , subq_5.booking_paid_at__quarter
+                , subq_5.booking_paid_at__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds
+                , subq_5.create_a_cycle_in_the_join_graph__ds__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_5.ds AS metric_time
+                , subq_5.ds__week AS metric_time__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter AS metric_time__quarter
+                , subq_5.ds__year AS metric_time__year
+                , subq_5.listing
+                , subq_5.guest
+                , subq_5.host
+                , subq_5.create_a_cycle_in_the_join_graph
+                , subq_5.create_a_cycle_in_the_join_graph__listing
+                , subq_5.create_a_cycle_in_the_join_graph__guest
+                , subq_5.create_a_cycle_in_the_join_graph__host
+                , subq_5.is_instant
+                , subq_5.create_a_cycle_in_the_join_graph__is_instant
+                , subq_5.bookings
+                , subq_5.instant_bookings
+                , subq_5.booking_value
+                , subq_5.max_booking_value
+                , subq_5.min_booking_value
+                , subq_5.bookers
+                , subq_5.average_booking_value
+                , subq_5.referred_bookings
               FROM (
                 -- Read Elements From Data Source 'bookings_source'
                 SELECT
@@ -279,88 +279,88 @@ FROM (
                   -- User Defined SQL Query
                   SELECT * FROM ***************************.fct_bookings
                 ) bookings_source_src_10001
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_5
+            ) subq_6
+          ) subq_7
           GROUP BY
-            subq_6.metric_time
-        ) subq_7
+            subq_7.metric_time
+        ) subq_8
       ) subq_9
       ON
-        subq_8.metric_time = subq_9.metric_time
+        subq_4.metric_time = subq_9.metric_time
     ) subq_10
-  ) subq_19
+  ) subq_11
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_14.metric_time
-      , subq_14.instant_bookings AS instant
+      subq_15.metric_time
+      , subq_15.instant_bookings AS instant
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_13.metric_time
-        , SUM(subq_13.instant_bookings) AS instant_bookings
+        subq_14.metric_time
+        , SUM(subq_14.instant_bookings) AS instant_bookings
       FROM (
         -- Pass Only Elements:
         --   ['instant_bookings', 'metric_time']
         SELECT
-          subq_12.metric_time
-          , subq_12.instant_bookings
+          subq_13.metric_time
+          , subq_13.instant_bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds_partitioned
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.booking_paid_at
-            , subq_11.booking_paid_at__week
-            , subq_11.booking_paid_at__month
-            , subq_11.booking_paid_at__quarter
-            , subq_11.booking_paid_at__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds
-            , subq_11.create_a_cycle_in_the_join_graph__ds__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_11.ds AS metric_time
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.create_a_cycle_in_the_join_graph
-            , subq_11.create_a_cycle_in_the_join_graph__listing
-            , subq_11.create_a_cycle_in_the_join_graph__guest
-            , subq_11.create_a_cycle_in_the_join_graph__host
-            , subq_11.is_instant
-            , subq_11.create_a_cycle_in_the_join_graph__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.max_booking_value
-            , subq_11.min_booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
-            , subq_11.referred_bookings
+            subq_12.ds
+            , subq_12.ds__week
+            , subq_12.ds__month
+            , subq_12.ds__quarter
+            , subq_12.ds__year
+            , subq_12.ds_partitioned
+            , subq_12.ds_partitioned__week
+            , subq_12.ds_partitioned__month
+            , subq_12.ds_partitioned__quarter
+            , subq_12.ds_partitioned__year
+            , subq_12.booking_paid_at
+            , subq_12.booking_paid_at__week
+            , subq_12.booking_paid_at__month
+            , subq_12.booking_paid_at__quarter
+            , subq_12.booking_paid_at__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds
+            , subq_12.create_a_cycle_in_the_join_graph__ds__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_12.ds AS metric_time
+            , subq_12.ds__week AS metric_time__week
+            , subq_12.ds__month AS metric_time__month
+            , subq_12.ds__quarter AS metric_time__quarter
+            , subq_12.ds__year AS metric_time__year
+            , subq_12.listing
+            , subq_12.guest
+            , subq_12.host
+            , subq_12.create_a_cycle_in_the_join_graph
+            , subq_12.create_a_cycle_in_the_join_graph__listing
+            , subq_12.create_a_cycle_in_the_join_graph__guest
+            , subq_12.create_a_cycle_in_the_join_graph__host
+            , subq_12.is_instant
+            , subq_12.create_a_cycle_in_the_join_graph__is_instant
+            , subq_12.bookings
+            , subq_12.instant_bookings
+            , subq_12.booking_value
+            , subq_12.max_booking_value
+            , subq_12.min_booking_value
+            , subq_12.bookers
+            , subq_12.average_booking_value
+            , subq_12.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -416,86 +416,86 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_12
+        ) subq_13
+      ) subq_14
       GROUP BY
-        subq_13.metric_time
-    ) subq_14
-  ) subq_20
+        subq_14.metric_time
+    ) subq_15
+  ) subq_16
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_11.metric_time = subq_16.metric_time
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_18.metric_time
-      , subq_18.bookings
+      subq_20.metric_time
+      , subq_20.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_17.metric_time
-        , SUM(subq_17.bookings) AS bookings
+        subq_19.metric_time
+        , SUM(subq_19.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_16.metric_time
-          , subq_16.bookings
+          subq_18.metric_time
+          , subq_18.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_15.ds
-            , subq_15.ds__week
-            , subq_15.ds__month
-            , subq_15.ds__quarter
-            , subq_15.ds__year
-            , subq_15.ds_partitioned
-            , subq_15.ds_partitioned__week
-            , subq_15.ds_partitioned__month
-            , subq_15.ds_partitioned__quarter
-            , subq_15.ds_partitioned__year
-            , subq_15.booking_paid_at
-            , subq_15.booking_paid_at__week
-            , subq_15.booking_paid_at__month
-            , subq_15.booking_paid_at__quarter
-            , subq_15.booking_paid_at__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds
-            , subq_15.create_a_cycle_in_the_join_graph__ds__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_15.ds AS metric_time
-            , subq_15.ds__week AS metric_time__week
-            , subq_15.ds__month AS metric_time__month
-            , subq_15.ds__quarter AS metric_time__quarter
-            , subq_15.ds__year AS metric_time__year
-            , subq_15.listing
-            , subq_15.guest
-            , subq_15.host
-            , subq_15.create_a_cycle_in_the_join_graph
-            , subq_15.create_a_cycle_in_the_join_graph__listing
-            , subq_15.create_a_cycle_in_the_join_graph__guest
-            , subq_15.create_a_cycle_in_the_join_graph__host
-            , subq_15.is_instant
-            , subq_15.create_a_cycle_in_the_join_graph__is_instant
-            , subq_15.bookings
-            , subq_15.instant_bookings
-            , subq_15.booking_value
-            , subq_15.max_booking_value
-            , subq_15.min_booking_value
-            , subq_15.bookers
-            , subq_15.average_booking_value
-            , subq_15.referred_bookings
+            subq_17.ds
+            , subq_17.ds__week
+            , subq_17.ds__month
+            , subq_17.ds__quarter
+            , subq_17.ds__year
+            , subq_17.ds_partitioned
+            , subq_17.ds_partitioned__week
+            , subq_17.ds_partitioned__month
+            , subq_17.ds_partitioned__quarter
+            , subq_17.ds_partitioned__year
+            , subq_17.booking_paid_at
+            , subq_17.booking_paid_at__week
+            , subq_17.booking_paid_at__month
+            , subq_17.booking_paid_at__quarter
+            , subq_17.booking_paid_at__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds
+            , subq_17.create_a_cycle_in_the_join_graph__ds__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_17.ds AS metric_time
+            , subq_17.ds__week AS metric_time__week
+            , subq_17.ds__month AS metric_time__month
+            , subq_17.ds__quarter AS metric_time__quarter
+            , subq_17.ds__year AS metric_time__year
+            , subq_17.listing
+            , subq_17.guest
+            , subq_17.host
+            , subq_17.create_a_cycle_in_the_join_graph
+            , subq_17.create_a_cycle_in_the_join_graph__listing
+            , subq_17.create_a_cycle_in_the_join_graph__guest
+            , subq_17.create_a_cycle_in_the_join_graph__host
+            , subq_17.is_instant
+            , subq_17.create_a_cycle_in_the_join_graph__is_instant
+            , subq_17.bookings
+            , subq_17.instant_bookings
+            , subq_17.booking_value
+            , subq_17.max_booking_value
+            , subq_17.min_booking_value
+            , subq_17.bookers
+            , subq_17.average_booking_value
+            , subq_17.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -551,13 +551,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_15
-        ) subq_16
-      ) subq_17
+          ) subq_17
+        ) subq_18
+      ) subq_19
       GROUP BY
-        subq_17.metric_time
-    ) subq_18
+        subq_19.metric_time
+    ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_19.metric_time, subq_20.metric_time) = subq_21.metric_time
+    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_42.metric_time, subq_43.metric_time, subq_44.metric_time) AS metric_time
-    , subq_42.non_referred AS non_referred
-    , subq_43.instant AS instant
+    COALESCE(subq_34.metric_time, subq_39.metric_time, subq_44.metric_time) AS metric_time
+    , subq_34.non_referred AS non_referred
+    , subq_39.instant AS instant
     , subq_44.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_31.metric_time, subq_32.metric_time) AS metric_time
-        , subq_31.ref_bookings AS ref_bookings
+        COALESCE(subq_27.metric_time, subq_32.metric_time) AS metric_time
+        , subq_27.ref_bookings AS ref_bookings
         , subq_32.bookings AS bookings
       FROM (
         -- Aggregate Measures
@@ -41,7 +41,7 @@ FROM (
         ) subq_25
         GROUP BY
           metric_time
-      ) subq_31
+      ) subq_27
       INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -60,14 +60,14 @@ FROM (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_29
+        ) subq_30
         GROUP BY
           metric_time
       ) subq_32
       ON
-        subq_31.metric_time = subq_32.metric_time
+        subq_27.metric_time = subq_32.metric_time
     ) subq_33
-  ) subq_42
+  ) subq_34
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -86,12 +86,12 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_36
+    ) subq_37
     GROUP BY
       metric_time
-  ) subq_43
+  ) subq_39
   ON
-    subq_42.metric_time = subq_43.metric_time
+    subq_34.metric_time = subq_39.metric_time
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -110,10 +110,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_40
+    ) subq_42
     GROUP BY
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_42.metric_time, subq_43.metric_time) = subq_44.metric_time
+    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -65,7 +65,11 @@ FROM (
           metric_time
       ) subq_32
       ON
-        subq_27.metric_time = subq_32.metric_time
+        (
+          subq_27.metric_time = subq_32.metric_time
+        ) OR (
+          (subq_27.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+        )
     ) subq_33
   ) subq_34
   INNER JOIN (
@@ -91,7 +95,11 @@ FROM (
       metric_time
   ) subq_39
   ON
-    subq_34.metric_time = subq_39.metric_time
+    (
+      subq_34.metric_time = subq_39.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_39.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -115,5 +123,9 @@ FROM (
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
+    (
+      subq_34.metric_time = subq_44.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_44.metric_time IS NULL)
+    )
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
@@ -135,78 +135,78 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_value
+    subq_8.metric_time
+    , subq_8.booking_value
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_value) AS booking_value
+      subq_7.metric_time
+      , SUM(subq_7.booking_value) AS booking_value
     FROM (
       -- Pass Only Elements:
       --   ['booking_value', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_value
+        subq_6.metric_time
+        , subq_6.booking_value
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.ds AS metric_time
-          , subq_4.ds__week AS metric_time__week
-          , subq_4.ds__month AS metric_time__month
-          , subq_4.ds__quarter AS metric_time__quarter
-          , subq_4.ds__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.bookings
-          , subq_4.instant_bookings
-          , subq_4.booking_value
-          , subq_4.max_booking_value
-          , subq_4.min_booking_value
-          , subq_4.bookers
-          , subq_4.average_booking_value
-          , subq_4.referred_bookings
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.ds AS metric_time
+          , subq_5.ds__week AS metric_time__week
+          , subq_5.ds__month AS metric_time__month
+          , subq_5.ds__quarter AS metric_time__quarter
+          , subq_5.ds__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.bookings
+          , subq_5.instant_bookings
+          , subq_5.booking_value
+          , subq_5.max_booking_value
+          , subq_5.min_booking_value
+          , subq_5.bookers
+          , subq_5.average_booking_value
+          , subq_5.referred_bookings
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -262,14 +262,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     ds
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
@@ -275,5 +275,9 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    subq_4.metric_time = subq_9.metric_time
+    (
+      subq_4.metric_time = subq_9.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+    )
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-    , subq_8.ref_bookings AS ref_bookings
+    COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+    , subq_4.ref_bookings AS ref_bookings
     , subq_9.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -140,78 +140,78 @@ FROM (
       GROUP BY
         subq_2.metric_time
     ) subq_3
-  ) subq_8
+  ) subq_4
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_7.metric_time
-      , subq_7.bookings
+      subq_8.metric_time
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time
-        , SUM(subq_6.bookings) AS bookings
+        subq_7.metric_time
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_5.metric_time
-          , subq_5.bookings
+          subq_6.metric_time
+          , subq_6.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds_partitioned
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.booking_paid_at
-            , subq_4.booking_paid_at__week
-            , subq_4.booking_paid_at__month
-            , subq_4.booking_paid_at__quarter
-            , subq_4.booking_paid_at__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds
-            , subq_4.create_a_cycle_in_the_join_graph__ds__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.create_a_cycle_in_the_join_graph
-            , subq_4.create_a_cycle_in_the_join_graph__listing
-            , subq_4.create_a_cycle_in_the_join_graph__guest
-            , subq_4.create_a_cycle_in_the_join_graph__host
-            , subq_4.is_instant
-            , subq_4.create_a_cycle_in_the_join_graph__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.ds_partitioned
+            , subq_5.ds_partitioned__week
+            , subq_5.ds_partitioned__month
+            , subq_5.ds_partitioned__quarter
+            , subq_5.ds_partitioned__year
+            , subq_5.booking_paid_at
+            , subq_5.booking_paid_at__week
+            , subq_5.booking_paid_at__month
+            , subq_5.booking_paid_at__quarter
+            , subq_5.booking_paid_at__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds
+            , subq_5.create_a_cycle_in_the_join_graph__ds__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.guest
+            , subq_5.host
+            , subq_5.create_a_cycle_in_the_join_graph
+            , subq_5.create_a_cycle_in_the_join_graph__listing
+            , subq_5.create_a_cycle_in_the_join_graph__guest
+            , subq_5.create_a_cycle_in_the_join_graph__host
+            , subq_5.is_instant
+            , subq_5.create_a_cycle_in_the_join_graph__is_instant
+            , subq_5.bookings
+            , subq_5.instant_bookings
+            , subq_5.booking_value
+            , subq_5.max_booking_value
+            , subq_5.min_booking_value
+            , subq_5.bookers
+            , subq_5.average_booking_value
+            , subq_5.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -267,13 +267,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_4
-        ) subq_5
-      ) subq_6
+          ) subq_5
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_6.metric_time
-    ) subq_7
+        subq_7.metric_time
+    ) subq_8
   ) subq_9
   ON
-    subq_8.metric_time = subq_9.metric_time
+    subq_4.metric_time = subq_9.metric_time
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
@@ -53,5 +53,9 @@ FROM (
       metric_time
   ) subq_20
   ON
-    subq_15.metric_time = subq_20.metric_time
+    (
+      subq_15.metric_time = subq_20.metric_time
+    ) OR (
+      (subq_15.metric_time IS NULL) AND (subq_20.metric_time IS NULL)
+    )
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time) AS metric_time
-    , subq_19.ref_bookings AS ref_bookings
+    COALESCE(subq_15.metric_time, subq_20.metric_time) AS metric_time
+    , subq_15.ref_bookings AS ref_bookings
     , subq_20.bookings AS bookings
   FROM (
     -- Aggregate Measures
@@ -29,7 +29,7 @@ FROM (
     ) subq_13
     GROUP BY
       metric_time
-  ) subq_19
+  ) subq_15
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -48,10 +48,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_17
+    ) subq_18
     GROUP BY
       metric_time
   ) subq_20
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_15.metric_time = subq_20.metric_time
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_10.bookings) AS bookings
+  MAX(subq_5.bookings) AS bookings
   , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
@@ -186,100 +186,100 @@ FROM (
       ) subq_2
     ) subq_3
   ) subq_4
-) subq_10
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_8.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements:
       --   ['listings']
       SELECT
-        subq_7.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.created_at
-          , subq_6.created_at__week
-          , subq_6.created_at__month
-          , subq_6.created_at__quarter
-          , subq_6.created_at__year
-          , subq_6.listing__ds
-          , subq_6.listing__ds__week
-          , subq_6.listing__ds__month
-          , subq_6.listing__ds__quarter
-          , subq_6.listing__ds__year
-          , subq_6.listing__created_at
-          , subq_6.listing__created_at__week
-          , subq_6.listing__created_at__month
-          , subq_6.listing__created_at__quarter
-          , subq_6.listing__created_at__year
-          , subq_6.metric_time
-          , subq_6.metric_time__week
-          , subq_6.metric_time__month
-          , subq_6.metric_time__quarter
-          , subq_6.metric_time__year
-          , subq_6.listing
-          , subq_6.user
-          , subq_6.listing__user
-          , subq_6.country_latest
-          , subq_6.is_lux_latest
-          , subq_6.capacity_latest
-          , subq_6.listing__country_latest
-          , subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.listings
-          , subq_6.largest_listing
-          , subq_6.smallest_listing
+          subq_7.ds
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.created_at
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.listing__ds
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__created_at
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.metric_time
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.created_at
-            , subq_5.created_at__week
-            , subq_5.created_at__month
-            , subq_5.created_at__quarter
-            , subq_5.created_at__year
-            , subq_5.listing__ds
-            , subq_5.listing__ds__week
-            , subq_5.listing__ds__month
-            , subq_5.listing__ds__quarter
-            , subq_5.listing__ds__year
-            , subq_5.listing__created_at
-            , subq_5.listing__created_at__week
-            , subq_5.listing__created_at__month
-            , subq_5.listing__created_at__quarter
-            , subq_5.listing__created_at__year
-            , subq_5.ds AS metric_time
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.listing
-            , subq_5.user
-            , subq_5.listing__user
-            , subq_5.country_latest
-            , subq_5.is_lux_latest
-            , subq_5.capacity_latest
-            , subq_5.listing__country_latest
-            , subq_5.listing__is_lux_latest
-            , subq_5.listing__capacity_latest
-            , subq_5.listings
-            , subq_5.largest_listing
-            , subq_5.smallest_listing
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.created_at
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.listing__ds
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__created_at
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Data Source 'listings_latest'
             SELECT
@@ -316,10 +316,10 @@ CROSS JOIN (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_5
-        ) subq_6
-        WHERE subq_6.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-      ) subq_7
-    ) subq_8
-  ) subq_9
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      ) subq_8
+    ) subq_9
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_22.bookings) AS bookings
+  MAX(subq_17.bookings) AS bookings
   , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
@@ -17,7 +17,7 @@ FROM (
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
   WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-) subq_22
+) subq_17
 CROSS JOIN (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
@@ -287,7 +287,11 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        subq_4.metric_time = subq_9.metric_time
+        (
+          subq_4.metric_time = subq_9.metric_time
+        ) OR (
+          (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+        )
     ) subq_10
   ) subq_11
   INNER JOIN (
@@ -424,7 +428,11 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    subq_11.metric_time = subq_16.metric_time
+    (
+      subq_11.metric_time = subq_16.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_16.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -559,5 +567,9 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
+    (
+      subq_11.metric_time = subq_21.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    )
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time, subq_21.metric_time) AS metric_time
-    , subq_19.non_referred AS non_referred
-    , subq_20.instant AS instant
+    COALESCE(subq_11.metric_time, subq_16.metric_time, subq_21.metric_time) AS metric_time
+    , subq_11.non_referred AS non_referred
+    , subq_16.instant AS instant
     , subq_21.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-        , subq_8.ref_bookings AS ref_bookings
+        COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+        , subq_4.ref_bookings AS ref_bookings
         , subq_9.bookings AS bookings
       FROM (
         -- Compute Metrics via Expressions
@@ -152,78 +152,78 @@ FROM (
           GROUP BY
             subq_2.metric_time
         ) subq_3
-      ) subq_8
+      ) subq_4
       INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
-          subq_7.metric_time
-          , subq_7.bookings
+          subq_8.metric_time
+          , subq_8.bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_6.metric_time
-            , SUM(subq_6.bookings) AS bookings
+            subq_7.metric_time
+            , SUM(subq_7.bookings) AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'metric_time']
             SELECT
-              subq_5.metric_time
-              , subq_5.bookings
+              subq_6.metric_time
+              , subq_6.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds_partitioned
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.booking_paid_at
-                , subq_4.booking_paid_at__week
-                , subq_4.booking_paid_at__month
-                , subq_4.booking_paid_at__quarter
-                , subq_4.booking_paid_at__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds
-                , subq_4.create_a_cycle_in_the_join_graph__ds__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_4.ds AS metric_time
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.create_a_cycle_in_the_join_graph
-                , subq_4.create_a_cycle_in_the_join_graph__listing
-                , subq_4.create_a_cycle_in_the_join_graph__guest
-                , subq_4.create_a_cycle_in_the_join_graph__host
-                , subq_4.is_instant
-                , subq_4.create_a_cycle_in_the_join_graph__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
+                subq_5.ds
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds_partitioned
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.booking_paid_at
+                , subq_5.booking_paid_at__week
+                , subq_5.booking_paid_at__month
+                , subq_5.booking_paid_at__quarter
+                , subq_5.booking_paid_at__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds
+                , subq_5.create_a_cycle_in_the_join_graph__ds__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_5.ds AS metric_time
+                , subq_5.ds__week AS metric_time__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter AS metric_time__quarter
+                , subq_5.ds__year AS metric_time__year
+                , subq_5.listing
+                , subq_5.guest
+                , subq_5.host
+                , subq_5.create_a_cycle_in_the_join_graph
+                , subq_5.create_a_cycle_in_the_join_graph__listing
+                , subq_5.create_a_cycle_in_the_join_graph__guest
+                , subq_5.create_a_cycle_in_the_join_graph__host
+                , subq_5.is_instant
+                , subq_5.create_a_cycle_in_the_join_graph__is_instant
+                , subq_5.bookings
+                , subq_5.instant_bookings
+                , subq_5.booking_value
+                , subq_5.max_booking_value
+                , subq_5.min_booking_value
+                , subq_5.bookers
+                , subq_5.average_booking_value
+                , subq_5.referred_bookings
               FROM (
                 -- Read Elements From Data Source 'bookings_source'
                 SELECT
@@ -279,88 +279,88 @@ FROM (
                   -- User Defined SQL Query
                   SELECT * FROM ***************************.fct_bookings
                 ) bookings_source_src_10001
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_5
+            ) subq_6
+          ) subq_7
           GROUP BY
-            subq_6.metric_time
-        ) subq_7
+            subq_7.metric_time
+        ) subq_8
       ) subq_9
       ON
-        subq_8.metric_time = subq_9.metric_time
+        subq_4.metric_time = subq_9.metric_time
     ) subq_10
-  ) subq_19
+  ) subq_11
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_14.metric_time
-      , subq_14.instant_bookings AS instant
+      subq_15.metric_time
+      , subq_15.instant_bookings AS instant
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_13.metric_time
-        , SUM(subq_13.instant_bookings) AS instant_bookings
+        subq_14.metric_time
+        , SUM(subq_14.instant_bookings) AS instant_bookings
       FROM (
         -- Pass Only Elements:
         --   ['instant_bookings', 'metric_time']
         SELECT
-          subq_12.metric_time
-          , subq_12.instant_bookings
+          subq_13.metric_time
+          , subq_13.instant_bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds_partitioned
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.booking_paid_at
-            , subq_11.booking_paid_at__week
-            , subq_11.booking_paid_at__month
-            , subq_11.booking_paid_at__quarter
-            , subq_11.booking_paid_at__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds
-            , subq_11.create_a_cycle_in_the_join_graph__ds__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_11.ds AS metric_time
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.create_a_cycle_in_the_join_graph
-            , subq_11.create_a_cycle_in_the_join_graph__listing
-            , subq_11.create_a_cycle_in_the_join_graph__guest
-            , subq_11.create_a_cycle_in_the_join_graph__host
-            , subq_11.is_instant
-            , subq_11.create_a_cycle_in_the_join_graph__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.max_booking_value
-            , subq_11.min_booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
-            , subq_11.referred_bookings
+            subq_12.ds
+            , subq_12.ds__week
+            , subq_12.ds__month
+            , subq_12.ds__quarter
+            , subq_12.ds__year
+            , subq_12.ds_partitioned
+            , subq_12.ds_partitioned__week
+            , subq_12.ds_partitioned__month
+            , subq_12.ds_partitioned__quarter
+            , subq_12.ds_partitioned__year
+            , subq_12.booking_paid_at
+            , subq_12.booking_paid_at__week
+            , subq_12.booking_paid_at__month
+            , subq_12.booking_paid_at__quarter
+            , subq_12.booking_paid_at__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds
+            , subq_12.create_a_cycle_in_the_join_graph__ds__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_12.ds AS metric_time
+            , subq_12.ds__week AS metric_time__week
+            , subq_12.ds__month AS metric_time__month
+            , subq_12.ds__quarter AS metric_time__quarter
+            , subq_12.ds__year AS metric_time__year
+            , subq_12.listing
+            , subq_12.guest
+            , subq_12.host
+            , subq_12.create_a_cycle_in_the_join_graph
+            , subq_12.create_a_cycle_in_the_join_graph__listing
+            , subq_12.create_a_cycle_in_the_join_graph__guest
+            , subq_12.create_a_cycle_in_the_join_graph__host
+            , subq_12.is_instant
+            , subq_12.create_a_cycle_in_the_join_graph__is_instant
+            , subq_12.bookings
+            , subq_12.instant_bookings
+            , subq_12.booking_value
+            , subq_12.max_booking_value
+            , subq_12.min_booking_value
+            , subq_12.bookers
+            , subq_12.average_booking_value
+            , subq_12.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -416,86 +416,86 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_12
+        ) subq_13
+      ) subq_14
       GROUP BY
-        subq_13.metric_time
-    ) subq_14
-  ) subq_20
+        subq_14.metric_time
+    ) subq_15
+  ) subq_16
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_11.metric_time = subq_16.metric_time
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_18.metric_time
-      , subq_18.bookings
+      subq_20.metric_time
+      , subq_20.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_17.metric_time
-        , SUM(subq_17.bookings) AS bookings
+        subq_19.metric_time
+        , SUM(subq_19.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_16.metric_time
-          , subq_16.bookings
+          subq_18.metric_time
+          , subq_18.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_15.ds
-            , subq_15.ds__week
-            , subq_15.ds__month
-            , subq_15.ds__quarter
-            , subq_15.ds__year
-            , subq_15.ds_partitioned
-            , subq_15.ds_partitioned__week
-            , subq_15.ds_partitioned__month
-            , subq_15.ds_partitioned__quarter
-            , subq_15.ds_partitioned__year
-            , subq_15.booking_paid_at
-            , subq_15.booking_paid_at__week
-            , subq_15.booking_paid_at__month
-            , subq_15.booking_paid_at__quarter
-            , subq_15.booking_paid_at__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds
-            , subq_15.create_a_cycle_in_the_join_graph__ds__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_15.ds AS metric_time
-            , subq_15.ds__week AS metric_time__week
-            , subq_15.ds__month AS metric_time__month
-            , subq_15.ds__quarter AS metric_time__quarter
-            , subq_15.ds__year AS metric_time__year
-            , subq_15.listing
-            , subq_15.guest
-            , subq_15.host
-            , subq_15.create_a_cycle_in_the_join_graph
-            , subq_15.create_a_cycle_in_the_join_graph__listing
-            , subq_15.create_a_cycle_in_the_join_graph__guest
-            , subq_15.create_a_cycle_in_the_join_graph__host
-            , subq_15.is_instant
-            , subq_15.create_a_cycle_in_the_join_graph__is_instant
-            , subq_15.bookings
-            , subq_15.instant_bookings
-            , subq_15.booking_value
-            , subq_15.max_booking_value
-            , subq_15.min_booking_value
-            , subq_15.bookers
-            , subq_15.average_booking_value
-            , subq_15.referred_bookings
+            subq_17.ds
+            , subq_17.ds__week
+            , subq_17.ds__month
+            , subq_17.ds__quarter
+            , subq_17.ds__year
+            , subq_17.ds_partitioned
+            , subq_17.ds_partitioned__week
+            , subq_17.ds_partitioned__month
+            , subq_17.ds_partitioned__quarter
+            , subq_17.ds_partitioned__year
+            , subq_17.booking_paid_at
+            , subq_17.booking_paid_at__week
+            , subq_17.booking_paid_at__month
+            , subq_17.booking_paid_at__quarter
+            , subq_17.booking_paid_at__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds
+            , subq_17.create_a_cycle_in_the_join_graph__ds__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_17.ds AS metric_time
+            , subq_17.ds__week AS metric_time__week
+            , subq_17.ds__month AS metric_time__month
+            , subq_17.ds__quarter AS metric_time__quarter
+            , subq_17.ds__year AS metric_time__year
+            , subq_17.listing
+            , subq_17.guest
+            , subq_17.host
+            , subq_17.create_a_cycle_in_the_join_graph
+            , subq_17.create_a_cycle_in_the_join_graph__listing
+            , subq_17.create_a_cycle_in_the_join_graph__guest
+            , subq_17.create_a_cycle_in_the_join_graph__host
+            , subq_17.is_instant
+            , subq_17.create_a_cycle_in_the_join_graph__is_instant
+            , subq_17.bookings
+            , subq_17.instant_bookings
+            , subq_17.booking_value
+            , subq_17.max_booking_value
+            , subq_17.min_booking_value
+            , subq_17.bookers
+            , subq_17.average_booking_value
+            , subq_17.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -551,13 +551,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_15
-        ) subq_16
-      ) subq_17
+          ) subq_17
+        ) subq_18
+      ) subq_19
       GROUP BY
-        subq_17.metric_time
-    ) subq_18
+        subq_19.metric_time
+    ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_19.metric_time, subq_20.metric_time) = subq_21.metric_time
+    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_42.metric_time, subq_43.metric_time, subq_44.metric_time) AS metric_time
-    , subq_42.non_referred AS non_referred
-    , subq_43.instant AS instant
+    COALESCE(subq_34.metric_time, subq_39.metric_time, subq_44.metric_time) AS metric_time
+    , subq_34.non_referred AS non_referred
+    , subq_39.instant AS instant
     , subq_44.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_31.metric_time, subq_32.metric_time) AS metric_time
-        , subq_31.ref_bookings AS ref_bookings
+        COALESCE(subq_27.metric_time, subq_32.metric_time) AS metric_time
+        , subq_27.ref_bookings AS ref_bookings
         , subq_32.bookings AS bookings
       FROM (
         -- Aggregate Measures
@@ -41,7 +41,7 @@ FROM (
         ) subq_25
         GROUP BY
           metric_time
-      ) subq_31
+      ) subq_27
       INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -60,14 +60,14 @@ FROM (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_29
+        ) subq_30
         GROUP BY
           metric_time
       ) subq_32
       ON
-        subq_31.metric_time = subq_32.metric_time
+        subq_27.metric_time = subq_32.metric_time
     ) subq_33
-  ) subq_42
+  ) subq_34
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -86,12 +86,12 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_36
+    ) subq_37
     GROUP BY
       metric_time
-  ) subq_43
+  ) subq_39
   ON
-    subq_42.metric_time = subq_43.metric_time
+    subq_34.metric_time = subq_39.metric_time
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -110,10 +110,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_40
+    ) subq_42
     GROUP BY
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_42.metric_time, subq_43.metric_time) = subq_44.metric_time
+    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -65,7 +65,11 @@ FROM (
           metric_time
       ) subq_32
       ON
-        subq_27.metric_time = subq_32.metric_time
+        (
+          subq_27.metric_time = subq_32.metric_time
+        ) OR (
+          (subq_27.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+        )
     ) subq_33
   ) subq_34
   INNER JOIN (
@@ -91,7 +95,11 @@ FROM (
       metric_time
   ) subq_39
   ON
-    subq_34.metric_time = subq_39.metric_time
+    (
+      subq_34.metric_time = subq_39.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_39.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -115,5 +123,9 @@ FROM (
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
+    (
+      subq_34.metric_time = subq_44.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_44.metric_time IS NULL)
+    )
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
@@ -135,78 +135,78 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_value
+    subq_8.metric_time
+    , subq_8.booking_value
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_value) AS booking_value
+      subq_7.metric_time
+      , SUM(subq_7.booking_value) AS booking_value
     FROM (
       -- Pass Only Elements:
       --   ['booking_value', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_value
+        subq_6.metric_time
+        , subq_6.booking_value
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.ds AS metric_time
-          , subq_4.ds__week AS metric_time__week
-          , subq_4.ds__month AS metric_time__month
-          , subq_4.ds__quarter AS metric_time__quarter
-          , subq_4.ds__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.bookings
-          , subq_4.instant_bookings
-          , subq_4.booking_value
-          , subq_4.max_booking_value
-          , subq_4.min_booking_value
-          , subq_4.bookers
-          , subq_4.average_booking_value
-          , subq_4.referred_bookings
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.ds AS metric_time
+          , subq_5.ds__week AS metric_time__week
+          , subq_5.ds__month AS metric_time__month
+          , subq_5.ds__quarter AS metric_time__quarter
+          , subq_5.ds__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.bookings
+          , subq_5.instant_bookings
+          , subq_5.booking_value
+          , subq_5.max_booking_value
+          , subq_5.min_booking_value
+          , subq_5.bookers
+          , subq_5.average_booking_value
+          , subq_5.referred_bookings
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -262,14 +262,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     ds
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
@@ -275,5 +275,9 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    subq_4.metric_time = subq_9.metric_time
+    (
+      subq_4.metric_time = subq_9.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+    )
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-    , subq_8.ref_bookings AS ref_bookings
+    COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+    , subq_4.ref_bookings AS ref_bookings
     , subq_9.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -140,78 +140,78 @@ FROM (
       GROUP BY
         subq_2.metric_time
     ) subq_3
-  ) subq_8
+  ) subq_4
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_7.metric_time
-      , subq_7.bookings
+      subq_8.metric_time
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time
-        , SUM(subq_6.bookings) AS bookings
+        subq_7.metric_time
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_5.metric_time
-          , subq_5.bookings
+          subq_6.metric_time
+          , subq_6.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds_partitioned
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.booking_paid_at
-            , subq_4.booking_paid_at__week
-            , subq_4.booking_paid_at__month
-            , subq_4.booking_paid_at__quarter
-            , subq_4.booking_paid_at__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds
-            , subq_4.create_a_cycle_in_the_join_graph__ds__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.create_a_cycle_in_the_join_graph
-            , subq_4.create_a_cycle_in_the_join_graph__listing
-            , subq_4.create_a_cycle_in_the_join_graph__guest
-            , subq_4.create_a_cycle_in_the_join_graph__host
-            , subq_4.is_instant
-            , subq_4.create_a_cycle_in_the_join_graph__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.ds_partitioned
+            , subq_5.ds_partitioned__week
+            , subq_5.ds_partitioned__month
+            , subq_5.ds_partitioned__quarter
+            , subq_5.ds_partitioned__year
+            , subq_5.booking_paid_at
+            , subq_5.booking_paid_at__week
+            , subq_5.booking_paid_at__month
+            , subq_5.booking_paid_at__quarter
+            , subq_5.booking_paid_at__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds
+            , subq_5.create_a_cycle_in_the_join_graph__ds__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.guest
+            , subq_5.host
+            , subq_5.create_a_cycle_in_the_join_graph
+            , subq_5.create_a_cycle_in_the_join_graph__listing
+            , subq_5.create_a_cycle_in_the_join_graph__guest
+            , subq_5.create_a_cycle_in_the_join_graph__host
+            , subq_5.is_instant
+            , subq_5.create_a_cycle_in_the_join_graph__is_instant
+            , subq_5.bookings
+            , subq_5.instant_bookings
+            , subq_5.booking_value
+            , subq_5.max_booking_value
+            , subq_5.min_booking_value
+            , subq_5.bookers
+            , subq_5.average_booking_value
+            , subq_5.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -267,13 +267,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_4
-        ) subq_5
-      ) subq_6
+          ) subq_5
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_6.metric_time
-    ) subq_7
+        subq_7.metric_time
+    ) subq_8
   ) subq_9
   ON
-    subq_8.metric_time = subq_9.metric_time
+    subq_4.metric_time = subq_9.metric_time
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
@@ -53,5 +53,9 @@ FROM (
       metric_time
   ) subq_20
   ON
-    subq_15.metric_time = subq_20.metric_time
+    (
+      subq_15.metric_time = subq_20.metric_time
+    ) OR (
+      (subq_15.metric_time IS NULL) AND (subq_20.metric_time IS NULL)
+    )
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time) AS metric_time
-    , subq_19.ref_bookings AS ref_bookings
+    COALESCE(subq_15.metric_time, subq_20.metric_time) AS metric_time
+    , subq_15.ref_bookings AS ref_bookings
     , subq_20.bookings AS bookings
   FROM (
     -- Aggregate Measures
@@ -29,7 +29,7 @@ FROM (
     ) subq_13
     GROUP BY
       metric_time
-  ) subq_19
+  ) subq_15
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -48,10 +48,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_17
+    ) subq_18
     GROUP BY
       metric_time
   ) subq_20
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_15.metric_time = subq_20.metric_time
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_10.bookings) AS bookings
+  MAX(subq_5.bookings) AS bookings
   , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
@@ -186,100 +186,100 @@ FROM (
       ) subq_2
     ) subq_3
   ) subq_4
-) subq_10
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_8.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements:
       --   ['listings']
       SELECT
-        subq_7.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.created_at
-          , subq_6.created_at__week
-          , subq_6.created_at__month
-          , subq_6.created_at__quarter
-          , subq_6.created_at__year
-          , subq_6.listing__ds
-          , subq_6.listing__ds__week
-          , subq_6.listing__ds__month
-          , subq_6.listing__ds__quarter
-          , subq_6.listing__ds__year
-          , subq_6.listing__created_at
-          , subq_6.listing__created_at__week
-          , subq_6.listing__created_at__month
-          , subq_6.listing__created_at__quarter
-          , subq_6.listing__created_at__year
-          , subq_6.metric_time
-          , subq_6.metric_time__week
-          , subq_6.metric_time__month
-          , subq_6.metric_time__quarter
-          , subq_6.metric_time__year
-          , subq_6.listing
-          , subq_6.user
-          , subq_6.listing__user
-          , subq_6.country_latest
-          , subq_6.is_lux_latest
-          , subq_6.capacity_latest
-          , subq_6.listing__country_latest
-          , subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.listings
-          , subq_6.largest_listing
-          , subq_6.smallest_listing
+          subq_7.ds
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.created_at
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.listing__ds
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__created_at
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.metric_time
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.created_at
-            , subq_5.created_at__week
-            , subq_5.created_at__month
-            , subq_5.created_at__quarter
-            , subq_5.created_at__year
-            , subq_5.listing__ds
-            , subq_5.listing__ds__week
-            , subq_5.listing__ds__month
-            , subq_5.listing__ds__quarter
-            , subq_5.listing__ds__year
-            , subq_5.listing__created_at
-            , subq_5.listing__created_at__week
-            , subq_5.listing__created_at__month
-            , subq_5.listing__created_at__quarter
-            , subq_5.listing__created_at__year
-            , subq_5.ds AS metric_time
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.listing
-            , subq_5.user
-            , subq_5.listing__user
-            , subq_5.country_latest
-            , subq_5.is_lux_latest
-            , subq_5.capacity_latest
-            , subq_5.listing__country_latest
-            , subq_5.listing__is_lux_latest
-            , subq_5.listing__capacity_latest
-            , subq_5.listings
-            , subq_5.largest_listing
-            , subq_5.smallest_listing
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.created_at
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.listing__ds
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__created_at
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Data Source 'listings_latest'
             SELECT
@@ -316,10 +316,10 @@ CROSS JOIN (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_5
-        ) subq_6
-        WHERE subq_6.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-      ) subq_7
-    ) subq_8
-  ) subq_9
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      ) subq_8
+    ) subq_9
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_22.bookings) AS bookings
+  MAX(subq_17.bookings) AS bookings
   , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
@@ -17,7 +17,7 @@ FROM (
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
   WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-) subq_22
+) subq_17
 CROSS JOIN (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
@@ -287,7 +287,11 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        subq_4.metric_time = subq_9.metric_time
+        (
+          subq_4.metric_time = subq_9.metric_time
+        ) OR (
+          (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+        )
     ) subq_10
   ) subq_11
   INNER JOIN (
@@ -424,7 +428,11 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    subq_11.metric_time = subq_16.metric_time
+    (
+      subq_11.metric_time = subq_16.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_16.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -559,5 +567,9 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
+    (
+      subq_11.metric_time = subq_21.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    )
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time, subq_21.metric_time) AS metric_time
-    , subq_19.non_referred AS non_referred
-    , subq_20.instant AS instant
+    COALESCE(subq_11.metric_time, subq_16.metric_time, subq_21.metric_time) AS metric_time
+    , subq_11.non_referred AS non_referred
+    , subq_16.instant AS instant
     , subq_21.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-        , subq_8.ref_bookings AS ref_bookings
+        COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+        , subq_4.ref_bookings AS ref_bookings
         , subq_9.bookings AS bookings
       FROM (
         -- Compute Metrics via Expressions
@@ -152,78 +152,78 @@ FROM (
           GROUP BY
             subq_2.metric_time
         ) subq_3
-      ) subq_8
+      ) subq_4
       INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
-          subq_7.metric_time
-          , subq_7.bookings
+          subq_8.metric_time
+          , subq_8.bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_6.metric_time
-            , SUM(subq_6.bookings) AS bookings
+            subq_7.metric_time
+            , SUM(subq_7.bookings) AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'metric_time']
             SELECT
-              subq_5.metric_time
-              , subq_5.bookings
+              subq_6.metric_time
+              , subq_6.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds_partitioned
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.booking_paid_at
-                , subq_4.booking_paid_at__week
-                , subq_4.booking_paid_at__month
-                , subq_4.booking_paid_at__quarter
-                , subq_4.booking_paid_at__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds
-                , subq_4.create_a_cycle_in_the_join_graph__ds__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_4.ds AS metric_time
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.create_a_cycle_in_the_join_graph
-                , subq_4.create_a_cycle_in_the_join_graph__listing
-                , subq_4.create_a_cycle_in_the_join_graph__guest
-                , subq_4.create_a_cycle_in_the_join_graph__host
-                , subq_4.is_instant
-                , subq_4.create_a_cycle_in_the_join_graph__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
+                subq_5.ds
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds_partitioned
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.booking_paid_at
+                , subq_5.booking_paid_at__week
+                , subq_5.booking_paid_at__month
+                , subq_5.booking_paid_at__quarter
+                , subq_5.booking_paid_at__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds
+                , subq_5.create_a_cycle_in_the_join_graph__ds__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_5.ds AS metric_time
+                , subq_5.ds__week AS metric_time__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter AS metric_time__quarter
+                , subq_5.ds__year AS metric_time__year
+                , subq_5.listing
+                , subq_5.guest
+                , subq_5.host
+                , subq_5.create_a_cycle_in_the_join_graph
+                , subq_5.create_a_cycle_in_the_join_graph__listing
+                , subq_5.create_a_cycle_in_the_join_graph__guest
+                , subq_5.create_a_cycle_in_the_join_graph__host
+                , subq_5.is_instant
+                , subq_5.create_a_cycle_in_the_join_graph__is_instant
+                , subq_5.bookings
+                , subq_5.instant_bookings
+                , subq_5.booking_value
+                , subq_5.max_booking_value
+                , subq_5.min_booking_value
+                , subq_5.bookers
+                , subq_5.average_booking_value
+                , subq_5.referred_bookings
               FROM (
                 -- Read Elements From Data Source 'bookings_source'
                 SELECT
@@ -279,88 +279,88 @@ FROM (
                   -- User Defined SQL Query
                   SELECT * FROM ***************************.fct_bookings
                 ) bookings_source_src_10001
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_5
+            ) subq_6
+          ) subq_7
           GROUP BY
-            subq_6.metric_time
-        ) subq_7
+            subq_7.metric_time
+        ) subq_8
       ) subq_9
       ON
-        subq_8.metric_time = subq_9.metric_time
+        subq_4.metric_time = subq_9.metric_time
     ) subq_10
-  ) subq_19
+  ) subq_11
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_14.metric_time
-      , subq_14.instant_bookings AS instant
+      subq_15.metric_time
+      , subq_15.instant_bookings AS instant
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_13.metric_time
-        , SUM(subq_13.instant_bookings) AS instant_bookings
+        subq_14.metric_time
+        , SUM(subq_14.instant_bookings) AS instant_bookings
       FROM (
         -- Pass Only Elements:
         --   ['instant_bookings', 'metric_time']
         SELECT
-          subq_12.metric_time
-          , subq_12.instant_bookings
+          subq_13.metric_time
+          , subq_13.instant_bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds_partitioned
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.booking_paid_at
-            , subq_11.booking_paid_at__week
-            , subq_11.booking_paid_at__month
-            , subq_11.booking_paid_at__quarter
-            , subq_11.booking_paid_at__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds
-            , subq_11.create_a_cycle_in_the_join_graph__ds__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_11.ds AS metric_time
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.create_a_cycle_in_the_join_graph
-            , subq_11.create_a_cycle_in_the_join_graph__listing
-            , subq_11.create_a_cycle_in_the_join_graph__guest
-            , subq_11.create_a_cycle_in_the_join_graph__host
-            , subq_11.is_instant
-            , subq_11.create_a_cycle_in_the_join_graph__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.max_booking_value
-            , subq_11.min_booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
-            , subq_11.referred_bookings
+            subq_12.ds
+            , subq_12.ds__week
+            , subq_12.ds__month
+            , subq_12.ds__quarter
+            , subq_12.ds__year
+            , subq_12.ds_partitioned
+            , subq_12.ds_partitioned__week
+            , subq_12.ds_partitioned__month
+            , subq_12.ds_partitioned__quarter
+            , subq_12.ds_partitioned__year
+            , subq_12.booking_paid_at
+            , subq_12.booking_paid_at__week
+            , subq_12.booking_paid_at__month
+            , subq_12.booking_paid_at__quarter
+            , subq_12.booking_paid_at__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds
+            , subq_12.create_a_cycle_in_the_join_graph__ds__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_12.ds AS metric_time
+            , subq_12.ds__week AS metric_time__week
+            , subq_12.ds__month AS metric_time__month
+            , subq_12.ds__quarter AS metric_time__quarter
+            , subq_12.ds__year AS metric_time__year
+            , subq_12.listing
+            , subq_12.guest
+            , subq_12.host
+            , subq_12.create_a_cycle_in_the_join_graph
+            , subq_12.create_a_cycle_in_the_join_graph__listing
+            , subq_12.create_a_cycle_in_the_join_graph__guest
+            , subq_12.create_a_cycle_in_the_join_graph__host
+            , subq_12.is_instant
+            , subq_12.create_a_cycle_in_the_join_graph__is_instant
+            , subq_12.bookings
+            , subq_12.instant_bookings
+            , subq_12.booking_value
+            , subq_12.max_booking_value
+            , subq_12.min_booking_value
+            , subq_12.bookers
+            , subq_12.average_booking_value
+            , subq_12.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -416,86 +416,86 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_12
+        ) subq_13
+      ) subq_14
       GROUP BY
-        subq_13.metric_time
-    ) subq_14
-  ) subq_20
+        subq_14.metric_time
+    ) subq_15
+  ) subq_16
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_11.metric_time = subq_16.metric_time
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_18.metric_time
-      , subq_18.bookings
+      subq_20.metric_time
+      , subq_20.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_17.metric_time
-        , SUM(subq_17.bookings) AS bookings
+        subq_19.metric_time
+        , SUM(subq_19.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_16.metric_time
-          , subq_16.bookings
+          subq_18.metric_time
+          , subq_18.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_15.ds
-            , subq_15.ds__week
-            , subq_15.ds__month
-            , subq_15.ds__quarter
-            , subq_15.ds__year
-            , subq_15.ds_partitioned
-            , subq_15.ds_partitioned__week
-            , subq_15.ds_partitioned__month
-            , subq_15.ds_partitioned__quarter
-            , subq_15.ds_partitioned__year
-            , subq_15.booking_paid_at
-            , subq_15.booking_paid_at__week
-            , subq_15.booking_paid_at__month
-            , subq_15.booking_paid_at__quarter
-            , subq_15.booking_paid_at__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds
-            , subq_15.create_a_cycle_in_the_join_graph__ds__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_15.ds AS metric_time
-            , subq_15.ds__week AS metric_time__week
-            , subq_15.ds__month AS metric_time__month
-            , subq_15.ds__quarter AS metric_time__quarter
-            , subq_15.ds__year AS metric_time__year
-            , subq_15.listing
-            , subq_15.guest
-            , subq_15.host
-            , subq_15.create_a_cycle_in_the_join_graph
-            , subq_15.create_a_cycle_in_the_join_graph__listing
-            , subq_15.create_a_cycle_in_the_join_graph__guest
-            , subq_15.create_a_cycle_in_the_join_graph__host
-            , subq_15.is_instant
-            , subq_15.create_a_cycle_in_the_join_graph__is_instant
-            , subq_15.bookings
-            , subq_15.instant_bookings
-            , subq_15.booking_value
-            , subq_15.max_booking_value
-            , subq_15.min_booking_value
-            , subq_15.bookers
-            , subq_15.average_booking_value
-            , subq_15.referred_bookings
+            subq_17.ds
+            , subq_17.ds__week
+            , subq_17.ds__month
+            , subq_17.ds__quarter
+            , subq_17.ds__year
+            , subq_17.ds_partitioned
+            , subq_17.ds_partitioned__week
+            , subq_17.ds_partitioned__month
+            , subq_17.ds_partitioned__quarter
+            , subq_17.ds_partitioned__year
+            , subq_17.booking_paid_at
+            , subq_17.booking_paid_at__week
+            , subq_17.booking_paid_at__month
+            , subq_17.booking_paid_at__quarter
+            , subq_17.booking_paid_at__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds
+            , subq_17.create_a_cycle_in_the_join_graph__ds__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_17.ds AS metric_time
+            , subq_17.ds__week AS metric_time__week
+            , subq_17.ds__month AS metric_time__month
+            , subq_17.ds__quarter AS metric_time__quarter
+            , subq_17.ds__year AS metric_time__year
+            , subq_17.listing
+            , subq_17.guest
+            , subq_17.host
+            , subq_17.create_a_cycle_in_the_join_graph
+            , subq_17.create_a_cycle_in_the_join_graph__listing
+            , subq_17.create_a_cycle_in_the_join_graph__guest
+            , subq_17.create_a_cycle_in_the_join_graph__host
+            , subq_17.is_instant
+            , subq_17.create_a_cycle_in_the_join_graph__is_instant
+            , subq_17.bookings
+            , subq_17.instant_bookings
+            , subq_17.booking_value
+            , subq_17.max_booking_value
+            , subq_17.min_booking_value
+            , subq_17.bookers
+            , subq_17.average_booking_value
+            , subq_17.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -551,13 +551,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_15
-        ) subq_16
-      ) subq_17
+          ) subq_17
+        ) subq_18
+      ) subq_19
       GROUP BY
-        subq_17.metric_time
-    ) subq_18
+        subq_19.metric_time
+    ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_19.metric_time, subq_20.metric_time) = subq_21.metric_time
+    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_42.metric_time, subq_43.metric_time, subq_44.metric_time) AS metric_time
-    , subq_42.non_referred AS non_referred
-    , subq_43.instant AS instant
+    COALESCE(subq_34.metric_time, subq_39.metric_time, subq_44.metric_time) AS metric_time
+    , subq_34.non_referred AS non_referred
+    , subq_39.instant AS instant
     , subq_44.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_31.metric_time, subq_32.metric_time) AS metric_time
-        , subq_31.ref_bookings AS ref_bookings
+        COALESCE(subq_27.metric_time, subq_32.metric_time) AS metric_time
+        , subq_27.ref_bookings AS ref_bookings
         , subq_32.bookings AS bookings
       FROM (
         -- Aggregate Measures
@@ -41,7 +41,7 @@ FROM (
         ) subq_25
         GROUP BY
           metric_time
-      ) subq_31
+      ) subq_27
       INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -60,14 +60,14 @@ FROM (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_29
+        ) subq_30
         GROUP BY
           metric_time
       ) subq_32
       ON
-        subq_31.metric_time = subq_32.metric_time
+        subq_27.metric_time = subq_32.metric_time
     ) subq_33
-  ) subq_42
+  ) subq_34
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -86,12 +86,12 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_36
+    ) subq_37
     GROUP BY
       metric_time
-  ) subq_43
+  ) subq_39
   ON
-    subq_42.metric_time = subq_43.metric_time
+    subq_34.metric_time = subq_39.metric_time
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -110,10 +110,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_40
+    ) subq_42
     GROUP BY
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_42.metric_time, subq_43.metric_time) = subq_44.metric_time
+    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -65,7 +65,11 @@ FROM (
           metric_time
       ) subq_32
       ON
-        subq_27.metric_time = subq_32.metric_time
+        (
+          subq_27.metric_time = subq_32.metric_time
+        ) OR (
+          (subq_27.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+        )
     ) subq_33
   ) subq_34
   INNER JOIN (
@@ -91,7 +95,11 @@ FROM (
       metric_time
   ) subq_39
   ON
-    subq_34.metric_time = subq_39.metric_time
+    (
+      subq_34.metric_time = subq_39.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_39.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -115,5 +123,9 @@ FROM (
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
+    (
+      subq_34.metric_time = subq_44.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_44.metric_time IS NULL)
+    )
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
@@ -135,78 +135,78 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_value
+    subq_8.metric_time
+    , subq_8.booking_value
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_value) AS booking_value
+      subq_7.metric_time
+      , SUM(subq_7.booking_value) AS booking_value
     FROM (
       -- Pass Only Elements:
       --   ['booking_value', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_value
+        subq_6.metric_time
+        , subq_6.booking_value
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.ds AS metric_time
-          , subq_4.ds__week AS metric_time__week
-          , subq_4.ds__month AS metric_time__month
-          , subq_4.ds__quarter AS metric_time__quarter
-          , subq_4.ds__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.bookings
-          , subq_4.instant_bookings
-          , subq_4.booking_value
-          , subq_4.max_booking_value
-          , subq_4.min_booking_value
-          , subq_4.bookers
-          , subq_4.average_booking_value
-          , subq_4.referred_bookings
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.ds AS metric_time
+          , subq_5.ds__week AS metric_time__week
+          , subq_5.ds__month AS metric_time__month
+          , subq_5.ds__quarter AS metric_time__quarter
+          , subq_5.ds__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.bookings
+          , subq_5.instant_bookings
+          , subq_5.booking_value
+          , subq_5.max_booking_value
+          , subq_5.min_booking_value
+          , subq_5.bookers
+          , subq_5.average_booking_value
+          , subq_5.referred_bookings
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -262,14 +262,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     ds
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
@@ -275,5 +275,9 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    subq_4.metric_time = subq_9.metric_time
+    (
+      subq_4.metric_time = subq_9.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+    )
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-    , subq_8.ref_bookings AS ref_bookings
+    COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+    , subq_4.ref_bookings AS ref_bookings
     , subq_9.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -140,78 +140,78 @@ FROM (
       GROUP BY
         subq_2.metric_time
     ) subq_3
-  ) subq_8
+  ) subq_4
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_7.metric_time
-      , subq_7.bookings
+      subq_8.metric_time
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time
-        , SUM(subq_6.bookings) AS bookings
+        subq_7.metric_time
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_5.metric_time
-          , subq_5.bookings
+          subq_6.metric_time
+          , subq_6.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds_partitioned
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.booking_paid_at
-            , subq_4.booking_paid_at__week
-            , subq_4.booking_paid_at__month
-            , subq_4.booking_paid_at__quarter
-            , subq_4.booking_paid_at__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds
-            , subq_4.create_a_cycle_in_the_join_graph__ds__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.create_a_cycle_in_the_join_graph
-            , subq_4.create_a_cycle_in_the_join_graph__listing
-            , subq_4.create_a_cycle_in_the_join_graph__guest
-            , subq_4.create_a_cycle_in_the_join_graph__host
-            , subq_4.is_instant
-            , subq_4.create_a_cycle_in_the_join_graph__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.ds_partitioned
+            , subq_5.ds_partitioned__week
+            , subq_5.ds_partitioned__month
+            , subq_5.ds_partitioned__quarter
+            , subq_5.ds_partitioned__year
+            , subq_5.booking_paid_at
+            , subq_5.booking_paid_at__week
+            , subq_5.booking_paid_at__month
+            , subq_5.booking_paid_at__quarter
+            , subq_5.booking_paid_at__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds
+            , subq_5.create_a_cycle_in_the_join_graph__ds__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.guest
+            , subq_5.host
+            , subq_5.create_a_cycle_in_the_join_graph
+            , subq_5.create_a_cycle_in_the_join_graph__listing
+            , subq_5.create_a_cycle_in_the_join_graph__guest
+            , subq_5.create_a_cycle_in_the_join_graph__host
+            , subq_5.is_instant
+            , subq_5.create_a_cycle_in_the_join_graph__is_instant
+            , subq_5.bookings
+            , subq_5.instant_bookings
+            , subq_5.booking_value
+            , subq_5.max_booking_value
+            , subq_5.min_booking_value
+            , subq_5.bookers
+            , subq_5.average_booking_value
+            , subq_5.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -267,13 +267,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_4
-        ) subq_5
-      ) subq_6
+          ) subq_5
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_6.metric_time
-    ) subq_7
+        subq_7.metric_time
+    ) subq_8
   ) subq_9
   ON
-    subq_8.metric_time = subq_9.metric_time
+    subq_4.metric_time = subq_9.metric_time
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
@@ -53,5 +53,9 @@ FROM (
       metric_time
   ) subq_20
   ON
-    subq_15.metric_time = subq_20.metric_time
+    (
+      subq_15.metric_time = subq_20.metric_time
+    ) OR (
+      (subq_15.metric_time IS NULL) AND (subq_20.metric_time IS NULL)
+    )
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time) AS metric_time
-    , subq_19.ref_bookings AS ref_bookings
+    COALESCE(subq_15.metric_time, subq_20.metric_time) AS metric_time
+    , subq_15.ref_bookings AS ref_bookings
     , subq_20.bookings AS bookings
   FROM (
     -- Aggregate Measures
@@ -29,7 +29,7 @@ FROM (
     ) subq_13
     GROUP BY
       metric_time
-  ) subq_19
+  ) subq_15
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -48,10 +48,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_17
+    ) subq_18
     GROUP BY
       metric_time
   ) subq_20
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_15.metric_time = subq_20.metric_time
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_10.bookings) AS bookings
+  MAX(subq_5.bookings) AS bookings
   , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
@@ -186,100 +186,100 @@ FROM (
       ) subq_2
     ) subq_3
   ) subq_4
-) subq_10
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_8.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements:
       --   ['listings']
       SELECT
-        subq_7.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.created_at
-          , subq_6.created_at__week
-          , subq_6.created_at__month
-          , subq_6.created_at__quarter
-          , subq_6.created_at__year
-          , subq_6.listing__ds
-          , subq_6.listing__ds__week
-          , subq_6.listing__ds__month
-          , subq_6.listing__ds__quarter
-          , subq_6.listing__ds__year
-          , subq_6.listing__created_at
-          , subq_6.listing__created_at__week
-          , subq_6.listing__created_at__month
-          , subq_6.listing__created_at__quarter
-          , subq_6.listing__created_at__year
-          , subq_6.metric_time
-          , subq_6.metric_time__week
-          , subq_6.metric_time__month
-          , subq_6.metric_time__quarter
-          , subq_6.metric_time__year
-          , subq_6.listing
-          , subq_6.user
-          , subq_6.listing__user
-          , subq_6.country_latest
-          , subq_6.is_lux_latest
-          , subq_6.capacity_latest
-          , subq_6.listing__country_latest
-          , subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.listings
-          , subq_6.largest_listing
-          , subq_6.smallest_listing
+          subq_7.ds
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.created_at
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.listing__ds
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__created_at
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.metric_time
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.created_at
-            , subq_5.created_at__week
-            , subq_5.created_at__month
-            , subq_5.created_at__quarter
-            , subq_5.created_at__year
-            , subq_5.listing__ds
-            , subq_5.listing__ds__week
-            , subq_5.listing__ds__month
-            , subq_5.listing__ds__quarter
-            , subq_5.listing__ds__year
-            , subq_5.listing__created_at
-            , subq_5.listing__created_at__week
-            , subq_5.listing__created_at__month
-            , subq_5.listing__created_at__quarter
-            , subq_5.listing__created_at__year
-            , subq_5.ds AS metric_time
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.listing
-            , subq_5.user
-            , subq_5.listing__user
-            , subq_5.country_latest
-            , subq_5.is_lux_latest
-            , subq_5.capacity_latest
-            , subq_5.listing__country_latest
-            , subq_5.listing__is_lux_latest
-            , subq_5.listing__capacity_latest
-            , subq_5.listings
-            , subq_5.largest_listing
-            , subq_5.smallest_listing
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.created_at
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.listing__ds
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__created_at
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Data Source 'listings_latest'
             SELECT
@@ -316,10 +316,10 @@ CROSS JOIN (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_5
-        ) subq_6
-        WHERE subq_6.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-      ) subq_7
-    ) subq_8
-  ) subq_9
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      ) subq_8
+    ) subq_9
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_22.bookings) AS bookings
+  MAX(subq_17.bookings) AS bookings
   , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
@@ -17,7 +17,7 @@ FROM (
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
   WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-) subq_22
+) subq_17
 CROSS JOIN (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
@@ -287,7 +287,11 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        subq_4.metric_time = subq_9.metric_time
+        (
+          subq_4.metric_time = subq_9.metric_time
+        ) OR (
+          (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+        )
     ) subq_10
   ) subq_11
   INNER JOIN (
@@ -424,7 +428,11 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    subq_11.metric_time = subq_16.metric_time
+    (
+      subq_11.metric_time = subq_16.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_16.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -559,5 +567,9 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
+    (
+      subq_11.metric_time = subq_21.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    )
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time, subq_21.metric_time) AS metric_time
-    , subq_19.non_referred AS non_referred
-    , subq_20.instant AS instant
+    COALESCE(subq_11.metric_time, subq_16.metric_time, subq_21.metric_time) AS metric_time
+    , subq_11.non_referred AS non_referred
+    , subq_16.instant AS instant
     , subq_21.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-        , subq_8.ref_bookings AS ref_bookings
+        COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+        , subq_4.ref_bookings AS ref_bookings
         , subq_9.bookings AS bookings
       FROM (
         -- Compute Metrics via Expressions
@@ -152,78 +152,78 @@ FROM (
           GROUP BY
             subq_2.metric_time
         ) subq_3
-      ) subq_8
+      ) subq_4
       INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
-          subq_7.metric_time
-          , subq_7.bookings
+          subq_8.metric_time
+          , subq_8.bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_6.metric_time
-            , SUM(subq_6.bookings) AS bookings
+            subq_7.metric_time
+            , SUM(subq_7.bookings) AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'metric_time']
             SELECT
-              subq_5.metric_time
-              , subq_5.bookings
+              subq_6.metric_time
+              , subq_6.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds_partitioned
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.booking_paid_at
-                , subq_4.booking_paid_at__week
-                , subq_4.booking_paid_at__month
-                , subq_4.booking_paid_at__quarter
-                , subq_4.booking_paid_at__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds
-                , subq_4.create_a_cycle_in_the_join_graph__ds__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_4.ds AS metric_time
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.create_a_cycle_in_the_join_graph
-                , subq_4.create_a_cycle_in_the_join_graph__listing
-                , subq_4.create_a_cycle_in_the_join_graph__guest
-                , subq_4.create_a_cycle_in_the_join_graph__host
-                , subq_4.is_instant
-                , subq_4.create_a_cycle_in_the_join_graph__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
+                subq_5.ds
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds_partitioned
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.booking_paid_at
+                , subq_5.booking_paid_at__week
+                , subq_5.booking_paid_at__month
+                , subq_5.booking_paid_at__quarter
+                , subq_5.booking_paid_at__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds
+                , subq_5.create_a_cycle_in_the_join_graph__ds__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_5.ds AS metric_time
+                , subq_5.ds__week AS metric_time__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter AS metric_time__quarter
+                , subq_5.ds__year AS metric_time__year
+                , subq_5.listing
+                , subq_5.guest
+                , subq_5.host
+                , subq_5.create_a_cycle_in_the_join_graph
+                , subq_5.create_a_cycle_in_the_join_graph__listing
+                , subq_5.create_a_cycle_in_the_join_graph__guest
+                , subq_5.create_a_cycle_in_the_join_graph__host
+                , subq_5.is_instant
+                , subq_5.create_a_cycle_in_the_join_graph__is_instant
+                , subq_5.bookings
+                , subq_5.instant_bookings
+                , subq_5.booking_value
+                , subq_5.max_booking_value
+                , subq_5.min_booking_value
+                , subq_5.bookers
+                , subq_5.average_booking_value
+                , subq_5.referred_bookings
               FROM (
                 -- Read Elements From Data Source 'bookings_source'
                 SELECT
@@ -279,88 +279,88 @@ FROM (
                   -- User Defined SQL Query
                   SELECT * FROM ***************************.fct_bookings
                 ) bookings_source_src_10001
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_5
+            ) subq_6
+          ) subq_7
           GROUP BY
-            subq_6.metric_time
-        ) subq_7
+            subq_7.metric_time
+        ) subq_8
       ) subq_9
       ON
-        subq_8.metric_time = subq_9.metric_time
+        subq_4.metric_time = subq_9.metric_time
     ) subq_10
-  ) subq_19
+  ) subq_11
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_14.metric_time
-      , subq_14.instant_bookings AS instant
+      subq_15.metric_time
+      , subq_15.instant_bookings AS instant
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_13.metric_time
-        , SUM(subq_13.instant_bookings) AS instant_bookings
+        subq_14.metric_time
+        , SUM(subq_14.instant_bookings) AS instant_bookings
       FROM (
         -- Pass Only Elements:
         --   ['instant_bookings', 'metric_time']
         SELECT
-          subq_12.metric_time
-          , subq_12.instant_bookings
+          subq_13.metric_time
+          , subq_13.instant_bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds_partitioned
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.booking_paid_at
-            , subq_11.booking_paid_at__week
-            , subq_11.booking_paid_at__month
-            , subq_11.booking_paid_at__quarter
-            , subq_11.booking_paid_at__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds
-            , subq_11.create_a_cycle_in_the_join_graph__ds__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_11.ds AS metric_time
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.create_a_cycle_in_the_join_graph
-            , subq_11.create_a_cycle_in_the_join_graph__listing
-            , subq_11.create_a_cycle_in_the_join_graph__guest
-            , subq_11.create_a_cycle_in_the_join_graph__host
-            , subq_11.is_instant
-            , subq_11.create_a_cycle_in_the_join_graph__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.max_booking_value
-            , subq_11.min_booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
-            , subq_11.referred_bookings
+            subq_12.ds
+            , subq_12.ds__week
+            , subq_12.ds__month
+            , subq_12.ds__quarter
+            , subq_12.ds__year
+            , subq_12.ds_partitioned
+            , subq_12.ds_partitioned__week
+            , subq_12.ds_partitioned__month
+            , subq_12.ds_partitioned__quarter
+            , subq_12.ds_partitioned__year
+            , subq_12.booking_paid_at
+            , subq_12.booking_paid_at__week
+            , subq_12.booking_paid_at__month
+            , subq_12.booking_paid_at__quarter
+            , subq_12.booking_paid_at__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds
+            , subq_12.create_a_cycle_in_the_join_graph__ds__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_12.ds AS metric_time
+            , subq_12.ds__week AS metric_time__week
+            , subq_12.ds__month AS metric_time__month
+            , subq_12.ds__quarter AS metric_time__quarter
+            , subq_12.ds__year AS metric_time__year
+            , subq_12.listing
+            , subq_12.guest
+            , subq_12.host
+            , subq_12.create_a_cycle_in_the_join_graph
+            , subq_12.create_a_cycle_in_the_join_graph__listing
+            , subq_12.create_a_cycle_in_the_join_graph__guest
+            , subq_12.create_a_cycle_in_the_join_graph__host
+            , subq_12.is_instant
+            , subq_12.create_a_cycle_in_the_join_graph__is_instant
+            , subq_12.bookings
+            , subq_12.instant_bookings
+            , subq_12.booking_value
+            , subq_12.max_booking_value
+            , subq_12.min_booking_value
+            , subq_12.bookers
+            , subq_12.average_booking_value
+            , subq_12.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -416,86 +416,86 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_12
+        ) subq_13
+      ) subq_14
       GROUP BY
-        subq_13.metric_time
-    ) subq_14
-  ) subq_20
+        subq_14.metric_time
+    ) subq_15
+  ) subq_16
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_11.metric_time = subq_16.metric_time
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_18.metric_time
-      , subq_18.bookings
+      subq_20.metric_time
+      , subq_20.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_17.metric_time
-        , SUM(subq_17.bookings) AS bookings
+        subq_19.metric_time
+        , SUM(subq_19.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_16.metric_time
-          , subq_16.bookings
+          subq_18.metric_time
+          , subq_18.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_15.ds
-            , subq_15.ds__week
-            , subq_15.ds__month
-            , subq_15.ds__quarter
-            , subq_15.ds__year
-            , subq_15.ds_partitioned
-            , subq_15.ds_partitioned__week
-            , subq_15.ds_partitioned__month
-            , subq_15.ds_partitioned__quarter
-            , subq_15.ds_partitioned__year
-            , subq_15.booking_paid_at
-            , subq_15.booking_paid_at__week
-            , subq_15.booking_paid_at__month
-            , subq_15.booking_paid_at__quarter
-            , subq_15.booking_paid_at__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds
-            , subq_15.create_a_cycle_in_the_join_graph__ds__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_15.ds AS metric_time
-            , subq_15.ds__week AS metric_time__week
-            , subq_15.ds__month AS metric_time__month
-            , subq_15.ds__quarter AS metric_time__quarter
-            , subq_15.ds__year AS metric_time__year
-            , subq_15.listing
-            , subq_15.guest
-            , subq_15.host
-            , subq_15.create_a_cycle_in_the_join_graph
-            , subq_15.create_a_cycle_in_the_join_graph__listing
-            , subq_15.create_a_cycle_in_the_join_graph__guest
-            , subq_15.create_a_cycle_in_the_join_graph__host
-            , subq_15.is_instant
-            , subq_15.create_a_cycle_in_the_join_graph__is_instant
-            , subq_15.bookings
-            , subq_15.instant_bookings
-            , subq_15.booking_value
-            , subq_15.max_booking_value
-            , subq_15.min_booking_value
-            , subq_15.bookers
-            , subq_15.average_booking_value
-            , subq_15.referred_bookings
+            subq_17.ds
+            , subq_17.ds__week
+            , subq_17.ds__month
+            , subq_17.ds__quarter
+            , subq_17.ds__year
+            , subq_17.ds_partitioned
+            , subq_17.ds_partitioned__week
+            , subq_17.ds_partitioned__month
+            , subq_17.ds_partitioned__quarter
+            , subq_17.ds_partitioned__year
+            , subq_17.booking_paid_at
+            , subq_17.booking_paid_at__week
+            , subq_17.booking_paid_at__month
+            , subq_17.booking_paid_at__quarter
+            , subq_17.booking_paid_at__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds
+            , subq_17.create_a_cycle_in_the_join_graph__ds__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_17.ds AS metric_time
+            , subq_17.ds__week AS metric_time__week
+            , subq_17.ds__month AS metric_time__month
+            , subq_17.ds__quarter AS metric_time__quarter
+            , subq_17.ds__year AS metric_time__year
+            , subq_17.listing
+            , subq_17.guest
+            , subq_17.host
+            , subq_17.create_a_cycle_in_the_join_graph
+            , subq_17.create_a_cycle_in_the_join_graph__listing
+            , subq_17.create_a_cycle_in_the_join_graph__guest
+            , subq_17.create_a_cycle_in_the_join_graph__host
+            , subq_17.is_instant
+            , subq_17.create_a_cycle_in_the_join_graph__is_instant
+            , subq_17.bookings
+            , subq_17.instant_bookings
+            , subq_17.booking_value
+            , subq_17.max_booking_value
+            , subq_17.min_booking_value
+            , subq_17.bookers
+            , subq_17.average_booking_value
+            , subq_17.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -551,13 +551,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_15
-        ) subq_16
-      ) subq_17
+          ) subq_17
+        ) subq_18
+      ) subq_19
       GROUP BY
-        subq_17.metric_time
-    ) subq_18
+        subq_19.metric_time
+    ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_19.metric_time, subq_20.metric_time) = subq_21.metric_time
+    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_42.metric_time, subq_43.metric_time, subq_44.metric_time) AS metric_time
-    , subq_42.non_referred AS non_referred
-    , subq_43.instant AS instant
+    COALESCE(subq_34.metric_time, subq_39.metric_time, subq_44.metric_time) AS metric_time
+    , subq_34.non_referred AS non_referred
+    , subq_39.instant AS instant
     , subq_44.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_31.metric_time, subq_32.metric_time) AS metric_time
-        , subq_31.ref_bookings AS ref_bookings
+        COALESCE(subq_27.metric_time, subq_32.metric_time) AS metric_time
+        , subq_27.ref_bookings AS ref_bookings
         , subq_32.bookings AS bookings
       FROM (
         -- Aggregate Measures
@@ -41,7 +41,7 @@ FROM (
         ) subq_25
         GROUP BY
           metric_time
-      ) subq_31
+      ) subq_27
       INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -60,14 +60,14 @@ FROM (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_29
+        ) subq_30
         GROUP BY
           metric_time
       ) subq_32
       ON
-        subq_31.metric_time = subq_32.metric_time
+        subq_27.metric_time = subq_32.metric_time
     ) subq_33
-  ) subq_42
+  ) subq_34
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -86,12 +86,12 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_36
+    ) subq_37
     GROUP BY
       metric_time
-  ) subq_43
+  ) subq_39
   ON
-    subq_42.metric_time = subq_43.metric_time
+    subq_34.metric_time = subq_39.metric_time
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -110,10 +110,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_40
+    ) subq_42
     GROUP BY
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_42.metric_time, subq_43.metric_time) = subq_44.metric_time
+    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -65,7 +65,11 @@ FROM (
           metric_time
       ) subq_32
       ON
-        subq_27.metric_time = subq_32.metric_time
+        (
+          subq_27.metric_time = subq_32.metric_time
+        ) OR (
+          (subq_27.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+        )
     ) subq_33
   ) subq_34
   INNER JOIN (
@@ -91,7 +95,11 @@ FROM (
       metric_time
   ) subq_39
   ON
-    subq_34.metric_time = subq_39.metric_time
+    (
+      subq_34.metric_time = subq_39.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_39.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -115,5 +123,9 @@ FROM (
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
+    (
+      subq_34.metric_time = subq_44.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_44.metric_time IS NULL)
+    )
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
@@ -135,78 +135,78 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_value
+    subq_8.metric_time
+    , subq_8.booking_value
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_value) AS booking_value
+      subq_7.metric_time
+      , SUM(subq_7.booking_value) AS booking_value
     FROM (
       -- Pass Only Elements:
       --   ['booking_value', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_value
+        subq_6.metric_time
+        , subq_6.booking_value
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.ds AS metric_time
-          , subq_4.ds__week AS metric_time__week
-          , subq_4.ds__month AS metric_time__month
-          , subq_4.ds__quarter AS metric_time__quarter
-          , subq_4.ds__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.bookings
-          , subq_4.instant_bookings
-          , subq_4.booking_value
-          , subq_4.max_booking_value
-          , subq_4.min_booking_value
-          , subq_4.bookers
-          , subq_4.average_booking_value
-          , subq_4.referred_bookings
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.ds AS metric_time
+          , subq_5.ds__week AS metric_time__week
+          , subq_5.ds__month AS metric_time__month
+          , subq_5.ds__quarter AS metric_time__quarter
+          , subq_5.ds__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.bookings
+          , subq_5.instant_bookings
+          , subq_5.booking_value
+          , subq_5.max_booking_value
+          , subq_5.min_booking_value
+          , subq_5.bookers
+          , subq_5.average_booking_value
+          , subq_5.referred_bookings
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -262,14 +262,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     ds
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
@@ -275,5 +275,9 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    subq_4.metric_time = subq_9.metric_time
+    (
+      subq_4.metric_time = subq_9.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+    )
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-    , subq_8.ref_bookings AS ref_bookings
+    COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+    , subq_4.ref_bookings AS ref_bookings
     , subq_9.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -140,78 +140,78 @@ FROM (
       GROUP BY
         subq_2.metric_time
     ) subq_3
-  ) subq_8
+  ) subq_4
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_7.metric_time
-      , subq_7.bookings
+      subq_8.metric_time
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time
-        , SUM(subq_6.bookings) AS bookings
+        subq_7.metric_time
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_5.metric_time
-          , subq_5.bookings
+          subq_6.metric_time
+          , subq_6.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds_partitioned
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.booking_paid_at
-            , subq_4.booking_paid_at__week
-            , subq_4.booking_paid_at__month
-            , subq_4.booking_paid_at__quarter
-            , subq_4.booking_paid_at__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds
-            , subq_4.create_a_cycle_in_the_join_graph__ds__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.create_a_cycle_in_the_join_graph
-            , subq_4.create_a_cycle_in_the_join_graph__listing
-            , subq_4.create_a_cycle_in_the_join_graph__guest
-            , subq_4.create_a_cycle_in_the_join_graph__host
-            , subq_4.is_instant
-            , subq_4.create_a_cycle_in_the_join_graph__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.ds_partitioned
+            , subq_5.ds_partitioned__week
+            , subq_5.ds_partitioned__month
+            , subq_5.ds_partitioned__quarter
+            , subq_5.ds_partitioned__year
+            , subq_5.booking_paid_at
+            , subq_5.booking_paid_at__week
+            , subq_5.booking_paid_at__month
+            , subq_5.booking_paid_at__quarter
+            , subq_5.booking_paid_at__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds
+            , subq_5.create_a_cycle_in_the_join_graph__ds__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.guest
+            , subq_5.host
+            , subq_5.create_a_cycle_in_the_join_graph
+            , subq_5.create_a_cycle_in_the_join_graph__listing
+            , subq_5.create_a_cycle_in_the_join_graph__guest
+            , subq_5.create_a_cycle_in_the_join_graph__host
+            , subq_5.is_instant
+            , subq_5.create_a_cycle_in_the_join_graph__is_instant
+            , subq_5.bookings
+            , subq_5.instant_bookings
+            , subq_5.booking_value
+            , subq_5.max_booking_value
+            , subq_5.min_booking_value
+            , subq_5.bookers
+            , subq_5.average_booking_value
+            , subq_5.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -267,13 +267,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_4
-        ) subq_5
-      ) subq_6
+          ) subq_5
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_6.metric_time
-    ) subq_7
+        subq_7.metric_time
+    ) subq_8
   ) subq_9
   ON
-    subq_8.metric_time = subq_9.metric_time
+    subq_4.metric_time = subq_9.metric_time
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
@@ -53,5 +53,9 @@ FROM (
       metric_time
   ) subq_20
   ON
-    subq_15.metric_time = subq_20.metric_time
+    (
+      subq_15.metric_time = subq_20.metric_time
+    ) OR (
+      (subq_15.metric_time IS NULL) AND (subq_20.metric_time IS NULL)
+    )
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time) AS metric_time
-    , subq_19.ref_bookings AS ref_bookings
+    COALESCE(subq_15.metric_time, subq_20.metric_time) AS metric_time
+    , subq_15.ref_bookings AS ref_bookings
     , subq_20.bookings AS bookings
   FROM (
     -- Aggregate Measures
@@ -29,7 +29,7 @@ FROM (
     ) subq_13
     GROUP BY
       metric_time
-  ) subq_19
+  ) subq_15
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -48,10 +48,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_17
+    ) subq_18
     GROUP BY
       metric_time
   ) subq_20
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_15.metric_time = subq_20.metric_time
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_10.bookings) AS bookings
+  MAX(subq_5.bookings) AS bookings
   , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
@@ -186,100 +186,100 @@ FROM (
       ) subq_2
     ) subq_3
   ) subq_4
-) subq_10
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_8.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements:
       --   ['listings']
       SELECT
-        subq_7.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.created_at
-          , subq_6.created_at__week
-          , subq_6.created_at__month
-          , subq_6.created_at__quarter
-          , subq_6.created_at__year
-          , subq_6.listing__ds
-          , subq_6.listing__ds__week
-          , subq_6.listing__ds__month
-          , subq_6.listing__ds__quarter
-          , subq_6.listing__ds__year
-          , subq_6.listing__created_at
-          , subq_6.listing__created_at__week
-          , subq_6.listing__created_at__month
-          , subq_6.listing__created_at__quarter
-          , subq_6.listing__created_at__year
-          , subq_6.metric_time
-          , subq_6.metric_time__week
-          , subq_6.metric_time__month
-          , subq_6.metric_time__quarter
-          , subq_6.metric_time__year
-          , subq_6.listing
-          , subq_6.user
-          , subq_6.listing__user
-          , subq_6.country_latest
-          , subq_6.is_lux_latest
-          , subq_6.capacity_latest
-          , subq_6.listing__country_latest
-          , subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.listings
-          , subq_6.largest_listing
-          , subq_6.smallest_listing
+          subq_7.ds
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.created_at
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.listing__ds
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__created_at
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.metric_time
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.created_at
-            , subq_5.created_at__week
-            , subq_5.created_at__month
-            , subq_5.created_at__quarter
-            , subq_5.created_at__year
-            , subq_5.listing__ds
-            , subq_5.listing__ds__week
-            , subq_5.listing__ds__month
-            , subq_5.listing__ds__quarter
-            , subq_5.listing__ds__year
-            , subq_5.listing__created_at
-            , subq_5.listing__created_at__week
-            , subq_5.listing__created_at__month
-            , subq_5.listing__created_at__quarter
-            , subq_5.listing__created_at__year
-            , subq_5.ds AS metric_time
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.listing
-            , subq_5.user
-            , subq_5.listing__user
-            , subq_5.country_latest
-            , subq_5.is_lux_latest
-            , subq_5.capacity_latest
-            , subq_5.listing__country_latest
-            , subq_5.listing__is_lux_latest
-            , subq_5.listing__capacity_latest
-            , subq_5.listings
-            , subq_5.largest_listing
-            , subq_5.smallest_listing
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.created_at
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.listing__ds
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__created_at
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Data Source 'listings_latest'
             SELECT
@@ -316,10 +316,10 @@ CROSS JOIN (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_5
-        ) subq_6
-        WHERE subq_6.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-      ) subq_7
-    ) subq_8
-  ) subq_9
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      ) subq_8
+    ) subq_9
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_22.bookings) AS bookings
+  MAX(subq_17.bookings) AS bookings
   , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
@@ -17,7 +17,7 @@ FROM (
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
   WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-) subq_22
+) subq_17
 CROSS JOIN (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
@@ -287,7 +287,11 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        subq_4.metric_time = subq_9.metric_time
+        (
+          subq_4.metric_time = subq_9.metric_time
+        ) OR (
+          (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+        )
     ) subq_10
   ) subq_11
   INNER JOIN (
@@ -424,7 +428,11 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    subq_11.metric_time = subq_16.metric_time
+    (
+      subq_11.metric_time = subq_16.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_16.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -559,5 +567,9 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
+    (
+      subq_11.metric_time = subq_21.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    )
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time, subq_21.metric_time) AS metric_time
-    , subq_19.non_referred AS non_referred
-    , subq_20.instant AS instant
+    COALESCE(subq_11.metric_time, subq_16.metric_time, subq_21.metric_time) AS metric_time
+    , subq_11.non_referred AS non_referred
+    , subq_16.instant AS instant
     , subq_21.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-        , subq_8.ref_bookings AS ref_bookings
+        COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+        , subq_4.ref_bookings AS ref_bookings
         , subq_9.bookings AS bookings
       FROM (
         -- Compute Metrics via Expressions
@@ -152,78 +152,78 @@ FROM (
           GROUP BY
             subq_2.metric_time
         ) subq_3
-      ) subq_8
+      ) subq_4
       INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
-          subq_7.metric_time
-          , subq_7.bookings
+          subq_8.metric_time
+          , subq_8.bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_6.metric_time
-            , SUM(subq_6.bookings) AS bookings
+            subq_7.metric_time
+            , SUM(subq_7.bookings) AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'metric_time']
             SELECT
-              subq_5.metric_time
-              , subq_5.bookings
+              subq_6.metric_time
+              , subq_6.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds_partitioned
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.booking_paid_at
-                , subq_4.booking_paid_at__week
-                , subq_4.booking_paid_at__month
-                , subq_4.booking_paid_at__quarter
-                , subq_4.booking_paid_at__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds
-                , subq_4.create_a_cycle_in_the_join_graph__ds__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_4.ds AS metric_time
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.create_a_cycle_in_the_join_graph
-                , subq_4.create_a_cycle_in_the_join_graph__listing
-                , subq_4.create_a_cycle_in_the_join_graph__guest
-                , subq_4.create_a_cycle_in_the_join_graph__host
-                , subq_4.is_instant
-                , subq_4.create_a_cycle_in_the_join_graph__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
+                subq_5.ds
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds_partitioned
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.booking_paid_at
+                , subq_5.booking_paid_at__week
+                , subq_5.booking_paid_at__month
+                , subq_5.booking_paid_at__quarter
+                , subq_5.booking_paid_at__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds
+                , subq_5.create_a_cycle_in_the_join_graph__ds__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_5.ds AS metric_time
+                , subq_5.ds__week AS metric_time__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter AS metric_time__quarter
+                , subq_5.ds__year AS metric_time__year
+                , subq_5.listing
+                , subq_5.guest
+                , subq_5.host
+                , subq_5.create_a_cycle_in_the_join_graph
+                , subq_5.create_a_cycle_in_the_join_graph__listing
+                , subq_5.create_a_cycle_in_the_join_graph__guest
+                , subq_5.create_a_cycle_in_the_join_graph__host
+                , subq_5.is_instant
+                , subq_5.create_a_cycle_in_the_join_graph__is_instant
+                , subq_5.bookings
+                , subq_5.instant_bookings
+                , subq_5.booking_value
+                , subq_5.max_booking_value
+                , subq_5.min_booking_value
+                , subq_5.bookers
+                , subq_5.average_booking_value
+                , subq_5.referred_bookings
               FROM (
                 -- Read Elements From Data Source 'bookings_source'
                 SELECT
@@ -279,88 +279,88 @@ FROM (
                   -- User Defined SQL Query
                   SELECT * FROM ***************************.fct_bookings
                 ) bookings_source_src_10001
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_5
+            ) subq_6
+          ) subq_7
           GROUP BY
-            subq_6.metric_time
-        ) subq_7
+            subq_7.metric_time
+        ) subq_8
       ) subq_9
       ON
-        subq_8.metric_time = subq_9.metric_time
+        subq_4.metric_time = subq_9.metric_time
     ) subq_10
-  ) subq_19
+  ) subq_11
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_14.metric_time
-      , subq_14.instant_bookings AS instant
+      subq_15.metric_time
+      , subq_15.instant_bookings AS instant
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_13.metric_time
-        , SUM(subq_13.instant_bookings) AS instant_bookings
+        subq_14.metric_time
+        , SUM(subq_14.instant_bookings) AS instant_bookings
       FROM (
         -- Pass Only Elements:
         --   ['instant_bookings', 'metric_time']
         SELECT
-          subq_12.metric_time
-          , subq_12.instant_bookings
+          subq_13.metric_time
+          , subq_13.instant_bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds_partitioned
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.booking_paid_at
-            , subq_11.booking_paid_at__week
-            , subq_11.booking_paid_at__month
-            , subq_11.booking_paid_at__quarter
-            , subq_11.booking_paid_at__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds
-            , subq_11.create_a_cycle_in_the_join_graph__ds__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_11.ds AS metric_time
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.create_a_cycle_in_the_join_graph
-            , subq_11.create_a_cycle_in_the_join_graph__listing
-            , subq_11.create_a_cycle_in_the_join_graph__guest
-            , subq_11.create_a_cycle_in_the_join_graph__host
-            , subq_11.is_instant
-            , subq_11.create_a_cycle_in_the_join_graph__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.max_booking_value
-            , subq_11.min_booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
-            , subq_11.referred_bookings
+            subq_12.ds
+            , subq_12.ds__week
+            , subq_12.ds__month
+            , subq_12.ds__quarter
+            , subq_12.ds__year
+            , subq_12.ds_partitioned
+            , subq_12.ds_partitioned__week
+            , subq_12.ds_partitioned__month
+            , subq_12.ds_partitioned__quarter
+            , subq_12.ds_partitioned__year
+            , subq_12.booking_paid_at
+            , subq_12.booking_paid_at__week
+            , subq_12.booking_paid_at__month
+            , subq_12.booking_paid_at__quarter
+            , subq_12.booking_paid_at__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds
+            , subq_12.create_a_cycle_in_the_join_graph__ds__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_12.ds AS metric_time
+            , subq_12.ds__week AS metric_time__week
+            , subq_12.ds__month AS metric_time__month
+            , subq_12.ds__quarter AS metric_time__quarter
+            , subq_12.ds__year AS metric_time__year
+            , subq_12.listing
+            , subq_12.guest
+            , subq_12.host
+            , subq_12.create_a_cycle_in_the_join_graph
+            , subq_12.create_a_cycle_in_the_join_graph__listing
+            , subq_12.create_a_cycle_in_the_join_graph__guest
+            , subq_12.create_a_cycle_in_the_join_graph__host
+            , subq_12.is_instant
+            , subq_12.create_a_cycle_in_the_join_graph__is_instant
+            , subq_12.bookings
+            , subq_12.instant_bookings
+            , subq_12.booking_value
+            , subq_12.max_booking_value
+            , subq_12.min_booking_value
+            , subq_12.bookers
+            , subq_12.average_booking_value
+            , subq_12.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -416,86 +416,86 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_12
+        ) subq_13
+      ) subq_14
       GROUP BY
-        subq_13.metric_time
-    ) subq_14
-  ) subq_20
+        subq_14.metric_time
+    ) subq_15
+  ) subq_16
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_11.metric_time = subq_16.metric_time
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_18.metric_time
-      , subq_18.bookings
+      subq_20.metric_time
+      , subq_20.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_17.metric_time
-        , SUM(subq_17.bookings) AS bookings
+        subq_19.metric_time
+        , SUM(subq_19.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_16.metric_time
-          , subq_16.bookings
+          subq_18.metric_time
+          , subq_18.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_15.ds
-            , subq_15.ds__week
-            , subq_15.ds__month
-            , subq_15.ds__quarter
-            , subq_15.ds__year
-            , subq_15.ds_partitioned
-            , subq_15.ds_partitioned__week
-            , subq_15.ds_partitioned__month
-            , subq_15.ds_partitioned__quarter
-            , subq_15.ds_partitioned__year
-            , subq_15.booking_paid_at
-            , subq_15.booking_paid_at__week
-            , subq_15.booking_paid_at__month
-            , subq_15.booking_paid_at__quarter
-            , subq_15.booking_paid_at__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds
-            , subq_15.create_a_cycle_in_the_join_graph__ds__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_15.ds AS metric_time
-            , subq_15.ds__week AS metric_time__week
-            , subq_15.ds__month AS metric_time__month
-            , subq_15.ds__quarter AS metric_time__quarter
-            , subq_15.ds__year AS metric_time__year
-            , subq_15.listing
-            , subq_15.guest
-            , subq_15.host
-            , subq_15.create_a_cycle_in_the_join_graph
-            , subq_15.create_a_cycle_in_the_join_graph__listing
-            , subq_15.create_a_cycle_in_the_join_graph__guest
-            , subq_15.create_a_cycle_in_the_join_graph__host
-            , subq_15.is_instant
-            , subq_15.create_a_cycle_in_the_join_graph__is_instant
-            , subq_15.bookings
-            , subq_15.instant_bookings
-            , subq_15.booking_value
-            , subq_15.max_booking_value
-            , subq_15.min_booking_value
-            , subq_15.bookers
-            , subq_15.average_booking_value
-            , subq_15.referred_bookings
+            subq_17.ds
+            , subq_17.ds__week
+            , subq_17.ds__month
+            , subq_17.ds__quarter
+            , subq_17.ds__year
+            , subq_17.ds_partitioned
+            , subq_17.ds_partitioned__week
+            , subq_17.ds_partitioned__month
+            , subq_17.ds_partitioned__quarter
+            , subq_17.ds_partitioned__year
+            , subq_17.booking_paid_at
+            , subq_17.booking_paid_at__week
+            , subq_17.booking_paid_at__month
+            , subq_17.booking_paid_at__quarter
+            , subq_17.booking_paid_at__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds
+            , subq_17.create_a_cycle_in_the_join_graph__ds__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_17.ds AS metric_time
+            , subq_17.ds__week AS metric_time__week
+            , subq_17.ds__month AS metric_time__month
+            , subq_17.ds__quarter AS metric_time__quarter
+            , subq_17.ds__year AS metric_time__year
+            , subq_17.listing
+            , subq_17.guest
+            , subq_17.host
+            , subq_17.create_a_cycle_in_the_join_graph
+            , subq_17.create_a_cycle_in_the_join_graph__listing
+            , subq_17.create_a_cycle_in_the_join_graph__guest
+            , subq_17.create_a_cycle_in_the_join_graph__host
+            , subq_17.is_instant
+            , subq_17.create_a_cycle_in_the_join_graph__is_instant
+            , subq_17.bookings
+            , subq_17.instant_bookings
+            , subq_17.booking_value
+            , subq_17.max_booking_value
+            , subq_17.min_booking_value
+            , subq_17.bookers
+            , subq_17.average_booking_value
+            , subq_17.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -551,13 +551,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_15
-        ) subq_16
-      ) subq_17
+          ) subq_17
+        ) subq_18
+      ) subq_19
       GROUP BY
-        subq_17.metric_time
-    ) subq_18
+        subq_19.metric_time
+    ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_19.metric_time, subq_20.metric_time) = subq_21.metric_time
+    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_42.metric_time, subq_43.metric_time, subq_44.metric_time) AS metric_time
-    , subq_42.non_referred AS non_referred
-    , subq_43.instant AS instant
+    COALESCE(subq_34.metric_time, subq_39.metric_time, subq_44.metric_time) AS metric_time
+    , subq_34.non_referred AS non_referred
+    , subq_39.instant AS instant
     , subq_44.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_31.metric_time, subq_32.metric_time) AS metric_time
-        , subq_31.ref_bookings AS ref_bookings
+        COALESCE(subq_27.metric_time, subq_32.metric_time) AS metric_time
+        , subq_27.ref_bookings AS ref_bookings
         , subq_32.bookings AS bookings
       FROM (
         -- Aggregate Measures
@@ -41,7 +41,7 @@ FROM (
         ) subq_25
         GROUP BY
           metric_time
-      ) subq_31
+      ) subq_27
       INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -60,14 +60,14 @@ FROM (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_29
+        ) subq_30
         GROUP BY
           metric_time
       ) subq_32
       ON
-        subq_31.metric_time = subq_32.metric_time
+        subq_27.metric_time = subq_32.metric_time
     ) subq_33
-  ) subq_42
+  ) subq_34
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -86,12 +86,12 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_36
+    ) subq_37
     GROUP BY
       metric_time
-  ) subq_43
+  ) subq_39
   ON
-    subq_42.metric_time = subq_43.metric_time
+    subq_34.metric_time = subq_39.metric_time
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -110,10 +110,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_40
+    ) subq_42
     GROUP BY
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_42.metric_time, subq_43.metric_time) = subq_44.metric_time
+    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -65,7 +65,11 @@ FROM (
           metric_time
       ) subq_32
       ON
-        subq_27.metric_time = subq_32.metric_time
+        (
+          subq_27.metric_time = subq_32.metric_time
+        ) OR (
+          (subq_27.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+        )
     ) subq_33
   ) subq_34
   INNER JOIN (
@@ -91,7 +95,11 @@ FROM (
       metric_time
   ) subq_39
   ON
-    subq_34.metric_time = subq_39.metric_time
+    (
+      subq_34.metric_time = subq_39.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_39.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -115,5 +123,9 @@ FROM (
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
+    (
+      subq_34.metric_time = subq_44.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_44.metric_time IS NULL)
+    )
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_value) AS booking_value
 FROM (
   -- Compute Metrics via Expressions
@@ -135,78 +135,78 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_value
+    subq_8.metric_time
+    , subq_8.booking_value
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_value) AS booking_value
+      subq_7.metric_time
+      , SUM(subq_7.booking_value) AS booking_value
     FROM (
       -- Pass Only Elements:
       --   ['booking_value', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_value
+        subq_6.metric_time
+        , subq_6.booking_value
       FROM (
         -- Metric Time Dimension 'ds'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.ds AS metric_time
-          , subq_4.ds__week AS metric_time__week
-          , subq_4.ds__month AS metric_time__month
-          , subq_4.ds__quarter AS metric_time__quarter
-          , subq_4.ds__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.bookings
-          , subq_4.instant_bookings
-          , subq_4.booking_value
-          , subq_4.max_booking_value
-          , subq_4.min_booking_value
-          , subq_4.bookers
-          , subq_4.average_booking_value
-          , subq_4.referred_bookings
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.ds AS metric_time
+          , subq_5.ds__week AS metric_time__week
+          , subq_5.ds__month AS metric_time__month
+          , subq_5.ds__quarter AS metric_time__quarter
+          , subq_5.ds__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.bookings
+          , subq_5.instant_bookings
+          , subq_5.booking_value
+          , subq_5.max_booking_value
+          , subq_5.min_booking_value
+          , subq_5.bookers
+          , subq_5.average_booking_value
+          , subq_5.referred_bookings
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -262,14 +262,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_common_data_source__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_value) AS booking_value
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     ds
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
@@ -275,5 +275,9 @@ FROM (
     ) subq_8
   ) subq_9
   ON
-    subq_4.metric_time = subq_9.metric_time
+    (
+      subq_4.metric_time = subq_9.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+    )
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-    , subq_8.ref_bookings AS ref_bookings
+    COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+    , subq_4.ref_bookings AS ref_bookings
     , subq_9.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -140,78 +140,78 @@ FROM (
       GROUP BY
         subq_2.metric_time
     ) subq_3
-  ) subq_8
+  ) subq_4
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_7.metric_time
-      , subq_7.bookings
+      subq_8.metric_time
+      , subq_8.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_6.metric_time
-        , SUM(subq_6.bookings) AS bookings
+        subq_7.metric_time
+        , SUM(subq_7.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_5.metric_time
-          , subq_5.bookings
+          subq_6.metric_time
+          , subq_6.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_4.ds
-            , subq_4.ds__week
-            , subq_4.ds__month
-            , subq_4.ds__quarter
-            , subq_4.ds__year
-            , subq_4.ds_partitioned
-            , subq_4.ds_partitioned__week
-            , subq_4.ds_partitioned__month
-            , subq_4.ds_partitioned__quarter
-            , subq_4.ds_partitioned__year
-            , subq_4.booking_paid_at
-            , subq_4.booking_paid_at__week
-            , subq_4.booking_paid_at__month
-            , subq_4.booking_paid_at__quarter
-            , subq_4.booking_paid_at__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds
-            , subq_4.create_a_cycle_in_the_join_graph__ds__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds__year
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_4.ds AS metric_time
-            , subq_4.ds__week AS metric_time__week
-            , subq_4.ds__month AS metric_time__month
-            , subq_4.ds__quarter AS metric_time__quarter
-            , subq_4.ds__year AS metric_time__year
-            , subq_4.listing
-            , subq_4.guest
-            , subq_4.host
-            , subq_4.create_a_cycle_in_the_join_graph
-            , subq_4.create_a_cycle_in_the_join_graph__listing
-            , subq_4.create_a_cycle_in_the_join_graph__guest
-            , subq_4.create_a_cycle_in_the_join_graph__host
-            , subq_4.is_instant
-            , subq_4.create_a_cycle_in_the_join_graph__is_instant
-            , subq_4.bookings
-            , subq_4.instant_bookings
-            , subq_4.booking_value
-            , subq_4.max_booking_value
-            , subq_4.min_booking_value
-            , subq_4.bookers
-            , subq_4.average_booking_value
-            , subq_4.referred_bookings
+            subq_5.ds
+            , subq_5.ds__week
+            , subq_5.ds__month
+            , subq_5.ds__quarter
+            , subq_5.ds__year
+            , subq_5.ds_partitioned
+            , subq_5.ds_partitioned__week
+            , subq_5.ds_partitioned__month
+            , subq_5.ds_partitioned__quarter
+            , subq_5.ds_partitioned__year
+            , subq_5.booking_paid_at
+            , subq_5.booking_paid_at__week
+            , subq_5.booking_paid_at__month
+            , subq_5.booking_paid_at__quarter
+            , subq_5.booking_paid_at__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds
+            , subq_5.create_a_cycle_in_the_join_graph__ds__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds__year
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_5.ds AS metric_time
+            , subq_5.ds__week AS metric_time__week
+            , subq_5.ds__month AS metric_time__month
+            , subq_5.ds__quarter AS metric_time__quarter
+            , subq_5.ds__year AS metric_time__year
+            , subq_5.listing
+            , subq_5.guest
+            , subq_5.host
+            , subq_5.create_a_cycle_in_the_join_graph
+            , subq_5.create_a_cycle_in_the_join_graph__listing
+            , subq_5.create_a_cycle_in_the_join_graph__guest
+            , subq_5.create_a_cycle_in_the_join_graph__host
+            , subq_5.is_instant
+            , subq_5.create_a_cycle_in_the_join_graph__is_instant
+            , subq_5.bookings
+            , subq_5.instant_bookings
+            , subq_5.booking_value
+            , subq_5.max_booking_value
+            , subq_5.min_booking_value
+            , subq_5.bookers
+            , subq_5.average_booking_value
+            , subq_5.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -267,13 +267,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_4
-        ) subq_5
-      ) subq_6
+          ) subq_5
+        ) subq_6
+      ) subq_7
       GROUP BY
-        subq_6.metric_time
-    ) subq_7
+        subq_7.metric_time
+    ) subq_8
   ) subq_9
   ON
-    subq_8.metric_time = subq_9.metric_time
+    subq_4.metric_time = subq_9.metric_time
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
@@ -53,5 +53,9 @@ FROM (
       metric_time
   ) subq_20
   ON
-    subq_15.metric_time = subq_20.metric_time
+    (
+      subq_15.metric_time = subq_20.metric_time
+    ) OR (
+      (subq_15.metric_time IS NULL) AND (subq_20.metric_time IS NULL)
+    )
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time) AS metric_time
-    , subq_19.ref_bookings AS ref_bookings
+    COALESCE(subq_15.metric_time, subq_20.metric_time) AS metric_time
+    , subq_15.ref_bookings AS ref_bookings
     , subq_20.bookings AS bookings
   FROM (
     -- Aggregate Measures
@@ -29,7 +29,7 @@ FROM (
     ) subq_13
     GROUP BY
       metric_time
-  ) subq_19
+  ) subq_15
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -48,10 +48,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_17
+    ) subq_18
     GROUP BY
       metric_time
   ) subq_20
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_15.metric_time = subq_20.metric_time
 ) subq_21

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_10.bookings) AS bookings
+  MAX(subq_5.bookings) AS bookings
   , MAX(subq_11.listings) AS listings
 FROM (
   -- Compute Metrics via Expressions
@@ -186,100 +186,100 @@ FROM (
       ) subq_2
     ) subq_3
   ) subq_4
-) subq_10
+) subq_5
 CROSS JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_9.listings
+    subq_10.listings
   FROM (
     -- Aggregate Measures
     SELECT
-      SUM(subq_8.listings) AS listings
+      SUM(subq_9.listings) AS listings
     FROM (
       -- Pass Only Elements:
       --   ['listings']
       SELECT
-        subq_7.listings
+        subq_8.listings
       FROM (
         -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
         SELECT
-          subq_6.ds
-          , subq_6.ds__week
-          , subq_6.ds__month
-          , subq_6.ds__quarter
-          , subq_6.ds__year
-          , subq_6.created_at
-          , subq_6.created_at__week
-          , subq_6.created_at__month
-          , subq_6.created_at__quarter
-          , subq_6.created_at__year
-          , subq_6.listing__ds
-          , subq_6.listing__ds__week
-          , subq_6.listing__ds__month
-          , subq_6.listing__ds__quarter
-          , subq_6.listing__ds__year
-          , subq_6.listing__created_at
-          , subq_6.listing__created_at__week
-          , subq_6.listing__created_at__month
-          , subq_6.listing__created_at__quarter
-          , subq_6.listing__created_at__year
-          , subq_6.metric_time
-          , subq_6.metric_time__week
-          , subq_6.metric_time__month
-          , subq_6.metric_time__quarter
-          , subq_6.metric_time__year
-          , subq_6.listing
-          , subq_6.user
-          , subq_6.listing__user
-          , subq_6.country_latest
-          , subq_6.is_lux_latest
-          , subq_6.capacity_latest
-          , subq_6.listing__country_latest
-          , subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.listings
-          , subq_6.largest_listing
-          , subq_6.smallest_listing
+          subq_7.ds
+          , subq_7.ds__week
+          , subq_7.ds__month
+          , subq_7.ds__quarter
+          , subq_7.ds__year
+          , subq_7.created_at
+          , subq_7.created_at__week
+          , subq_7.created_at__month
+          , subq_7.created_at__quarter
+          , subq_7.created_at__year
+          , subq_7.listing__ds
+          , subq_7.listing__ds__week
+          , subq_7.listing__ds__month
+          , subq_7.listing__ds__quarter
+          , subq_7.listing__ds__year
+          , subq_7.listing__created_at
+          , subq_7.listing__created_at__week
+          , subq_7.listing__created_at__month
+          , subq_7.listing__created_at__quarter
+          , subq_7.listing__created_at__year
+          , subq_7.metric_time
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.listing
+          , subq_7.user
+          , subq_7.listing__user
+          , subq_7.country_latest
+          , subq_7.is_lux_latest
+          , subq_7.capacity_latest
+          , subq_7.listing__country_latest
+          , subq_7.listing__is_lux_latest
+          , subq_7.listing__capacity_latest
+          , subq_7.listings
+          , subq_7.largest_listing
+          , subq_7.smallest_listing
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_5.ds
-            , subq_5.ds__week
-            , subq_5.ds__month
-            , subq_5.ds__quarter
-            , subq_5.ds__year
-            , subq_5.created_at
-            , subq_5.created_at__week
-            , subq_5.created_at__month
-            , subq_5.created_at__quarter
-            , subq_5.created_at__year
-            , subq_5.listing__ds
-            , subq_5.listing__ds__week
-            , subq_5.listing__ds__month
-            , subq_5.listing__ds__quarter
-            , subq_5.listing__ds__year
-            , subq_5.listing__created_at
-            , subq_5.listing__created_at__week
-            , subq_5.listing__created_at__month
-            , subq_5.listing__created_at__quarter
-            , subq_5.listing__created_at__year
-            , subq_5.ds AS metric_time
-            , subq_5.ds__week AS metric_time__week
-            , subq_5.ds__month AS metric_time__month
-            , subq_5.ds__quarter AS metric_time__quarter
-            , subq_5.ds__year AS metric_time__year
-            , subq_5.listing
-            , subq_5.user
-            , subq_5.listing__user
-            , subq_5.country_latest
-            , subq_5.is_lux_latest
-            , subq_5.capacity_latest
-            , subq_5.listing__country_latest
-            , subq_5.listing__is_lux_latest
-            , subq_5.listing__capacity_latest
-            , subq_5.listings
-            , subq_5.largest_listing
-            , subq_5.smallest_listing
+            subq_6.ds
+            , subq_6.ds__week
+            , subq_6.ds__month
+            , subq_6.ds__quarter
+            , subq_6.ds__year
+            , subq_6.created_at
+            , subq_6.created_at__week
+            , subq_6.created_at__month
+            , subq_6.created_at__quarter
+            , subq_6.created_at__year
+            , subq_6.listing__ds
+            , subq_6.listing__ds__week
+            , subq_6.listing__ds__month
+            , subq_6.listing__ds__quarter
+            , subq_6.listing__ds__year
+            , subq_6.listing__created_at
+            , subq_6.listing__created_at__week
+            , subq_6.listing__created_at__month
+            , subq_6.listing__created_at__quarter
+            , subq_6.listing__created_at__year
+            , subq_6.ds AS metric_time
+            , subq_6.ds__week AS metric_time__week
+            , subq_6.ds__month AS metric_time__month
+            , subq_6.ds__quarter AS metric_time__quarter
+            , subq_6.ds__year AS metric_time__year
+            , subq_6.listing
+            , subq_6.user
+            , subq_6.listing__user
+            , subq_6.country_latest
+            , subq_6.is_lux_latest
+            , subq_6.capacity_latest
+            , subq_6.listing__country_latest
+            , subq_6.listing__is_lux_latest
+            , subq_6.listing__capacity_latest
+            , subq_6.listings
+            , subq_6.largest_listing
+            , subq_6.smallest_listing
           FROM (
             -- Read Elements From Data Source 'listings_latest'
             SELECT
@@ -316,10 +316,10 @@ CROSS JOIN (
               , listings_latest_src_10004.user_id AS user
               , listings_latest_src_10004.user_id AS listing__user
             FROM ***************************.dim_listings_latest listings_latest_src_10004
-          ) subq_5
-        ) subq_6
-        WHERE subq_6.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-      ) subq_7
-    ) subq_8
-  ) subq_9
+          ) subq_6
+        ) subq_7
+        WHERE subq_7.metric_time BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
+      ) subq_8
+    ) subq_9
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,6 +1,6 @@
 -- Combine Metrics
 SELECT
-  MAX(subq_22.bookings) AS bookings
+  MAX(subq_17.bookings) AS bookings
   , MAX(subq_23.listings) AS listings
 FROM (
   -- Read Elements From Data Source 'bookings_source'
@@ -17,7 +17,7 @@ FROM (
     SELECT * FROM ***************************.fct_bookings
   ) bookings_source_src_10001
   WHERE ds BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-01' AS TIMESTAMP)
-) subq_22
+) subq_17
 CROSS JOIN (
   -- Read Elements From Data Source 'listings_latest'
   -- Metric Time Dimension 'ds'

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
@@ -287,7 +287,11 @@ FROM (
         ) subq_8
       ) subq_9
       ON
-        subq_4.metric_time = subq_9.metric_time
+        (
+          subq_4.metric_time = subq_9.metric_time
+        ) OR (
+          (subq_4.metric_time IS NULL) AND (subq_9.metric_time IS NULL)
+        )
     ) subq_10
   ) subq_11
   INNER JOIN (
@@ -424,7 +428,11 @@ FROM (
     ) subq_15
   ) subq_16
   ON
-    subq_11.metric_time = subq_16.metric_time
+    (
+      subq_11.metric_time = subq_16.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_16.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -559,5 +567,9 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
+    (
+      subq_11.metric_time = subq_21.metric_time
+    ) OR (
+      (subq_11.metric_time IS NULL) AND (subq_21.metric_time IS NULL)
+    )
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_19.metric_time, subq_20.metric_time, subq_21.metric_time) AS metric_time
-    , subq_19.non_referred AS non_referred
-    , subq_20.instant AS instant
+    COALESCE(subq_11.metric_time, subq_16.metric_time, subq_21.metric_time) AS metric_time
+    , subq_11.non_referred AS non_referred
+    , subq_16.instant AS instant
     , subq_21.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-        , subq_8.ref_bookings AS ref_bookings
+        COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+        , subq_4.ref_bookings AS ref_bookings
         , subq_9.bookings AS bookings
       FROM (
         -- Compute Metrics via Expressions
@@ -152,78 +152,78 @@ FROM (
           GROUP BY
             subq_2.metric_time
         ) subq_3
-      ) subq_8
+      ) subq_4
       INNER JOIN (
         -- Compute Metrics via Expressions
         SELECT
-          subq_7.metric_time
-          , subq_7.bookings
+          subq_8.metric_time
+          , subq_8.bookings
         FROM (
           -- Aggregate Measures
           SELECT
-            subq_6.metric_time
-            , SUM(subq_6.bookings) AS bookings
+            subq_7.metric_time
+            , SUM(subq_7.bookings) AS bookings
           FROM (
             -- Pass Only Elements:
             --   ['bookings', 'metric_time']
             SELECT
-              subq_5.metric_time
-              , subq_5.bookings
+              subq_6.metric_time
+              , subq_6.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds_partitioned
-                , subq_4.ds_partitioned__week
-                , subq_4.ds_partitioned__month
-                , subq_4.ds_partitioned__quarter
-                , subq_4.ds_partitioned__year
-                , subq_4.booking_paid_at
-                , subq_4.booking_paid_at__week
-                , subq_4.booking_paid_at__month
-                , subq_4.booking_paid_at__quarter
-                , subq_4.booking_paid_at__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds
-                , subq_4.create_a_cycle_in_the_join_graph__ds__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds__year
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-                , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-                , subq_4.ds AS metric_time
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.listing
-                , subq_4.guest
-                , subq_4.host
-                , subq_4.create_a_cycle_in_the_join_graph
-                , subq_4.create_a_cycle_in_the_join_graph__listing
-                , subq_4.create_a_cycle_in_the_join_graph__guest
-                , subq_4.create_a_cycle_in_the_join_graph__host
-                , subq_4.is_instant
-                , subq_4.create_a_cycle_in_the_join_graph__is_instant
-                , subq_4.bookings
-                , subq_4.instant_bookings
-                , subq_4.booking_value
-                , subq_4.max_booking_value
-                , subq_4.min_booking_value
-                , subq_4.bookers
-                , subq_4.average_booking_value
-                , subq_4.referred_bookings
+                subq_5.ds
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds_partitioned
+                , subq_5.ds_partitioned__week
+                , subq_5.ds_partitioned__month
+                , subq_5.ds_partitioned__quarter
+                , subq_5.ds_partitioned__year
+                , subq_5.booking_paid_at
+                , subq_5.booking_paid_at__week
+                , subq_5.booking_paid_at__month
+                , subq_5.booking_paid_at__quarter
+                , subq_5.booking_paid_at__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds
+                , subq_5.create_a_cycle_in_the_join_graph__ds__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds__year
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , subq_5.ds AS metric_time
+                , subq_5.ds__week AS metric_time__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter AS metric_time__quarter
+                , subq_5.ds__year AS metric_time__year
+                , subq_5.listing
+                , subq_5.guest
+                , subq_5.host
+                , subq_5.create_a_cycle_in_the_join_graph
+                , subq_5.create_a_cycle_in_the_join_graph__listing
+                , subq_5.create_a_cycle_in_the_join_graph__guest
+                , subq_5.create_a_cycle_in_the_join_graph__host
+                , subq_5.is_instant
+                , subq_5.create_a_cycle_in_the_join_graph__is_instant
+                , subq_5.bookings
+                , subq_5.instant_bookings
+                , subq_5.booking_value
+                , subq_5.max_booking_value
+                , subq_5.min_booking_value
+                , subq_5.bookers
+                , subq_5.average_booking_value
+                , subq_5.referred_bookings
               FROM (
                 -- Read Elements From Data Source 'bookings_source'
                 SELECT
@@ -279,88 +279,88 @@ FROM (
                   -- User Defined SQL Query
                   SELECT * FROM ***************************.fct_bookings
                 ) bookings_source_src_10001
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_5
+            ) subq_6
+          ) subq_7
           GROUP BY
-            subq_6.metric_time
-        ) subq_7
+            subq_7.metric_time
+        ) subq_8
       ) subq_9
       ON
-        subq_8.metric_time = subq_9.metric_time
+        subq_4.metric_time = subq_9.metric_time
     ) subq_10
-  ) subq_19
+  ) subq_11
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_14.metric_time
-      , subq_14.instant_bookings AS instant
+      subq_15.metric_time
+      , subq_15.instant_bookings AS instant
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_13.metric_time
-        , SUM(subq_13.instant_bookings) AS instant_bookings
+        subq_14.metric_time
+        , SUM(subq_14.instant_bookings) AS instant_bookings
       FROM (
         -- Pass Only Elements:
         --   ['instant_bookings', 'metric_time']
         SELECT
-          subq_12.metric_time
-          , subq_12.instant_bookings
+          subq_13.metric_time
+          , subq_13.instant_bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_11.ds
-            , subq_11.ds__week
-            , subq_11.ds__month
-            , subq_11.ds__quarter
-            , subq_11.ds__year
-            , subq_11.ds_partitioned
-            , subq_11.ds_partitioned__week
-            , subq_11.ds_partitioned__month
-            , subq_11.ds_partitioned__quarter
-            , subq_11.ds_partitioned__year
-            , subq_11.booking_paid_at
-            , subq_11.booking_paid_at__week
-            , subq_11.booking_paid_at__month
-            , subq_11.booking_paid_at__quarter
-            , subq_11.booking_paid_at__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds
-            , subq_11.create_a_cycle_in_the_join_graph__ds__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds__year
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_11.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_11.ds AS metric_time
-            , subq_11.ds__week AS metric_time__week
-            , subq_11.ds__month AS metric_time__month
-            , subq_11.ds__quarter AS metric_time__quarter
-            , subq_11.ds__year AS metric_time__year
-            , subq_11.listing
-            , subq_11.guest
-            , subq_11.host
-            , subq_11.create_a_cycle_in_the_join_graph
-            , subq_11.create_a_cycle_in_the_join_graph__listing
-            , subq_11.create_a_cycle_in_the_join_graph__guest
-            , subq_11.create_a_cycle_in_the_join_graph__host
-            , subq_11.is_instant
-            , subq_11.create_a_cycle_in_the_join_graph__is_instant
-            , subq_11.bookings
-            , subq_11.instant_bookings
-            , subq_11.booking_value
-            , subq_11.max_booking_value
-            , subq_11.min_booking_value
-            , subq_11.bookers
-            , subq_11.average_booking_value
-            , subq_11.referred_bookings
+            subq_12.ds
+            , subq_12.ds__week
+            , subq_12.ds__month
+            , subq_12.ds__quarter
+            , subq_12.ds__year
+            , subq_12.ds_partitioned
+            , subq_12.ds_partitioned__week
+            , subq_12.ds_partitioned__month
+            , subq_12.ds_partitioned__quarter
+            , subq_12.ds_partitioned__year
+            , subq_12.booking_paid_at
+            , subq_12.booking_paid_at__week
+            , subq_12.booking_paid_at__month
+            , subq_12.booking_paid_at__quarter
+            , subq_12.booking_paid_at__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds
+            , subq_12.create_a_cycle_in_the_join_graph__ds__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds__year
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_12.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_12.ds AS metric_time
+            , subq_12.ds__week AS metric_time__week
+            , subq_12.ds__month AS metric_time__month
+            , subq_12.ds__quarter AS metric_time__quarter
+            , subq_12.ds__year AS metric_time__year
+            , subq_12.listing
+            , subq_12.guest
+            , subq_12.host
+            , subq_12.create_a_cycle_in_the_join_graph
+            , subq_12.create_a_cycle_in_the_join_graph__listing
+            , subq_12.create_a_cycle_in_the_join_graph__guest
+            , subq_12.create_a_cycle_in_the_join_graph__host
+            , subq_12.is_instant
+            , subq_12.create_a_cycle_in_the_join_graph__is_instant
+            , subq_12.bookings
+            , subq_12.instant_bookings
+            , subq_12.booking_value
+            , subq_12.max_booking_value
+            , subq_12.min_booking_value
+            , subq_12.bookers
+            , subq_12.average_booking_value
+            , subq_12.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -416,86 +416,86 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_11
-        ) subq_12
-      ) subq_13
+          ) subq_12
+        ) subq_13
+      ) subq_14
       GROUP BY
-        subq_13.metric_time
-    ) subq_14
-  ) subq_20
+        subq_14.metric_time
+    ) subq_15
+  ) subq_16
   ON
-    subq_19.metric_time = subq_20.metric_time
+    subq_11.metric_time = subq_16.metric_time
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_18.metric_time
-      , subq_18.bookings
+      subq_20.metric_time
+      , subq_20.bookings
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_17.metric_time
-        , SUM(subq_17.bookings) AS bookings
+        subq_19.metric_time
+        , SUM(subq_19.bookings) AS bookings
       FROM (
         -- Pass Only Elements:
         --   ['bookings', 'metric_time']
         SELECT
-          subq_16.metric_time
-          , subq_16.bookings
+          subq_18.metric_time
+          , subq_18.bookings
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_15.ds
-            , subq_15.ds__week
-            , subq_15.ds__month
-            , subq_15.ds__quarter
-            , subq_15.ds__year
-            , subq_15.ds_partitioned
-            , subq_15.ds_partitioned__week
-            , subq_15.ds_partitioned__month
-            , subq_15.ds_partitioned__quarter
-            , subq_15.ds_partitioned__year
-            , subq_15.booking_paid_at
-            , subq_15.booking_paid_at__week
-            , subq_15.booking_paid_at__month
-            , subq_15.booking_paid_at__quarter
-            , subq_15.booking_paid_at__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds
-            , subq_15.create_a_cycle_in_the_join_graph__ds__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds__year
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__week
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__month
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__ds_partitioned__year
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__week
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__month
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-            , subq_15.create_a_cycle_in_the_join_graph__booking_paid_at__year
-            , subq_15.ds AS metric_time
-            , subq_15.ds__week AS metric_time__week
-            , subq_15.ds__month AS metric_time__month
-            , subq_15.ds__quarter AS metric_time__quarter
-            , subq_15.ds__year AS metric_time__year
-            , subq_15.listing
-            , subq_15.guest
-            , subq_15.host
-            , subq_15.create_a_cycle_in_the_join_graph
-            , subq_15.create_a_cycle_in_the_join_graph__listing
-            , subq_15.create_a_cycle_in_the_join_graph__guest
-            , subq_15.create_a_cycle_in_the_join_graph__host
-            , subq_15.is_instant
-            , subq_15.create_a_cycle_in_the_join_graph__is_instant
-            , subq_15.bookings
-            , subq_15.instant_bookings
-            , subq_15.booking_value
-            , subq_15.max_booking_value
-            , subq_15.min_booking_value
-            , subq_15.bookers
-            , subq_15.average_booking_value
-            , subq_15.referred_bookings
+            subq_17.ds
+            , subq_17.ds__week
+            , subq_17.ds__month
+            , subq_17.ds__quarter
+            , subq_17.ds__year
+            , subq_17.ds_partitioned
+            , subq_17.ds_partitioned__week
+            , subq_17.ds_partitioned__month
+            , subq_17.ds_partitioned__quarter
+            , subq_17.ds_partitioned__year
+            , subq_17.booking_paid_at
+            , subq_17.booking_paid_at__week
+            , subq_17.booking_paid_at__month
+            , subq_17.booking_paid_at__quarter
+            , subq_17.booking_paid_at__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds
+            , subq_17.create_a_cycle_in_the_join_graph__ds__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds__year
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_17.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_17.ds AS metric_time
+            , subq_17.ds__week AS metric_time__week
+            , subq_17.ds__month AS metric_time__month
+            , subq_17.ds__quarter AS metric_time__quarter
+            , subq_17.ds__year AS metric_time__year
+            , subq_17.listing
+            , subq_17.guest
+            , subq_17.host
+            , subq_17.create_a_cycle_in_the_join_graph
+            , subq_17.create_a_cycle_in_the_join_graph__listing
+            , subq_17.create_a_cycle_in_the_join_graph__guest
+            , subq_17.create_a_cycle_in_the_join_graph__host
+            , subq_17.is_instant
+            , subq_17.create_a_cycle_in_the_join_graph__is_instant
+            , subq_17.bookings
+            , subq_17.instant_bookings
+            , subq_17.booking_value
+            , subq_17.max_booking_value
+            , subq_17.min_booking_value
+            , subq_17.bookers
+            , subq_17.average_booking_value
+            , subq_17.referred_bookings
           FROM (
             -- Read Elements From Data Source 'bookings_source'
             SELECT
@@ -551,13 +551,13 @@ FROM (
               -- User Defined SQL Query
               SELECT * FROM ***************************.fct_bookings
             ) bookings_source_src_10001
-          ) subq_15
-        ) subq_16
-      ) subq_17
+          ) subq_17
+        ) subq_18
+      ) subq_19
       GROUP BY
-        subq_17.metric_time
-    ) subq_18
+        subq_19.metric_time
+    ) subq_20
   ) subq_21
   ON
-    COALESCE(subq_19.metric_time, subq_20.metric_time) = subq_21.metric_time
+    COALESCE(subq_11.metric_time, subq_16.metric_time) = subq_21.metric_time
 ) subq_22

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Metrics
   SELECT
-    COALESCE(subq_42.metric_time, subq_43.metric_time, subq_44.metric_time) AS metric_time
-    , subq_42.non_referred AS non_referred
-    , subq_43.instant AS instant
+    COALESCE(subq_34.metric_time, subq_39.metric_time, subq_44.metric_time) AS metric_time
+    , subq_34.non_referred AS non_referred
+    , subq_39.instant AS instant
     , subq_44.bookings AS bookings
   FROM (
     -- Compute Metrics via Expressions
@@ -17,8 +17,8 @@ FROM (
     FROM (
       -- Combine Metrics
       SELECT
-        COALESCE(subq_31.metric_time, subq_32.metric_time) AS metric_time
-        , subq_31.ref_bookings AS ref_bookings
+        COALESCE(subq_27.metric_time, subq_32.metric_time) AS metric_time
+        , subq_27.ref_bookings AS ref_bookings
         , subq_32.bookings AS bookings
       FROM (
         -- Aggregate Measures
@@ -41,7 +41,7 @@ FROM (
         ) subq_25
         GROUP BY
           metric_time
-      ) subq_31
+      ) subq_27
       INNER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -60,14 +60,14 @@ FROM (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_29
+        ) subq_30
         GROUP BY
           metric_time
       ) subq_32
       ON
-        subq_31.metric_time = subq_32.metric_time
+        subq_27.metric_time = subq_32.metric_time
     ) subq_33
-  ) subq_42
+  ) subq_34
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -86,12 +86,12 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_36
+    ) subq_37
     GROUP BY
       metric_time
-  ) subq_43
+  ) subq_39
   ON
-    subq_42.metric_time = subq_43.metric_time
+    subq_34.metric_time = subq_39.metric_time
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -110,10 +110,10 @@ FROM (
         -- User Defined SQL Query
         SELECT * FROM ***************************.fct_bookings
       ) bookings_source_src_10001
-    ) subq_40
+    ) subq_42
     GROUP BY
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_42.metric_time, subq_43.metric_time) = subq_44.metric_time
+    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_nested_derived_metric__plan0_optimized.sql
@@ -65,7 +65,11 @@ FROM (
           metric_time
       ) subq_32
       ON
-        subq_27.metric_time = subq_32.metric_time
+        (
+          subq_27.metric_time = subq_32.metric_time
+        ) OR (
+          (subq_27.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+        )
     ) subq_33
   ) subq_34
   INNER JOIN (
@@ -91,7 +95,11 @@ FROM (
       metric_time
   ) subq_39
   ON
-    subq_34.metric_time = subq_39.metric_time
+    (
+      subq_34.metric_time = subq_39.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_39.metric_time IS NULL)
+    )
   INNER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -115,5 +123,9 @@ FROM (
       metric_time
   ) subq_44
   ON
-    COALESCE(subq_34.metric_time, subq_39.metric_time) = subq_44.metric_time
+    (
+      subq_34.metric_time = subq_44.metric_time
+    ) OR (
+      (subq_34.metric_time IS NULL) AND (subq_44.metric_time IS NULL)
+    )
 ) subq_45

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric__plan0.xml
@@ -28,12 +28,12 @@
             <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-            <!-- join_0 =                                                    -->
-            <!--   {'class': 'SqlJoinDescription',                           -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
-            <!--    'right_source_alias': 'subq_9',                          -->
-            <!--    'join_type': SqlJoinType.INNER,                          -->
-            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
+            <!--    'right_source_alias': 'subq_9',                         -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -35,7 +35,7 @@
             <!-- join_0 =                                                    -->
             <!--   {'class': 'SqlJoinDescription',                           -->
             <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),   -->
-            <!--    'right_source_alias': 'subq_20',                         -->
+            <!--    'right_source_alias': 'subq_16',                         -->
             <!--    'join_type': SqlJoinType.INNER,                          -->
             <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
             <!-- join_1 =                                                    -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_nested_derived_metric__plan0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = ss_26 -->
         <!-- col0 =                                                    -->
         <!--   {'class': 'SqlSelectColumn',                            -->
-        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_473),  -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_472),  -->
         <!--    'column_alias': 'metric_time'}                         -->
         <!-- col1 =                                                                                             -->
         <!--   {'class': 'SqlSelectColumn',                                                                     -->
@@ -17,33 +17,33 @@
             <!-- node_id = ss_25 -->
             <!-- col0 =                                                                            -->
             <!--   {'class': 'SqlSelectColumn',                                                    -->
-            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_6, sql_function=COALESCE),  -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE),  -->
             <!--    'column_alias': 'metric_time'}                                                 -->
             <!-- col1 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_466),  -->
             <!--    'column_alias': 'non_referred'}                        -->
             <!-- col2 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_467),  -->
             <!--    'column_alias': 'instant'}                             -->
             <!-- col3 =                                                    -->
             <!--   {'class': 'SqlSelectColumn',                            -->
-            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_469),  -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_468),  -->
             <!--    'column_alias': 'bookings'}                            -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
-            <!-- join_0 =                                                    -->
-            <!--   {'class': 'SqlJoinDescription',                           -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),   -->
-            <!--    'right_source_alias': 'subq_16',                         -->
-            <!--    'join_type': SqlJoinType.INNER,                          -->
-            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
-            <!-- join_1 =                                                    -->
-            <!--   {'class': 'SqlJoinDescription',                           -->
-            <!--    'right_source': SqlSelectStatementNode(node_id=ss_24),   -->
-            <!--    'right_source_alias': 'subq_21',                         -->
-            <!--    'join_type': SqlJoinType.INNER,                          -->
-            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_2)}  -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_20),  -->
+            <!--    'right_source_alias': 'subq_16',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_3)}     -->
+            <!-- join_1 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_24),  -->
+            <!--    'right_source_alias': 'subq_21',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_5)}     -->
             <!-- where = None -->
             <SqlSelectStatementNode>
                 <!-- description = Compute Metrics via Expressions -->
@@ -74,12 +74,12 @@
                     <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
                     <!--    'column_alias': 'bookings'}                            -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-                    <!-- join_0 =                                                    -->
-                    <!--   {'class': 'SqlJoinDescription',                           -->
-                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
-                    <!--    'right_source_alias': 'subq_9',                          -->
-                    <!--    'join_type': SqlJoinType.INNER,                          -->
-                    <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+                    <!-- join_0 =                                                   -->
+                    <!--   {'class': 'SqlJoinDescription',                          -->
+                    <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),  -->
+                    <!--    'right_source_alias': 'subq_9',                         -->
+                    <!--    'join_type': SqlJoinType.INNER,                         -->
+                    <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
                     <!-- where = None -->
                     <SqlSelectStatementNode>
                         <!-- description = Compute Metrics via Expressions -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
@@ -135,71 +135,71 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_payments
+    subq_8.metric_time
+    , subq_8.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_payments) AS booking_payments
+      subq_7.metric_time
+      , SUM(subq_7.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_payments
+        subq_6.metric_time
+        , subq_6.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.booking_paid_at AS metric_time
-          , subq_4.booking_paid_at__week AS metric_time__week
-          , subq_4.booking_paid_at__month AS metric_time__month
-          , subq_4.booking_paid_at__quarter AS metric_time__quarter
-          , subq_4.booking_paid_at__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.booking_payments
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.booking_paid_at AS metric_time
+          , subq_5.booking_paid_at__week AS metric_time__week
+          , subq_5.booking_paid_at__month AS metric_time__month
+          , subq_5.booking_paid_at__quarter AS metric_time__quarter
+          , subq_5.booking_paid_at__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.booking_payments
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -255,14 +255,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'booking_paid_at'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     metric_time
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
   metric_time

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
@@ -135,71 +135,71 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_payments
+    subq_8.metric_time
+    , subq_8.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_payments) AS booking_payments
+      subq_7.metric_time
+      , SUM(subq_7.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_payments
+        subq_6.metric_time
+        , subq_6.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.booking_paid_at AS metric_time
-          , subq_4.booking_paid_at__week AS metric_time__week
-          , subq_4.booking_paid_at__month AS metric_time__month
-          , subq_4.booking_paid_at__quarter AS metric_time__quarter
-          , subq_4.booking_paid_at__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.booking_payments
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.booking_paid_at AS metric_time
+          , subq_5.booking_paid_at__week AS metric_time__week
+          , subq_5.booking_paid_at__month AS metric_time__month
+          , subq_5.booking_paid_at__quarter AS metric_time__quarter
+          , subq_5.booking_paid_at__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.booking_payments
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -255,14 +255,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DatabricksSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'booking_paid_at'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     booking_paid_at
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
@@ -135,71 +135,71 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_payments
+    subq_8.metric_time
+    , subq_8.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_payments) AS booking_payments
+      subq_7.metric_time
+      , SUM(subq_7.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_payments
+        subq_6.metric_time
+        , subq_6.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.booking_paid_at AS metric_time
-          , subq_4.booking_paid_at__week AS metric_time__week
-          , subq_4.booking_paid_at__month AS metric_time__month
-          , subq_4.booking_paid_at__quarter AS metric_time__quarter
-          , subq_4.booking_paid_at__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.booking_payments
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.booking_paid_at AS metric_time
+          , subq_5.booking_paid_at__week AS metric_time__week
+          , subq_5.booking_paid_at__month AS metric_time__month
+          , subq_5.booking_paid_at__quarter AS metric_time__quarter
+          , subq_5.booking_paid_at__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.booking_payments
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -255,14 +255,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDbSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'booking_paid_at'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     booking_paid_at
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
@@ -135,71 +135,71 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_payments
+    subq_8.metric_time
+    , subq_8.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_payments) AS booking_payments
+      subq_7.metric_time
+      , SUM(subq_7.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_payments
+        subq_6.metric_time
+        , subq_6.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.booking_paid_at AS metric_time
-          , subq_4.booking_paid_at__week AS metric_time__week
-          , subq_4.booking_paid_at__month AS metric_time__month
-          , subq_4.booking_paid_at__quarter AS metric_time__quarter
-          , subq_4.booking_paid_at__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.booking_payments
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.booking_paid_at AS metric_time
+          , subq_5.booking_paid_at__week AS metric_time__week
+          , subq_5.booking_paid_at__month AS metric_time__month
+          , subq_5.booking_paid_at__quarter AS metric_time__quarter
+          , subq_5.booking_paid_at__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.booking_payments
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -255,14 +255,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/PostgresSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'booking_paid_at'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     booking_paid_at
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
@@ -135,71 +135,71 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_payments
+    subq_8.metric_time
+    , subq_8.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_payments) AS booking_payments
+      subq_7.metric_time
+      , SUM(subq_7.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_payments
+        subq_6.metric_time
+        , subq_6.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.booking_paid_at AS metric_time
-          , subq_4.booking_paid_at__week AS metric_time__week
-          , subq_4.booking_paid_at__month AS metric_time__month
-          , subq_4.booking_paid_at__quarter AS metric_time__quarter
-          , subq_4.booking_paid_at__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.booking_payments
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.booking_paid_at AS metric_time
+          , subq_5.booking_paid_at__week AS metric_time__week
+          , subq_5.booking_paid_at__month AS metric_time__month
+          , subq_5.booking_paid_at__quarter AS metric_time__quarter
+          , subq_5.booking_paid_at__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.booking_payments
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -255,14 +255,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/RedshiftSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'booking_paid_at'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     booking_paid_at
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_8.metric_time, subq_9.metric_time) AS metric_time
-  , MAX(subq_8.bookings) AS bookings
+  COALESCE(subq_4.metric_time, subq_9.metric_time) AS metric_time
+  , MAX(subq_4.bookings) AS bookings
   , MAX(subq_9.booking_payments) AS booking_payments
 FROM (
   -- Compute Metrics via Expressions
@@ -135,71 +135,71 @@ FROM (
     GROUP BY
       subq_2.metric_time
   ) subq_3
-) subq_8
+) subq_4
 FULL OUTER JOIN (
   -- Compute Metrics via Expressions
   SELECT
-    subq_7.metric_time
-    , subq_7.booking_payments
+    subq_8.metric_time
+    , subq_8.booking_payments
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_6.metric_time
-      , SUM(subq_6.booking_payments) AS booking_payments
+      subq_7.metric_time
+      , SUM(subq_7.booking_payments) AS booking_payments
     FROM (
       -- Pass Only Elements:
       --   ['booking_payments', 'metric_time']
       SELECT
-        subq_5.metric_time
-        , subq_5.booking_payments
+        subq_6.metric_time
+        , subq_6.booking_payments
       FROM (
         -- Metric Time Dimension 'booking_paid_at'
         SELECT
-          subq_4.ds
-          , subq_4.ds__week
-          , subq_4.ds__month
-          , subq_4.ds__quarter
-          , subq_4.ds__year
-          , subq_4.ds_partitioned
-          , subq_4.ds_partitioned__week
-          , subq_4.ds_partitioned__month
-          , subq_4.ds_partitioned__quarter
-          , subq_4.ds_partitioned__year
-          , subq_4.booking_paid_at
-          , subq_4.booking_paid_at__week
-          , subq_4.booking_paid_at__month
-          , subq_4.booking_paid_at__quarter
-          , subq_4.booking_paid_at__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds
-          , subq_4.create_a_cycle_in_the_join_graph__ds__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds__year
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__week
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__month
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__ds_partitioned__year
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__week
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__month
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
-          , subq_4.create_a_cycle_in_the_join_graph__booking_paid_at__year
-          , subq_4.booking_paid_at AS metric_time
-          , subq_4.booking_paid_at__week AS metric_time__week
-          , subq_4.booking_paid_at__month AS metric_time__month
-          , subq_4.booking_paid_at__quarter AS metric_time__quarter
-          , subq_4.booking_paid_at__year AS metric_time__year
-          , subq_4.listing
-          , subq_4.guest
-          , subq_4.host
-          , subq_4.create_a_cycle_in_the_join_graph
-          , subq_4.create_a_cycle_in_the_join_graph__listing
-          , subq_4.create_a_cycle_in_the_join_graph__guest
-          , subq_4.create_a_cycle_in_the_join_graph__host
-          , subq_4.is_instant
-          , subq_4.create_a_cycle_in_the_join_graph__is_instant
-          , subq_4.booking_payments
+          subq_5.ds
+          , subq_5.ds__week
+          , subq_5.ds__month
+          , subq_5.ds__quarter
+          , subq_5.ds__year
+          , subq_5.ds_partitioned
+          , subq_5.ds_partitioned__week
+          , subq_5.ds_partitioned__month
+          , subq_5.ds_partitioned__quarter
+          , subq_5.ds_partitioned__year
+          , subq_5.booking_paid_at
+          , subq_5.booking_paid_at__week
+          , subq_5.booking_paid_at__month
+          , subq_5.booking_paid_at__quarter
+          , subq_5.booking_paid_at__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds
+          , subq_5.create_a_cycle_in_the_join_graph__ds__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds__year
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+          , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+          , subq_5.booking_paid_at AS metric_time
+          , subq_5.booking_paid_at__week AS metric_time__week
+          , subq_5.booking_paid_at__month AS metric_time__month
+          , subq_5.booking_paid_at__quarter AS metric_time__quarter
+          , subq_5.booking_paid_at__year AS metric_time__year
+          , subq_5.listing
+          , subq_5.guest
+          , subq_5.host
+          , subq_5.create_a_cycle_in_the_join_graph
+          , subq_5.create_a_cycle_in_the_join_graph__listing
+          , subq_5.create_a_cycle_in_the_join_graph__guest
+          , subq_5.create_a_cycle_in_the_join_graph__host
+          , subq_5.is_instant
+          , subq_5.create_a_cycle_in_the_join_graph__is_instant
+          , subq_5.booking_payments
         FROM (
           -- Read Elements From Data Source 'bookings_source'
           SELECT
@@ -255,14 +255,14 @@ FULL OUTER JOIN (
             -- User Defined SQL Query
             SELECT * FROM ***************************.fct_bookings
           ) bookings_source_src_10001
-        ) subq_4
-      ) subq_5
-    ) subq_6
+        ) subq_5
+      ) subq_6
+    ) subq_7
     GROUP BY
-      subq_6.metric_time
-  ) subq_7
+      subq_7.metric_time
+  ) subq_8
 ) subq_9
 ON
-  subq_8.metric_time = subq_9.metric_time
+  subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_8.metric_time, subq_9.metric_time)
+  COALESCE(subq_4.metric_time, subq_9.metric_time)

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/SnowflakeSqlClient/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Metrics
 SELECT
-  COALESCE(subq_18.metric_time, subq_19.metric_time) AS metric_time
-  , MAX(subq_18.bookings) AS bookings
+  COALESCE(subq_14.metric_time, subq_19.metric_time) AS metric_time
+  , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
   -- Aggregate Measures
@@ -24,7 +24,7 @@ FROM (
   ) subq_12
   GROUP BY
     metric_time
-) subq_18
+) subq_14
 FULL OUTER JOIN (
   -- Read Elements From Data Source 'bookings_source'
   -- Metric Time Dimension 'booking_paid_at'
@@ -43,6 +43,6 @@ FULL OUTER JOIN (
     booking_paid_at
 ) subq_19
 ON
-  subq_18.metric_time = subq_19.metric_time
+  subq_14.metric_time = subq_19.metric_time
 GROUP BY
-  COALESCE(subq_18.metric_time, subq_19.metric_time)
+  COALESCE(subq_14.metric_time, subq_19.metric_time)


### PR DESCRIPTION
The CombineMetricsNode was originally designed to join together multiple
fully computed metrics nodes for rendering unified results to an
end user. As such, it relied on a FULL OUTER JOIN, and doing so in
a way that failed to account for NULL values on the selected dimensions
would result in potential duplicate sets of dimension values.

In addressing this annoyance we noticed that derived metrics were using
this node to join input metrics for subsequent expression computation,
and using an INNER JOIN for consistency with multiple-measure
computations, which themselves use INNER JOIN because we have no
current mechanism for users to consistently handle NULL inputs to
measure/metric expressions.

This means the on condition MUST account for NULL inputs correctly. The
original join, which was essentially `ON a.dimension = b.dimension`, would
exclude the joined row altogether if both `a.dimension` and `b.dimension` were
NULL. The technique we were forced to adopt for the FULL OUTER JOIN case
would not work here, because that does a re-aggregation pass, but here we
need to prevent the rows from being thrown away.

Therefore, this PR effectively converts the ON condition for any join type
other than FULL OUTER JOIN to a compound test of the form:

`ON a.dimension = b.dimension OR (a.dimension IS NULL AND b.dimension IS NULL)`

Doing this required a certain amount of additional testing and restructuring of code,
which is documented in the commit structure of this PR.