### PR TITLE
Add all group by columns to select in semi-additive join node

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1265,7 +1265,7 @@ class DataflowToSqlQueryPlanConverter(Generic[SqlDataSetT], DataflowPlanNodeVisi
         # Construct SelectNode for Row filtering
         row_filter_sql_select_node = SqlSelectStatementNode(
             description=f"Filter row on {node.agg_by_function.name}({time_dimension_column_name})",
-            select_columns=tuple(identifier_select_columns) + (time_dimension_select_column,),
+            select_columns=row_filter_group_bys + (time_dimension_select_column,),
             from_source=from_data_set.sql_select_node,
             from_source_alias=inner_join_data_set_alias,
             joins_descs=(),

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -31,7 +31,8 @@ FROM (
 INNER JOIN (
   -- Filter row on MIN(ds)
   SELECT
-    MIN(subq_1.ds) AS ds__complete
+    subq_1.ds__week
+    , MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -32,13 +32,14 @@ INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds__complete
+    DATE_TRUNC(ds, isoweek) AS ds__week
+    , MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
   GROUP BY
-    DATE_TRUNC(ds, isoweek)
+    ds__week
 ) subq_5
 ON
   subq_3.ds = subq_5.ds__complete

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -31,7 +31,8 @@ FROM (
 INNER JOIN (
   -- Filter row on MIN(ds)
   SELECT
-    MIN(subq_1.ds) AS ds__complete
+    subq_1.ds__week
+    , MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -32,7 +32,8 @@ INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds__complete
+    DATE_TRUNC('week', ds) AS ds__week
+    , MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -31,7 +31,8 @@ FROM (
 INNER JOIN (
   -- Filter row on MIN(ds)
   SELECT
-    MIN(subq_1.ds) AS ds__complete
+    subq_1.ds__week
+    , MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -32,7 +32,8 @@ INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds__complete
+    DATE_TRUNC('week', ds) AS ds__week
+    , MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -31,7 +31,8 @@ FROM (
 INNER JOIN (
   -- Filter row on MIN(ds)
   SELECT
-    MIN(subq_1.ds) AS ds__complete
+    subq_1.ds__week
+    , MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -32,7 +32,8 @@ INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds__complete
+    DATE_TRUNC('week', ds) AS ds__week
+    , MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -31,7 +31,8 @@ FROM (
 INNER JOIN (
   -- Filter row on MIN(ds)
   SELECT
-    MIN(subq_1.ds) AS ds__complete
+    subq_1.ds__week
+    , MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -32,7 +32,8 @@ INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds__complete
+    DATE_TRUNC('week', ds) AS ds__week
+    , MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -31,7 +31,8 @@ FROM (
 INNER JOIN (
   -- Filter row on MIN(ds)
   SELECT
-    MIN(subq_1.ds) AS ds__complete
+    subq_1.ds__week
+    , MIN(subq_1.ds) AS ds__complete
   FROM (
     -- Read Elements From Data Source 'accounts_source'
     SELECT

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_semi_additive_join_node_with_queried_group_by__plan0_optimized.sql
@@ -32,7 +32,8 @@ INNER JOIN (
   -- Read Elements From Data Source 'accounts_source'
   -- Filter row on MIN(ds)
   SELECT
-    MIN(ds) AS ds__complete
+    DATE_TRUNC('week', ds) AS ds__week
+    , MIN(ds) AS ds__complete
   FROM (
     -- User Defined SQL Query
     SELECT * FROM ***************************.fct_accounts

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -103,7 +103,11 @@
         <SqlSelectStatementNode>
             <!-- description = Filter row on MIN(ds) -->
             <!-- node_id = ss_0 -->
-            <!-- col0 =                                                                       -->
+            <!-- col0 =                                                  -->
+            <!--   {'class': 'SqlSelectColumn',                          -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_1),  -->
+            <!--    'column_alias': 'ds__week'}                          -->
+            <!-- col1 =                                                                       -->
             <!--   {'class': 'SqlSelectColumn',                                               -->
             <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN),  -->
             <!--    'column_alias': 'ds__complete'}                                           -->


### PR DESCRIPTION
Under certain conditions the semi-additive join node rendering
produces slightly strange SQL, where columns in the `GROUP BY`
statement are not included in the `SELECT`. For example, the inner
query for the filter join might look like this:

```
SELECT MIN(ds) AS ds__complete
FROM input_table
GROUP BY DATE_TRUNC(ds, isoweek)
```

This is confusing, as the DATE_TRUNC expression in the group by
allows for multiple rows of output. In this case, since the `ds`
columns are dates, there will always be exactly 1 row per `isoweek`,
however it's not obvious that this is the intent of the query.

This also causes problems with certain rendering approaches, as
we typically render either a raw expression OR an alias in `GROUP BY`
statements. In cases where we render the latter, this query will
break because the `DATE_TRUNC()` *must* be rendered as a full expression.
Depending on inputs and optimizer layouts this could, for certain engines,
result in broken SQL, a problem which is easily avoided if the expression
is included in the `SELECT` statement as a properly aliased column expression.

This change adds the full set of `GROUP BY` columns to the `SELECT` expression,
which results in the following updated SQL (for expr-style group by references):

```
SELECT DATE_TRUNC(ds, isoweek) AS ds__week, MIN(ds) AS ds__complete
FROM input_table
GROUP BY DATE_TRUNC(ds, isoweek)
```