### PR TITLE
Derived Metric Offset

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -205,16 +205,6 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                     ),
                     metric_specs=[metric_spec],
                 )
-                if metric_spec.offset_window or metric_spec.offset_to_grain:
-                    join_to_time_spine_node = JoinToTimeSpineNode(
-                        parent_node=compute_metrics_node,
-                        time_range_constraint=time_range_constraint,
-                        offset_window=metric_spec.offset_window,
-                        offset_to_grain=metric_spec.offset_to_grain,
-                    )
-                    output_nodes.append(join_to_time_spine_node)
-                else:
-                    output_nodes.append(compute_metrics_node)
             else:
                 metric_input_measure_specs = self._metric_semantics.measures_for_metric(metric_reference)
 
@@ -244,12 +234,21 @@ class DataflowPlanBuilder(Generic[SqlDataSetT]):
                         metric.type_params.grain_to_date if metric.type == MetricType.CUMULATIVE else None
                     ),
                 )
-                output_nodes.append(
-                    self.build_computed_metrics_node(
-                        metric_spec=metric_spec,
-                        aggregated_measures_node=aggregated_measures_node,
-                    )
+                compute_metrics_node = self.build_computed_metrics_node(
+                    metric_spec=metric_spec,
+                    aggregated_measures_node=aggregated_measures_node,
                 )
+
+            if metric_spec.offset_window or metric_spec.offset_to_grain:
+                join_to_time_spine_node = JoinToTimeSpineNode(
+                    parent_node=compute_metrics_node,
+                    time_range_constraint=time_range_constraint,
+                    offset_window=metric_spec.offset_window,
+                    offset_to_grain=metric_spec.offset_to_grain,
+                )
+                output_nodes.append(join_to_time_spine_node)
+            else:
+                output_nodes.append(compute_metrics_node)
         if len(output_nodes) == 1:
             return output_nodes[0]
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -442,7 +442,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
         logger.info(f"Query spec is:\n{pformat_big_objects(query_spec)}")
 
-        if self._semantic_model.metric_semantics.contains_cumulative_metric(
+        if self._semantic_model.metric_semantics.contains_cumulative_or_time_offset_metric(
             tuple(m.as_reference for m in query_spec.metric_specs)
         ):
             self._time_spine_table_builder.create_if_necessary()

--- a/metricflow/model/objects/metric.py
+++ b/metricflow/model/objects/metric.py
@@ -65,16 +65,8 @@ class MetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
         return MeasureReference(element_name=self.alias or self.name)
 
 
-class MetricInput(HashableBaseModel):
-    """Provides a pointer to a metric along with the additional properties used on that metric."""
-
-    name: str
-    constraint: Optional[WhereClauseConstraint]
-    alias: Optional[str]
-
-
 class MetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
-    """Describes the window of time the metric should be accumulated over. ie '1 day', '2 weeks', etc"""
+    """Describes the window of time the metric should be accumulated over, e.g., '1 day', '2 weeks', etc"""
 
     count: int
     granularity: TimeGranularity
@@ -105,7 +97,7 @@ class MetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
         parts = window.split(" ")
         if len(parts) != 2:
             raise ParsingException(
-                f"Invalid window ({window}) in cumulative metric. Should be of the form `<count> <granularity>`, ie `28 days`",
+                f"Invalid window ({window}) in cumulative metric. Should be of the form `<count> <granularity>`, e.g., `28 days`",
             )
 
         granularity = parts[1]
@@ -126,6 +118,16 @@ class MetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
             count=int(count),
             granularity=string_to_time_granularity(granularity),
         )
+
+
+class MetricInput(HashableBaseModel):
+    """Provides a pointer to a metric along with the additional properties used on that metric."""
+
+    name: str
+    constraint: Optional[WhereClauseConstraint]
+    alias: Optional[str]
+    offset_window: Optional[MetricTimeWindow]
+    offset_to_grain: Optional[TimeGranularity]
 
 
 class MetricTypeParams(HashableBaseModel):

--- a/metricflow/model/parsing/schemas.py
+++ b/metricflow/model/parsing/schemas.py
@@ -102,6 +102,8 @@ metric_input_schema = {
         "name": {"type": "string"},
         "constraint": {"type": "string"},
         "alias": {"type": "string"},
+        "offset_window": {"type": "string"},
+        "offset_to_grain": {"type": "string"},
     },
     "additionalProperties": False,
 }

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -652,6 +652,12 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "offset_to_grain": {
+                    "type": "string"
+                },
+                "offset_window": {
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/metricflow/model/validations/metrics.py
+++ b/metricflow/model/validations/metrics.py
@@ -38,7 +38,7 @@ class CumulativeMetricRule(ModelValidationRule):
 
             if metric.type_params.window:
                 try:
-                    _, _ = MetricTimeWindow.parse(metric.type_params.window.to_string())
+                    MetricTimeWindow.parse(metric.type_params.window.to_string())
                 except ParsingException as e:
                     issues.append(
                         ValidationError(
@@ -113,6 +113,25 @@ class DerivedMetricRule(ModelValidationRule):
         return issues
 
     @staticmethod
+    @validate_safely(whats_being_done="checking that input metric time offset params are valid")
+    def _validate_time_offset_params(metric: Metric) -> List[ValidationIssueType]:
+        issues: List[ValidationIssueType] = []
+
+        for input_metric in metric.input_metrics or []:
+            if input_metric.offset_window and input_metric.offset_to_grain:
+                issues.append(
+                    ValidationError(
+                        context=MetricContext(
+                            file_context=FileContext.from_metadata(metadata=metric.metadata),
+                            metric=MetricModelReference(metric_name=metric.name),
+                        ),
+                        message=f"Both offset_window and offset_to_grain set for derived metric '{metric.name}' on input metric '{input_metric.name}'. Please set one or the other.",
+                    )
+                )
+
+        return issues
+
+    @staticmethod
     @validate_safely(
         whats_being_done="running model validation ensuring derived metrics properties are configured properly"
     )
@@ -122,4 +141,5 @@ class DerivedMetricRule(ModelValidationRule):
         issues += DerivedMetricRule._validate_input_metrics_exist(model=model)
         for metric in model.metrics or []:
             issues += DerivedMetricRule._validate_alias_collision(metric=metric)
+            issues += DerivedMetricRule._validate_time_offset_params(metric=metric)
         return issues

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -176,8 +176,8 @@ class MetricSemanticsAccessor(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def contains_cumulative_metric(self, metric_references: Sequence[MetricReference]) -> bool:
-        """Returns true if any of the specs correspond to a cumulative metric."""
+    def contains_cumulative_or_time_offset_metric(self, metric_references: Sequence[MetricReference]) -> bool:
+        """Returns true if any of the specs correspond to a cumulative metric or a derived metric with time offset."""
         raise NotImplementedError
 
     @abstractmethod

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -163,8 +163,8 @@ class MetricFlowQueryParser:
         finally:
             logger.info(f"Parsing the query took: {time.time() - start_time:.2f}s")
 
-    def _validate_no_dimension_query_for_metric(self, metric_references: Sequence[MetricReference]) -> None:
-        """Validate if all requested metrics are queryable without any dimensions."""
+    def _validate_no_time_dimension_query(self, metric_references: Sequence[MetricReference]) -> None:
+        """Validate if all requested metrics are queryable without a time dimension."""
         for metric_reference in metric_references:
             metric = self._metric_semantics.get_metric(metric_reference)
             if metric.type == MetricType.CUMULATIVE:
@@ -174,6 +174,14 @@ class MetricFlowQueryParser:
                         f"Metric {metric.name} is a cumulative metric specified with a window/grain_to_date "
                         f"which must be queried with the dimension 'metric_time'.",
                     )
+            elif metric.type == MetricType.DERIVED:
+                for input_metric in metric.type_params.metrics or []:
+                    if input_metric.offset_window or input_metric.offset_to_grain:
+                        raise UnableToSatisfyQueryError(
+                            f"Metric '{metric.name}' is a derived metric that contains input metrics with "
+                            "an `offset_window` or `offset_to_grain` which must be queried with the "
+                            "dimension 'metric_time'."
+                        )
 
     def _validate_linkable_specs(
         self,
@@ -278,9 +286,6 @@ class MetricFlowQueryParser:
             # If the time constraint is all time, just ignore and not render
             time_constraint = None
 
-        if len(group_by_names) == 0:
-            self._validate_no_dimension_query_for_metric(metric_references=metric_references)
-
         requested_linkable_specs = self._parse_linkable_element_names(group_by_names, metric_references)
         partial_time_dimension_spec_replacements = (
             self._time_granularity_solver.resolve_granularity_for_partial_time_dimension_specs(
@@ -298,6 +303,8 @@ class MetricFlowQueryParser:
         time_dimension_specs = requested_linkable_specs.time_dimension_specs + tuple(
             time_dimension_spec for _, time_dimension_spec in partial_time_dimension_spec_replacements.items()
         )
+        if len(time_dimension_specs) == 0:
+            self._validate_no_time_dimension_query(metric_references=metric_references)
 
         self._time_granularity_solver.validate_time_granularity(metric_references, time_dimension_specs)
 
@@ -515,7 +522,7 @@ class MetricFlowQueryParser:
             metric = self._metric_semantics.get_metric(metric_reference)
             if metric.type == MetricType.DERIVED:
                 input_metrics = self._parse_metric_names([metric.name for metric in metric.input_metrics])
-                metric_references.extend(list(input_metrics))
+                metric_references.extend([metric_reference] + list(input_metrics))
             else:
                 metric_references.append(metric_reference)
         return tuple(metric_references)

--- a/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/metricflow/test/fixtures/model_yamls/simple_model/metrics.yaml
@@ -617,3 +617,68 @@ metric:
   type_params:
     measures:
       - approximate_discrete_booking_value_p99
+---
+metric:
+  name: "bookings_growth_2_weeks"
+  description: |
+    percentage growth of bookings compared to bookings 2 weeks prior,
+    used to test derived metrics with an offset_window.
+  owners:
+    - support@transformdata.io
+  type: derived
+  type_params:
+    expr: (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago
+    metrics:
+      - name: bookings
+      - name: bookings
+        offset_window: 14 days
+        alias: bookings_2_weeks_ago
+---
+metric:
+  name: "bookings_growth_since_start_of_month"
+  description: |
+    percentage growth of bookings since the start of the month,
+    used to test derived metrics with an offset_to_grain.
+  owners:
+    - support@transformdata.io
+  type: derived
+  type_params:
+    expr: (bookings - bookings_at_start_of_month) / bookings_at_start_of_month
+    metrics:
+      - name: bookings
+      - name: bookings
+        offset_to_grain: month
+        alias: bookings_at_start_of_month
+---
+metric:
+  name: "bookings_month_start_compared_to_1_month_prior"
+  description: |
+    percentage growth of bookings compared to bookings 2 weeks prior,
+    used to test derived metrics with an offset_window.
+  owners:
+    - support@transformdata.io
+  type: derived
+  type_params:
+    expr: month_start_bookings / bookings_1_month_ago
+    metrics:
+      - name: bookings
+        offset_to_grain: month
+        alias: month_start_bookings
+      - name: bookings
+        offset_window: 1 month
+        alias: bookings_1_month_ago
+---
+metric:
+  name: "bookings_5_day_lag"
+  description: |
+    number of bookings 5 days ago. used to test derived metric offset
+    with only one input metric.
+  owners:
+    - support@transformdata.io
+  type: derived
+  type_params:
+    expr: bookings_5_days_ago
+    metrics:
+      - name: bookings
+        offset_window: 5 days
+        alias: bookings_5_days_ago

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -671,3 +671,137 @@ integration_test:
       GROUP BY 2
     ) vw
     ON bk.is_lux = vw.is_lux OR (bk.is_lux IS NULL AND vw.is_lux IS NULL)
+---
+integration_test:
+  name: derived_metric_with_offset_window
+  description: Tests a derived metric query with an offset_window
+  model: SIMPLE_MODEL
+  metrics: ["bookings_growth_2_weeks"]
+  group_bys: ["metric_time"]
+  check_query: |
+    SELECT
+      COALESCE(a.metric_time, b.metric_time) AS metric_time
+      , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+    FROM (
+      SELECT
+        ds AS metric_time
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        metric_time
+    ) a
+    INNER JOIN (
+      SELECT
+        c.ds AS metric_time
+        , d.bookings_2_weeks_ago AS bookings_2_weeks_ago
+      FROM {{ source_schema }}.mf_time_spine c
+      LEFT OUTER JOIN (
+        SELECT
+          ds AS metric_time
+          , SUM(1) AS bookings_2_weeks_ago
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          metric_time
+      ) d
+      ON c.ds - INTERVAL 14 day = d.metric_time
+    ) b
+    ON a.metric_time = b.metric_time
+---
+integration_test:
+  name: derived_metric_with_offset_to_grain
+  description: Tests a derived metric query with an offset_to_grain
+  model: SIMPLE_MODEL
+  metrics: ["bookings_growth_since_start_of_month"]
+  group_bys: ["metric_time"]
+  check_query: |
+    SELECT
+      COALESCE(a.metric_time, b.metric_time) AS metric_time
+      , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+    FROM (
+      SELECT
+        ds AS metric_time
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        metric_time
+    ) a
+    INNER JOIN (
+      SELECT
+        c.ds AS metric_time
+        , d.bookings_at_start_of_month AS bookings_at_start_of_month
+      FROM {{ source_schema }}.mf_time_spine c
+      LEFT OUTER JOIN (
+        SELECT
+          ds AS metric_time
+          , SUM(1) AS bookings_at_start_of_month
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          metric_time
+      ) d
+      ON DATE_TRUNC('month', c.ds) = d.metric_time
+    ) b
+    ON a.metric_time = b.metric_time    
+---
+integration_test:
+  name: derived_metric_with_offset_window_and_offset_to_grain
+  description: Tests a derived metric query with 2 input metrics, one with an offset_window and one with an offset_to_grain
+  model: SIMPLE_MODEL
+  metrics: ["bookings_month_start_compared_to_1_month_prior"]
+  group_bys: ["metric_time"]
+  check_query: |
+    SELECT
+      COALESCE(a.metric_time, b.metric_time) AS metric_time
+      , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+    FROM (
+      SELECT
+        g.ds AS metric_time
+        , f.bookings AS bookings_1_month_ago
+      FROM {{ source_schema }}.mf_time_spine g
+      LEFT OUTER JOIN (
+        SELECT
+          ds AS metric_time
+          , SUM(1) AS bookings
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          metric_time
+      ) f
+      ON g.ds - INTERVAL 1 month = f.metric_time
+    ) a
+    INNER JOIN (
+      SELECT
+        c.ds AS metric_time
+        , d.bookings AS month_start_bookings
+      FROM {{ source_schema }}.mf_time_spine c
+      LEFT OUTER JOIN (
+        SELECT
+          ds AS metric_time
+          , SUM(1) AS bookings
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          metric_time
+      ) d
+      ON DATE_TRUNC('month', c.ds) = d.metric_time
+    ) b
+    ON a.metric_time = b.metric_time    
+---
+integration_test:
+  name: derived_metric_offset_with_one_metric_input
+  description: Tests a derived metric offset query with only one input metric
+  model: SIMPLE_MODEL
+  metrics: ["bookings_5_day_lag"]
+  group_bys: ["metric_time"]
+  # this should be wrong & fail; correct later
+  check_query: |
+    SELECT
+      a.ds AS metric_time
+      , b.bookings_5_day_lag
+    FROM {{ source_schema }}.mf_time_spine a
+    LEFT OUTER JOIN (
+      SELECT
+        ds AS metric_time
+        , SUM(1) AS bookings_5_day_lag
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        metric_time
+    ) b
+    ON a.ds - INTERVAL 5 day = b.metric_time

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -738,7 +738,7 @@ integration_test:
         GROUP BY
           metric_time
       ) d
-      ON DATE_TRUNC('month', c.ds) = d.metric_time
+      ON {{ render_date_trunc("c.ds", TimeGranularity.MONTH) }} = d.metric_time
     ) b
     ON a.metric_time = b.metric_time    
 ---
@@ -780,7 +780,7 @@ integration_test:
         GROUP BY
           metric_time
       ) d
-      ON DATE_TRUNC('month', c.ds) = d.metric_time
+      ON {{ render_date_trunc("c.ds", TimeGranularity.MONTH) }} = d.metric_time
     ) b
     ON a.metric_time = b.metric_time    
 ---

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -703,7 +703,7 @@ integration_test:
         GROUP BY
           metric_time
       ) d
-      ON c.ds - INTERVAL 14 day = d.metric_time
+      ON {{ render_date_sub("C", "ds", 14, TimeGranularity.DAY) }} = d.metric_time
     ) b
     ON a.metric_time = b.metric_time
 ---
