### PR TITLE
Bug fix: error for restricted granularity

### DIFF
--- a/metricflow/test/fixtures/model_yamls/extended_date_model/metrics/bookings_cumulative.yaml
+++ b/metricflow/test/fixtures/model_yamls/extended_date_model/metrics/bookings_cumulative.yaml
@@ -1,0 +1,10 @@
+metric:
+  name: "weekly_bookers"
+  description: "weekly_bookers"
+  owners:
+    - support@transformdata.io
+  type: cumulative
+  type_params:
+    measures:
+      - bookings
+    window: 7 days

--- a/metricflow/test/time/test_time_granularity_solver.py
+++ b/metricflow/test/time/test_time_granularity_solver.py
@@ -140,6 +140,19 @@ def test_granularity_solution_for_day_and_month_metrics(  # noqa: D
     ) == {PARTIAL_PTD_SPEC: MTD_SPEC_MONTH}
 
 
+def test_granularity_error_for_cumulative_metric(  # noqa: D
+    time_granularity_solver: TimeGranularitySolver,
+) -> None:
+    with pytest.raises(RequestTimeGranularityException):
+        time_granularity_solver.validate_time_granularity(
+            metric_references=[
+                MetricReference(element_name="weekly_bookers"),
+                MetricReference(element_name="bookings_monthly"),
+            ],
+            time_dimension_specs=[MTD_SPEC_MONTH],
+        )
+
+
 def test_time_granularity_parameter(  # noqa: D
     time_granularity_solver: TimeGranularitySolver,
 ) -> None:

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -107,7 +107,7 @@ class TimeGranularitySolver:
         named 'ds' with granularity DAY.
 
         The 'monthly_bookings' measure is in defined in the 'fct_bookings_monthly' data source. 'fct_bookings_monthly'
-        has a local time dimension named 'ds' with granularity DAY.
+        has a local time dimension named 'ds' with granularity MONTH.
 
         Then this would return [DAY, MONTH].
         """

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -156,14 +156,16 @@ class TimeGranularitySolver:
                 # If there is a cumulative metric, granularity changes aren't supported.
                 for metric_reference in metric_references:
                     metric = self._semantic_model.metric_semantics.get_metric(metric_reference)
-                    if (
-                        metric.type == MetricType.CUMULATIVE
-                        and time_dimension_spec.time_granularity != min_granularity_for_querying
-                    ):
-                        raise RequestTimeGranularityException(
-                            f"For querying cumulative metric '{metric_reference.element_name}', the granularity of "
-                            f"'{time_dimension_spec.qualified_name}' must be {min_granularity_for_querying.name}"
+                    if metric.type == MetricType.CUMULATIVE:
+                        _, only_queryable_granularity = self.local_dimension_granularity_range(
+                            metric_references=[metric_reference],
+                            local_time_dimension_reference=time_dimension_spec.reference,
                         )
+                        if time_dimension_spec.time_granularity != only_queryable_granularity:
+                            raise RequestTimeGranularityException(
+                                f"For querying cumulative metric '{metric_reference.element_name}', the granularity of "
+                                f"'{time_dimension_spec.qualified_name}' must be {only_queryable_granularity.name}"
+                            )
 
         # TODO: Validate non-local time dimension granularities here instead of during plan building.
 

--- a/metricflow/time/time_granularity_solver.py
+++ b/metricflow/time/time_granularity_solver.py
@@ -153,7 +153,8 @@ class TimeGranularitySolver:
                         f"{min_granularity_for_querying}. Got {time_dimension_spec}"
                     )
 
-                # If there is a cumulative metric, granularity changes aren't supported.
+                # If there is a cumulative metric, granularity changes aren't supported. We need to check the granularity
+                # specified in the configs for the cumulative metric alone, since `min_granularity_for_querying` may not be supported.
                 for metric_reference in metric_references:
                     metric = self._semantic_model.metric_semantics.get_metric(metric_reference)
                     if metric.type == MetricType.CUMULATIVE:


### PR DESCRIPTION
Previously, a bug was allowing some queries to succeed for multiple metrics with no overlapping granularities. This fixes that.

Example:
`bookings_cumulative` only supports `day` granularity
`bookings_monthly` only supports `month` granularity or larger
Querying for `bookings_cumulative` and `bookings_monthly` together with a granularity of `month` would succeed, though we would expect it to fail since querying `bookings_cumulative` alone with `month` granularity would fail.