### PR TITLE
Add workflow to measure validation test duration on PRs and main

### DIFF
--- a/.github/workflows/ci-validation-duration.yaml
+++ b/.github/workflows/ci-validation-duration.yaml
@@ -1,0 +1,24 @@
+name: Measure Validation Test Duration
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validation-tests:
+    name: Run validation tests and measure duration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Deps
+        run: cd metricflow && poetry install
+
+      - name: Run Validation Tests
+        run: poetry run pytest  --durations=0 metricflow/test/model/validations/


### PR DESCRIPTION
Chatted with Marco offline and he suggested a workflow be added for test runs to avoid local caching/pytest artifacts interfering with getting a stable read on what the proper baseline is for tests (after I was playing around with a local branch that changed our SQL parser and then completely changed the test duration baseline).