### PR TITLE
Suppress user warnings from fuzzywuzzy (specifically Levenshtein)

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 class ModelValidator:
     """A Validator that acts on UserConfiguredModel"""
-
+    # Invoke the correct rule manually in the validation tests
     DEFAULT_RULES = (
         PercentileAggregationRule(),
         DerivedMetricRule(),

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -6,7 +6,11 @@ import time
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Dict, Sequence
 
-import fuzzywuzzy.fuzz
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=UserWarning)
+    import fuzzywuzzy.fuzz
 import fuzzywuzzy.process
 
 from metricflow.constraints.time_constraint import TimeRangeConstraint

--- a/metricflow/test/model/validations/test_validity_param_definitions.py
+++ b/metricflow/test/model/validations/test_validity_param_definitions.py
@@ -70,6 +70,7 @@ def test_validity_window_must_have_a_start() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_model_file(), validity_window_file])
 
+    #foo bar test commit
     with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
         ModelValidator().checked_validations(model.model)
 


### PR DESCRIPTION
- Make Levenshstein user warning go away
- Suppresses warnings produced by importing the fuzzywuzzy stuff (levenshtein) and useing the warnings library to catching anything that may get 
produced. 
