### PR TITLE
Importing fuzzywuzzy causes warning due to non-installed levenshstein package. Suppress this by catching the warning during the import in query_parser because this package is not required.

### DIFF
--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -6,7 +6,6 @@ import time
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Dict, Sequence
 
-import fuzzywuzzy.fuzz
 import fuzzywuzzy.process
 
 from metricflow.constraints.time_constraint import TimeRangeConstraint
@@ -42,6 +41,11 @@ from metricflow.time.time_granularity_solver import (
     PartialTimeDimensionSpec,
     RequestTimeGranularityException,
 )
+
+logging.captureWarnings(True)
+import fuzzywuzzy.fuzz  # noqa: E402
+
+logging.captureWarnings(False)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
After digging around to find where it was triggered I discovered that the fuzzywuzzy.fuzz import in query_parser.py is what produces the levenshtein warning. Suppressed it using this warning capture but not sure if there are preferred other ways of doing so.

After making this change the original error (from running 'poetry run pytest  metricflow/test/model/validations/') no longer shows up.

Original error:

../../miniconda3/envs/mf3.9/lib/python3.9/site-packages/fuzzywuzzy/fuzz.py:11
/Users/jimmyzhu/miniconda3/envs/mf3.9/lib/python3.9/site-packages/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')