### PR TITLE
Update makefile and developer docs for dbt-cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,11 @@ Welcome to the MetricFlow developer community, we're thrilled to have you aboard
 6. Run `make install` to get all of your dependencies loaded and ready for development
     - This includes useful dev tools, including pre-commit for linting.
     - You may run `pre-commit install` if you would like the linters to run prior to all local git commits
+7. OPTIONAL: install dbt dependencies. Developers working on dbt integrations will need to install these in order to work on those integrations and run the relevant tests. Any of the following commands should be sufficient for development purposes:
+    - `poetry install -E "dbt-postgres dbt-cloud"`
+    - `poetry install -E "dbt-redshift dbt-cloud"`
+    - `poetry install -E "dbt-snowflake dbt-cloud"`
+    - `poetry install -E "dbt-bigquery dbt-cloud"`
 
 ## Start testing and development
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,15 @@ install:
 # Testing and linting
 .PHONY: test
 test:
-	poetry run pytest metricflow/test/
+	poetry run pytest metricflow/test/ --ignore metricflow/test/model/dbt_cloud_parsing
+
+.PHONY: test-dbt
+test-dbt:
+	poetry run pytest metricflow/test/model/dbt_cloud_parsing
+
+.PHONY: test-all
+test-all:
+	poetry run pytest metricflow/test
 
 .PHONY: test-postgresql
 test-postgresql:


### PR DESCRIPTION
Our integration with dbt-cloud adds optional dependencies
which are currently required to run the complete test suite.

This doesn't resolve the broader issue raised in #387, but it
does bring our developer documentation up to date with the current
state of our main branch.
