### PR TITLE
Render aliases in group by expressions for BigQuery

### DIFF
--- a/metricflow/sql/render/expr_renderer.py
+++ b/metricflow/sql/render/expr_renderer.py
@@ -32,6 +32,7 @@ from metricflow.sql.sql_exprs import (
     SqlBetweenExpression,
     SqlWindowFunctionExpression,
 )
+from metricflow.sql.sql_plan import SqlSelectColumn
 from metricflow.time.time_granularity import TimeGranularity
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,14 @@ class SqlExpressionRenderer(SqlExpressionNodeVisitor[SqlExpressionRenderResult],
     def render_sql_expr(self, sql_expr: SqlExpressionNode) -> SqlExpressionRenderResult:
         """Render the given expression to a string."""
         return sql_expr.accept(self)
+
+    def render_group_by_expr(self, group_by_column: SqlSelectColumn) -> SqlExpressionRenderResult:
+        """Render the input group by column to a string.
+
+        This allows for engine-level overrides of the group by rendering behavior, since some engines only support
+        rendering group by columns based on aliases.
+        """
+        return self.render_sql_expr(sql_expr=group_by_column.expr)
 
     @property
     def double_data_type(self) -> str:

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -198,7 +198,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
         params = SqlBindParameters()
         first = True
         for group_by_column in group_by_columns:
-            group_by_expr_rendered = self.EXPR_RENDERER.render_sql_expr(group_by_column.expr)
+            group_by_expr_rendered = self.EXPR_RENDERER.render_group_by_expr(group_by_column)
             params = params.combine(group_by_expr_rendered.execution_parameters)
             if first:
                 first = False

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_common_data_source__plan0.sql
@@ -137,7 +137,7 @@ FROM (
       ) subq_1
     ) subq_2
     GROUP BY
-      subq_2.metric_time
+      metric_time
   ) subq_3
 ) subq_4
 FULL OUTER JOIN (
@@ -274,10 +274,10 @@ FULL OUTER JOIN (
       ) subq_6
     ) subq_7
     GROUP BY
-      subq_7.metric_time
+      metric_time
   ) subq_8
 ) subq_9
 ON
   subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_4.metric_time, subq_9.metric_time)
+  metric_time

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier__plan0.sql
@@ -68,6 +68,6 @@ FROM (
     ) subq_1
   ) subq_2
   GROUP BY
-    subq_2.user_team___team_id
-    , subq_2.user_team___user_id
+    user_team___team_id
+    , user_team___user_id
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_join__plan0.sql
@@ -149,7 +149,7 @@ FROM (
     ) subq_5
   ) subq_6
   GROUP BY
-    subq_6.user_team___team_id
-    , subq_6.user_team___user_id
-    , subq_6.user_team__country
+    user_team___team_id
+    , user_team___user_id
+    , user_team__country
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_composite_identifier_with_order_by__plan0.sql
@@ -74,8 +74,8 @@ FROM (
       ) subq_1
     ) subq_2
     GROUP BY
-      subq_2.user_team___team_id
-      , subq_2.user_team___user_id
+      user_team___team_id
+      , user_team___user_id
   ) subq_3
 ) subq_4
 ORDER BY subq_4.user_team___team_id DESC, subq_4.user_team___user_id DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node__plan0.sql
@@ -128,6 +128,6 @@ FROM (
       subq_1.listing = subq_3.listing
   ) subq_4
   GROUP BY
-    subq_4.listing
-    , subq_4.listing__country_latest
+    listing
+    , listing__country_latest
 ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_multiple_data_sources__plan0.sql
@@ -252,8 +252,8 @@ FROM (
         ) subq_6
       ) subq_7
       GROUP BY
-        subq_7.ds
-        , subq_7.listing__country_latest
+        ds
+        , listing__country_latest
     ) subq_8
     INNER JOIN (
       -- Aggregate Measures
@@ -442,8 +442,8 @@ FROM (
         ) subq_15
       ) subq_16
       GROUP BY
-        subq_16.ds
-        , subq_16.listing__country_latest
+        ds
+        , listing__country_latest
     ) subq_17
     ON
       (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_ratio_from_single_data_source__plan0.sql
@@ -131,6 +131,6 @@ FROM (
       subq_1.listing = subq_3.listing
   ) subq_4
   GROUP BY
-    subq_4.listing
-    , subq_4.listing__country_latest
+    listing
+    , listing__country_latest
 ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_compute_metrics_node_simple_expr__plan0.sql
@@ -128,6 +128,6 @@ FROM (
       subq_1.listing = subq_3.listing
   ) subq_4
   GROUP BY
-    subq_4.listing
-    , subq_4.listing__country_latest
+    listing
+    , listing__country_latest
 ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric__plan0.sql
@@ -46,5 +46,5 @@ FROM (
     ) subq_1
   ) subq_3
   GROUP BY
