### PR TITLE
Improve Terminology and Implementation of `TransformModel`

### DIFF
--- a/metricflow/model/parsing/dbt_cloud_to_model.py
+++ b/metricflow/model/parsing/dbt_cloud_to_model.py
@@ -40,8 +40,7 @@ def get_dbt_cloud_metrics(auth: str, job_id: str) -> list[MetricNode]:
 def parse_dbt_cloud_metrics_to_model(dbt_metrics: List[MetricNode]) -> ModelBuildResult:
     """Builds a UserConfiguredModel from a list of dbt cloud MetricNodes"""
     build_result = DbtConverter().convert(dbt_metrics=tuple(dbt_metrics))
-    transformed_model = ModelTransformer.pre_validation_transform_model(model=build_result.model)
-    transformed_model = ModelTransformer.post_validation_transform_model(model=transformed_model)
+    transformed_model = ModelTransformer.transform(model=build_result.model)
     return ModelBuildResult(model=transformed_model, issues=build_result.issues)
 
 

--- a/metricflow/model/parsing/dbt_dir_to_model.py
+++ b/metricflow/model/parsing/dbt_dir_to_model.py
@@ -40,6 +40,5 @@ def parse_dbt_project_to_model(
     """Parse dbt model files in the given directory to a UserConfiguredModel."""
     manifest = get_dbt_project_manifest(directory=directory, profile=profile, target=target)
     build_result = DbtManifestTransformer(manifest=manifest).build_user_configured_model()
-    transformed_model = ModelTransformer.pre_validation_transform_model(model=build_result.model)
-    transformed_model = ModelTransformer.post_validation_transform_model(model=transformed_model)
+    transformed_model = ModelTransformer.transform(model=build_result.model)
     return ModelBuildResult(model=transformed_model, issues=build_result.issues)

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -183,10 +183,10 @@ def parse_yaml_files_to_validation_ready_model(
     build_issues = build_result.issues
     try:
         if apply_pre_transformations:
-            model = ModelTransformer.pre_validation_transform_model(model)
+            model = ModelTransformer.transform(model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,))
 
         if apply_post_transformations:
-            model = ModelTransformer.post_validation_transform_model(model)
+            model = ModelTransformer.transform(model, ordered_rule_sequences=(ModelTransformer.SECONDARY_RULES,))
     except Exception as e:
         transformation_issue_results = ModelValidationResults(errors=[ValidationError(message=str(e))])
         build_issues = ModelValidationResults.merge([build_issues, transformation_issue_results])

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -104,8 +104,7 @@ def collect_yaml_config_file_paths(directory: str) -> List[str]:
 def parse_directory_of_yaml_files_to_model(
     directory: str,
     template_mapping: Optional[Dict[str, str]] = None,
-    apply_pre_transformations: Optional[bool] = True,
-    apply_post_transformations: Optional[bool] = True,
+    apply_transformations: Optional[bool] = True,
     raise_issues_as_exceptions: bool = True,
 ) -> ModelBuildResult:
     """Parse files in the given directory to a UserConfiguredModel.
@@ -116,8 +115,7 @@ def parse_directory_of_yaml_files_to_model(
     return parse_yaml_file_paths_to_model(
         file_paths=file_paths,
         template_mapping=template_mapping,
-        apply_pre_transformations=apply_pre_transformations,
-        apply_post_transformations=apply_post_transformations,
+        apply_transformations=apply_transformations,
         raise_issues_as_exceptions=raise_issues_as_exceptions,
     )
 
@@ -125,8 +123,7 @@ def parse_directory_of_yaml_files_to_model(
 def parse_yaml_file_paths_to_model(
     file_paths: List[str],
     template_mapping: Optional[Dict[str, str]] = None,
-    apply_pre_transformations: Optional[bool] = True,
-    apply_post_transformations: Optional[bool] = True,
+    apply_transformations: Optional[bool] = True,
     raise_issues_as_exceptions: bool = True,
 ) -> ModelBuildResult:
     """Parse files the given list of file paths to a UserConfiguredModel.
@@ -157,16 +154,14 @@ def parse_yaml_file_paths_to_model(
 
     return parse_yaml_files_to_validation_ready_model(
         yaml_config_files=yaml_config_files,
-        apply_pre_transformations=apply_pre_transformations,
-        apply_post_transformations=apply_post_transformations,
+        apply_transformations=apply_transformations,
         raise_issues_as_exceptions=raise_issues_as_exceptions,
     )
 
 
 def parse_yaml_files_to_validation_ready_model(
     yaml_config_files: List[YamlConfigFile],
-    apply_pre_transformations: Optional[bool] = True,
-    apply_post_transformations: Optional[bool] = True,
+    apply_transformations: Optional[bool] = True,
     raise_issues_as_exceptions: bool = True,
 ) -> ModelBuildResult:
     """Parse and transform the given set of in-memory YamlConfigFiles to a UserConfigured model
@@ -182,11 +177,8 @@ def parse_yaml_files_to_validation_ready_model(
 
     build_issues = build_result.issues
     try:
-        if apply_pre_transformations:
-            model = ModelTransformer.transform(model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,))
-
-        if apply_post_transformations:
-            model = ModelTransformer.transform(model, ordered_rule_sequences=(ModelTransformer.SECONDARY_RULES,))
+        if apply_transformations:
+            model = ModelTransformer.transform(model)
     except Exception as e:
         transformation_issue_results = ModelValidationResults(errors=[ValidationError(message=str(e))])
         build_issues = ModelValidationResults.merge([build_issues, transformation_issue_results])

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -253,7 +253,7 @@ def simple_user_configured_model(template_mapping: Dict[str, str]) -> UserConfig
 
 
 @pytest.fixture(scope="session")
-def simple_model__pre_transforms(template_mapping: Dict[str, str]) -> UserConfiguredModel:
+def simple_model__with_primary_transforms(template_mapping: Dict[str, str]) -> UserConfiguredModel:
     """Model used for tests pre-transformations."""
 
     model_build_result = parse_directory_of_yaml_files_to_model(

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -11,6 +11,7 @@ import pytest
 from metricflow.dataflow.builder.source_node import SourceNodeBuilder
 from metricflow.dataflow.dataflow_plan import ReadSqlSourceNode, BaseOutput
 from metricflow.dataset.convert_data_source import DataSourceToDataSetConverter
+from metricflow.model.model_transformer import ModelTransformer
 from metricflow.model.model_validator import ModelValidator
 from metricflow.model.objects.data_source import DataSource
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -258,10 +259,12 @@ def simple_model__pre_transforms(template_mapping: Dict[str, str]) -> UserConfig
     model_build_result = parse_directory_of_yaml_files_to_model(
         os.path.join(os.path.dirname(__file__), "model_yamls/simple_model"),
         template_mapping=template_mapping,
-        apply_pre_transformations=True,
-        apply_post_transformations=False,
+        apply_transformations=False,
     )
-    return model_build_result.model
+    transformed_model = ModelTransformer.transform(
+        model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
+    )
+    return transformed_model
 
 
 @pytest.fixture(scope="session")

--- a/metricflow/test/model/transformations/test_configurable_transform_rules.py
+++ b/metricflow/test/model/transformations/test_configurable_transform_rules.py
@@ -20,13 +20,7 @@ def test_can_configure_model_transform_rules(simple_model__pre_transforms: UserC
     pre_model = simple_model__pre_transforms
     assert not all(len(x.name) == 3 for x in pre_model.data_sources)
 
-    # Confirms that a custom transformation works for pre-validation transform
-    pre_model = ModelTransformer.pre_validation_transform_model(pre_model, rules=[SliceNamesRule()])
-    assert all(len(x.name) == 3 for x in pre_model.data_sources)
-
-    post_model = simple_model__pre_transforms
-    assert not all(len(x.name) == 3 for x in post_model.data_sources)
-
-    # Confirms that a custom transformation works for post-validation transform
-    post_model = ModelTransformer.post_validation_transform_model(post_model, rules=[SliceNamesRule()])
-    assert all(len(x.name) == 3 for x in post_model.data_sources)
+    # Confirms that a custom transformation works `for ModelTransformer.transform`
+    rules = [SliceNamesRule()]
+    transformed_model = ModelTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
+    assert all(len(x.name) == 3 for x in transformed_model.data_sources)

--- a/metricflow/test/model/transformations/test_configurable_transform_rules.py
+++ b/metricflow/test/model/transformations/test_configurable_transform_rules.py
@@ -16,8 +16,10 @@ class SliceNamesRule(ModelTransformRule):
         return model
 
 
-def test_can_configure_model_transform_rules(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    pre_model = simple_model__pre_transforms
+def test_can_configure_model_transform_rules(  # noqa: D
+    simple_model__with_primary_transforms: UserConfiguredModel,
+) -> None:
+    pre_model = simple_model__with_primary_transforms
     assert not all(len(x.name) == 3 for x in pre_model.data_sources)
 
     # Confirms that a custom transformation works `for ModelTransformer.transform`

--- a/metricflow/test/model/validations/test_common_identifiers.py
+++ b/metricflow/test/model/validations/test_common_identifiers.py
@@ -12,8 +12,8 @@ from metricflow.test.test_utils import find_data_source_with
 
 
 @pytest.mark.skip("TODO: re-enforce after validations improvements")
-def test_lonely_identifier_raises_issue(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    model = copy.deepcopy(simple_model__pre_transforms)
+def test_lonely_identifier_raises_issue(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    model = copy.deepcopy(simple_model__with_primary_transforms)
     lonely_identifier_name = "hi_im_lonely"
 
     func: Callable[[DataSource], bool] = lambda data_source: len(data_source.identifiers) > 0

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -8,9 +8,11 @@ from metricflow.test.model.validations.helpers import materialization_with_guara
 from metricflow.test.test_utils import model_with_materialization
 
 
-def test_can_configure_model_validator_rules(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_can_configure_model_validator_rules(  # noqa: D
+    simple_model__with_primary_transforms: UserConfiguredModel,
+) -> None:
     model = model_with_materialization(
-        simple_model__pre_transforms,
+        simple_model__with_primary_transforms,
         [
             materialization_with_guaranteed_meta(
                 name="foobar",

--- a/metricflow/test/model/validations/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/validations/test_data_warehouse_tasks.py
@@ -280,8 +280,7 @@ def test_validate_metrics(  # noqa: D
     )
     model.data_sources[0].measures = new_measures
     model.metrics = []
-    model = ModelTransformer.pre_validation_transform_model(model)
-    model = ModelTransformer.post_validation_transform_model(model)
+    model = ModelTransformer.transform(model)
 
     # Validate new metric created by proxy causes an issue (because the column used doesn't exist)
     dw_validator = DataWarehouseModelValidator(

--- a/metricflow/test/model/validations/test_element_const.py
+++ b/metricflow/test/model/validations/test_element_const.py
@@ -15,8 +15,8 @@ def _categorical_dimensions(data_source: DataSource) -> Tuple[Dimension, ...]:
     return tuple(dim for dim in data_source.dimensions if dim.type == DimensionType.CATEGORICAL)
 
 
-def test_cross_element_names(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copy.deepcopy(simple_model__pre_transforms)
+def test_cross_element_names(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copy.deepcopy(simple_model__with_primary_transforms)
 
     # ensure we have a usable data source for the test
     usable_ds, usable_ds_index = find_data_source_with(

--- a/metricflow/test/model/validations/test_identifiers.py
+++ b/metricflow/test/model/validations/test_identifiers.py
@@ -33,10 +33,10 @@ from metricflow.time.time_granularity import TimeGranularity
 
 
 def test_data_source_cant_have_more_than_one_primary_identifier(
-    simple_model__pre_transforms: UserConfiguredModel,
+    simple_model__with_primary_transforms: UserConfiguredModel,
 ) -> None:  # noqa: D
     """Add an additional primary identifier to a data source and assert that it cannot have two"""
-    model = copy.deepcopy(simple_model__pre_transforms)
+    model = copy.deepcopy(simple_model__with_primary_transforms)
     func: Callable[[DataSource], bool] = lambda data_source: len(data_source.identifiers) > 1
 
     multiple_identifier_data_source, _ = find_data_source_with(model, func)
@@ -216,13 +216,13 @@ def test_composite_identifiers_ref_and_name() -> None:  # noqa:D
         )
 
 
-def test_mismatched_identifier(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_mismatched_identifier(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     """Testing two mismatched identifiers in two data sources
 
     Add two identifiers with mismatched sub-identifiers to two data sources in the model
     Ensure that our composite identifiers rule catches this incompatibility
     """
-    model = copy.deepcopy(simple_model__pre_transforms)
+    model = copy.deepcopy(simple_model__with_primary_transforms)
 
     bookings_source, _ = find_data_source_with(
         model=model,

--- a/metricflow/test/model/validations/test_materializations.py
+++ b/metricflow/test/model/validations/test_materializations.py
@@ -10,16 +10,16 @@ from metricflow.test.test_utils import (
 logger = logging.getLogger(__name__)
 
 
-def test_materialization_validation(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    ValidMaterializationRule.validate_model(simple_model__pre_transforms)
+def test_materialization_validation(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    ValidMaterializationRule.validate_model(simple_model__with_primary_transforms)
 
 
-def test_identifier(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_identifier(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     assert (
         len(
             ValidMaterializationRule.validate_model(
                 model_with_materialization(
-                    simple_model__pre_transforms,
+                    simple_model__with_primary_transforms,
                     [
                         materialization_with_guaranteed_meta(
                             name="foobar",
@@ -34,12 +34,12 @@ def test_identifier(simple_model__pre_transforms: UserConfiguredModel) -> None: 
     )
 
 
-def test_invalid_metric_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_invalid_metric_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     assert (
         len(
             ValidMaterializationRule.validate_model(
                 model_with_materialization(
-                    simple_model__pre_transforms,
+                    simple_model__with_primary_transforms,
                     [
                         materialization_with_guaranteed_meta(
                             name="foobar",
@@ -54,12 +54,12 @@ def test_invalid_metric_name(simple_model__pre_transforms: UserConfiguredModel) 
     )
 
 
-def test_invalid_dimension_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_invalid_dimension_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     assert (
         len(
             ValidMaterializationRule.validate_model(
                 model_with_materialization(
-                    simple_model__pre_transforms,
+                    simple_model__with_primary_transforms,
                     [
                         materialization_with_guaranteed_meta(
                             name="foobar",
@@ -74,13 +74,13 @@ def test_invalid_dimension_name(simple_model__pre_transforms: UserConfiguredMode
     )
 
 
-def test_missing_primary_time_dimension(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_missing_primary_time_dimension(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     """Materializations should have the primary time dimension listed as a dimension"""
     assert (
         len(
             ValidMaterializationRule.validate_model(
                 model_with_materialization(
-                    simple_model__pre_transforms,
+                    simple_model__with_primary_transforms,
                     [
                         materialization_with_guaranteed_meta(
                             name="foobar",
@@ -95,12 +95,12 @@ def test_missing_primary_time_dimension(simple_model__pre_transforms: UserConfig
     )
 
 
-def test_valid_time_granularity(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_valid_time_granularity(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     assert (
         len(
             ValidMaterializationRule.validate_model(
                 model_with_materialization(
-                    simple_model__pre_transforms,
+                    simple_model__with_primary_transforms,
                     [
                         materialization_with_guaranteed_meta(
                             name="materialization_test_case",
@@ -115,12 +115,12 @@ def test_valid_time_granularity(simple_model__pre_transforms: UserConfiguredMode
     )
 
 
-def test_invalid_time_granularity(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
+def test_invalid_time_granularity(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
     assert (
         len(
             ValidMaterializationRule.validate_model(
                 model_with_materialization(
-                    simple_model__pre_transforms,
+                    simple_model__with_primary_transforms,
                     [
                         materialization_with_guaranteed_meta(
                             name="materialization_test_case",

--- a/metricflow/test/model/validations/test_reserved_keywords.py
+++ b/metricflow/test/model/validations/test_reserved_keywords.py
@@ -11,17 +11,17 @@ def random_keyword() -> str:  # noqa: D
     return random.choice(RESERVED_KEYWORDS)
 
 
-def copied_model(simple_model__pre_transforms: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
-    return copy.deepcopy(simple_model__pre_transforms)
+def copied_model(simple_model__with_primary_transforms: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
+    return copy.deepcopy(simple_model__with_primary_transforms)
 
 
-def test_no_reserved_keywords(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    issues = ReservedKeywordsRule.validate_model(simple_model__pre_transforms)
+def test_no_reserved_keywords(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    issues = ReservedKeywordsRule.validate_model(simple_model__with_primary_transforms)
     assert len(issues) == 0
 
 
-def test_reserved_keywords_in_sql_table(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    model = copied_model(simple_model__pre_transforms)
+def test_reserved_keywords_in_sql_table(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    model = copied_model(simple_model__with_primary_transforms)
     (data_source_with_sql_table, _index) = find_data_source_with(
         model=model, function=lambda data_source: data_source.sql_table is not None
     )
@@ -32,8 +32,8 @@ def test_reserved_keywords_in_sql_table(simple_model__pre_transforms: UserConfig
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_dimensions(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    model = copied_model(simple_model__pre_transforms)
+def test_reserved_keywords_in_dimensions(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    model = copied_model(simple_model__with_primary_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.dimensions) > 0
     )
@@ -45,8 +45,8 @@ def test_reserved_keywords_in_dimensions(simple_model__pre_transforms: UserConfi
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_measures(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    model = copied_model(simple_model__pre_transforms)
+def test_reserved_keywords_in_measures(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    model = copied_model(simple_model__with_primary_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.measures) > 0
     )
@@ -58,8 +58,10 @@ def test_reserved_keywords_in_measures(simple_model__pre_transforms: UserConfigu
     assert issues[0].level == ValidationIssueLevel.ERROR
 
 
-def test_reserved_keywords_in_identifiers(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    model = copied_model(simple_model__pre_transforms)
+def test_reserved_keywords_in_identifiers(  # noqa: D
+    simple_model__with_primary_transforms: UserConfiguredModel,
+) -> None:
+    model = copied_model(simple_model__with_primary_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.identifiers) > 0
     )
@@ -73,9 +75,9 @@ def test_reserved_keywords_in_identifiers(simple_model__pre_transforms: UserConf
 
 
 def test_reserved_keywords_in_composite_identifiers(  # noqa: D
-    simple_model__pre_transforms: UserConfiguredModel,
+    simple_model__with_primary_transforms: UserConfiguredModel,
 ) -> None:
-    model = copied_model(simple_model__pre_transforms)
+    model = copied_model(simple_model__with_primary_transforms)
     (data_source, _index) = find_data_source_with(
         model=model, function=lambda data_source: len(data_source.identifiers) > 0
     )

--- a/metricflow/test/model/validations/test_unique_valid_name.py
+++ b/metricflow/test/model/validations/test_unique_valid_name.py
@@ -9,8 +9,8 @@ from metricflow.object_utils import flatten_nested_sequence
 from metricflow.test.test_utils import find_data_source_with
 
 
-def copied_model(simple_model__pre_transforms: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
-    return copy.deepcopy(simple_model__pre_transforms)
+def copied_model(simple_model__with_primary_transforms: UserConfiguredModel) -> UserConfiguredModel:  # noqa: D
+    return copy.deepcopy(simple_model__with_primary_transforms)
 
 
 """
@@ -27,8 +27,8 @@ def copied_model(simple_model__pre_transforms: UserConfiguredModel) -> UserConfi
 """
 
 
-def test_duplicate_data_source_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa: D
-    model = copied_model(simple_model__pre_transforms)
+def test_duplicate_data_source_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa: D
+    model = copied_model(simple_model__with_primary_transforms)
     duplicated_data_source = model.data_sources[0]
     model.data_sources.append(duplicated_data_source)
     with pytest.raises(
@@ -38,8 +38,8 @@ def test_duplicate_data_source_name(simple_model__pre_transforms: UserConfigured
         ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
-def test_duplicate_metric_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copied_model(simple_model__pre_transforms)
+def test_duplicate_metric_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(simple_model__with_primary_transforms)
     duplicated_metric = model.metrics[0]
     model.metrics.append(duplicated_metric)
     with pytest.raises(
@@ -49,8 +49,8 @@ def test_duplicate_metric_name(simple_model__pre_transforms: UserConfiguredModel
         ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
-def test_duplicate_materalization_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copied_model(simple_model__pre_transforms)
+def test_duplicate_materalization_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(simple_model__with_primary_transforms)
     duplicated_materialization = model.materializations[0]
     model.materializations.append(duplicated_materialization)
     with pytest.raises(
@@ -61,12 +61,12 @@ def test_duplicate_materalization_name(simple_model__pre_transforms: UserConfigu
 
 
 def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(
-    simple_model__pre_transforms: UserConfiguredModel,
+    simple_model__with_primary_transforms: UserConfiguredModel,
 ) -> None:  # noqa:D
-    metric_name = simple_model__pre_transforms.metrics[0].name
+    metric_name = simple_model__with_primary_transforms.metrics[0].name
 
-    model_data_source = copied_model(simple_model__pre_transforms)
-    model_materialization = copied_model(simple_model__pre_transforms)
+    model_data_source = copied_model(simple_model__with_primary_transforms)
+    model_materialization = copied_model(simple_model__with_primary_transforms)
 
     model_data_source.data_sources[0].name = metric_name
     model_materialization.materializations[0].name = model_data_source.metrics[0].name
@@ -76,10 +76,10 @@ def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(
 
 
 def test_top_level_elements_cant_share_names_except_with_metrics(
-    simple_model__pre_transforms: UserConfiguredModel,
+    simple_model__with_primary_transforms: UserConfiguredModel,
 ) -> None:  # noqa:D
-    data_source_name = simple_model__pre_transforms.data_sources[0].name
-    model_ds_and_mat = copied_model(simple_model__pre_transforms)
+    data_source_name = simple_model__with_primary_transforms.data_sources[0].name
+    model_ds_and_mat = copied_model(simple_model__with_primary_transforms)
     model_ds_and_mat.materializations[0].name = data_source_name
 
     with pytest.raises(
@@ -101,8 +101,8 @@ def test_top_level_elements_cant_share_names_except_with_metrics(
 """
 
 
-def test_duplicate_measure_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copied_model(simple_model__pre_transforms)
+def test_duplicate_measure_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(simple_model__with_primary_transforms)
 
     # Ensure we have a usable data source for the test
     data_source_with_measures, _ = find_data_source_with(model, lambda data_source: len(data_source.measures) > 0)
@@ -118,8 +118,8 @@ def test_duplicate_measure_name(simple_model__pre_transforms: UserConfiguredMode
         ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
-def test_duplicate_dimension_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copied_model(simple_model__pre_transforms)
+def test_duplicate_dimension_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(simple_model__with_primary_transforms)
 
     # Ensure we have a usable data source for the test
     data_source_with_dimensions, _ = find_data_source_with(model, lambda data_source: len(data_source.dimensions) > 0)
@@ -136,8 +136,8 @@ def test_duplicate_dimension_name(simple_model__pre_transforms: UserConfiguredMo
         ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
-def test_duplicate_identifier_name(simple_model__pre_transforms: UserConfiguredModel) -> None:  # noqa:D
-    model = copied_model(simple_model__pre_transforms)
+def test_duplicate_identifier_name(simple_model__with_primary_transforms: UserConfiguredModel) -> None:  # noqa:D
+    model = copied_model(simple_model__with_primary_transforms)
 
     # Ensure we have a usable data source for the test
     data_source_with_identifiers, _ = find_data_source_with(model, lambda data_source: len(data_source.identifiers) > 0)


### PR DESCRIPTION
There are no longer any `pre` validation transformations or `post` validation transformations. There are however transformation rules which require other transformation rules to be run first. Additionally, we can imagine
there being more ordered levels or transformation rules than just two. This PR adds a new `transform` method to the `ModelTransformer` which takes ina tuple of rule sequences. These rule sequences are operated over in order, i.e.
the first sequence is run before the second sequence, and etc. This makes transformations more flexible going forward, resolves the naming with the actual state of things, and simlifies the majority of use cases involving `ModelTransformer`. Additionally, we have deprecated the `pre` and `post`functions, which will eventually be removed.

# Summary
* Adds new `ModelTransformer.transform` method
* Deprecates `ModelTransfomer` `.pre_validation_transform_rules` and `.post_validation_transform_rules` methods
* Switches use of `.pre_validation_transform_rules` and `.post_validation_transform_rules` throughout the code base to `.transform` accordingly
* BREAKING: Alters the call signatures of the following in `dir_to_model.py`
  - `parse_directory_of_yaml_files_to_model`
  - `parse_yaml_file_paths_to_model`
  - `parse_yaml_files_to_validation_ready_model`