### PR TITLE
Clean Up Logging indents and Bind Parameter Logging

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, List, Sequence
@@ -33,6 +32,7 @@ from metricflow.errors.errors import ExecutionException, MaterializationNotFound
 from metricflow.execution.execution_plan import ExecutionPlan, SqlQuery
 from metricflow.execution.execution_plan_to_text import execution_plan_to_text
 from metricflow.execution.executor import SequentialPlanExecutor
+from metricflow.logging.formatting import indent_log_line
 from metricflow.model.semantic_model import SemanticModel
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.object_utils import pformat_big_objects, random_id
@@ -274,8 +274,6 @@ class AbstractMetricFlowEngine(ABC):
 class MetricFlowEngine(AbstractMetricFlowEngine):
     """Main entry point for queries."""
 
-    _LOGGING_INDENT = "   "
-
     @staticmethod
     def from_config(handler: YamlFileHandler) -> MetricFlowEngine:
         """Initialize MetricFlowEngine via yaml config file."""
@@ -398,10 +396,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def query(self, mf_request: MetricFlowQueryRequest) -> MetricFlowQueryResult:  # noqa: D
-        logger.info(
-            f"Starting query request:\n"
-            f"{textwrap.indent(pformat_big_objects(mf_request), prefix=MetricFlowEngine._LOGGING_INDENT)}"
-        )
+        logger.info(f"Starting query request:\n" f"{indent_log_line(pformat_big_objects(mf_request))}")
         explain_result = self._create_execution_plan(mf_request)
         execution_plan = explain_result.execution_plan
 

--- a/metricflow/logging/formatting.py
+++ b/metricflow/logging/formatting.py
@@ -1,0 +1,5 @@
+import textwrap
+
+
+def indent_log_line(message: str, indent_level: int = 1) -> str:  # noqa: D
+    return textwrap.indent(message, prefix="    " * indent_level)

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -69,9 +69,6 @@ class MetricFlowQueryParser:
     "user_id__country" is the "country" dimension that is retrieved by joining "user_id" to the measure data source.
     """
 
-    # Prefix to use for indents when logging.
-    _INDENT_PREFIX = "  "
-
     def __init__(  # noqa: D
         self,
         model: SemanticModel,


### PR DESCRIPTION
This PR cleans up how logging indents are generated and also formats the bind parameters so they are more legible when there are many parameters.