### PR TITLE
Fix pre-commit version discrepancies

### DIFF
--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -30,10 +30,10 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             ~/.cache
-          key: ${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}-ubuntu-latest-22.04
+          key: ${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml', '.github/workflows/ci-linting.yaml') }}-ubuntu-latest-22.04
 
       - name: Install deps
-        run: pip install pre-commit
+        run: pip install "pre-commit>=2.18,<3"
 
       - name: Run Linter
         run: pre-commit run --show-diff-on-failure --color=always --all-files || (cat /home/runner/.cache/pre-commit/pre-commit.log && false)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         verbose: true
         additional_dependencies:
           [
-            sqlalchemy,
+            "sqlalchemy<2.0",
             sqlalchemy2-stubs,
             types-flask,
             types-requests,


### PR DESCRIPTION
Pre-commit recently released a 3.0, but our project configuration is
restricted to version 2.x (specifically, 2.18 or higher, but less than
3.0).

SQLAlchemy just released version 2.0, but our project configuration is
restricted to version 1.4.x.

Both of these are causing failures in CI, as our configurations allow for
latest version installations of pre-commit itself, and latest version of
SQLAlchemy within the pre-commit runtime environment.

Making MetricFlow compatible with these version updates is more involved
than a simple version change, so we limit the version ranges for the time being.
