### PR TITLE
Rename `CumulativeMetricWindow` to `MetricTimeWindow`

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -41,7 +41,7 @@ from metricflow.dataflow.optimizer.dataflow_plan_optimizer import DataflowPlanOp
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.dataset import DataSet
 from metricflow.errors.errors import UnableToSatisfyQueryError
-from metricflow.model.objects.metric import MetricType, CumulativeMetricWindow
+from metricflow.model.objects.metric import MetricType, MetricTimeWindow
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.spec_converters import WhereConstraintConverter
 from metricflow.object_utils import pformat_big_objects, assert_exactly_one_arg_set
@@ -604,7 +604,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         where_constraint: Optional[SpecWhereClauseConstraint] = None,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         cumulative: Optional[bool] = False,
-        cumulative_window: Optional[CumulativeMetricWindow] = None,
+        cumulative_window: Optional[MetricTimeWindow] = None,
         cumulative_grain_to_date: Optional[TimeGranularity] = None,
     ) -> BaseOutput[SqlDataSetT]:
         """Returns a node where the measures are aggregated by the linkable specs and constrained appropriately.
@@ -689,7 +689,7 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
         where_constraint: Optional[SpecWhereClauseConstraint] = None,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         cumulative: Optional[bool] = False,
-        cumulative_window: Optional[CumulativeMetricWindow] = None,
+        cumulative_window: Optional[MetricTimeWindow] = None,
         cumulative_grain_to_date: Optional[TimeGranularity] = None,
     ) -> BaseOutput[SqlDataSetT]:
         metric_time_dimension_requested = self._metric_time_dimension_reference.element_name in [

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -35,7 +35,7 @@ from metricflow.dataflow.builder.partitions import (
 )
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.dataset.dataset import DataSet
-from metricflow.model.objects.metric import CumulativeMetricWindow
+from metricflow.model.objects.metric import MetricTimeWindow
 from metricflow.object_utils import pformat_big_objects
 from metricflow.references import TimeDimensionReference
 from metricflow.specs import (
@@ -365,7 +365,7 @@ class JoinOverTimeRangeNode(Generic[SourceDataSetT], BaseOutput[SourceDataSetT])
     def __init__(
         self,
         parent_node: BaseOutput[SourceDataSetT],
-        window: Optional[CumulativeMetricWindow],
+        window: Optional[MetricTimeWindow],
         grain_to_date: Optional[TimeGranularity],
         node_id: Optional[NodeId] = None,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
@@ -414,7 +414,7 @@ class JoinOverTimeRangeNode(Generic[SourceDataSetT], BaseOutput[SourceDataSetT])
         return self._parent_node
 
     @property
-    def window(self) -> Optional[CumulativeMetricWindow]:  # noqa: D
+    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D
         return self._window
 
     @property

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -73,7 +73,7 @@ class MetricInput(HashableBaseModel):
     alias: Optional[str]
 
 
-class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
+class MetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
     """Describes the window of time the metric should be accumulated over. ie '1 day', '2 weeks', etc"""
 
     count: int
@@ -83,21 +83,21 @@ class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
         return f"{self.count} {self.granularity.value}"
 
     @classmethod
-    def _from_yaml_value(cls, input: PydanticParseableValueType) -> CumulativeMetricWindow:
-        """Parses a CumulativeMetricWindow from a string input found in a user provided model specification
+    def _from_yaml_value(cls, input: PydanticParseableValueType) -> MetricTimeWindow:
+        """Parses a MetricTimeWindow from a string input found in a user provided model specification
 
-        The CumulativeMetricWindow is always expected to be provided as a string in user-defined YAML configs.
+        The MetricTimeWindow is always expected to be provided as a string in user-defined YAML configs.
         """
         if isinstance(input, str):
-            return CumulativeMetricWindow.parse(input)
+            return MetricTimeWindow.parse(input)
         else:
             raise ValueError(
-                f"CumulativeMetricWindow inputs from model configs are expected to always be of type string, but got "
+                f"MetricTimeWindow inputs from model configs are expected to always be of type string, but got "
                 f"type {type(input)} with value: {input}"
             )
 
     @staticmethod
-    def parse(window: str) -> CumulativeMetricWindow:
+    def parse(window: str) -> MetricTimeWindow:
         """Returns window values if parsing succeeds, None otherwise
 
         Output of the form: (<time unit count>, <time granularity>, <error message>) - error message is None if window is formatted properly
@@ -122,7 +122,7 @@ class CumulativeMetricWindow(PydanticCustomInputParser, HashableBaseModel):
         if not count.isdigit():
             raise ParsingException(f"Invalid count ({count}) in cumulative metric window string: ({window})")
 
-        return CumulativeMetricWindow(
+        return MetricTimeWindow(
             count=int(count),
             granularity=string_to_time_granularity(granularity),
         )
@@ -136,7 +136,7 @@ class MetricTypeParams(HashableBaseModel):
     numerator: Optional[MetricInputMeasure]
     denominator: Optional[MetricInputMeasure]
     expr: Optional[str]
-    window: Optional[CumulativeMetricWindow]
+    window: Optional[MetricTimeWindow]
     grain_to_date: Optional[TimeGranularity]
     metrics: Optional[List[MetricInput]]
 

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -3,7 +3,7 @@ from typing import List
 
 from metricflow.errors.errors import ParsingException
 from metricflow.instances import MetricModelReference
-from metricflow.model.objects.metric import Metric, MetricType, CumulativeMetricWindow
+from metricflow.model.objects.metric import Metric, MetricType, MetricTimeWindow
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
 from metricflow.model.validations.unique_valid_name import UniqueAndValidNameRule
 from metricflow.model.validations.validator_helpers import (
@@ -38,7 +38,7 @@ class CumulativeMetricRule(ModelValidationRule):
 
             if metric.type_params.window:
                 try:
-                    _, _ = CumulativeMetricWindow.parse(metric.type_params.window.to_string())
+                    _, _ = MetricTimeWindow.parse(metric.type_params.window.to_string())
                 except ParsingException as e:
                     issues.append(
                         ValidationError(

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -2,7 +2,7 @@ import textwrap
 
 from metricflow.model.objects.common import YamlConfigFile
 from metricflow.model.objects.constraints.where import WhereClauseConstraint
-from metricflow.model.objects.metric import CumulativeMetricWindow, MetricInput, MetricInputMeasure, MetricType
+from metricflow.model.objects.metric import MetricTimeWindow, MetricInput, MetricInputMeasure, MetricType
 from metricflow.model.parsing.dir_to_model import parse_yaml_files_to_model
 from metricflow.model.validations.validator_helpers import ModelValidationException
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
@@ -229,7 +229,7 @@ def test_cumulative_window_metric_parsing() -> None:
     assert metric.name == "cumulative_test"
     assert metric.type is MetricType.CUMULATIVE
     assert metric.type_params.measures == [MetricInputMeasure(name="cumulative_measure")]
-    assert metric.type_params.window == CumulativeMetricWindow(count=7, granularity=TimeGranularity.DAY)
+    assert metric.type_params.window == MetricTimeWindow(count=7, granularity=TimeGranularity.DAY)
 
 
 def test_grain_to_date_metric_parsing() -> None:


### PR DESCRIPTION
This class will soon be used to specify offset windows for derived metrics. Renaming to something that makes sense for both use cases!