-    subq_3.ds__month
+    ds__month
 ) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_grain_to_date__plan0.sql
@@ -46,5 +46,5 @@ FROM (
     ) subq_1
   ) subq_3
   GROUP BY
-    subq_3.ds__month
+    ds__month
 ) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window__plan0.sql
@@ -46,5 +46,5 @@ FROM (
     ) subq_1
   ) subq_3
   GROUP BY
-    subq_3.ds__month
+    ds__month
 ) subq_4

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -63,5 +63,5 @@ FROM (
     ) subq_2
   ) subq_4
   GROUP BY
-    subq_4.ds__month
+    ds__month
 ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -63,5 +63,5 @@ FROM (
     ) subq_2
   ) subq_4
   GROUP BY
-    subq_4.ds__month
+    ds__month
 ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric__plan0.sql
@@ -142,7 +142,7 @@ FROM (
         ) subq_1
       ) subq_2
       GROUP BY
-        subq_2.metric_time
+        metric_time
     ) subq_3
   ) subq_4
   INNER JOIN (
@@ -279,7 +279,7 @@ FROM (
         ) subq_6
       ) subq_7
       GROUP BY
-        subq_7.metric_time
+        metric_time
     ) subq_8
   ) subq_9
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_distinct_values__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_distinct_values__plan0.sql
@@ -241,7 +241,7 @@ FROM (
         ) subq_6
       ) subq_7
       GROUP BY
-        subq_7.listing__country_latest
+        listing__country_latest
     ) subq_8
   ) subq_9
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -250,5 +250,5 @@ FROM (
     ) subq_8
   ) subq_9
   GROUP BY
-    subq_9.is_instant
+    is_instant
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_join_to_scd_dimension__plan0.sql
@@ -171,5 +171,5 @@ FROM (
     ) subq_7
   ) subq_8
   GROUP BY
-    subq_8.metric_time
+    metric_time
 ) subq_9

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_limit_rows__plan0.sql
@@ -136,7 +136,7 @@ FROM (
       ) subq_1
     ) subq_2
     GROUP BY
-      subq_2.ds
+      ds
   ) subq_3
 ) subq_4
 LIMIT 1

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_local_dimension_using_local_identifier__plan0.sql
@@ -93,5 +93,5 @@ FROM (
     ) subq_1
   ) subq_2
   GROUP BY
-    subq_2.listing__country_latest
+    listing__country_latest
 ) subq_3

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint__plan0.sql
@@ -271,7 +271,7 @@ FROM (
         ) subq_8
       ) subq_9
       GROUP BY
-        subq_9.metric_time
+        metric_time
     ) subq_10
     INNER JOIN (
       -- Aggregate Measures
@@ -402,7 +402,7 @@ FROM (
         ) subq_12
       ) subq_13
       GROUP BY
-        subq_13.metric_time
+        metric_time
     ) subq_14
     ON
       (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_reused_measure__plan0.sql
@@ -160,7 +160,7 @@ FROM (
         ) subq_3
       ) subq_4
       GROUP BY
-        subq_4.metric_time
+        metric_time
     ) subq_5
     INNER JOIN (
       -- Aggregate Measures
@@ -291,7 +291,7 @@ FROM (
         ) subq_7
       ) subq_8
       GROUP BY
-        subq_8.metric_time
+        metric_time
     ) subq_9
     ON
       (

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -147,5 +147,5 @@ FROM (
     ) subq_3
   ) subq_4
   GROUP BY
-    subq_4.metric_time
+    metric_time
 ) subq_5

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_through_scd_dimension__plan0.sql
@@ -247,6 +247,6 @@ FROM (
     ) subq_8
   ) subq_9
   GROUP BY
-    subq_9.metric_time
-    , subq_9.listing__user__home_state_latest
+    metric_time
+    , listing__user__home_state_latest
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multi_hop_to_scd_dimension__plan0.sql
@@ -233,6 +233,6 @@ FROM (
     ) subq_8
   ) subq_9
   GROUP BY
-    subq_9.metric_time
-    , subq_9.listing__lux_listing__is_confirmed_lux
+    metric_time
+    , listing__lux_listing__is_confirmed_lux
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_multihop_node__plan0.sql
@@ -214,5 +214,5 @@ FROM (
     ) subq_8
   ) subq_9
   GROUP BY
-    subq_9.account_id__customer_id__customer_name
+    account_id__customer_id__customer_name
 ) subq_10

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_nested_derived_metric__plan0.sql
@@ -154,7 +154,7 @@ FROM (
             ) subq_1
           ) subq_2
           GROUP BY