@@ -765,7 +765,7 @@ integration_test:
         GROUP BY
           metric_time
       ) f
-      ON g.ds - INTERVAL 1 month = f.metric_time
+      ON {{ render_date_sub("g", "ds", 1, TimeGranularity.MONTH) }} = f.metric_time
     ) a
     INNER JOIN (
       SELECT
@@ -790,7 +790,6 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["bookings_5_day_lag"]
   group_bys: ["metric_time"]
-  # this should be wrong & fail; correct later
   check_query: |
     SELECT
       a.ds AS metric_time
@@ -804,4 +803,4 @@ integration_test:
       GROUP BY
         metric_time
     ) b
-    ON a.ds - INTERVAL 5 day = b.metric_time
+    ON {{ render_date_sub("a", "ds", 5, TimeGranularity.DAY) }} = b.metric_time

--- a/metricflow/test/model/parsing/test_metric_parsing.py
+++ b/metricflow/test/model/parsing/test_metric_parsing.py
@@ -258,6 +258,74 @@ def test_grain_to_date_metric_parsing() -> None:
     assert metric.type_params.grain_to_date is TimeGranularity.WEEK
 
 
+def test_derived_metric_offset_window_parsing() -> None:
+    """Test for parsing a derived metric with an offset window."""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: derived_offset_test
+          type: derived
+          type_params:
+            expr: bookings / bookings_2_weeks_ago
+            metrics:
+              - name: bookings
+              - name: bookings
+                offset_window: 14 days
+                alias: bookings_2_weeks_ago
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_model(files=[file])
+
+    assert len(build_result.issues.all_issues) == 0
+    assert len(build_result.model.metrics) == 1
+    metric = build_result.model.metrics[0]
+    assert metric.name == "derived_offset_test"
+    assert metric.type is MetricType.DERIVED
+    assert metric.type_params.metrics and len(metric.type_params.metrics) == 2
+    metric1, metric2 = metric.type_params.metrics
+    assert metric1.offset_window is None
+    assert metric2.offset_window == MetricTimeWindow(count=14, granularity=TimeGranularity.DAY)
+    assert metric1.alias is None
+    assert metric2.alias == "bookings_2_weeks_ago"
+    assert metric.type_params.expr == "bookings / bookings_2_weeks_ago"
+
+
+def test_derive_metric_offset_to_grain_parsing() -> None:
+    """Test for parsing a derived metric with an offset to grain to date."""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: derived_offset_to_grain_test
+          type: derived
+          type_params:
+            expr: bookings / bookings_at_start_of_month
+            metrics:
+              - name: bookings
+              - name: bookings
+                offset_to_grain: month
+                alias: bookings_at_start_of_month
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_model(files=[file])
+
+    assert len(build_result.issues.all_issues) == 0
+    assert len(build_result.model.metrics) == 1
+    metric = build_result.model.metrics[0]
+    assert metric.name == "derived_offset_to_grain_test"
+    assert metric.type is MetricType.DERIVED
+    assert metric.type_params.metrics and len(metric.type_params.metrics) == 2
+    metric1, metric2 = metric.type_params.metrics
+    assert metric1.offset_to_grain is None
+    assert metric2.offset_to_grain == TimeGranularity.MONTH
+    assert metric1.alias is None
+    assert metric2.alias == "bookings_at_start_of_month"
+    assert metric.type_params.expr == "bookings / bookings_at_start_of_month"
+
+
 def test_constraint_metric_parsing() -> None:
     """Test for parsing a metric specification with a constraint included"""
     yaml_contents = textwrap.dedent(

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -1765,3 +1765,95 @@ def test_common_data_source(  # noqa: D
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )
+
+
+def test_derived_metric_with_offset_window(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter[DataSourceDataSet],
+    sql_client: SqlClient,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+def test_derived_metric_with_offset_to_grain(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter[DataSourceDataSet],
+    sql_client: SqlClient,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_growth_since_start_of_month"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter[DataSourceDataSet],
+    sql_client: SqlClient,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_month_start_compared_to_1_month_prior"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+def test_derived_metric_with_one_input_metric(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder[DataSourceDataSet],
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter[DataSourceDataSet],
+    sql_client: SqlClient,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_5_day_lag"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_at_start_of_month
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_TRUNC(subq_10.metric_time, month) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_at_start_of_month
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_TRUNC(subq_25.ds, month) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_2_weeks_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_SUB(CAST(subq_10.metric_time AS DATETIME), INTERVAL 14 day) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_2_weeks_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_SUB(CAST(subq_25.ds AS DATETIME), INTERVAL 14 day) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -1,0 +1,331 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_16.metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_7.metric_time, subq_15.metric_time) AS metric_time
+    , subq_7.month_start_bookings AS month_start_bookings
+    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time AS metric_time
+      , subq_4.month_start_bookings AS month_start_bookings
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_6.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_3.metric_time
+        , subq_3.bookings AS month_start_bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_2.metric_time
+          , SUM(subq_2.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_1.metric_time
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds_partitioned
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.booking_paid_at
+              , subq_0.booking_paid_at__week
+              , subq_0.booking_paid_at__month
+              , subq_0.booking_paid_at__quarter
+              , subq_0.booking_paid_at__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds
+              , subq_0.create_a_cycle_in_the_join_graph__ds__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_0.ds AS metric_time
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.create_a_cycle_in_the_join_graph
+              , subq_0.create_a_cycle_in_the_join_graph__listing
+              , subq_0.create_a_cycle_in_the_join_graph__guest
+              , subq_0.create_a_cycle_in_the_join_graph__host
+              , subq_0.is_instant
+              , subq_0.create_a_cycle_in_the_join_graph__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        GROUP BY
+          metric_time
+      ) subq_3
+    ) subq_4
+    ON
+      DATE_TRUNC(subq_5.metric_time, month) = subq_4.metric_time
+  ) subq_7
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_13.metric_time AS metric_time
+      , subq_12.bookings_1_month_ago AS bookings_1_month_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_14.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_14
+    ) subq_13
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time
+        , subq_11.bookings AS bookings_1_month_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_10.metric_time
+          , SUM(subq_10.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_9.metric_time
+            , subq_9.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_8.ds
+              , subq_8.ds__week
+              , subq_8.ds__month
+              , subq_8.ds__quarter
+              , subq_8.ds__year
+              , subq_8.ds_partitioned
+              , subq_8.ds_partitioned__week
+              , subq_8.ds_partitioned__month
+              , subq_8.ds_partitioned__quarter
+              , subq_8.ds_partitioned__year
+              , subq_8.booking_paid_at
+              , subq_8.booking_paid_at__week
+              , subq_8.booking_paid_at__month
+              , subq_8.booking_paid_at__quarter
+              , subq_8.booking_paid_at__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds
+              , subq_8.create_a_cycle_in_the_join_graph__ds__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_8.ds AS metric_time
+              , subq_8.ds__week AS metric_time__week
+              , subq_8.ds__month AS metric_time__month
+              , subq_8.ds__quarter AS metric_time__quarter
+              , subq_8.ds__year AS metric_time__year
+              , subq_8.listing
+              , subq_8.guest
+              , subq_8.host
+              , subq_8.create_a_cycle_in_the_join_graph
+              , subq_8.create_a_cycle_in_the_join_graph__listing
+              , subq_8.create_a_cycle_in_the_join_graph__guest
+              , subq_8.create_a_cycle_in_the_join_graph__host
+              , subq_8.is_instant
+              , subq_8.create_a_cycle_in_the_join_graph__is_instant
+              , subq_8.bookings
+              , subq_8.instant_bookings
+              , subq_8.booking_value
+              , subq_8.max_booking_value
+              , subq_8.min_booking_value
+              , subq_8.bookers
+              , subq_8.average_booking_value
+              , subq_8.referred_bookings
+              , subq_8.median_booking_value
+              , subq_8.booking_value_p99
+              , subq_8.discrete_booking_value_p99
+              , subq_8.approximate_continuous_booking_value_p99
+              , subq_8.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_8
+          ) subq_9
+        ) subq_10
+        GROUP BY
+          metric_time
+      ) subq_11
+    ) subq_12
+    ON
+      DATE_SUB(CAST(subq_13.metric_time AS DATETIME), INTERVAL 1 month) = subq_12.metric_time
+  ) subq_15
+  ON
+    (
+      subq_7.metric_time = subq_15.metric_time
+    ) OR (
+      (subq_7.metric_time IS NULL) AND (subq_15.metric_time IS NULL)
+    )
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,79 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time, subq_32.metric_time) AS metric_time
+    , subq_24.month_start_bookings AS month_start_bookings
+    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time
+      , subq_21.month_start_bookings AS month_start_bookings
+    FROM ***************************.mf_time_spine subq_23
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS month_start_bookings
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_19
+      GROUP BY
+        metric_time
+    ) subq_21
+    ON
+      DATE_TRUNC(subq_23.ds, month) = subq_21.metric_time
+  ) subq_24
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_31.ds AS metric_time
+      , subq_29.bookings_1_month_ago AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_31
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_1_month_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_27
+      GROUP BY
+        metric_time
+    ) subq_29
+    ON
+      DATE_SUB(CAST(subq_31.ds AS DATETIME), INTERVAL 1 month) = subq_29.metric_time
+  ) subq_32
+  ON
+    (
+      subq_24.metric_time = subq_32.metric_time
+    ) OR (
+      (subq_24.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+    )
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_one_input_metric__plan0.sql
@@ -1,0 +1,161 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_5.metric_time AS metric_time
+    , subq_4.bookings_5_days_ago AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_6.ds AS metric_time
+    FROM ***************************.mf_time_spine subq_6
+  ) subq_5
+  LEFT OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings AS bookings_5_days_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoyear) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoyear) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoweek) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, month) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, quarter) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.booking_paid_at, isoyear) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        metric_time
+    ) subq_3
+  ) subq_4
+  ON
+    DATE_SUB(CAST(subq_5.metric_time AS DATETIME), INTERVAL 5 day) = subq_4.metric_time
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuerySqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_14.ds AS metric_time
+    , subq_12.bookings_5_days_ago AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_14
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings_5_days_ago
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_10
+    GROUP BY
+      metric_time
+  ) subq_12
+  ON
+    DATE_SUB(CAST(subq_14.ds AS DATETIME), INTERVAL 5 day) = subq_12.metric_time
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_at_start_of_month
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_TRUNC('month', subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_at_start_of_month
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_TRUNC('month', subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_2_weeks_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATEADD(day, -14, subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_2_weeks_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATEADD(day, -14, subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -1,0 +1,331 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_16.metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_7.metric_time, subq_15.metric_time) AS metric_time
+    , subq_7.month_start_bookings AS month_start_bookings
+    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time AS metric_time
+      , subq_4.month_start_bookings AS month_start_bookings
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_6.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_3.metric_time
+        , subq_3.bookings AS month_start_bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_2.metric_time
+          , SUM(subq_2.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_1.metric_time
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds_partitioned
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.booking_paid_at
+              , subq_0.booking_paid_at__week
+              , subq_0.booking_paid_at__month
+              , subq_0.booking_paid_at__quarter
+              , subq_0.booking_paid_at__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds
+              , subq_0.create_a_cycle_in_the_join_graph__ds__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_0.ds AS metric_time
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.create_a_cycle_in_the_join_graph
+              , subq_0.create_a_cycle_in_the_join_graph__listing
+              , subq_0.create_a_cycle_in_the_join_graph__guest
+              , subq_0.create_a_cycle_in_the_join_graph__host
+              , subq_0.is_instant
+              , subq_0.create_a_cycle_in_the_join_graph__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        GROUP BY
+          subq_2.metric_time
+      ) subq_3
+    ) subq_4
+    ON
+      DATE_TRUNC('month', subq_5.metric_time) = subq_4.metric_time
+  ) subq_7
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_13.metric_time AS metric_time
+      , subq_12.bookings_1_month_ago AS bookings_1_month_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_14.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_14
+    ) subq_13
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time
+        , subq_11.bookings AS bookings_1_month_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_10.metric_time
+          , SUM(subq_10.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_9.metric_time
+            , subq_9.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_8.ds
+              , subq_8.ds__week
+              , subq_8.ds__month
+              , subq_8.ds__quarter
+              , subq_8.ds__year
+              , subq_8.ds_partitioned
+              , subq_8.ds_partitioned__week
+              , subq_8.ds_partitioned__month
+              , subq_8.ds_partitioned__quarter
+              , subq_8.ds_partitioned__year
+              , subq_8.booking_paid_at
+              , subq_8.booking_paid_at__week
+              , subq_8.booking_paid_at__month
+              , subq_8.booking_paid_at__quarter
+              , subq_8.booking_paid_at__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds
+              , subq_8.create_a_cycle_in_the_join_graph__ds__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_8.ds AS metric_time
+              , subq_8.ds__week AS metric_time__week
+              , subq_8.ds__month AS metric_time__month
+              , subq_8.ds__quarter AS metric_time__quarter
+              , subq_8.ds__year AS metric_time__year
+              , subq_8.listing
+              , subq_8.guest
+              , subq_8.host
+              , subq_8.create_a_cycle_in_the_join_graph
+              , subq_8.create_a_cycle_in_the_join_graph__listing
+              , subq_8.create_a_cycle_in_the_join_graph__guest
+              , subq_8.create_a_cycle_in_the_join_graph__host
+              , subq_8.is_instant
+              , subq_8.create_a_cycle_in_the_join_graph__is_instant
+              , subq_8.bookings
+              , subq_8.instant_bookings
+              , subq_8.booking_value
+              , subq_8.max_booking_value
+              , subq_8.min_booking_value
+              , subq_8.bookers
+              , subq_8.average_booking_value
+              , subq_8.referred_bookings
+              , subq_8.median_booking_value
+              , subq_8.booking_value_p99
+              , subq_8.discrete_booking_value_p99
+              , subq_8.approximate_continuous_booking_value_p99
+              , subq_8.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_8
+          ) subq_9
+        ) subq_10
+        GROUP BY
+          subq_10.metric_time
+      ) subq_11
+    ) subq_12
+    ON
+      DATEADD(month, -1, subq_13.metric_time) = subq_12.metric_time
+  ) subq_15
+  ON
+    (
+      subq_7.metric_time = subq_15.metric_time
+    ) OR (
+      (subq_7.metric_time IS NULL) AND (subq_15.metric_time IS NULL)
+    )
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,79 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time, subq_32.metric_time) AS metric_time
+    , subq_24.month_start_bookings AS month_start_bookings
+    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time
+      , subq_21.month_start_bookings AS month_start_bookings
+    FROM ***************************.mf_time_spine subq_23
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS month_start_bookings
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_19
+      GROUP BY
+        metric_time
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time
+  ) subq_24
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_31.ds AS metric_time
+      , subq_29.bookings_1_month_ago AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_31
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_1_month_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_27
+      GROUP BY
+        metric_time
+    ) subq_29
+    ON
+      DATEADD(month, -1, subq_31.ds) = subq_29.metric_time
+  ) subq_32
+  ON
+    (
+      subq_24.metric_time = subq_32.metric_time
+    ) OR (
+      (subq_24.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+    )
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
@@ -1,0 +1,161 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_5.metric_time AS metric_time
+    , subq_4.bookings_5_days_ago AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_6.ds AS metric_time
+    FROM ***************************.mf_time_spine subq_6
+  ) subq_5
+  LEFT OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings AS bookings_5_days_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  ON
+    DATEADD(day, -5, subq_5.metric_time) = subq_4.metric_time
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DatabricksSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_14.ds AS metric_time
+    , subq_12.bookings_5_days_ago AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_14
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings_5_days_ago
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_10
+    GROUP BY
+      metric_time
+  ) subq_12
+  ON
+    DATEADD(day, -5, subq_14.ds) = subq_12.metric_time
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_at_start_of_month
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_TRUNC('month', subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_at_start_of_month
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_TRUNC('month', subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_2_weeks_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      subq_10.metric_time - INTERVAL 14 day = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_2_weeks_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      subq_25.ds - INTERVAL 14 day = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -1,0 +1,331 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_16.metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_7.metric_time, subq_15.metric_time) AS metric_time
+    , subq_7.month_start_bookings AS month_start_bookings
+    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time AS metric_time
+      , subq_4.month_start_bookings AS month_start_bookings
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_6.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_3.metric_time
+        , subq_3.bookings AS month_start_bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_2.metric_time
+          , SUM(subq_2.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_1.metric_time
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds_partitioned
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.booking_paid_at
+              , subq_0.booking_paid_at__week
+              , subq_0.booking_paid_at__month
+              , subq_0.booking_paid_at__quarter
+              , subq_0.booking_paid_at__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds
+              , subq_0.create_a_cycle_in_the_join_graph__ds__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_0.ds AS metric_time
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.create_a_cycle_in_the_join_graph
+              , subq_0.create_a_cycle_in_the_join_graph__listing
+              , subq_0.create_a_cycle_in_the_join_graph__guest
+              , subq_0.create_a_cycle_in_the_join_graph__host
+              , subq_0.is_instant
+              , subq_0.create_a_cycle_in_the_join_graph__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        GROUP BY
+          subq_2.metric_time
+      ) subq_3
+    ) subq_4
+    ON
+      DATE_TRUNC('month', subq_5.metric_time) = subq_4.metric_time
+  ) subq_7
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_13.metric_time AS metric_time
+      , subq_12.bookings_1_month_ago AS bookings_1_month_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_14.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_14
+    ) subq_13
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time
+        , subq_11.bookings AS bookings_1_month_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_10.metric_time
+          , SUM(subq_10.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_9.metric_time
+            , subq_9.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_8.ds
+              , subq_8.ds__week
+              , subq_8.ds__month
+              , subq_8.ds__quarter
+              , subq_8.ds__year
+              , subq_8.ds_partitioned
+              , subq_8.ds_partitioned__week
+              , subq_8.ds_partitioned__month
+              , subq_8.ds_partitioned__quarter
+              , subq_8.ds_partitioned__year
+              , subq_8.booking_paid_at
+              , subq_8.booking_paid_at__week
+              , subq_8.booking_paid_at__month
+              , subq_8.booking_paid_at__quarter
+              , subq_8.booking_paid_at__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds
+              , subq_8.create_a_cycle_in_the_join_graph__ds__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_8.ds AS metric_time
+              , subq_8.ds__week AS metric_time__week
+              , subq_8.ds__month AS metric_time__month
+              , subq_8.ds__quarter AS metric_time__quarter
+              , subq_8.ds__year AS metric_time__year
+              , subq_8.listing
+              , subq_8.guest
+              , subq_8.host
+              , subq_8.create_a_cycle_in_the_join_graph
+              , subq_8.create_a_cycle_in_the_join_graph__listing
+              , subq_8.create_a_cycle_in_the_join_graph__guest
+              , subq_8.create_a_cycle_in_the_join_graph__host
+              , subq_8.is_instant
+              , subq_8.create_a_cycle_in_the_join_graph__is_instant
+              , subq_8.bookings
+              , subq_8.instant_bookings
+              , subq_8.booking_value
+              , subq_8.max_booking_value
+              , subq_8.min_booking_value
+              , subq_8.bookers
+              , subq_8.average_booking_value
+              , subq_8.referred_bookings
+              , subq_8.median_booking_value
+              , subq_8.booking_value_p99
+              , subq_8.discrete_booking_value_p99
+              , subq_8.approximate_continuous_booking_value_p99
+              , subq_8.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_8
+          ) subq_9
+        ) subq_10
+        GROUP BY
+          subq_10.metric_time
+      ) subq_11
+    ) subq_12
+    ON
+      subq_13.metric_time - INTERVAL 1 month = subq_12.metric_time
+  ) subq_15
+  ON
+    (
+      subq_7.metric_time = subq_15.metric_time
+    ) OR (
+      (subq_7.metric_time IS NULL) AND (subq_15.metric_time IS NULL)
+    )
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,79 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time, subq_32.metric_time) AS metric_time
+    , subq_24.month_start_bookings AS month_start_bookings
+    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time
+      , subq_21.month_start_bookings AS month_start_bookings
+    FROM ***************************.mf_time_spine subq_23
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS month_start_bookings
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_19
+      GROUP BY
+        metric_time
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time
+  ) subq_24
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_31.ds AS metric_time
+      , subq_29.bookings_1_month_ago AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_31
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_1_month_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_27
+      GROUP BY
+        metric_time
+    ) subq_29
+    ON
+      subq_31.ds - INTERVAL 1 month = subq_29.metric_time
+  ) subq_32
+  ON
+    (
+      subq_24.metric_time = subq_32.metric_time
+    ) OR (
+      (subq_24.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+    )
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
@@ -1,0 +1,161 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_5.metric_time AS metric_time
+    , subq_4.bookings_5_days_ago AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_6.ds AS metric_time
+    FROM ***************************.mf_time_spine subq_6
+  ) subq_5
+  LEFT OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings AS bookings_5_days_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  ON
+    subq_5.metric_time - INTERVAL 5 day = subq_4.metric_time
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDbSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_14.ds AS metric_time
+    , subq_12.bookings_5_days_ago AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_14
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings_5_days_ago
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_10
+    GROUP BY
+      metric_time
+  ) subq_12
+  ON
+    subq_14.ds - INTERVAL 5 day = subq_12.metric_time
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_at_start_of_month
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_TRUNC('month', subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_at_start_of_month
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_TRUNC('month', subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_2_weeks_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      subq_10.metric_time - MAKE_INTERVAL(days => 14) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_2_weeks_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      subq_25.ds - MAKE_INTERVAL(days => 14) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -1,0 +1,331 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_16.metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_7.metric_time, subq_15.metric_time) AS metric_time
+    , subq_7.month_start_bookings AS month_start_bookings
+    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time AS metric_time
+      , subq_4.month_start_bookings AS month_start_bookings
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_6.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_3.metric_time
+        , subq_3.bookings AS month_start_bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_2.metric_time
+          , SUM(subq_2.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_1.metric_time
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds_partitioned
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.booking_paid_at
+              , subq_0.booking_paid_at__week
+              , subq_0.booking_paid_at__month
+              , subq_0.booking_paid_at__quarter
+              , subq_0.booking_paid_at__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds
+              , subq_0.create_a_cycle_in_the_join_graph__ds__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_0.ds AS metric_time
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.create_a_cycle_in_the_join_graph
+              , subq_0.create_a_cycle_in_the_join_graph__listing
+              , subq_0.create_a_cycle_in_the_join_graph__guest
+              , subq_0.create_a_cycle_in_the_join_graph__host
+              , subq_0.is_instant
+              , subq_0.create_a_cycle_in_the_join_graph__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        GROUP BY
+          subq_2.metric_time
+      ) subq_3
+    ) subq_4
+    ON
+      DATE_TRUNC('month', subq_5.metric_time) = subq_4.metric_time
+  ) subq_7
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_13.metric_time AS metric_time
+      , subq_12.bookings_1_month_ago AS bookings_1_month_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_14.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_14
+    ) subq_13
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time
+        , subq_11.bookings AS bookings_1_month_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_10.metric_time
+          , SUM(subq_10.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_9.metric_time
+            , subq_9.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_8.ds
+              , subq_8.ds__week
+              , subq_8.ds__month
+              , subq_8.ds__quarter
+              , subq_8.ds__year
+              , subq_8.ds_partitioned
+              , subq_8.ds_partitioned__week
+              , subq_8.ds_partitioned__month
+              , subq_8.ds_partitioned__quarter
+              , subq_8.ds_partitioned__year
+              , subq_8.booking_paid_at
+              , subq_8.booking_paid_at__week
+              , subq_8.booking_paid_at__month
+              , subq_8.booking_paid_at__quarter
+              , subq_8.booking_paid_at__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds
+              , subq_8.create_a_cycle_in_the_join_graph__ds__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_8.ds AS metric_time
+              , subq_8.ds__week AS metric_time__week
+              , subq_8.ds__month AS metric_time__month
+              , subq_8.ds__quarter AS metric_time__quarter
+              , subq_8.ds__year AS metric_time__year
+              , subq_8.listing
+              , subq_8.guest
+              , subq_8.host
+              , subq_8.create_a_cycle_in_the_join_graph
+              , subq_8.create_a_cycle_in_the_join_graph__listing
+              , subq_8.create_a_cycle_in_the_join_graph__guest
+              , subq_8.create_a_cycle_in_the_join_graph__host
+              , subq_8.is_instant
+              , subq_8.create_a_cycle_in_the_join_graph__is_instant
+              , subq_8.bookings
+              , subq_8.instant_bookings
+              , subq_8.booking_value
+              , subq_8.max_booking_value
+              , subq_8.min_booking_value
+              , subq_8.bookers
+              , subq_8.average_booking_value
+              , subq_8.referred_bookings
+              , subq_8.median_booking_value
+              , subq_8.booking_value_p99
+              , subq_8.discrete_booking_value_p99
+              , subq_8.approximate_continuous_booking_value_p99
+              , subq_8.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_8
+          ) subq_9
+        ) subq_10
+        GROUP BY
+          subq_10.metric_time
+      ) subq_11
+    ) subq_12
+    ON
+      subq_13.metric_time - MAKE_INTERVAL(months => 1) = subq_12.metric_time
+  ) subq_15
+  ON
+    (
+      subq_7.metric_time = subq_15.metric_time
+    ) OR (
+      (subq_7.metric_time IS NULL) AND (subq_15.metric_time IS NULL)
+    )
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,79 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time, subq_32.metric_time) AS metric_time
+    , subq_24.month_start_bookings AS month_start_bookings
+    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time
+      , subq_21.month_start_bookings AS month_start_bookings
+    FROM ***************************.mf_time_spine subq_23
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS month_start_bookings
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_19
+      GROUP BY
+        metric_time
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time
+  ) subq_24
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_31.ds AS metric_time
+      , subq_29.bookings_1_month_ago AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_31
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_1_month_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_27
+      GROUP BY
+        metric_time
+    ) subq_29
+    ON
+      subq_31.ds - MAKE_INTERVAL(months => 1) = subq_29.metric_time
+  ) subq_32
+  ON
+    (
+      subq_24.metric_time = subq_32.metric_time
+    ) OR (
+      (subq_24.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+    )
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
@@ -1,0 +1,161 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_5.metric_time AS metric_time
+    , subq_4.bookings_5_days_ago AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_6.ds AS metric_time
+    FROM ***************************.mf_time_spine subq_6
+  ) subq_5
+  LEFT OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings AS bookings_5_days_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  ON
+    subq_5.metric_time - MAKE_INTERVAL(days => 5) = subq_4.metric_time
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/PostgresSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_14.ds AS metric_time
+    , subq_12.bookings_5_days_ago AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_14
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings_5_days_ago
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_10
+    GROUP BY
+      metric_time
+  ) subq_12
+  ON
+    subq_14.ds - MAKE_INTERVAL(days => 5) = subq_12.metric_time
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_at_start_of_month
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_TRUNC('month', subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_at_start_of_month
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_TRUNC('month', subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_2_weeks_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATEADD(day, -14, subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_2_weeks_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATEADD(day, -14, subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -1,0 +1,331 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_16.metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_7.metric_time, subq_15.metric_time) AS metric_time
+    , subq_7.month_start_bookings AS month_start_bookings
+    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time AS metric_time
+      , subq_4.month_start_bookings AS month_start_bookings
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_6.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_3.metric_time
+        , subq_3.bookings AS month_start_bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_2.metric_time
+          , SUM(subq_2.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_1.metric_time
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds_partitioned
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.booking_paid_at
+              , subq_0.booking_paid_at__week
+              , subq_0.booking_paid_at__month
+              , subq_0.booking_paid_at__quarter
+              , subq_0.booking_paid_at__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds
+              , subq_0.create_a_cycle_in_the_join_graph__ds__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_0.ds AS metric_time
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.create_a_cycle_in_the_join_graph
+              , subq_0.create_a_cycle_in_the_join_graph__listing
+              , subq_0.create_a_cycle_in_the_join_graph__guest
+              , subq_0.create_a_cycle_in_the_join_graph__host
+              , subq_0.is_instant
+              , subq_0.create_a_cycle_in_the_join_graph__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        GROUP BY
+          subq_2.metric_time
+      ) subq_3
+    ) subq_4
+    ON
+      DATE_TRUNC('month', subq_5.metric_time) = subq_4.metric_time
+  ) subq_7
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_13.metric_time AS metric_time
+      , subq_12.bookings_1_month_ago AS bookings_1_month_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_14.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_14
+    ) subq_13
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time
+        , subq_11.bookings AS bookings_1_month_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_10.metric_time
+          , SUM(subq_10.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_9.metric_time
+            , subq_9.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_8.ds
+              , subq_8.ds__week
+              , subq_8.ds__month
+              , subq_8.ds__quarter
+              , subq_8.ds__year
+              , subq_8.ds_partitioned
+              , subq_8.ds_partitioned__week
+              , subq_8.ds_partitioned__month
+              , subq_8.ds_partitioned__quarter
+              , subq_8.ds_partitioned__year
+              , subq_8.booking_paid_at
+              , subq_8.booking_paid_at__week
+              , subq_8.booking_paid_at__month
+              , subq_8.booking_paid_at__quarter
+              , subq_8.booking_paid_at__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds
+              , subq_8.create_a_cycle_in_the_join_graph__ds__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_8.ds AS metric_time
+              , subq_8.ds__week AS metric_time__week
+              , subq_8.ds__month AS metric_time__month
+              , subq_8.ds__quarter AS metric_time__quarter
+              , subq_8.ds__year AS metric_time__year
+              , subq_8.listing
+              , subq_8.guest
+              , subq_8.host
+              , subq_8.create_a_cycle_in_the_join_graph
+              , subq_8.create_a_cycle_in_the_join_graph__listing
+              , subq_8.create_a_cycle_in_the_join_graph__guest
+              , subq_8.create_a_cycle_in_the_join_graph__host
+              , subq_8.is_instant
+              , subq_8.create_a_cycle_in_the_join_graph__is_instant
+              , subq_8.bookings
+              , subq_8.instant_bookings
+              , subq_8.booking_value
+              , subq_8.max_booking_value
+              , subq_8.min_booking_value
+              , subq_8.bookers
+              , subq_8.average_booking_value
+              , subq_8.referred_bookings
+              , subq_8.median_booking_value
+              , subq_8.booking_value_p99
+              , subq_8.discrete_booking_value_p99
+              , subq_8.approximate_continuous_booking_value_p99
+              , subq_8.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_8
+          ) subq_9
+        ) subq_10
+        GROUP BY
+          subq_10.metric_time
+      ) subq_11
+    ) subq_12
+    ON
+      DATEADD(month, -1, subq_13.metric_time) = subq_12.metric_time
+  ) subq_15
+  ON
+    (
+      subq_7.metric_time = subq_15.metric_time
+    ) OR (
+      (subq_7.metric_time IS NULL) AND (subq_15.metric_time IS NULL)
+    )
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,79 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time, subq_32.metric_time) AS metric_time
+    , subq_24.month_start_bookings AS month_start_bookings
+    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time
+      , subq_21.month_start_bookings AS month_start_bookings
+    FROM ***************************.mf_time_spine subq_23
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS month_start_bookings
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_19
+      GROUP BY
+        metric_time
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time
+  ) subq_24
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_31.ds AS metric_time
+      , subq_29.bookings_1_month_ago AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_31
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_1_month_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_27
+      GROUP BY
+        metric_time
+    ) subq_29
+    ON
+      DATEADD(month, -1, subq_31.ds) = subq_29.metric_time
+  ) subq_32
+  ON
+    (
+      subq_24.metric_time = subq_32.metric_time
+    ) OR (
+      (subq_24.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+    )
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
@@ -1,0 +1,161 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_5.metric_time AS metric_time
+    , subq_4.bookings_5_days_ago AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_6.ds AS metric_time
+    FROM ***************************.mf_time_spine subq_6
+  ) subq_5
+  LEFT OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings AS bookings_5_days_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  ON
+    DATEADD(day, -5, subq_5.metric_time) = subq_4.metric_time
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/RedshiftSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_14.ds AS metric_time
+    , subq_12.bookings_5_days_ago AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_14
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings_5_days_ago
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_10
+    GROUP BY
+      metric_time
+  ) subq_12
+  ON
+    DATEADD(day, -5, subq_14.ds) = subq_12.metric_time
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_at_start_of_month
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATE_TRUNC('month', subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_at_start_of_month) / bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_at_start_of_month AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_at_start_of_month AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_at_start_of_month
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATE_TRUNC('month', subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window__plan0.sql
@@ -1,0 +1,317 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_4.metric_time, subq_12.metric_time) AS metric_time
+    , subq_4.bookings AS bookings
+    , subq_12.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_10.metric_time AS metric_time
+      , subq_9.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_11.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_11
+    ) subq_10
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_8.metric_time
+        , subq_8.bookings AS bookings_2_weeks_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_7.metric_time
+          , SUM(subq_7.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_6.metric_time
+            , subq_6.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds_partitioned
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.booking_paid_at
+              , subq_5.booking_paid_at__week
+              , subq_5.booking_paid_at__month
+              , subq_5.booking_paid_at__quarter
+              , subq_5.booking_paid_at__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds
+              , subq_5.create_a_cycle_in_the_join_graph__ds__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds__year
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_5.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_5.ds AS metric_time
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.create_a_cycle_in_the_join_graph
+              , subq_5.create_a_cycle_in_the_join_graph__listing
+              , subq_5.create_a_cycle_in_the_join_graph__guest
+              , subq_5.create_a_cycle_in_the_join_graph__host
+              , subq_5.is_instant
+              , subq_5.create_a_cycle_in_the_join_graph__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+        ) subq_7
+        GROUP BY
+          subq_7.metric_time
+      ) subq_8
+    ) subq_9
+    ON
+      DATEADD(day, -14, subq_10.metric_time) = subq_9.metric_time
+  ) subq_12
+  ON
+    (
+      subq_4.metric_time = subq_12.metric_time
+    ) OR (
+      (subq_4.metric_time IS NULL) AND (subq_12.metric_time IS NULL)
+    )
+) subq_13

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -1,0 +1,70 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , (bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_18.metric_time, subq_26.metric_time) AS metric_time
+    , subq_18.bookings AS bookings
+    , subq_26.bookings_2_weeks_ago AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      metric_time
+  ) subq_18
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_25.ds AS metric_time
+      , subq_23.bookings_2_weeks_ago AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_25
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_2_weeks_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_21
+      GROUP BY
+        metric_time
+    ) subq_23
+    ON
+      DATEADD(day, -14, subq_25.ds) = subq_23.metric_time
+  ) subq_26
+  ON
+    (
+      subq_18.metric_time = subq_26.metric_time
+    ) OR (
+      (subq_18.metric_time IS NULL) AND (subq_26.metric_time IS NULL)
+    )
+) subq_27

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -1,0 +1,331 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_16.metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_7.metric_time, subq_15.metric_time) AS metric_time
+    , subq_7.month_start_bookings AS month_start_bookings
+    , subq_15.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time AS metric_time
+      , subq_4.month_start_bookings AS month_start_bookings
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_6.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_3.metric_time
+        , subq_3.bookings AS month_start_bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_2.metric_time
+          , SUM(subq_2.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_1.metric_time
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds_partitioned
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.booking_paid_at
+              , subq_0.booking_paid_at__week
+              , subq_0.booking_paid_at__month
+              , subq_0.booking_paid_at__quarter
+              , subq_0.booking_paid_at__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds
+              , subq_0.create_a_cycle_in_the_join_graph__ds__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds__year
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_0.ds AS metric_time
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.create_a_cycle_in_the_join_graph
+              , subq_0.create_a_cycle_in_the_join_graph__listing
+              , subq_0.create_a_cycle_in_the_join_graph__guest
+              , subq_0.create_a_cycle_in_the_join_graph__host
+              , subq_0.is_instant
+              , subq_0.create_a_cycle_in_the_join_graph__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        GROUP BY
+          subq_2.metric_time
+      ) subq_3
+    ) subq_4
+    ON
+      DATE_TRUNC('month', subq_5.metric_time) = subq_4.metric_time
+  ) subq_7
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_13.metric_time AS metric_time
+      , subq_12.bookings_1_month_ago AS bookings_1_month_ago
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_14.ds AS metric_time
+      FROM ***************************.mf_time_spine subq_14
+    ) subq_13
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time
+        , subq_11.bookings AS bookings_1_month_ago
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_10.metric_time
+          , SUM(subq_10.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time']
+          SELECT
+            subq_9.metric_time
+            , subq_9.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_8.ds
+              , subq_8.ds__week
+              , subq_8.ds__month
+              , subq_8.ds__quarter
+              , subq_8.ds__year
+              , subq_8.ds_partitioned
+              , subq_8.ds_partitioned__week
+              , subq_8.ds_partitioned__month
+              , subq_8.ds_partitioned__quarter
+              , subq_8.ds_partitioned__year
+              , subq_8.booking_paid_at
+              , subq_8.booking_paid_at__week
+              , subq_8.booking_paid_at__month
+              , subq_8.booking_paid_at__quarter
+              , subq_8.booking_paid_at__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds
+              , subq_8.create_a_cycle_in_the_join_graph__ds__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds__year
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , subq_8.create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , subq_8.ds AS metric_time
+              , subq_8.ds__week AS metric_time__week
+              , subq_8.ds__month AS metric_time__month
+              , subq_8.ds__quarter AS metric_time__quarter
+              , subq_8.ds__year AS metric_time__year
+              , subq_8.listing
+              , subq_8.guest
+              , subq_8.host
+              , subq_8.create_a_cycle_in_the_join_graph
+              , subq_8.create_a_cycle_in_the_join_graph__listing
+              , subq_8.create_a_cycle_in_the_join_graph__guest
+              , subq_8.create_a_cycle_in_the_join_graph__host
+              , subq_8.is_instant
+              , subq_8.create_a_cycle_in_the_join_graph__is_instant
+              , subq_8.bookings
+              , subq_8.instant_bookings
+              , subq_8.booking_value
+              , subq_8.max_booking_value
+              , subq_8.min_booking_value
+              , subq_8.bookers
+              , subq_8.average_booking_value
+              , subq_8.referred_bookings
+              , subq_8.median_booking_value
+              , subq_8.booking_value_p99
+              , subq_8.discrete_booking_value_p99
+              , subq_8.approximate_continuous_booking_value_p99
+              , subq_8.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Data Source 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , bookings_source_src_10001.ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , bookings_source_src_10001.ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+                , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+                , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+                , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+                , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+                , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+                , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+                , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+                , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+              FROM (
+                -- User Defined SQL Query
+                SELECT * FROM ***************************.fct_bookings
+              ) bookings_source_src_10001
+            ) subq_8
+          ) subq_9
+        ) subq_10
+        GROUP BY
+          subq_10.metric_time
+      ) subq_11
+    ) subq_12
+    ON
+      DATEADD(month, -1, subq_13.metric_time) = subq_12.metric_time
+  ) subq_15
+  ON
+    (
+      subq_7.metric_time = subq_15.metric_time
+    ) OR (
+      (subq_7.metric_time IS NULL) AND (subq_15.metric_time IS NULL)
+    )
+) subq_16

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -1,0 +1,79 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , month_start_bookings / bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time, subq_32.metric_time) AS metric_time
+    , subq_24.month_start_bookings AS month_start_bookings
+    , subq_32.bookings_1_month_ago AS bookings_1_month_ago
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time
+      , subq_21.month_start_bookings AS month_start_bookings
+    FROM ***************************.mf_time_spine subq_23
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS month_start_bookings
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_19
+      GROUP BY
+        metric_time
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time
+  ) subq_24
+  INNER JOIN (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_31.ds AS metric_time
+      , subq_29.bookings_1_month_ago AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_31
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time
+        , SUM(bookings) AS bookings_1_month_ago
+      FROM (
+        -- Read Elements From Data Source 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          ds AS metric_time
+          , 1 AS bookings
+        FROM (
+          -- User Defined SQL Query
+          SELECT * FROM ***************************.fct_bookings
+        ) bookings_source_src_10001
+      ) subq_27
+      GROUP BY
+        metric_time
+    ) subq_29
+    ON
+      DATEADD(month, -1, subq_31.ds) = subq_29.metric_time
+  ) subq_32
+  ON
+    (
+      subq_24.metric_time = subq_32.metric_time
+    ) OR (
+      (subq_24.metric_time IS NULL) AND (subq_32.metric_time IS NULL)
+    )
+) subq_33

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_one_input_metric__plan0.sql
@@ -1,0 +1,161 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_5.metric_time AS metric_time
+    , subq_4.bookings_5_days_ago AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_6.ds AS metric_time
+    FROM ***************************.mf_time_spine subq_6
+  ) subq_5
+  LEFT OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.metric_time
+      , subq_3.bookings AS bookings_5_days_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.metric_time
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time']
+        SELECT
+          subq_1.metric_time
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds_partitioned
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.booking_paid_at
+            , subq_0.booking_paid_at__week
+            , subq_0.booking_paid_at__month
+            , subq_0.booking_paid_at__quarter
+            , subq_0.booking_paid_at__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds
+            , subq_0.create_a_cycle_in_the_join_graph__ds__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds__year
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__week
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__month
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__ds_partitioned__year
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__week
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__month
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+            , subq_0.create_a_cycle_in_the_join_graph__booking_paid_at__year
+            , subq_0.ds AS metric_time
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.create_a_cycle_in_the_join_graph
+            , subq_0.create_a_cycle_in_the_join_graph__listing
+            , subq_0.create_a_cycle_in_the_join_graph__guest
+            , subq_0.create_a_cycle_in_the_join_graph__host
+            , subq_0.is_instant
+            , subq_0.create_a_cycle_in_the_join_graph__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Data Source 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , bookings_source_src_10001.ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , bookings_source_src_10001.ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS booking_paid_at__year
+              , bookings_source_src_10001.is_instant AS create_a_cycle_in_the_join_graph__is_instant
+              , bookings_source_src_10001.ds AS create_a_cycle_in_the_join_graph__ds
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS create_a_cycle_in_the_join_graph__ds__year
+              , bookings_source_src_10001.ds_partitioned AS create_a_cycle_in_the_join_graph__ds_partitioned
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS create_a_cycle_in_the_join_graph__ds_partitioned__year
+              , bookings_source_src_10001.booking_paid_at AS create_a_cycle_in_the_join_graph__booking_paid_at
+              , DATE_TRUNC('week', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.booking_paid_at) AS create_a_cycle_in_the_join_graph__booking_paid_at__year
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph
+              , bookings_source_src_10001.listing_id AS create_a_cycle_in_the_join_graph__listing
+              , bookings_source_src_10001.guest_id AS create_a_cycle_in_the_join_graph__guest
+              , bookings_source_src_10001.host_id AS create_a_cycle_in_the_join_graph__host
+            FROM (
+              -- User Defined SQL Query
+              SELECT * FROM ***************************.fct_bookings
+            ) bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.metric_time
+    ) subq_3
+  ) subq_4
+  ON
+    DATEADD(day, -5, subq_5.metric_time) = subq_4.metric_time
+) subq_7

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/SnowflakeSqlClient/test_derived_metric_with_one_input_metric__plan0_optimized.sql
@@ -1,0 +1,35 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_14.ds AS metric_time
+    , subq_12.bookings_5_days_ago AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_14
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time
+      , SUM(bookings) AS bookings_5_days_ago
+    FROM (
+      -- Read Elements From Data Source 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time']
+      SELECT
+        ds AS metric_time
+        , 1 AS bookings
+      FROM (
+        -- User Defined SQL Query
+        SELECT * FROM ***************************.fct_bookings
+      ) bookings_source_src_10001
+    ) subq_10
+    GROUP BY
+      metric_time
+  ) subq_12
+  ON
+    DATEADD(day, -5, subq_14.ds) = subq_12.metric_time
+) subq_15

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_to_grain__plan0.xml
@@ -1,0 +1,1083 @@
+<SqlQueryPlan>
+    <SqlSelectStatementNode>
+        <!-- description = Compute Metrics via Expressions -->
+        <!-- node_id = ss_18 -->
+        <!-- col0 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+        <!--    'column_alias': 'metric_time'}                         -->
+        <!-- col1 =                                                                                                                        -->
+        <!--   {'class': 'SqlSelectColumn',                                                                                                -->
+        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=(bookings - bookings_at_start_of_month) / bookings_at_start_of_month),  -->
+        <!--    'column_alias': 'bookings_growth_since_start_of_month'}                                                                    -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+        <!-- where = None -->
+        <SqlSelectStatementNode>
+            <!-- description = Combine Metrics -->
+            <!-- node_id = ss_17 -->
+            <!-- col0 =                                                                            -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time'}                                                 -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+            <!--    'column_alias': 'bookings'}                            -->
+            <!-- col2 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+            <!--    'column_alias': 'bookings_at_start_of_month'}          -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
+            <!--    'right_source_alias': 'subq_12',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- where = None -->
+            <SqlSelectStatementNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_10 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'column_alias': 'bookings'}                            -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Aggregate Measures -->
+                    <!-- node_id = ss_9 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                                       -->
+                    <!--   {'class': 'SqlSelectColumn',                                               -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
+                    <!--    'column_alias': 'bookings'}                                               -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- group_by0 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description =                    -->
+                        <!--   Pass Only Elements:            -->
+                        <!--     ['bookings', 'metric_time']  -->
+                        <!-- node_id = ss_8 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description = Metric Time Dimension 'ds' -->
+                            <!-- node_id = ss_7 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'column_alias': 'ds'}                                  -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'column_alias': 'ds__week'}                            -->
+                            <!-- col2 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'column_alias': 'ds__month'}                           -->
+                            <!-- col3 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'column_alias': 'ds__quarter'}                         -->
+                            <!-- col4 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'column_alias': 'ds__year'}                            -->
+                            <!-- col5 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                      -->
+                            <!-- col6 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}                -->
+                            <!-- col7 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}               -->
+                            <!-- col8 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                            <!-- col9 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}                -->
+                            <!-- col10 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'column_alias': 'booking_paid_at'}                     -->
+                            <!-- col11 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'column_alias': 'booking_paid_at__week'}               -->
+                            <!-- col12 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'column_alias': 'booking_paid_at__month'}              -->
+                            <!-- col13 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                            <!-- col14 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'column_alias': 'booking_paid_at__year'}               -->
+                            <!-- col15 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                            <!-- col16 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                            <!-- col17 =                                                            -->
+                            <!--   {'class': 'SqlSelectColumn',                                     -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                            <!-- col18 =                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                            <!-- col19 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                            <!-- col20 =                                                                 -->
+                            <!--   {'class': 'SqlSelectColumn',                                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                            <!-- col21 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                            <!-- col22 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                            <!-- col23 =                                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                            <!-- col24 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                            <!-- col25 =                                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                            <!-- col26 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                            <!-- col27 =                                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                            <!-- col28 =                                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                            <!-- col29 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col30 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col31 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col32 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col33 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col34 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col35 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col36 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col37 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col38 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                            <!-- col39 =                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                            <!-- col40 =                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                            <!-- col41 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                            <!-- col42 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col43 =                                                             -->
+                            <!--   {'class': 'SqlSelectColumn',                                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col44 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col45 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col46 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col47 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col48 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col49 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
+                            <!-- col50 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
+                            <!-- col51 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
+                            <!-- col52 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
+                            <!-- col53 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
+                            <!-- col54 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                            <!-- col55 =                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                            <!-- col56 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                <!-- node_id = ss_10001 -->
+                                <!-- col0 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                <!--    'column_alias': 'bookings'}                                 -->
+                                <!-- col1 =                                                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                <!-- col2 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                <!--    'column_alias': 'booking_value'}                         -->
+                                <!-- col3 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                <!-- col4 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                <!-- col5 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                <!--    'column_alias': 'bookers'}                               -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                <!--    'column_alias': 'booking_payments'}                      -->
+                                <!-- col8 =                                                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                <!-- col9 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                <!--    'column_alias': 'median_booking_value'}                  -->
+                                <!-- col10 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                     -->
+                                <!-- col11 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                <!-- col12 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col13 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                <!--    'column_alias': 'is_instant'}                            -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col17 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col19 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col20 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col22 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col23 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col24 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                <!-- col26 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                <!-- col28 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                <!-- col29 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                <!-- col30 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col31 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col32 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col33 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col34 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col35 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col36 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col37 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col38 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col39 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col40 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col41 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col42 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col43 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col44 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col45 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col46 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                <!--    'column_alias': 'listing'}                               -->
+                                <!-- col47 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                <!--    'column_alias': 'guest'}                                 -->
+                                <!-- col48 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'column_alias': 'host'}                                  -->
+                                <!-- col49 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                <!-- col50 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col51 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col52 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectQueryFromClauseNode>
+                                    <!-- description = Read From a Select Query -->
+                                    <!-- node_id = tfc_10001 -->
+                                </SqlSelectQueryFromClauseNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Join to Time Spine Dataset -->
+                <!-- node_id = ss_16 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                <!--    'column_alias': 'bookings_at_start_of_month'}          -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                <!-- join_0 =                                                    -->
+                <!--   {'class': 'SqlJoinDescription',                           -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
+                <!--    'right_source_alias': 'subq_9',                          -->
+                <!--    'join_type': SqlJoinType.LEFT_OUTER,                     -->
+                <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Date Spine -->
+                    <!-- node_id = ss_15 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                    <!-- where = None -->
+                    <SqlTableFromClauseNode>
+                        <!-- description = Read from ***************************.mf_time_spine -->
+                        <!-- node_id = tfc_0 -->
+                        <!-- table_id = ***************************.mf_time_spine -->
+                    </SqlTableFromClauseNode>
+                </SqlSelectStatementNode>
+                <SqlSelectStatementNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = ss_14 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                    <!--    'column_alias': 'bookings_at_start_of_month'}          -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = ss_13 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                                       -->
+                        <!--   {'class': 'SqlSelectColumn',                                               -->
+                        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
+                        <!--    'column_alias': 'bookings'}                                               -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                        <!-- group_by0 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description =                    -->
+                            <!--   Pass Only Elements:            -->
+                            <!--     ['bookings', 'metric_time']  -->
+                            <!-- node_id = ss_12 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = ss_11 -->
+                                <!-- col0 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                <!--    'column_alias': 'ds'}                                  -->
+                                <!-- col1 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                <!--    'column_alias': 'ds__week'}                            -->
+                                <!-- col2 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                <!--    'column_alias': 'ds__month'}                           -->
+                                <!-- col3 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                <!--    'column_alias': 'ds__quarter'}                         -->
+                                <!-- col4 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                <!--    'column_alias': 'ds__year'}                            -->
+                                <!-- col5 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                      -->
+                                <!-- col6 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}                -->
+                                <!-- col7 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}               -->
+                                <!-- col8 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                                <!-- col9 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}                -->
+                                <!-- col10 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                     -->
+                                <!-- col11 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}               -->
+                                <!-- col12 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}              -->
+                                <!-- col13 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                                <!-- col14 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}               -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col16 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col17 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col18 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col19 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col20 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col21 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col22 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col23 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col24 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col25 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col26 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col27 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col28 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col29 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col30 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col31 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col32 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col33 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col34 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col35 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col36 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col37 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col38 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                                <!-- col39 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col40 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col41 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- col42 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col43 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col44 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col45 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col46 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col47 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col48 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col49 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
+                                <!-- col50 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
+                                <!-- col51 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
+                                <!-- col52 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
+                                <!-- col53 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
+                                <!-- col54 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                                <!-- col55 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col56 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectStatementNode>
+                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                    <!-- node_id = ss_10001 -->
+                                    <!-- col0 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                    <!--    'column_alias': 'bookings'}                                 -->
+                                    <!-- col1 =                                                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                    <!-- col2 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                    <!--    'column_alias': 'booking_value'}                         -->
+                                    <!-- col3 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                     -->
+                                    <!-- col4 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                     -->
+                                    <!-- col5 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                    <!--    'column_alias': 'bookers'}                               -->
+                                    <!-- col6 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                    <!--    'column_alias': 'average_booking_value'}                 -->
+                                    <!-- col7 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                    <!--    'column_alias': 'booking_payments'}                      -->
+                                    <!-- col8 =                                                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                    <!-- col9 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                  -->
+                                    <!-- col10 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                     -->
+                                    <!-- col11 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                    <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                    <!-- col12 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                    <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                    <!-- col13 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                    <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                    <!-- col14 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                    <!--    'column_alias': 'is_instant'}                            -->
+                                    <!-- col15 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                    <!--    'column_alias': 'ds'}                                    -->
+                                    <!-- col16 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                    <!--    'column_alias': 'ds__week'}                        -->
+                                    <!-- col17 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                    <!--    'column_alias': 'ds__month'}                       -->
+                                    <!-- col18 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                    <!--    'column_alias': 'ds__quarter'}                     -->
+                                    <!-- col19 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                    <!--    'column_alias': 'ds__year'}                        -->
+                                    <!-- col20 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                    <!--    'column_alias': 'ds_partitioned'}                        -->
+                                    <!-- col21 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                    <!-- col22 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                    <!-- col23 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                    <!-- col24 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                    <!-- col25 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                    <!--    'column_alias': 'booking_paid_at'}                       -->
+                                    <!-- col26 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                    <!-- col28 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                    <!-- col29 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                    <!-- col30 =                                                             -->
+                                    <!--   {'class': 'SqlSelectColumn',                                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col31 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                    <!-- col32 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                    <!-- col33 =                                                            -->
+                                    <!--   {'class': 'SqlSelectColumn',                                     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                    <!-- col34 =                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                       -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                    <!-- col35 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                    <!-- col36 =                                                                 -->
+                                    <!--   {'class': 'SqlSelectColumn',                                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                    <!-- col37 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                    <!-- col38 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                    <!-- col39 =                                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                    <!-- col40 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                    <!-- col41 =                                                                  -->
+                                    <!--   {'class': 'SqlSelectColumn',                                           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                    <!-- col42 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                    <!-- col43 =                                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                    <!-- col44 =                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                    <!-- col45 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col46 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
+                                    <!-- col47 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                    <!--    'column_alias': 'guest'}                                 -->
+                                    <!-- col48 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'column_alias': 'host'}                                  -->
+                                    <!-- col49 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                    <!-- col50 =                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                    <!-- col51 =                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                    <!-- col52 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                    <!-- where = None -->
+                                    <SqlSelectQueryFromClauseNode>
+                                        <!-- description = Read From a Select Query -->
+                                        <!-- node_id = tfc_10001 -->
+                                    </SqlSelectQueryFromClauseNode>
+                                </SqlSelectStatementNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+        </SqlSelectStatementNode>
+    </SqlSelectStatementNode>
+</SqlQueryPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window__plan0.xml
@@ -1,0 +1,1083 @@
+<SqlQueryPlan>
+    <SqlSelectStatementNode>
+        <!-- description = Compute Metrics via Expressions -->
+        <!-- node_id = ss_18 -->
+        <!-- col0 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_365),  -->
+        <!--    'column_alias': 'metric_time'}                         -->
+        <!-- col1 =                                                                                                            -->
+        <!--   {'class': 'SqlSelectColumn',                                                                                    -->
+        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=(bookings - bookings_2_weeks_ago) / bookings_2_weeks_ago),  -->
+        <!--    'column_alias': 'bookings_growth_2_weeks'}                                                                     -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+        <!-- where = None -->
+        <SqlSelectStatementNode>
+            <!-- description = Combine Metrics -->
+            <!-- node_id = ss_17 -->
+            <!-- col0 =                                                                            -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time'}                                                 -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_361),  -->
+            <!--    'column_alias': 'bookings'}                            -->
+            <!-- col2 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+            <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),  -->
+            <!--    'right_source_alias': 'subq_12',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- where = None -->
+            <SqlSelectStatementNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_10 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'column_alias': 'bookings'}                            -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Aggregate Measures -->
+                    <!-- node_id = ss_9 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                                       -->
+                    <!--   {'class': 'SqlSelectColumn',                                               -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
+                    <!--    'column_alias': 'bookings'}                                               -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- group_by0 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description =                    -->
+                        <!--   Pass Only Elements:            -->
+                        <!--     ['bookings', 'metric_time']  -->
+                        <!-- node_id = ss_8 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description = Metric Time Dimension 'ds' -->
+                            <!-- node_id = ss_7 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'column_alias': 'ds'}                                  -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'column_alias': 'ds__week'}                            -->
+                            <!-- col2 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'column_alias': 'ds__month'}                           -->
+                            <!-- col3 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'column_alias': 'ds__quarter'}                         -->
+                            <!-- col4 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'column_alias': 'ds__year'}                            -->
+                            <!-- col5 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                      -->
+                            <!-- col6 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}                -->
+                            <!-- col7 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}               -->
+                            <!-- col8 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                            <!-- col9 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}                -->
+                            <!-- col10 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'column_alias': 'booking_paid_at'}                     -->
+                            <!-- col11 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'column_alias': 'booking_paid_at__week'}               -->
+                            <!-- col12 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'column_alias': 'booking_paid_at__month'}              -->
+                            <!-- col13 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                            <!-- col14 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'column_alias': 'booking_paid_at__year'}               -->
+                            <!-- col15 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                            <!-- col16 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                            <!-- col17 =                                                            -->
+                            <!--   {'class': 'SqlSelectColumn',                                     -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                            <!-- col18 =                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                            <!-- col19 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                            <!-- col20 =                                                                 -->
+                            <!--   {'class': 'SqlSelectColumn',                                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                            <!-- col21 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                            <!-- col22 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                            <!-- col23 =                                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                            <!-- col24 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                            <!-- col25 =                                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                            <!-- col26 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                            <!-- col27 =                                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                            <!-- col28 =                                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                            <!-- col29 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col30 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col31 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col32 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col33 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col34 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col35 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col36 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col37 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col38 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                            <!-- col39 =                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                            <!-- col40 =                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                            <!-- col41 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                            <!-- col42 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col43 =                                                             -->
+                            <!--   {'class': 'SqlSelectColumn',                                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col44 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col45 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col46 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col47 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col48 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col49 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
+                            <!-- col50 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
+                            <!-- col51 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
+                            <!-- col52 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
+                            <!-- col53 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
+                            <!-- col54 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                            <!-- col55 =                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                            <!-- col56 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                <!-- node_id = ss_10001 -->
+                                <!-- col0 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                <!--    'column_alias': 'bookings'}                                 -->
+                                <!-- col1 =                                                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                <!-- col2 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                <!--    'column_alias': 'booking_value'}                         -->
+                                <!-- col3 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                <!-- col4 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                <!-- col5 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                <!--    'column_alias': 'bookers'}                               -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                <!--    'column_alias': 'booking_payments'}                      -->
+                                <!-- col8 =                                                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                <!-- col9 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                <!--    'column_alias': 'median_booking_value'}                  -->
+                                <!-- col10 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                     -->
+                                <!-- col11 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                <!-- col12 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col13 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                <!--    'column_alias': 'is_instant'}                            -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col17 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col19 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col20 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col22 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col23 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col24 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                <!-- col26 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                <!-- col28 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                <!-- col29 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                <!-- col30 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col31 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col32 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col33 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col34 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col35 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col36 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col37 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col38 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col39 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col40 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col41 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col42 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col43 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col44 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col45 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col46 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                <!--    'column_alias': 'listing'}                               -->
+                                <!-- col47 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                <!--    'column_alias': 'guest'}                                 -->
+                                <!-- col48 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'column_alias': 'host'}                                  -->
+                                <!-- col49 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                <!-- col50 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col51 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col52 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectQueryFromClauseNode>
+                                    <!-- description = Read From a Select Query -->
+                                    <!-- node_id = tfc_10001 -->
+                                </SqlSelectQueryFromClauseNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Join to Time Spine Dataset -->
+                <!-- node_id = ss_16 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                <!-- join_0 =                                                    -->
+                <!--   {'class': 'SqlJoinDescription',                           -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_14),   -->
+                <!--    'right_source_alias': 'subq_9',                          -->
+                <!--    'join_type': SqlJoinType.LEFT_OUTER,                     -->
+                <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Date Spine -->
+                    <!-- node_id = ss_15 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                    <!-- where = None -->
+                    <SqlTableFromClauseNode>
+                        <!-- description = Read from ***************************.mf_time_spine -->
+                        <!-- node_id = tfc_0 -->
+                        <!-- table_id = ***************************.mf_time_spine -->
+                    </SqlTableFromClauseNode>
+                </SqlSelectStatementNode>
+                <SqlSelectStatementNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = ss_14 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                    <!--    'column_alias': 'bookings_2_weeks_ago'}                -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = ss_13 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                                       -->
+                        <!--   {'class': 'SqlSelectColumn',                                               -->
+                        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
+                        <!--    'column_alias': 'bookings'}                                               -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                        <!-- group_by0 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description =                    -->
+                            <!--   Pass Only Elements:            -->
+                            <!--     ['bookings', 'metric_time']  -->
+                            <!-- node_id = ss_12 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = ss_11 -->
+                                <!-- col0 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                <!--    'column_alias': 'ds'}                                  -->
+                                <!-- col1 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),  -->
+                                <!--    'column_alias': 'ds__week'}                            -->
+                                <!-- col2 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),  -->
+                                <!--    'column_alias': 'ds__month'}                           -->
+                                <!-- col3 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                <!--    'column_alias': 'ds__quarter'}                         -->
+                                <!-- col4 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),  -->
+                                <!--    'column_alias': 'ds__year'}                            -->
+                                <!-- col5 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                      -->
+                                <!-- col6 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}                -->
+                                <!-- col7 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}               -->
+                                <!-- col8 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                                <!-- col9 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}                -->
+                                <!-- col10 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                     -->
+                                <!-- col11 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}               -->
+                                <!-- col12 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}              -->
+                                <!-- col13 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                                <!-- col14 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}               -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col16 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col17 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col18 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col19 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col20 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),                -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col21 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col22 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col23 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),                         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col24 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col25 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col26 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col27 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                        -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col28 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col29 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col30 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col31 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col32 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col33 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col34 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col35 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col36 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col37 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col38 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                                <!-- col39 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col40 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col41 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- col42 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col43 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col44 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col45 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_292),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col46 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_293),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col47 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col48 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col49 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
+                                <!-- col50 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
+                                <!-- col51 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
+                                <!-- col52 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
+                                <!-- col53 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
+                                <!-- col54 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                                <!-- col55 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),        -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col56 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),      -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectStatementNode>
+                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                    <!-- node_id = ss_10001 -->
+                                    <!-- col0 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                    <!--    'column_alias': 'bookings'}                                 -->
+                                    <!-- col1 =                                                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                    <!-- col2 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                    <!--    'column_alias': 'booking_value'}                         -->
+                                    <!-- col3 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                     -->
+                                    <!-- col4 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                     -->
+                                    <!-- col5 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                    <!--    'column_alias': 'bookers'}                               -->
+                                    <!-- col6 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                    <!--    'column_alias': 'average_booking_value'}                 -->
+                                    <!-- col7 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                    <!--    'column_alias': 'booking_payments'}                      -->
+                                    <!-- col8 =                                                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                    <!-- col9 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                  -->
+                                    <!-- col10 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                     -->
+                                    <!-- col11 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                    <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                    <!-- col12 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                    <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                    <!-- col13 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                    <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                    <!-- col14 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                    <!--    'column_alias': 'is_instant'}                            -->
+                                    <!-- col15 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                    <!--    'column_alias': 'ds'}                                    -->
+                                    <!-- col16 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                    <!--    'column_alias': 'ds__week'}                        -->
+                                    <!-- col17 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                    <!--    'column_alias': 'ds__month'}                       -->
+                                    <!-- col18 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                    <!--    'column_alias': 'ds__quarter'}                     -->
+                                    <!-- col19 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                    <!--    'column_alias': 'ds__year'}                        -->
+                                    <!-- col20 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                    <!--    'column_alias': 'ds_partitioned'}                        -->
+                                    <!-- col21 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                    <!-- col22 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                    <!-- col23 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                    <!-- col24 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                    <!-- col25 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                    <!--    'column_alias': 'booking_paid_at'}                       -->
+                                    <!-- col26 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                    <!-- col28 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                    <!-- col29 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                    <!-- col30 =                                                             -->
+                                    <!--   {'class': 'SqlSelectColumn',                                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col31 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                    <!-- col32 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                    <!-- col33 =                                                            -->
+                                    <!--   {'class': 'SqlSelectColumn',                                     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                    <!-- col34 =                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                       -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                    <!-- col35 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                    <!-- col36 =                                                                 -->
+                                    <!--   {'class': 'SqlSelectColumn',                                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                    <!-- col37 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                    <!-- col38 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                    <!-- col39 =                                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                    <!-- col40 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                    <!-- col41 =                                                                  -->
+                                    <!--   {'class': 'SqlSelectColumn',                                           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                    <!-- col42 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                    <!-- col43 =                                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                    <!-- col44 =                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                    <!-- col45 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col46 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
+                                    <!-- col47 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                    <!--    'column_alias': 'guest'}                                 -->
+                                    <!-- col48 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'column_alias': 'host'}                                  -->
+                                    <!-- col49 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                    <!-- col50 =                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                    <!-- col51 =                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                    <!-- col52 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                    <!-- where = None -->
+                                    <SqlSelectQueryFromClauseNode>
+                                        <!-- description = Read From a Select Query -->
+                                        <!-- node_id = tfc_10001 -->
+                                    </SqlSelectQueryFromClauseNode>
+                                </SqlSelectStatementNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+        </SqlSelectStatementNode>
+    </SqlSelectStatementNode>
+</SqlQueryPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.xml
@@ -1,0 +1,1118 @@
+<SqlQueryPlan>
+    <SqlSelectStatementNode>
+        <!-- description = Compute Metrics via Expressions -->
+        <!-- node_id = ss_20 -->
+        <!-- col0 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_370),  -->
+        <!--    'column_alias': 'metric_time'}                         -->
+        <!-- col1 =                                                                                               -->
+        <!--   {'class': 'SqlSelectColumn',                                                                       -->
+        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=month_start_bookings / bookings_1_month_ago),  -->
+        <!--    'column_alias': 'bookings_month_start_compared_to_1_month_prior'}                                 -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+        <!-- where = None -->
+        <SqlSelectStatementNode>
+            <!-- description = Combine Metrics -->
+            <!-- node_id = ss_19 -->
+            <!-- col0 =                                                                            -->
+            <!--   {'class': 'SqlSelectColumn',                                                    -->
+            <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COALESCE),  -->
+            <!--    'column_alias': 'metric_time'}                                                 -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_366),  -->
+            <!--    'column_alias': 'month_start_bookings'}                -->
+            <!-- col2 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_367),  -->
+            <!--    'column_alias': 'bookings_1_month_ago'}                -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- join_0 =                                                   -->
+            <!--   {'class': 'SqlJoinDescription',                          -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_18),  -->
+            <!--    'right_source_alias': 'subq_15',                        -->
+            <!--    'join_type': SqlJoinType.INNER,                         -->
+            <!--    'on_condition': SqlLogicalExpression(node_id=lo_1)}     -->
+            <!-- where = None -->
+            <SqlSelectStatementNode>
+                <!-- description = Join to Time Spine Dataset -->
+                <!-- node_id = ss_12 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+                <!--    'column_alias': 'month_start_bookings'}                -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- join_0 =                                                    -->
+                <!--   {'class': 'SqlJoinDescription',                           -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_10),   -->
+                <!--    'right_source_alias': 'subq_4',                          -->
+                <!--    'join_type': SqlJoinType.LEFT_OUTER,                     -->
+                <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Date Spine -->
+                    <!-- node_id = ss_11 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                    <!-- where = None -->
+                    <SqlTableFromClauseNode>
+                        <!-- description = Read from ***************************.mf_time_spine -->
+                        <!-- node_id = tfc_0 -->
+                        <!-- table_id = ***************************.mf_time_spine -->
+                    </SqlTableFromClauseNode>
+                </SqlSelectStatementNode>
+                <SqlSelectStatementNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = ss_10 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                    <!--    'column_alias': 'month_start_bookings'}                -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = ss_9 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                                       -->
+                        <!--   {'class': 'SqlSelectColumn',                                               -->
+                        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
+                        <!--    'column_alias': 'bookings'}                                               -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                        <!-- group_by0 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description =                    -->
+                            <!--   Pass Only Elements:            -->
+                            <!--     ['bookings', 'metric_time']  -->
+                            <!-- node_id = ss_8 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = ss_7 -->
+                                <!-- col0 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                                <!--    'column_alias': 'ds'}                                  -->
+                                <!-- col1 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                                <!--    'column_alias': 'ds__week'}                            -->
+                                <!-- col2 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                                <!--    'column_alias': 'ds__month'}                           -->
+                                <!-- col3 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                                <!--    'column_alias': 'ds__quarter'}                         -->
+                                <!-- col4 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                                <!--    'column_alias': 'ds__year'}                            -->
+                                <!-- col5 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                      -->
+                                <!-- col6 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}                -->
+                                <!-- col7 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}               -->
+                                <!-- col8 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                                <!-- col9 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}                -->
+                                <!-- col10 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                     -->
+                                <!-- col11 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}               -->
+                                <!-- col12 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}              -->
+                                <!-- col13 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                                <!-- col14 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}               -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col16 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col17 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col18 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col19 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col20 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col21 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col22 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col23 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col24 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col25 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col26 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col27 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col28 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col29 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col30 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col31 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col32 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col33 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col34 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col35 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col36 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col37 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col38 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                                <!-- col39 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col40 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col41 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- col42 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col43 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col44 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col45 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col46 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col47 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col48 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col49 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
+                                <!-- col50 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
+                                <!-- col51 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
+                                <!-- col52 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
+                                <!-- col53 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
+                                <!-- col54 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                                <!-- col55 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col56 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectStatementNode>
+                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                    <!-- node_id = ss_10001 -->
+                                    <!-- col0 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                    <!--    'column_alias': 'bookings'}                                 -->
+                                    <!-- col1 =                                                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                    <!-- col2 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                    <!--    'column_alias': 'booking_value'}                         -->
+                                    <!-- col3 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                     -->
+                                    <!-- col4 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                     -->
+                                    <!-- col5 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                    <!--    'column_alias': 'bookers'}                               -->
+                                    <!-- col6 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                    <!--    'column_alias': 'average_booking_value'}                 -->
+                                    <!-- col7 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                    <!--    'column_alias': 'booking_payments'}                      -->
+                                    <!-- col8 =                                                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                    <!-- col9 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                  -->
+                                    <!-- col10 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                     -->
+                                    <!-- col11 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                    <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                    <!-- col12 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                    <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                    <!-- col13 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                    <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                    <!-- col14 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                    <!--    'column_alias': 'is_instant'}                            -->
+                                    <!-- col15 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                    <!--    'column_alias': 'ds'}                                    -->
+                                    <!-- col16 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                    <!--    'column_alias': 'ds__week'}                        -->
+                                    <!-- col17 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                    <!--    'column_alias': 'ds__month'}                       -->
+                                    <!-- col18 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                    <!--    'column_alias': 'ds__quarter'}                     -->
+                                    <!-- col19 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                    <!--    'column_alias': 'ds__year'}                        -->
+                                    <!-- col20 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                    <!--    'column_alias': 'ds_partitioned'}                        -->
+                                    <!-- col21 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                    <!-- col22 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                    <!-- col23 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                    <!-- col24 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                    <!-- col25 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                    <!--    'column_alias': 'booking_paid_at'}                       -->
+                                    <!-- col26 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                    <!-- col28 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                    <!-- col29 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                    <!-- col30 =                                                             -->
+                                    <!--   {'class': 'SqlSelectColumn',                                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col31 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                    <!-- col32 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                    <!-- col33 =                                                            -->
+                                    <!--   {'class': 'SqlSelectColumn',                                     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                    <!-- col34 =                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                       -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                    <!-- col35 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                    <!-- col36 =                                                                 -->
+                                    <!--   {'class': 'SqlSelectColumn',                                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                    <!-- col37 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                    <!-- col38 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                    <!-- col39 =                                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                    <!-- col40 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                    <!-- col41 =                                                                  -->
+                                    <!--   {'class': 'SqlSelectColumn',                                           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                    <!-- col42 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                    <!-- col43 =                                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                    <!-- col44 =                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                    <!-- col45 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col46 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
+                                    <!-- col47 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                    <!--    'column_alias': 'guest'}                                 -->
+                                    <!-- col48 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'column_alias': 'host'}                                  -->
+                                    <!-- col49 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                    <!-- col50 =                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                    <!-- col51 =                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                    <!-- col52 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                    <!-- where = None -->
+                                    <SqlSelectQueryFromClauseNode>
+                                        <!-- description = Read From a Select Query -->
+                                        <!-- node_id = tfc_10001 -->
+                                    </SqlSelectQueryFromClauseNode>
+                                </SqlSelectStatementNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Join to Time Spine Dataset -->
+                <!-- node_id = ss_18 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_362),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_363),  -->
+                <!--    'column_alias': 'bookings_1_month_ago'}                -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                <!-- join_0 =                                                    -->
+                <!--   {'class': 'SqlJoinDescription',                           -->
+                <!--    'right_source': SqlSelectStatementNode(node_id=ss_16),   -->
+                <!--    'right_source_alias': 'subq_12',                         -->
+                <!--    'join_type': SqlJoinType.LEFT_OUTER,                     -->
+                <!--    'on_condition': SqlComparisonExpression(node_id=cmp_1)}  -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Date Spine -->
+                    <!-- node_id = ss_17 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_359),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_1) -->
+                    <!-- where = None -->
+                    <SqlTableFromClauseNode>
+                        <!-- description = Read from ***************************.mf_time_spine -->
+                        <!-- node_id = tfc_1 -->
+                        <!-- table_id = ***************************.mf_time_spine -->
+                    </SqlTableFromClauseNode>
+                </SqlSelectStatementNode>
+                <SqlSelectStatementNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = ss_16 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_357),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_358),  -->
+                    <!--    'column_alias': 'bookings_1_month_ago'}                -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = ss_15 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                                       -->
+                        <!--   {'class': 'SqlSelectColumn',                                               -->
+                        <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM),  -->
+                        <!--    'column_alias': 'bookings'}                                               -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                        <!-- group_by0 =                                               -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_356),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description =                    -->
+                            <!--   Pass Only Elements:            -->
+                            <!--     ['bookings', 'metric_time']  -->
+                            <!-- node_id = ss_14 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_354),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_353),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = ss_13 -->
+                                <!-- col0 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_311),  -->
+                                <!--    'column_alias': 'ds'}                                  -->
+                                <!-- col1 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_312),  -->
+                                <!--    'column_alias': 'ds__week'}                            -->
+                                <!-- col2 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_313),  -->
+                                <!--    'column_alias': 'ds__month'}                           -->
+                                <!-- col3 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_314),  -->
+                                <!--    'column_alias': 'ds__quarter'}                         -->
+                                <!-- col4 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_315),  -->
+                                <!--    'column_alias': 'ds__year'}                            -->
+                                <!-- col5 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_316),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                      -->
+                                <!-- col6 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_317),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}                -->
+                                <!-- col7 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_318),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}               -->
+                                <!-- col8 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_319),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                                <!-- col9 =                                                    -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_320),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}                -->
+                                <!-- col10 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_321),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                     -->
+                                <!-- col11 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_322),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}               -->
+                                <!-- col12 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_323),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}              -->
+                                <!-- col13 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_324),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                                <!-- col14 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_325),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}               -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_326),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col16 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_327),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col17 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_328),           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col18 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_329),             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col19 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_330),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col20 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_331),                -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col21 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_332),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col22 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_333),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col23 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_334),                         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col24 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_335),                      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col25 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_336),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col26 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_337),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col27 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_338),                        -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col28 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_339),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col29 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_340),                       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col30 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_341),  -->
+                                <!--    'column_alias': 'metric_time'}                         -->
+                                <!-- col31 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_342),  -->
+                                <!--    'column_alias': 'metric_time__week'}                   -->
+                                <!-- col32 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_343),  -->
+                                <!--    'column_alias': 'metric_time__month'}                  -->
+                                <!-- col33 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_344),  -->
+                                <!--    'column_alias': 'metric_time__quarter'}                -->
+                                <!-- col34 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_345),  -->
+                                <!--    'column_alias': 'metric_time__year'}                   -->
+                                <!-- col35 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_346),  -->
+                                <!--    'column_alias': 'listing'}                             -->
+                                <!-- col36 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_347),  -->
+                                <!--    'column_alias': 'guest'}                               -->
+                                <!-- col37 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_348),  -->
+                                <!--    'column_alias': 'host'}                                -->
+                                <!-- col38 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_349),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                                <!-- col39 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_350),         -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col40 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_351),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col41 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_352),      -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- col42 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_309),  -->
+                                <!--    'column_alias': 'is_instant'}                          -->
+                                <!-- col43 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_310),            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col44 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+                                <!--    'column_alias': 'bookings'}                            -->
+                                <!-- col45 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_297),  -->
+                                <!--    'column_alias': 'instant_bookings'}                    -->
+                                <!-- col46 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_298),  -->
+                                <!--    'column_alias': 'booking_value'}                       -->
+                                <!-- col47 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_299),  -->
+                                <!--    'column_alias': 'max_booking_value'}                   -->
+                                <!-- col48 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_300),  -->
+                                <!--    'column_alias': 'min_booking_value'}                   -->
+                                <!-- col49 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_301),  -->
+                                <!--    'column_alias': 'bookers'}                             -->
+                                <!-- col50 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_302),  -->
+                                <!--    'column_alias': 'average_booking_value'}               -->
+                                <!-- col51 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_303),  -->
+                                <!--    'column_alias': 'referred_bookings'}                   -->
+                                <!-- col52 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_304),  -->
+                                <!--    'column_alias': 'median_booking_value'}                -->
+                                <!-- col53 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_305),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                   -->
+                                <!-- col54 =                                                   -->
+                                <!--   {'class': 'SqlSelectColumn',                            -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_306),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                                <!-- col55 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_307),        -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col56 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_308),      -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectStatementNode>
+                                    <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                    <!-- node_id = ss_10001 -->
+                                    <!-- col0 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                    <!--    'column_alias': 'bookings'}                                 -->
+                                    <!-- col1 =                                                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                    <!-- col2 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                    <!--    'column_alias': 'booking_value'}                         -->
+                                    <!-- col3 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                    <!--    'column_alias': 'max_booking_value'}                     -->
+                                    <!-- col4 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                    <!--    'column_alias': 'min_booking_value'}                     -->
+                                    <!-- col5 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                    <!--    'column_alias': 'bookers'}                               -->
+                                    <!-- col6 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                    <!--    'column_alias': 'average_booking_value'}                 -->
+                                    <!-- col7 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                    <!--    'column_alias': 'booking_payments'}                      -->
+                                    <!-- col8 =                                                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                    <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                    <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                    <!-- col9 =                                                      -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                    <!--    'column_alias': 'median_booking_value'}                  -->
+                                    <!-- col10 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                    <!--    'column_alias': 'booking_value_p99'}                     -->
+                                    <!-- col11 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                    <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                    <!-- col12 =                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                  -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                    <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                    <!-- col13 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                    <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                    <!-- col14 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                    <!--    'column_alias': 'is_instant'}                            -->
+                                    <!-- col15 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                    <!--    'column_alias': 'ds'}                                    -->
+                                    <!-- col16 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                    <!--    'column_alias': 'ds__week'}                        -->
+                                    <!-- col17 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                    <!--    'column_alias': 'ds__month'}                       -->
+                                    <!-- col18 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                    <!--    'column_alias': 'ds__quarter'}                     -->
+                                    <!-- col19 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                    <!--    'column_alias': 'ds__year'}                        -->
+                                    <!-- col20 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                    <!--    'column_alias': 'ds_partitioned'}                        -->
+                                    <!-- col21 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                    <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                    <!-- col22 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                    <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                    <!-- col23 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                    <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                    <!-- col24 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                    <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                    <!-- col25 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                    <!--    'column_alias': 'booking_paid_at'}                       -->
+                                    <!-- col26 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                    <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                    <!-- col27 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                    <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                    <!-- col28 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                    <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                    <!-- col29 =                                               -->
+                                    <!--   {'class': 'SqlSelectColumn',                        -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                    <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                    <!-- col30 =                                                             -->
+                                    <!--   {'class': 'SqlSelectColumn',                                      -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                    <!-- col31 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                    <!-- col32 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                    <!-- col33 =                                                            -->
+                                    <!--   {'class': 'SqlSelectColumn',                                     -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                    <!-- col34 =                                                              -->
+                                    <!--   {'class': 'SqlSelectColumn',                                       -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                    <!-- col35 =                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                    <!-- col36 =                                                                 -->
+                                    <!--   {'class': 'SqlSelectColumn',                                          -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                    <!-- col37 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                    <!-- col38 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                    <!-- col39 =                                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                    <!-- col40 =                                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                    <!-- col41 =                                                                  -->
+                                    <!--   {'class': 'SqlSelectColumn',                                           -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                    <!-- col42 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                    <!-- col43 =                                                                         -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                    <!-- col44 =                                                                           -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                    <!-- col45 =                                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                    <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                    <!-- col46 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                    <!--    'column_alias': 'listing'}                               -->
+                                    <!-- col47 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                    <!--    'column_alias': 'guest'}                                 -->
+                                    <!-- col48 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                    <!--    'column_alias': 'host'}                                  -->
+                                    <!-- col49 =                                                     -->
+                                    <!--   {'class': 'SqlSelectColumn',                              -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                    <!-- col50 =                                                          -->
+                                    <!--   {'class': 'SqlSelectColumn',                                   -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                    <!-- col51 =                                                        -->
+                                    <!--   {'class': 'SqlSelectColumn',                                 -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                    <!-- col52 =                                                       -->
+                                    <!--   {'class': 'SqlSelectColumn',                                -->
+                                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                    <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                    <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                    <!-- where = None -->
+                                    <SqlSelectQueryFromClauseNode>
+                                        <!-- description = Read From a Select Query -->
+                                        <!-- node_id = tfc_10001 -->
+                                    </SqlSelectQueryFromClauseNode>
+                                </SqlSelectStatementNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+        </SqlSelectStatementNode>
+    </SqlSelectStatementNode>
+</SqlQueryPlan>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_one_input_metric__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_derived_metric_with_one_input_metric__plan0.xml
@@ -1,0 +1,555 @@
+<SqlQueryPlan>
+    <SqlSelectStatementNode>
+        <!-- description = Compute Metrics via Expressions -->
+        <!-- node_id = ss_13 -->
+        <!-- col0 =                                                    -->
+        <!--   {'class': 'SqlSelectColumn',                            -->
+        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_296),  -->
+        <!--    'column_alias': 'metric_time'}                         -->
+        <!-- col1 =                                                                       -->
+        <!--   {'class': 'SqlSelectColumn',                                               -->
+        <!--    'expr': SqlStringExpression(node_id=str_0 sql_expr=bookings_5_days_ago),  -->
+        <!--    'column_alias': 'bookings_5_day_lag'}                                     -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+        <!-- where = None -->
+        <SqlSelectStatementNode>
+            <!-- description = Join to Time Spine Dataset -->
+            <!-- node_id = ss_12 -->
+            <!-- col0 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_294),  -->
+            <!--    'column_alias': 'metric_time'}                         -->
+            <!-- col1 =                                                    -->
+            <!--   {'class': 'SqlSelectColumn',                            -->
+            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_295),  -->
+            <!--    'column_alias': 'bookings_5_days_ago'}                 -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- join_0 =                                                    -->
+            <!--   {'class': 'SqlJoinDescription',                           -->
+            <!--    'right_source': SqlSelectStatementNode(node_id=ss_10),   -->
+            <!--    'right_source_alias': 'subq_4',                          -->
+            <!--    'join_type': SqlJoinType.LEFT_OUTER,                     -->
+            <!--    'on_condition': SqlComparisonExpression(node_id=cmp_0)}  -->
+            <!-- where = None -->
+            <SqlSelectStatementNode>
+                <!-- description = Date Spine -->
+                <!-- node_id = ss_11 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_291),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                <!-- where = None -->
+                <SqlTableFromClauseNode>
+                    <!-- description = Read from ***************************.mf_time_spine -->
+                    <!-- node_id = tfc_0 -->
+                    <!-- table_id = ***************************.mf_time_spine -->
+                </SqlTableFromClauseNode>
+            </SqlSelectStatementNode>
+            <SqlSelectStatementNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = ss_10 -->
+                <!-- col0 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_289),  -->
+                <!--    'column_alias': 'metric_time'}                         -->
+                <!-- col1 =                                                    -->
+                <!--   {'class': 'SqlSelectColumn',                            -->
+                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_290),  -->
+                <!--    'column_alias': 'bookings_5_days_ago'}                 -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- where = None -->
+                <SqlSelectStatementNode>
+                    <!-- description = Aggregate Measures -->
+                    <!-- node_id = ss_9 -->
+                    <!-- col0 =                                                    -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- col1 =                                                                       -->
+                    <!--   {'class': 'SqlSelectColumn',                                               -->
+                    <!--    'expr': SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM),  -->
+                    <!--    'column_alias': 'bookings'}                                               -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- group_by0 =                                               -->
+                    <!--   {'class': 'SqlSelectColumn',                            -->
+                    <!--    'expr': SqlColumnReferenceExpression(node_id=cr_288),  -->
+                    <!--    'column_alias': 'metric_time'}                         -->
+                    <!-- where = None -->
+                    <SqlSelectStatementNode>
+                        <!-- description =                    -->
+                        <!--   Pass Only Elements:            -->
+                        <!--     ['bookings', 'metric_time']  -->
+                        <!-- node_id = ss_8 -->
+                        <!-- col0 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_286),  -->
+                        <!--    'column_alias': 'metric_time'}                         -->
+                        <!-- col1 =                                                    -->
+                        <!--   {'class': 'SqlSelectColumn',                            -->
+                        <!--    'expr': SqlColumnReferenceExpression(node_id=cr_285),  -->
+                        <!--    'column_alias': 'bookings'}                            -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- where = None -->
+                        <SqlSelectStatementNode>
+                            <!-- description = Metric Time Dimension 'ds' -->
+                            <!-- node_id = ss_7 -->
+                            <!-- col0 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_243),  -->
+                            <!--    'column_alias': 'ds'}                                  -->
+                            <!-- col1 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_244),  -->
+                            <!--    'column_alias': 'ds__week'}                            -->
+                            <!-- col2 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_245),  -->
+                            <!--    'column_alias': 'ds__month'}                           -->
+                            <!-- col3 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_246),  -->
+                            <!--    'column_alias': 'ds__quarter'}                         -->
+                            <!-- col4 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_247),  -->
+                            <!--    'column_alias': 'ds__year'}                            -->
+                            <!-- col5 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_248),  -->
+                            <!--    'column_alias': 'ds_partitioned'}                      -->
+                            <!-- col6 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_249),  -->
+                            <!--    'column_alias': 'ds_partitioned__week'}                -->
+                            <!-- col7 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_250),  -->
+                            <!--    'column_alias': 'ds_partitioned__month'}               -->
+                            <!-- col8 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_251),  -->
+                            <!--    'column_alias': 'ds_partitioned__quarter'}             -->
+                            <!-- col9 =                                                    -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_252),  -->
+                            <!--    'column_alias': 'ds_partitioned__year'}                -->
+                            <!-- col10 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_253),  -->
+                            <!--    'column_alias': 'booking_paid_at'}                     -->
+                            <!-- col11 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_254),  -->
+                            <!--    'column_alias': 'booking_paid_at__week'}               -->
+                            <!-- col12 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_255),  -->
+                            <!--    'column_alias': 'booking_paid_at__month'}              -->
+                            <!-- col13 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_256),  -->
+                            <!--    'column_alias': 'booking_paid_at__quarter'}            -->
+                            <!-- col14 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_257),  -->
+                            <!--    'column_alias': 'booking_paid_at__year'}               -->
+                            <!-- col15 =                                                     -->
+                            <!--   {'class': 'SqlSelectColumn',                              -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_258),    -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                            <!-- col16 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_259),          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                            <!-- col17 =                                                            -->
+                            <!--   {'class': 'SqlSelectColumn',                                     -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_260),           -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                            <!-- col18 =                                                              -->
+                            <!--   {'class': 'SqlSelectColumn',                                       -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_261),             -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                            <!-- col19 =                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_262),          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                            <!-- col20 =                                                                 -->
+                            <!--   {'class': 'SqlSelectColumn',                                          -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_263),                -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                            <!-- col21 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_264),                      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                            <!-- col22 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_265),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                            <!-- col23 =                                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_266),                         -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                            <!-- col24 =                                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_267),                      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                            <!-- col25 =                                                                  -->
+                            <!--   {'class': 'SqlSelectColumn',                                           -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_268),                 -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                            <!-- col26 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_269),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                            <!-- col27 =                                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_270),                        -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                            <!-- col28 =                                                                           -->
+                            <!--   {'class': 'SqlSelectColumn',                                                    -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_271),                          -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                            <!-- col29 =                                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_272),                       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                            <!-- col30 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_273),  -->
+                            <!--    'column_alias': 'metric_time'}                         -->
+                            <!-- col31 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_274),  -->
+                            <!--    'column_alias': 'metric_time__week'}                   -->
+                            <!-- col32 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_275),  -->
+                            <!--    'column_alias': 'metric_time__month'}                  -->
+                            <!-- col33 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_276),  -->
+                            <!--    'column_alias': 'metric_time__quarter'}                -->
+                            <!-- col34 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_277),  -->
+                            <!--    'column_alias': 'metric_time__year'}                   -->
+                            <!-- col35 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_278),  -->
+                            <!--    'column_alias': 'listing'}                             -->
+                            <!-- col36 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_279),  -->
+                            <!--    'column_alias': 'guest'}                               -->
+                            <!-- col37 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_280),  -->
+                            <!--    'column_alias': 'host'}                                -->
+                            <!-- col38 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_281),  -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}    -->
+                            <!-- col39 =                                                          -->
+                            <!--   {'class': 'SqlSelectColumn',                                   -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_282),         -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                            <!-- col40 =                                                        -->
+                            <!--   {'class': 'SqlSelectColumn',                                 -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_283),       -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                            <!-- col41 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_284),      -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                            <!-- col42 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_241),  -->
+                            <!--    'column_alias': 'is_instant'}                          -->
+                            <!-- col43 =                                                             -->
+                            <!--   {'class': 'SqlSelectColumn',                                      -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_242),            -->
+                            <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                            <!-- col44 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_228),  -->
+                            <!--    'column_alias': 'bookings'}                            -->
+                            <!-- col45 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_229),  -->
+                            <!--    'column_alias': 'instant_bookings'}                    -->
+                            <!-- col46 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_230),  -->
+                            <!--    'column_alias': 'booking_value'}                       -->
+                            <!-- col47 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_231),  -->
+                            <!--    'column_alias': 'max_booking_value'}                   -->
+                            <!-- col48 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_232),  -->
+                            <!--    'column_alias': 'min_booking_value'}                   -->
+                            <!-- col49 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_233),  -->
+                            <!--    'column_alias': 'bookers'}                             -->
+                            <!-- col50 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_234),  -->
+                            <!--    'column_alias': 'average_booking_value'}               -->
+                            <!-- col51 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_235),  -->
+                            <!--    'column_alias': 'referred_bookings'}                   -->
+                            <!-- col52 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_236),  -->
+                            <!--    'column_alias': 'median_booking_value'}                -->
+                            <!-- col53 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_237),  -->
+                            <!--    'column_alias': 'booking_value_p99'}                   -->
+                            <!-- col54 =                                                   -->
+                            <!--   {'class': 'SqlSelectColumn',                            -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_238),  -->
+                            <!--    'column_alias': 'discrete_booking_value_p99'}          -->
+                            <!-- col55 =                                                         -->
+                            <!--   {'class': 'SqlSelectColumn',                                  -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_239),        -->
+                            <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                            <!-- col56 =                                                       -->
+                            <!--   {'class': 'SqlSelectColumn',                                -->
+                            <!--    'expr': SqlColumnReferenceExpression(node_id=cr_240),      -->
+                            <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10001) -->
+                            <!-- where = None -->
+                            <SqlSelectStatementNode>
+                                <!-- description = Read Elements From Data Source 'bookings_source' -->
+                                <!-- node_id = ss_10001 -->
+                                <!-- col0 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10000 sql_expr=1),  -->
+                                <!--    'column_alias': 'bookings'}                                 -->
+                                <!-- col1 =                                                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                      -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10001 sql_expr=CASE WHEN is_instant THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'instant_bookings'}                                                              -->
+                                <!-- col2 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10010),  -->
+                                <!--    'column_alias': 'booking_value'}                         -->
+                                <!-- col3 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10011),  -->
+                                <!--    'column_alias': 'max_booking_value'}                     -->
+                                <!-- col4 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10012),  -->
+                                <!--    'column_alias': 'min_booking_value'}                     -->
+                                <!-- col5 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10013),  -->
+                                <!--    'column_alias': 'bookers'}                               -->
+                                <!-- col6 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10014),  -->
+                                <!--    'column_alias': 'average_booking_value'}                 -->
+                                <!-- col7 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10015),  -->
+                                <!--    'column_alias': 'booking_payments'}                      -->
+                                <!-- col8 =                                                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                                                   -->
+                                <!--    'expr': SqlStringExpression(node_id=str_10002 sql_expr=CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END),  -->
+                                <!--    'column_alias': 'referred_bookings'}                                                                          -->
+                                <!-- col9 =                                                      -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10016),  -->
+                                <!--    'column_alias': 'median_booking_value'}                  -->
+                                <!-- col10 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10017),  -->
+                                <!--    'column_alias': 'booking_value_p99'}                     -->
+                                <!-- col11 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10018),  -->
+                                <!--    'column_alias': 'discrete_booking_value_p99'}            -->
+                                <!-- col12 =                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                  -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10019),      -->
+                                <!--    'column_alias': 'approximate_continuous_booking_value_p99'}  -->
+                                <!-- col13 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10020),    -->
+                                <!--    'column_alias': 'approximate_discrete_booking_value_p99'}  -->
+                                <!-- col14 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10021),  -->
+                                <!--    'column_alias': 'is_instant'}                            -->
+                                <!-- col15 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10022),  -->
+                                <!--    'column_alias': 'ds'}                                    -->
+                                <!-- col16 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10004),  -->
+                                <!--    'column_alias': 'ds__week'}                        -->
+                                <!-- col17 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10005),  -->
+                                <!--    'column_alias': 'ds__month'}                       -->
+                                <!-- col18 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10006),  -->
+                                <!--    'column_alias': 'ds__quarter'}                     -->
+                                <!-- col19 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10007),  -->
+                                <!--    'column_alias': 'ds__year'}                        -->
+                                <!-- col20 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10027),  -->
+                                <!--    'column_alias': 'ds_partitioned'}                        -->
+                                <!-- col21 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10008),  -->
+                                <!--    'column_alias': 'ds_partitioned__week'}            -->
+                                <!-- col22 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10009),  -->
+                                <!--    'column_alias': 'ds_partitioned__month'}           -->
+                                <!-- col23 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10010),  -->
+                                <!--    'column_alias': 'ds_partitioned__quarter'}         -->
+                                <!-- col24 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10011),  -->
+                                <!--    'column_alias': 'ds_partitioned__year'}            -->
+                                <!-- col25 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10032),  -->
+                                <!--    'column_alias': 'booking_paid_at'}                       -->
+                                <!-- col26 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10012),  -->
+                                <!--    'column_alias': 'booking_paid_at__week'}           -->
+                                <!-- col27 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10013),  -->
+                                <!--    'column_alias': 'booking_paid_at__month'}          -->
+                                <!-- col28 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10014),  -->
+                                <!--    'column_alias': 'booking_paid_at__quarter'}        -->
+                                <!-- col29 =                                               -->
+                                <!--   {'class': 'SqlSelectColumn',                        -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10015),  -->
+                                <!--    'column_alias': 'booking_paid_at__year'}           -->
+                                <!-- col30 =                                                             -->
+                                <!--   {'class': 'SqlSelectColumn',                                      -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10037),          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__is_instant'}  -->
+                                <!-- col31 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10038),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds'}  -->
+                                <!-- col32 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10016),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__week'}  -->
+                                <!-- col33 =                                                            -->
+                                <!--   {'class': 'SqlSelectColumn',                                     -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10017),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__month'}  -->
+                                <!-- col34 =                                                              -->
+                                <!--   {'class': 'SqlSelectColumn',                                       -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10018),                 -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__quarter'}  -->
+                                <!-- col35 =                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10019),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds__year'}  -->
+                                <!-- col36 =                                                                 -->
+                                <!--   {'class': 'SqlSelectColumn',                                          -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10043),              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned'}  -->
+                                <!-- col37 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10020),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__week'}  -->
+                                <!-- col38 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10021),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__month'}  -->
+                                <!-- col39 =                                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                                   -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10022),                             -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__quarter'}  -->
+                                <!-- col40 =                                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                                -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10023),                          -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__ds_partitioned__year'}  -->
+                                <!-- col41 =                                                                  -->
+                                <!--   {'class': 'SqlSelectColumn',                                           -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10048),               -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at'}  -->
+                                <!-- col42 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10024),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__week'}  -->
+                                <!-- col43 =                                                                         -->
+                                <!--   {'class': 'SqlSelectColumn',                                                  -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10025),                            -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__month'}  -->
+                                <!-- col44 =                                                                           -->
+                                <!--   {'class': 'SqlSelectColumn',                                                    -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10026),                              -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__quarter'}  -->
+                                <!-- col45 =                                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                                 -->
+                                <!--    'expr': SqlDateTruncExpression(node_id=dt_10027),                           -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__booking_paid_at__year'}  -->
+                                <!-- col46 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10053),  -->
+                                <!--    'column_alias': 'listing'}                               -->
+                                <!-- col47 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10054),  -->
+                                <!--    'column_alias': 'guest'}                                 -->
+                                <!-- col48 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10055),  -->
+                                <!--    'column_alias': 'host'}                                  -->
+                                <!-- col49 =                                                     -->
+                                <!--   {'class': 'SqlSelectColumn',                              -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10056),  -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph'}      -->
+                                <!-- col50 =                                                          -->
+                                <!--   {'class': 'SqlSelectColumn',                                   -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10057),       -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__listing'}  -->
+                                <!-- col51 =                                                        -->
+                                <!--   {'class': 'SqlSelectColumn',                                 -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10058),     -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__guest'}  -->
+                                <!-- col52 =                                                       -->
+                                <!--   {'class': 'SqlSelectColumn',                                -->
+                                <!--    'expr': SqlColumnReferenceExpression(node_id=cr_10059),    -->
+                                <!--    'column_alias': 'create_a_cycle_in_the_join_graph__host'}  -->
+                                <!-- from_source = SqlSelectQueryFromClauseNode(node_id=tfc_10001) -->
+                                <!-- where = None -->
+                                <SqlSelectQueryFromClauseNode>
+                                    <!-- description = Read From a Select Query -->
+                                    <!-- node_id = tfc_10001 -->
+                                </SqlSelectQueryFromClauseNode>
+                            </SqlSelectStatementNode>
+                        </SqlSelectStatementNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+        </SqlSelectStatementNode>
+    </SqlSelectStatementNode>
+</SqlQueryPlan>


### PR DESCRIPTION
Enable users to set a time offset for input metrics within a derived metric, specifying either an offset_window or an offset_to_grain. Examples for what these metrics should look like are available [here](https://www.notion.so/transformdata/Derived-Metric-Offset-f235a0aa4aab4100b42b7aa4afa87a1e).