### PR TITLE
Fix `dbt_to_metricflow` new linting errors that come from `pre-commit 3.0.0`

### DIFF
--- a/metricflow/model/transformations/dbt_to_metricflow.py
+++ b/metricflow/model/transformations/dbt_to_metricflow.py
@@ -90,7 +90,7 @@ class DbtManifestTransformer:
         if dbt_metric.model is None:
             raise RuntimeError("Unable to resolve a model for a `DbtMetric.model` value of `None`")
 
-        target_model = None
+        target_model: Optional[str] = None
         target_package = None
 
         if dbt_metric.model[:4] == "ref(":
@@ -105,6 +105,8 @@ class DbtManifestTransformer:
                 ref_invalid_args(dbt_metric.name, ref_parts)
         else:
             target_model = dbt_metric.model
+
+        assert target_model is not None, "Failed to set `target_model`"
 
         hashed = hash((target_model, target_package, self.manifest.metadata.project_id, dbt_metric.package_name))
         if hashed not in self._resolved_dbt_model_refs:


### PR DESCRIPTION
The package `pre-commit` recently went from `2.2.1` to `3.0.0`. Running `mypy` on branch `main` with `pre-commit 2.2.1` succeeds, but if using `pre-commit 3.0.0` it fails with the following error
```
metricflow/model/transformations/dbt_to_metricflow.py:112: error: Argument "target_model_name" to "resolve_ref" of "Manifest" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
```
This is a small update to make it clear to `mypy` the typing of `target_model` in `dbt_to_metricflow`