-            subq_2.metric_time
+            metric_time
         ) subq_3
       ) subq_4
       INNER JOIN (
@@ -291,7 +291,7 @@ FROM (
             ) subq_6
           ) subq_7
           GROUP BY
-            subq_7.metric_time
+            metric_time
         ) subq_8
       ) subq_9
       ON
@@ -436,7 +436,7 @@ FROM (
         ) subq_13
       ) subq_14
       GROUP BY
-        subq_14.metric_time
+        metric_time
     ) subq_15
   ) subq_16
   ON
@@ -579,7 +579,7 @@ FROM (
         ) subq_18
       ) subq_19
       GROUP BY
-        subq_19.metric_time
+        metric_time
     ) subq_20
   ) subq_21
   ON

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_order_by_node__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_order_by_node__plan0.sql
@@ -82,8 +82,8 @@ FROM (
       ) subq_0
     ) subq_1
     GROUP BY
-      subq_1.ds
-      , subq_1.is_instant
+      ds
+      , is_instant
   ) subq_2
 ) subq_3
 ORDER BY subq_3.ds, subq_3.bookings DESC

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_partitioned_join__plan0.sql
@@ -150,5 +150,5 @@ FROM (
     ) subq_5
   ) subq_6
   GROUP BY
-    subq_6.user__home_state
+    user__home_state
 ) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0.sql
@@ -52,7 +52,7 @@ INNER JOIN (
     ) accounts_source_src_10000
   ) subq_1
   GROUP BY
-    subq_1.user
+    user
 ) subq_2
 ON
   (subq_0.ds = subq_2.ds__complete) AND (subq_0.user = subq_2.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_grouping__plan0_optimized.sql
@@ -39,7 +39,7 @@ INNER JOIN (
     SELECT * FROM ***************************.fct_accounts
   ) accounts_source_src_10000
   GROUP BY
-    user_id
+    user
 ) subq_5
 ON
   (subq_3.ds = subq_5.ds__complete) AND (subq_3.user = subq_5.user)

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_semi_additive_join_node_with_queried_group_by__plan0.sql
@@ -52,7 +52,7 @@ INNER JOIN (
     ) accounts_source_src_10000
   ) subq_1
   GROUP BY
-    subq_1.ds__week
+    ds__week
 ) subq_2
 ON
   subq_0.ds = subq_2.ds__complete

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuerySqlClient/test_simple_query_with_metric_time_dimension__plan0.sql
@@ -137,7 +137,7 @@ FROM (
       ) subq_1
     ) subq_2
     GROUP BY
-      subq_2.metric_time
+      metric_time
   ) subq_3
 ) subq_4
 FULL OUTER JOIN (
@@ -265,10 +265,10 @@ FULL OUTER JOIN (
       ) subq_6
     ) subq_7
     GROUP BY
-      subq_7.metric_time
+      metric_time
   ) subq_8
 ) subq_9
 ON
   subq_4.metric_time = subq_9.metric_time
 GROUP BY
-  COALESCE(subq_4.metric_time, subq_9.metric_time)
+  metric_time

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuerySqlClient/test_component_rendering__plan4.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuerySqlClient/test_component_rendering__plan4.sql
@@ -13,4 +13,4 @@ LEFT OUTER JOIN
 ON
   a.user_id = c.user_id
 GROUP BY
-  b.country
+  user__country

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuerySqlClient/test_component_rendering__plan5.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuerySqlClient/test_component_rendering__plan5.sql
@@ -13,5 +13,5 @@ LEFT OUTER JOIN
 ON
   a.user_id = c.user_id
 GROUP BY
-  b.country
-  , c.country
+  user__country
+  , listing__country


### PR DESCRIPTION
Metricflow's default renderer produces `GROUP BY` expressions
that exactly mirror the `SELECT` expression in a query. This would
look something like:

```
  SELECT COALESCE(x, y) AS x_or_y, SUM(1)
  FROM source_table
  GROUP BY COALESCE(x, y)
```

The use of the `COALESCE` expression in the `GROUP BY` causes BigQuery
to throw an exception.

Previously, all queries involving a `GROUP BY` expression have not
caused issues, because they were either column name references
(e.g., `SELECT x, SUM(1) FROM source_table GROUP BY x`), or else
they were run through our optimizer stack. The optimizer stack
includes a subquery reducer, which will convert consolidated
select expressions into appropriately aliased `GROUP BY` references
as needed.

With the recent updates to how we join metric data sets together,
we have uncovered some edge cases where that optimizer will not
trigger. It is, therefore, finally time for us to render BigQuery
`GROUP BY` expressions correctly. This commit changes BigQuery's
rendering to:

```
  SELECT COALESCE(x, y) AS x_or_y, SUM(1)
  FROM source_table
  GROUP BY x_or_y
```