### PR TITLE
Add Databricks SQL Warehouse runtime to sql engine tests

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -107,9 +107,9 @@ jobs:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
 
-  databricks-tests:
+  databricks-cluster-tests:
     environment: DW_INTEGRATION_TESTS
-    name: Databricks Tests
+    name: Databricks Cluster Tests
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
     runs-on: ubuntu-latest
     steps:
@@ -137,7 +137,40 @@ jobs:
       - name: Run MetricFlow unit tests with Databricks configs
         run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
         env:
-          MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_URL }}
+          MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_CLUSTER_URL }}
+          MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
+
+  databricks-sql-warehouse-tests:
+    environment: DW_INTEGRATION_TESTS
+    name: Databricks SQL Warehouse Tests
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run_mf_sql_engine_tests' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.pythonLocation }}
+            ~/.cache/pypoetry
+          key: ${{ env.pythonLocation }}-${{ hashFiles('poetry.lock') }}-ubuntu-latest-22.04
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Deps
+        run: cd metricflow && poetry install
+
+      - name: Run MetricFlow unit tests with Databricks configs
+        run: poetry run pytest metricflow/test/ --ignore=metricflow/test/model/dbt_cloud_parsing
+        env:
+          MF_SQL_ENGINE_URL: ${{ secrets.MF_DATABRICKS_SQL_WAREHOUSE_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_DATABRICKS_PWD }}
 
   postgres-tests:


### PR DESCRIPTION
The existing SQL engine tests only exercised our Databricks
engine implementations as SQL queries against a Databricks
cluster configuration. However, it's more common for analytics
query workloads to target a Databricks SQL warehouse configuration.

Since we support both, we should test both.
