### PR TITLE
Ensure consistent sort order for order-dependent integration test cases

### DIFF
--- a/metricflow/test/integration/test_cases/itest_composite_identifier.yaml
+++ b/metricflow/test/integration/test_cases/itest_composite_identifier.yaml
@@ -21,7 +21,7 @@ integration_test:
   model: COMPOSITE_IDENTIFIER_MODEL
   metrics: ["messages"]
   group_bys: ["user_team"]
-  order_bys: ["user_team"]
+  order_bys: ["user_team", "messages"]
   check_order: true
   check_query: |
     SELECT
@@ -35,6 +35,7 @@ integration_test:
     ORDER BY
       team_id
       , user_id
+      , messages
 ---
 integration_test:
   name: composite_key_join

--- a/metricflow/test/integration/test_cases/itest_order_limit.yaml
+++ b/metricflow/test/integration/test_cases/itest_order_limit.yaml
@@ -5,7 +5,7 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
   group_bys: ["metric_time"]
-  order_bys: ["-booking_value"]
+  order_bys: ["-booking_value", "metric_time"]
   check_order: true
   check_query: |
     SELECT
@@ -15,7 +15,7 @@ integration_test:
     GROUP BY
       ds
     ORDER BY
-      booking_value DESC
+      booking_value DESC, metric_time
 ---
 integration_test:
   name: order_asc
@@ -23,7 +23,7 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
   group_bys: ["metric_time"]
-  order_bys: ["booking_value"]
+  order_bys: ["booking_value", "metric_time"]
   check_order: true
   check_query: |
     SELECT
@@ -33,7 +33,7 @@ integration_test:
     GROUP BY
       ds
     ORDER BY
-      booking_value
+      booking_value, metric_time
 ---
 integration_test:
   name: order_limit
@@ -41,7 +41,7 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["booking_value"]
   group_bys: ["metric_time"]
-  order_bys: ["booking_value"]
+  order_bys: ["booking_value", "metric_time"]
   limit: 2
   check_order: true
   check_query: |
@@ -52,7 +52,7 @@ integration_test:
     GROUP BY
       ds
     ORDER BY
-      booking_value
+      booking_value, metric_time
     LIMIT 2
 ---
 integration_test:
@@ -62,7 +62,7 @@ integration_test:
   required_features: ["DATE_TRUNC"]
   metrics: ["booking_value"]
   group_bys: ["metric_time__month"]
-  order_bys: ["-metric_time__month"]
+  order_bys: ["-metric_time__month", "booking_value"]
   check_order: true
   check_query: |
     SELECT
@@ -72,4 +72,4 @@ integration_test:
     GROUP BY
       metric_time__month
     ORDER BY
-      metric_time__month DESC
+      metric_time__month DESC, booking_value


### PR DESCRIPTION
Recent changes added some values to our dummy test data which
produced multiple correct sort orders for output rows in the
itest_order_limit test cases. Although this has not yet come up in
our CI we have seen intermittent output order failures on these tests
in other runtime contexts, so adding explicit ordering
directives are necessary to ensure test robustness.

This commit makes a similar update to the composite_key_order integration
test to prevent a future recurrence of this issue.

This does not affect other tests as they rely on
comparisons of unordered output.
