### PR TITLE
Consolidate metric constraints in DataflowPlanBuilder

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -43,7 +43,6 @@ from metricflow.dataset.dataset import DataSet
 from metricflow.errors.errors import UnableToSatisfyQueryError
 from metricflow.model.objects.metric import MetricType, MetricTimeWindow
 from metricflow.model.semantic_model import SemanticModel
-from metricflow.model.spec_converters import WhereConstraintConverter
 from metricflow.object_utils import pformat_big_objects, assert_exactly_one_arg_set
 from metricflow.plan_conversion.column_resolver import DefaultColumnAssociationResolver
 from metricflow.plan_conversion.node_processor import PreDimensionJoinNodeProcessor
@@ -186,7 +185,6 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
             logger.info(f"Generating compute metrics node for {metric_spec}")
             metric_reference = metric_spec.as_reference
             metric = self._metric_semantics.get_metric(metric_reference)
-            metric_input_measure_specs = self._metric_semantics.measures_for_metric(metric_reference)
 
             if metric.type == MetricType.DERIVED:
                 metric_input_specs = self._metric_semantics.metric_input_specs_for_metric(metric_reference)
@@ -223,12 +221,6 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                     f"{pformat_big_objects(metric_input_measure_specs=metric_input_measure_specs)}"
                 )
                 combined_where = where_constraint
-                if metric.constraint:
-                    metric_constraint = WhereConstraintConverter.convert_to_spec_where_constraint(
-                        self._data_source_semantics, metric.constraint
-                    )
-                    combined_where = combined_where.combine(metric_constraint) if combined_where else metric_constraint
-
                 if metric_spec.constraint:
                     combined_where = (
                         combined_where.combine(metric_spec.constraint) if combined_where else metric_spec.constraint
@@ -250,6 +242,9 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                         aggregated_measures_node=aggregated_measures_node,
                     )
                 )
+
+        assert len(output_nodes) > 0, "ComputeMetricsNode was not properly constructed"
+
         if len(output_nodes) == 1:
             return output_nodes[0]
 

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -1633,7 +1633,24 @@ def test_join_to_scd_dimension(
     """Tests conversion of a plan using a dimension with a validity window inside a measure constraint"""
     dataflow_plan = scd_dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="family_bookings"),),
+            metric_specs=(
+                MetricSpec(
+                    element_name="family_bookings",
+                    constraint=SpecWhereClauseConstraint(
+                        where_condition="listing__capacity > 2",
+                        linkable_names=("listing__capacity",),
+                        linkable_spec_set=LinkableSpecSet(
+                            dimension_specs=(
+                                DimensionSpec(
+                                    element_name="capacity",
+                                    identifier_links=(IdentifierReference(element_name="listing"),),
+                                ),
+                            ),
+                        ),
+                        execution_parameters=SqlBindParameters(),
+                    ),
+                ),
+            ),
             time_dimension_specs=(MTD_SPEC_DAY,),
         ),
     )

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -52,13 +52,23 @@
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_1 -->
-                <!-- metric_spec =                                -->
-                <!--   {'class': 'MetricSpec',                    -->
-                <!--    'element_name': 'instant_booking_value',  -->
-                <!--    'constraint': None,                       -->
-                <!--    'alias': None,                            -->
-                <!--    'offset_window': None,                    -->
-                <!--    'offset_to_grain': None}                  -->
+                <!-- metric_spec =                                                                               -->
+                <!--   {'class': 'MetricSpec',                                                                   -->
+                <!--    'element_name': 'instant_booking_value',                                                 -->
+                <!--    'constraint': {'class': 'SpecWhereClauseConstraint',                                     -->
+                <!--                   'where_condition': 'is_instant',                                          -->
+                <!--                   'linkable_names': ('is_instant',),                                        -->
+                <!--                   'linkable_spec_set': {'class': 'LinkableSpecSet',                         -->
+                <!--                                         'dimension_specs': ({'class': 'DimensionSpec',      -->
+                <!--                                                              'element_name': 'is_instant',  -->
+                <!--                                                              'identifier_links': ()},),     -->
+                <!--                                         'time_dimension_specs': (),                         -->
+                <!--                                         'identifier_specs': ()},                            -->
+                <!--                   'execution_parameters': {'class': 'SqlBindParameters',                    -->
+                <!--                                            'param_items': ()}},                             -->
+                <!--    'alias': None,                                                                           -->
+                <!--    'offset_window': None,                                                                   -->
+                <!--    'offset_to_grain': None}                                                                 -->
                 <AggregateMeasuresNode>
                     <!-- description = Aggregate Measures -->
                     <!-- node_id = am_1 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -52,13 +52,23 @@
             <ComputeMetricsNode>
                 <!-- description = Compute Metrics via Expressions -->
                 <!-- node_id = cm_3 -->
-                <!-- metric_spec =                                -->
-                <!--   {'class': 'MetricSpec',                    -->
-                <!--    'element_name': 'instant_booking_value',  -->
-                <!--    'constraint': None,                       -->
-                <!--    'alias': None,                            -->
-                <!--    'offset_window': None,                    -->
-                <!--    'offset_to_grain': None}                  -->
+                <!-- metric_spec =                                                                               -->
+                <!--   {'class': 'MetricSpec',                                                                   -->
+                <!--    'element_name': 'instant_booking_value',                                                 -->
+                <!--    'constraint': {'class': 'SpecWhereClauseConstraint',                                     -->
+                <!--                   'where_condition': 'is_instant',                                          -->
+                <!--                   'linkable_names': ('is_instant',),                                        -->
+                <!--                   'linkable_spec_set': {'class': 'LinkableSpecSet',                         -->
+                <!--                                         'dimension_specs': ({'class': 'DimensionSpec',      -->
+                <!--                                                              'element_name': 'is_instant',  -->
+                <!--                                                              'identifier_links': ()},),     -->
+                <!--                                         'time_dimension_specs': (),                         -->
+                <!--                                         'identifier_specs': ()},                            -->
+                <!--                   'execution_parameters': {'class': 'SqlBindParameters',                    -->
+                <!--                                            'param_items': ()}},                             -->
+                <!--    'alias': None,                                                                           -->
+                <!--    'offset_window': None,                                                                   -->
+                <!--    'offset_to_grain': None}                                                                 -->
                 <AggregateMeasuresNode>
                     <!-- description = Aggregate Measures -->
                     <!-- node_id = am_3 -->


### PR DESCRIPTION
## Context
https://github.com/transform-data/metricflow/pull/352#discussion_r1049226384


## Changes
Essentially in the DataflowPlanBuilder, given a MetricSpec
1. we get the Metric object corresponding to that MetricSpec and combine the where constraint defined in the Metric
2. combine on the where constraint defined in the MetricSpec as well

Currently, it doesn't seem like there's a use case of doing both of these other than to cause slight confusion. At runtime when building the query, we just pass a list of MetricSpec to the builder that was initialized by the metric names only. So to remove the redundancy here, in the query parser we should attach the constraint to the MetricSpec that gets passed to the builder so that we don't have to retrieve the metric constraint from the Metric object directly downstream.